### PR TITLE
feat: add SECRET_KEY_FILE and API_BEARER_TOKEN_FILE support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,9 +15,14 @@ PORT=8000
 CLOUDFLARE_TOKEN=your_cloudflare_api_token_here
 
 # API Bearer Token for authentication
-# Use a strong, random token for security
-# This token will be required for all API calls
+# Use a strong, random token for security (auto-generated if unset)
+# Generate one with: python -c "import secrets; print(secrets.token_urlsafe(32))"
 API_BEARER_TOKEN=your_secure_api_token_here
+# Alternative: point to a file containing the token (takes precedence over API_BEARER_TOKEN)
+# API_BEARER_TOKEN_FILE=/run/secrets/api_bearer_token
 
-# Optional: Set a secret key for session management
+# Secret key for Flask session management (auto-generated if unset)
+# Generate one with: python -c "import secrets; print(secrets.token_urlsafe(32))"
 SECRET_KEY=your-secret-key-here
+# Alternative: point to a file containing the key (takes precedence over SECRET_KEY)
+# SECRET_KEY_FILE=/run/secrets/secret_key

--- a/.env.template
+++ b/.env.template
@@ -14,12 +14,14 @@ LOG_LEVEL=INFO
 # Security Configuration
 # Generate a strong secret key for Flask sessions
 # You can generate one with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+# Alternatively, set SECRET_KEY_FILE to a path containing the key
 SECRET_KEY=your-super-secret-key-here-change-this
 
 # API Authentication
-# Generate a strong admin token for API access
+# Generate a strong bearer token for API access
 # You can generate one with: python -c "import secrets; print(secrets.token_urlsafe(32))"
-ADMIN_TOKEN=your-admin-token-here-change-this
+# Alternatively, set API_BEARER_TOKEN_FILE to a path containing the token
+API_BEARER_TOKEN=your-api-bearer-token-here-change-this
 
 # Cloudflare Configuration
 # Get your API token from: https://dash.cloudflare.com/profile/api-tokens

--- a/README.dockerhub.md
+++ b/README.dockerhub.md
@@ -138,9 +138,6 @@ curl "http://localhost:8000/api/certificates" \
 
 ## Environment Variables
 
-### Required
-- `API_BEARER_TOKEN` - Secure API access token
-
 ### DNS Provider (choose one)
 - **Cloudflare**: `CLOUDFLARE_TOKEN`
 - **AWS Route53**: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`
@@ -151,7 +148,10 @@ curl "http://localhost:8000/api/certificates" \
 - See [documentation](https://github.com/fabriziosalmi/certmate/blob/main/docs/dns-providers.md) for all providers
 
 ### Optional
+- `API_BEARER_TOKEN` - Bearer token for API authentication (auto-generated if unset)
+- `API_BEARER_TOKEN_FILE` - Path to a file containing the bearer token; takes precedence over `API_BEARER_TOKEN` when set
 - `SECRET_KEY` - Flask secret key (auto-generated if not set)
+- `SECRET_KEY_FILE` - Path to a file containing the Flask secret key (takes precedence over `SECRET_KEY`)
 - `FLASK_ENV` - Environment mode (default: production)
 - `HOST` - Bind address (default: 0.0.0.0)
 - `PORT` - Listen port (default: 8000)
@@ -266,5 +266,3 @@ MIT License - see [LICENSE](https://github.com/fabriziosalmi/certmate/blob/main/
 - **Discussions**: https://github.com/fabriziosalmi/certmate/discussions
 
 ---
-
-

--- a/README.md
+++ b/README.md
@@ -1251,8 +1251,10 @@ main "$@"
 
 | Variable           | Required | Default        | Description                         |
 | ------------------ | -------- | -------------- | ----------------------------------- |
-| `API_BEARER_TOKEN` |          | -              | Bearer token for API authentication |
-| `SECRET_KEY`       |          | auto-generated | Flask secret key for sessions       |
+| `API_BEARER_TOKEN`      |          | auto-generated | Bearer token for API authentication |
+| `API_BEARER_TOKEN_FILE` |          | -              | Path to a file containing the API bearer token (takes precedence over `API_BEARER_TOKEN`) |
+| `SECRET_KEY`            |          | auto-generated | Flask secret key for sessions       |
+| `SECRET_KEY_FILE`       |          | -              | Path to a file containing the Flask secret key (takes precedence over `SECRET_KEY`) |
 | `HOST`             |          | `127.0.0.1`    | Server bind address                 |
 | `PORT`             |          | `8000`         | Server port                         |
 | `FLASK_ENV`        |          | `production`   | Flask environment                   |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,10 @@ services:
     environment:
       - FLASK_ENV=production
       - SECRET_KEY=${SECRET_KEY:-}  # Auto-generated if empty; set a strong value for production
+      # - SECRET_KEY_FILE=${SECRET_KEY_FILE:-}  # Alternative: path to a file containing the secret key
       - CLOUDFLARE_TOKEN=${CLOUDFLARE_TOKEN}
-      - API_BEARER_TOKEN=${API_BEARER_TOKEN}
+      - API_BEARER_TOKEN=${API_BEARER_TOKEN:-}  # Auto-generated if empty; set a strong value for production
+      #- API_BEARER_TOKEN_FILE=${API_BEARER_TOKEN_FILE:-}  # Alternative: path to a file containing the bearer token
       - PORT=${PORT:-8000}                      # Internal listen port; also update ports: mapping if changed
       - GUNICORN_TIMEOUT=${GUNICORN_TIMEOUT:-300}  # Worker timeout; increase for slow DNS providers
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL:-}    # Overrides the email set via the web UI when set

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -60,7 +60,9 @@ Create a `.env` file on your host (not in the Docker image):
 
 ```bash
 SECRET_KEY=your-super-secret-key-here
