### PR TITLE
chore: bump base image python:3.12-slim → python:3.12-slim-trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for optimized image size and faster builds
-FROM python:3.12-slim AS builder
+FROM python:3.12-slim-trixie AS builder
 
 # Set working directory for build stage
 WORKDIR /build
@@ -23,7 +23,7 @@ RUN pip install -U pip setuptools wheel && \
     pip install --no-cache-dir -r ${REQUIREMENTS_FILE}
 
 # Production stage
-FROM python:3.12-slim
+FROM python:3.12-slim-trixie
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## Summary

Two-character change in `Dockerfile`. Expected to close ~11-13 of the 13 open Critical+High Trivy findings on main — all of which are base-image OS CVEs (gnutls, libssh2, ncurses, systemd, libcap) that are fixed in trixie's package versions but not backported to bookworm.

| Component | bookworm (current) | trixie (this PR) |
|---|---|---|
| Debian | 12 | 13 (stable since June 2025) |
| glibc | 2.36 | 2.40 (forward-compat, no rebuild needed) |
| OpenSSL system | 3.0.x | 3.4.x (irrelevant — `cryptography` bundles its own) |
| gnutls | 3.7.9 | 3.8.7 (closes #253, #254, #255, #256, #257) |
| ncurses | 6.4 | 6.5 (closes #182, #193, #200, #201) |
| systemd | 252 | 256+ (closes #190, #194) |
| libcap | 2.66 | 2.68+ (closes #178) |
| libssh2 | 1.10.0 | 1.11.x (probably closes #274) |

## Risk assessment

- **glibc 2.36 → 2.40**: forward-compatible, no wheel rebuild needed.
- **OpenSSL system bump**: irrelevant — `cryptography` ships its own OpenSSL via manylinux wheels.
- **`gcc` / `curl` / `tini` apt packages**: unchanged across bookworm/trixie main.
- **Multi-arch (linux/amd64 + linux/arm64)**: trixie manifests cover both, same as bookworm.
- **pip wheel compatibility**: verified locally — full `requirements.txt` install (certbot 2.10 + 14 DNS plugins + cryptography + cloudflare + boto3 + azure-* + flask) succeeds on trixie/amd64. CI runs the multi-arch verification.

## Test plan

- [x] Local single-arch amd64 docker build succeeds; all pip wheels install cleanly on trixie
- [ ] CI multi-arch build (linux/amd64, linux/arm64) — gated by this PR
- [ ] CI test (3.12) — exercises the full e2e suite against the trixie-based container
- [ ] Trivy scan post-build — confirm Critical drops from 1 → 0 and High drops from 12 → ≤2

## Rollback

Single `git revert` if any check goes red. Image tag stays `:vX.Y.Z`, no Docker Hub coordination needed.