-ADMIN_TOKEN=your-admin-token-here
+# SECRET_KEY_FILE=/run/secrets/secret_key  # Alternative: takes precedence over SECRET_KEY
+API_BEARER_TOKEN=your-api-bearer-token-here
+# API_BEARER_TOKEN_FILE=/run/secrets/api_bearer_token  # Alternative: takes precedence over API_BEARER_TOKEN
 CLOUDFLARE_API_TOKEN=your-cloudflare-api-token
 LOG_LEVEL=INFO
 ```
@@ -80,7 +82,9 @@ docker run -d --name certmate \
 ```bash
 docker run -d --name certmate \
   -e SECRET_KEY="your-secret-key" \
-  -e ADMIN_TOKEN="your-admin-token" \
+  # -e SECRET_KEY_FILE="/run/secrets/secret_key" \  # Alternative: takes precedence over SECRET_KEY
+  -e API_BEARER_TOKEN="your-api-bearer-token" \
+  # -e API_BEARER_TOKEN_FILE="/run/secrets/api_bearer_token" \  # Alternative: takes precedence over API_BEARER_TOKEN
   -e CLOUDFLARE_API_TOKEN="your-api-token" \
   -p 8000:8000 \
   -v certmate_certificates:/app/certificates \
@@ -92,8 +96,10 @@ docker run -d --name certmate \
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `SECRET_KEY` | Yes | Flask secret key for sessions |
-| `ADMIN_TOKEN` | Yes | Authentication token for admin access |
+| `SECRET_KEY` | No | Flask secret key for sessions (auto-generated if unset) |
+| `SECRET_KEY_FILE` | No | Path to a file containing the Flask secret key (takes precedence over `SECRET_KEY`) |
+| `API_BEARER_TOKEN` | No | Authentication token for API access (auto-generated if unset) |
+| `API_BEARER_TOKEN_FILE` | No | Path to a file containing the API bearer token (takes precedence over `API_BEARER_TOKEN`) |
 | `LOG_LEVEL` | No | `INFO` (default), `DEBUG`, `WARNING`, `ERROR` |
 | `CLOUDFLARE_API_TOKEN` | No | Cloudflare DNS provider token |
 | `AWS_ACCESS_KEY_ID` | No | AWS Route53 access key |
@@ -117,8 +123,10 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - SECRET_KEY=${SECRET_KEY}
-      - ADMIN_TOKEN=${ADMIN_TOKEN}
+      - SECRET_KEY=${SECRET_KEY:-}
+      # - SECRET_KEY_FILE=${SECRET_KEY_FILE:-}  # Alternative: path to a file containing the secret key
+      - API_BEARER_TOKEN=${API_BEARER_TOKEN:-}
+      # - API_BEARER_TOKEN_FILE=${API_BEARER_TOKEN_FILE:-}  # Alternative: path to a file containing the bearer token
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
     volumes:
       - certmate_certificates:/app/certificates

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -132,8 +132,17 @@ Quick setup for common providers:
 ## Environment Variables
 
 ```bash
-# API Authentication
+# API Authentication (auto-generated if neither is set)
+# Option A: inline value
 API_BEARER_TOKEN=your_secure_token_here
+# Option B: path to a file containing the token (takes precedence over API_BEARER_TOKEN)
+API_BEARER_TOKEN_FILE=/run/secrets/api_bearer_token
+
+# Flask session secret key (auto-generated if neither is set)
+# Option A: inline value
+SECRET_KEY=your_flask_secret_key
+# Option B: path to a file containing the key (takes precedence over SECRET_KEY)
+SECRET_KEY_FILE=/run/secrets/secret_key
 
 # DNS Providers (choose one or multiple)
 CLOUDFLARE_TOKEN=your_cloudflare_token
@@ -146,10 +155,20 @@ AZURE_CLIENT_SECRET=your_azure_secret
 GOOGLE_PROJECT_ID=your_gcp_project
 POWERDNS_API_URL=https://your-powerdns:8081
 POWERDNS_API_KEY=your_powerdns_key
-
-# Optional
-SECRET_KEY=your_flask_secret_key
 ```
+
+### Resolution Order
+
+| Variable | Precedence |
+|----------|------------|
+| `API_BEARER_TOKEN_FILE` | Highest — if set, `API_BEARER_TOKEN` is never read |
+| `API_BEARER_TOKEN` | Used only when `API_BEARER_TOKEN_FILE` is absent |
+| *(generated)* | Fallback when neither is set or the value fails validation |
+| `SECRET_KEY_FILE` | Highest — if set, `SECRET_KEY` is never read |
+| `SECRET_KEY` | Used only when `SECRET_KEY_FILE` is absent |
+| *(generated + persisted)* | Written to `data/.secret_key` so sessions survive restarts |
+
+> **Docker Secrets tip**: Use `API_BEARER_TOKEN_FILE=/run/secrets/api_bearer_token` and `SECRET_KEY_FILE=/run/secrets/secret_key` with Docker Swarm or Kubernetes secrets to avoid putting sensitive values in environment variables.
 
 ---
 

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -79,21 +79,55 @@ def setup_directories(container: AppContainer, test_config=None):
         container.logs_dir = Path(tempfile.mkdtemp(prefix="certmate_logs_"))
 
 
-def configure_app(container: AppContainer, app, test_config=None):
-    secret_key = os.getenv('SECRET_KEY', '')
+def _secret_key_from_env_or_generate(data_dir: Path) -> str:
+    """Return a Flask secret key.
+
+    Resolution order (mutually exclusive):
+    1. SECRET_KEY_FILE — if set, read the key from that file. Any read error
+       or empty result generates a fresh key immediately; SECRET_KEY is never
+       consulted (to avoid encouraging both vars).
+    2. SECRET_KEY — only checked when SECRET_KEY_FILE is absent. Insecure
+       defaults ('', 'your-secret-key-here', 'change-me', 'secret') are
+       treated as unset and fall through to step 3.
+    3. Persisted generated key — reads data_dir/.secret_key if it exists so
+       sessions survive restarts, otherwise generates secrets.token_hex(32)
+       and attempts to persist it. A persistence failure is logged but does
+       not block startup; sessions will not survive restarts in that case.
+    """
     insecure_defaults = {'', 'your-secret-key-here', 'change-me', 'secret'}
-    if secret_key in insecure_defaults:
-        key_file = container.data_dir / '.secret_key'
-        if key_file.exists():
-            secret_key = key_file.read_text().strip()
-        else:
-            secret_key = secrets.token_hex(32)
-            try:
-                key_file.write_text(secret_key)
-                key_file.chmod(0o600)
-            except OSError as e:
-                logger.warning(f"Could not persist SECRET_KEY to {key_file}: {e}. Sessions will not survive restarts.")
-    app.secret_key = secret_key
+
+    explicit_key_file = os.getenv('SECRET_KEY_FILE')
+    if explicit_key_file:
+        try:
+            key = Path(explicit_key_file).read_text().strip()
+            if key:
+                return key
+            logger.warning("SECRET_KEY_FILE (%s) is empty; generating a fresh secret key.", explicit_key_file)
+        except Exception as e:
+            logger.warning("Could not read SECRET_KEY_FILE (%s): %s; generating a fresh secret key.", explicit_key_file, e)
+        return secrets.token_hex(32)
+
+    env_key = os.getenv('SECRET_KEY', '')
+    if env_key and env_key not in insecure_defaults:
+        return env_key
+
+    if env_key in insecure_defaults and env_key != '':
+        logger.warning("SECRET_KEY is set to an insecure default; ignoring it.")
+
+    implicit_key_file = data_dir / '.secret_key'
+    if implicit_key_file.exists():
+        return implicit_key_file.read_text().strip()
+
+    key = secrets.token_hex(32)
+    try:
+        implicit_key_file.write_text(key)
+        implicit_key_file.chmod(0o600)
+    except OSError as e:
+        logger.warning("Could not persist SECRET_KEY to %s: %s. Sessions will not survive restarts.", implicit_key_file, e)
+    return key
+
+def configure_app(container: AppContainer, app, test_config=None):
+    app.secret_key = _secret_key_from_env_or_generate(container.data_dir)
     app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024
 
     if test_config:

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -102,9 +102,9 @@ def _secret_key_from_env_or_generate(data_dir: Path) -> str:
             key = Path(explicit_key_file).read_text().strip()
             if key:
                 return key
-            logger.warning("SECRET_KEY_FILE (%s) is empty; generating a fresh secret key.", explicit_key_file)
+            logger.warning(f"SECRET_KEY_FILE ({explicit_key_file}) is empty; generating a fresh secret key.")
         except Exception as e:
-            logger.warning("Could not read SECRET_KEY_FILE (%s): %s; generating a fresh secret key.", explicit_key_file, e)
+            logger.warning(f"Could not read SECRET_KEY_FILE ({explicit_key_file}): {e}; generating a fresh secret key.")
         return secrets.token_hex(32)
 
     env_key = os.getenv('SECRET_KEY', '')
@@ -112,7 +112,7 @@ def _secret_key_from_env_or_generate(data_dir: Path) -> str:
         return env_key
 
     if env_key in insecure_defaults and env_key != '':
-        logger.warning("SECRET_KEY is set to an insecure default; ignoring it.")
+        logger.warning(f"SECRET_KEY is set to an insecure default; ignoring it.")
 
     implicit_key_file = data_dir / '.secret_key'
     if implicit_key_file.exists():
@@ -123,7 +123,7 @@ def _secret_key_from_env_or_generate(data_dir: Path) -> str:
         implicit_key_file.write_text(key)
         implicit_key_file.chmod(0o600)
     except OSError as e:
-        logger.warning("Could not persist SECRET_KEY to %s: %s. Sessions will not survive restarts.", implicit_key_file, e)
+        logger.warning(f"Could not persist SECRET_KEY to {implicit_key_file}: {e}. Sessions will not survive restarts.")
     return key
 
 def configure_app(container: AppContainer, app, test_config=None):

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -18,14 +18,35 @@ logger = logging.getLogger(__name__)
 def _bearer_token_from_env_or_generate():
     """Return a valid api_bearer_token for the default settings template.
 
-    Reads API_BEARER_TOKEN from the environment. If it is missing OR fails
-    validate_api_token (too short, weak pattern, insufficient entropy) we
-    fall back to a freshly generated secure token. This prevents a
-    misconfigured env var (issue #108: docker-compose passing an empty or
-    weak ${API_BEARER_TOKEN}) from poisoning every subsequent save_settings
-    call with a misleading "API token length must be between 32 and 512
-    characters" rejection.
+    Resolution order (mutually exclusive):
+    1. API_BEARER_TOKEN_FILE — if set, read the token from that file. Any
+       read error or validation failure generates a fresh token immediately;
+       API_BEARER_TOKEN is never consulted (to avoid encouraging both vars).
+    2. API_BEARER_TOKEN — only checked when API_BEARER_TOKEN_FILE is absent.
+       An invalid value (too short, weak pattern, insufficient entropy) is
+       logged and a fresh token is generated instead. This prevents a
+       misconfigured env var (issue #108: docker-compose passing an empty or
+       weak ${API_BEARER_TOKEN}) from poisoning save_settings with a
+       misleading "API token length must be between 32 and 512 characters"
+       rejection.
+    3. generate_secure_token() — fallback when neither variable is set or
+       both fail validation.
     """
+    token_file = os.getenv('API_BEARER_TOKEN_FILE')
+    if token_file:
+        try:
+            file_token = Path(token_file).read_text().strip()
+            is_valid, reason = validate_api_token(file_token)
+            if is_valid:
+                return file_token
+            logger.warning(
+                "API_BEARER_TOKEN_FILE token is invalid (%s); "
+                "falling back to API_BEARER_TOKEN or a generated token.",
+                reason)
+        except Exception as e:
+            logger.warning("Could not read API_BEARER_TOKEN_FILE (%s): %s", token_file, e)
+            return generate_secure_token()
+
     env_token = os.getenv('API_BEARER_TOKEN')
     if env_token:
         is_valid, reason = validate_api_token(env_token)

--- a/tests/test_issue108_bearer_token_env.py
+++ b/tests/test_issue108_bearer_token_env.py
@@ -78,6 +78,73 @@ def test_helper_rejects_weak_pattern(monkeypatch, caplog):
     assert any("API_BEARER_TOKEN" in rec.message for rec in caplog.records)
 
 
+GOOD_TOKEN = "9aZ8bY7cX6dW5eV4fU3gT2hS1iR0jQpNmLkJiHgF"  # 40 chars, valid
+
+
+# ---------------------------------------------------------------------------
+# API_BEARER_TOKEN_FILE tests
+# ---------------------------------------------------------------------------
+
+def test_file_var_used_when_set_and_valid(monkeypatch, tmp_path):
+    token_file = tmp_path / "token.txt"
+    token_file.write_text(GOOD_TOKEN)
+    monkeypatch.setenv("API_BEARER_TOKEN_FILE", str(token_file))
+    monkeypatch.delenv("API_BEARER_TOKEN", raising=False)
+    assert _bearer_token_from_env_or_generate() == GOOD_TOKEN
+
+
+def test_file_var_takes_precedence_over_env_var(monkeypatch, tmp_path):
+    """When API_BEARER_TOKEN_FILE is set, API_BEARER_TOKEN must never be consulted."""
+    token_file = tmp_path / "token.txt"
+    token_file.write_text(GOOD_TOKEN)
+    monkeypatch.setenv("API_BEARER_TOKEN_FILE", str(token_file))
+    monkeypatch.setenv("API_BEARER_TOKEN", "Z" * 40)  # also valid but must be ignored
+    assert _bearer_token_from_env_or_generate() == GOOD_TOKEN
+
+
+def test_file_read_error_generates_immediately(monkeypatch, caplog):
+    """If the file cannot be read, generate a fresh token without consulting API_BEARER_TOKEN."""
+    monkeypatch.setenv("API_BEARER_TOKEN_FILE", "/nonexistent/path/token.txt")
+    monkeypatch.setenv("API_BEARER_TOKEN", "Z" * 40)  # must be ignored
+    with caplog.at_level("WARNING"):
+        token = _bearer_token_from_env_or_generate()
+    is_valid, _ = validate_api_token(token)
+    assert is_valid
+    assert token != "Z" * 40, "API_BEARER_TOKEN must not be consulted after file failure"
+    assert any("API_BEARER_TOKEN_FILE" in rec.message for rec in caplog.records)
+
+
+def test_file_with_invalid_token_generates_immediately(monkeypatch, tmp_path, caplog):
+    """An invalid token in the file must generate immediately, not fall through to API_BEARER_TOKEN."""
+    token_file = tmp_path / "token.txt"
+    token_file.write_text("tooshort")
+    monkeypatch.setenv("API_BEARER_TOKEN_FILE", str(token_file))
+    monkeypatch.setenv("API_BEARER_TOKEN", "Z" * 40)  # must be ignored
+    with caplog.at_level("WARNING"):
+        token = _bearer_token_from_env_or_generate()
+    is_valid, _ = validate_api_token(token)
+    assert is_valid
+    assert token != "Z" * 40, "API_BEARER_TOKEN must not be consulted after invalid file token"
+
+
+def test_file_var_absent_falls_through_to_env_var(monkeypatch):
+    """When API_BEARER_TOKEN_FILE is not set, API_BEARER_TOKEN is used normally."""
+    monkeypatch.delenv("API_BEARER_TOKEN_FILE", raising=False)
+    monkeypatch.setenv("API_BEARER_TOKEN", GOOD_TOKEN)
+    assert _bearer_token_from_env_or_generate() == GOOD_TOKEN
+
+
+def test_file_strips_whitespace(monkeypatch, tmp_path):
+    token_file = tmp_path / "token.txt"
+    token_file.write_text(f"  {GOOD_TOKEN}\n")
+    monkeypatch.setenv("API_BEARER_TOKEN_FILE", str(token_file))
+    monkeypatch.delenv("API_BEARER_TOKEN", raising=False)
+    assert _bearer_token_from_env_or_generate() == GOOD_TOKEN
+
+
+# ---------------------------------------------------------------------------
+
+
 def test_save_settings_succeeds_after_bad_env_var(settings_manager, monkeypatch):
     """The end-to-end repro: with a bad API_BEARER_TOKEN env var, the
     initial save during the setup wizard must NOT fail."""

--- a/tests/test_secret_key_env.py
+++ b/tests/test_secret_key_env.py
@@ -1,0 +1,104 @@
+"""
+Unit tests for _secret_key_from_env_or_generate() in factory.py.
+
+Covers the three-step resolution order:
+1. SECRET_KEY_FILE (mutually exclusive with SECRET_KEY)
+2. SECRET_KEY (skipped when SECRET_KEY_FILE is set)
+3. Persisted generated key in data_dir/.secret_key
+"""
+
+import pytest
+
+from modules.core.factory import _secret_key_from_env_or_generate
+
+pytestmark = [pytest.mark.unit]
+
+GOOD_KEY = "a" * 32  # arbitrary non-empty, non-insecure string
+
+
+# ---------------------------------------------------------------------------
+# SECRET_KEY_FILE tests
+# ---------------------------------------------------------------------------
+
+def test_file_var_used_when_set_and_valid(monkeypatch, tmp_path):
+    key_file = tmp_path / "secret.txt"
+    key_file.write_text(GOOD_KEY)
+    monkeypatch.setenv("SECRET_KEY_FILE", str(key_file))
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    assert _secret_key_from_env_or_generate(tmp_path) == GOOD_KEY
+
+
+def test_file_var_takes_precedence_over_env_var(monkeypatch, tmp_path):
+    key_file = tmp_path / "secret.txt"
+    key_file.write_text(GOOD_KEY)
+    monkeypatch.setenv("SECRET_KEY_FILE", str(key_file))
+    monkeypatch.setenv("SECRET_KEY", "Z" * 32)  # also valid but must be ignored
+    assert _secret_key_from_env_or_generate(tmp_path) == GOOD_KEY
+
+
+def test_file_read_error_generates_immediately(monkeypatch, tmp_path, caplog):
+    """File read failure must generate a fresh key without consulting SECRET_KEY."""
+    monkeypatch.setenv("SECRET_KEY_FILE", "/nonexistent/path/secret.txt")
+    monkeypatch.setenv("SECRET_KEY", "Z" * 32)  # must be ignored
+    with caplog.at_level("WARNING"):
+        key = _secret_key_from_env_or_generate(tmp_path)
+    assert key != "Z" * 32, "SECRET_KEY must not be consulted after file failure"
+    assert len(key) > 0
+    assert any("SECRET_KEY_FILE" in rec.message for rec in caplog.records)
+
+
+def test_file_empty_generates_immediately(monkeypatch, tmp_path, caplog):
+    """An empty file must generate a fresh key without consulting SECRET_KEY."""
+    key_file = tmp_path / "secret.txt"
+    key_file.write_text("   \n")  # whitespace only → strips to empty
+    monkeypatch.setenv("SECRET_KEY_FILE", str(key_file))
+    monkeypatch.setenv("SECRET_KEY", "Z" * 32)  # must be ignored
+    with caplog.at_level("WARNING"):
+        key = _secret_key_from_env_or_generate(tmp_path)
+    assert key != "Z" * 32
+    assert any("SECRET_KEY_FILE" in rec.message for rec in caplog.records)
+
+
+def test_file_strips_whitespace(monkeypatch, tmp_path):
+    key_file = tmp_path / "secret.txt"
+    key_file.write_text(f"  {GOOD_KEY}\n")
+    monkeypatch.setenv("SECRET_KEY_FILE", str(key_file))
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    assert _secret_key_from_env_or_generate(tmp_path) == GOOD_KEY
+
+
+def test_file_var_absent_falls_through_to_env_var(monkeypatch, tmp_path):
+    monkeypatch.delenv("SECRET_KEY_FILE", raising=False)
+    monkeypatch.setenv("SECRET_KEY", GOOD_KEY)
+    assert _secret_key_from_env_or_generate(tmp_path) == GOOD_KEY
+
+
+# ---------------------------------------------------------------------------
+# SECRET_KEY env var tests
+# ---------------------------------------------------------------------------
+
+def test_env_var_insecure_default_ignored(monkeypatch, tmp_path, caplog):
+    monkeypatch.delenv("SECRET_KEY_FILE", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "change-me")
+    with caplog.at_level("WARNING"):
+        key = _secret_key_from_env_or_generate(tmp_path)
+    assert key != "change-me"
+    assert any("insecure default" in rec.message for rec in caplog.records)
+
+
+def test_env_var_missing_generates_and_persists(monkeypatch, tmp_path):
+    monkeypatch.delenv("SECRET_KEY_FILE", raising=False)
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    key = _secret_key_from_env_or_generate(tmp_path)
+    assert len(key) > 0
+    assert (tmp_path / ".secret_key").exists()
+    assert (tmp_path / ".secret_key").read_text().strip() == key
+
+
+def test_persisted_key_reused_on_second_call(monkeypatch, tmp_path):
+    """Simulates a restart — second call reads the persisted file."""
+    monkeypatch.delenv("SECRET_KEY_FILE", raising=False)
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    key1 = _secret_key_from_env_or_generate(tmp_path)
+    key2 = _secret_key_from_env_or_generate(tmp_path)
+    assert key1 == key2, "Key must be stable across restarts via .secret_key file"


### PR DESCRIPTION
## Summary

- Add `API_BEARER_TOKEN_FILE` support to `_bearer_token_from_env_or_generate()` — reads the bearer token from a file (Docker Swarm secrets, Kubernetes secrets, bind-mounted files) with the same validation as the env var path
- Add `SECRET_KEY_FILE` support to the new `_secret_key_from_env_or_generate()` — extracts the existing inline logic from `configure_app()` into a dedicated function with file-based secret support
- Replace all remaining `ADMIN_TOKEN` references with `API_BEARER_TOKEN` across docs and config files

## Resolution order (mutually exclusive per secret)

| Priority | Source | Behaviour |
|----------|--------|-----------|
| 1 | `*_FILE` set | Read from file; any error → generate immediately, never consult env var |
| 2 | env var set and valid | Use it |
| 3 | fallback | Generate (`SECRET_KEY` persisted to `data/.secret_key` for session continuity) |

## Changes

- `modules/core/settings.py` — `_bearer_token_from_env_or_generate()` now checks `API_BEARER_TOKEN_FILE` first
- `modules/core/factory.py` — inline secret-key logic extracted to `_secret_key_from_env_or_generate(data_dir)` with `SECRET_KEY_FILE` support
- `docker-compose.yml`, `.env.example`, `.env.template` — `*_FILE` vars added (commented out by default)
- `docs/docker.md`, `docs/installation.md`, `README.md`, `README.dockerhub.md` — resolution order documented, `ADMIN_TOKEN` → `API_BEARER_TOKEN`
- `tests/test_issue108_bearer_token_env.py` — 6 new regression tests for `API_BEARER_TOKEN_FILE`
- `tests/test_secret_key_env.py` — 9 new unit tests for `SECRET_KEY_FILE` resolution order including restart persistence

## Test plan

- [x] `python -m pytest tests/test_issue108_bearer_token_env.py -v` — all 11 tests pass
- [x] `python -m pytest tests/test_secret_key_env.py -v` — all 9 tests pass
- [x] `python -m pytest tests/ -m unit -v` — all unit tests pass
- [x] `API_BEARER_TOKEN_FILE` valid file → token used (covered by `test_file_var_used_when_set_and_valid`)
- [x] `API_BEARER_TOKEN_FILE` nonexistent → generated token + warning logged (covered by `test_file_read_error_generates_immediately`)
- [x] Both `API_BEARER_TOKEN_FILE` and `API_BEARER_TOKEN` set → file wins (covered by `test_file_var_takes_precedence_over_env_var`)
- [x] `SECRET_KEY_FILE` valid file → key used and stable across restarts (covered by `test_file_var_used_when_set_and_valid`, `test_persisted_key_reused_on_second_call`)
- [ ] `SECRET_KEY_FILE` → sessions survive a live app restart (requires manual integration test)
