### PR TITLE
Add JSON certificate download mode for automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,8 +681,8 @@ Content-Type: application/json
 POST /api/certificates/example.com/renew
 Authorization: Bearer your_token_here
 
-# Download certificate (ZIP format)
-GET /api/certificates/example.com/download
+# Download certificate bundle as JSON
+GET /api/certificates/example.com/download?format=json
 Authorization: Bearer your_token_here
 
 # Check certificate deployment status
@@ -842,14 +842,13 @@ This endpoint returns a ZIP file containing all certificate files:
 #### cURL Download
 ```bash
 curl -H "Authorization: Bearer your_token_here" \
- -o example.com-tls.zip \
- https://your-certmate-server.com/example.com/tls
+ -o example.com-tls.json \
+ https://your-certmate-server.com/api/certificates/example.com/download?format=json
 ```
 
 #### Python SDK Example
 ```python
 import requests
-import zipfile
 from pathlib import Path
 
 class CertMateClient:
@@ -857,23 +856,13 @@ class CertMateClient:
  self.base_url = base_url.rstrip('/')
  self.headers = {"Authorization": f"Bearer {token}"}
  
- def download_certificate(self, domain, extract_to=None):
- """Download and optionally extract certificate for domain"""
- url = f"{self.base_url}/{domain}/tls"
+ def download_certificate(self, domain):
+ """Download certificate bundle as JSON for domain"""
+ url = f"{self.base_url}/api/certificates/{domain}/download?format=json"
  
  response = requests.get(url, headers=self.headers)
  response.raise_for_status()
- 
- zip_path = f"{domain}-tls.zip"
- with open(zip_path, 'wb') as f:
- f.write(response.content)
- 
- if extract_to:
- Path(extract_to).mkdir(parents=True, exist_ok=True)
- with zipfile.ZipFile(zip_path, 'r') as zip_ref:
- zip_ref.extractall(extract_to)
- 
- return zip_path
+ return response.json()
  
  def list_certificates(self):
  """List all managed certificates"""
@@ -905,8 +894,18 @@ client = CertMateClient("https://certmate.company.com", "your_token_here")
 
 # List and download certificates
 certs = client.list_certificates()
-client.download_certificate("api.company.com", extract_to="/etc/ssl/certs/api/")
+bundle = client.download_certificate("api.company.com")
+Path("/etc/ssl/certs/api").mkdir(parents=True, exist_ok=True)
+for name, key in {
+    "cert.pem": "cert_pem",
+    "chain.pem": "chain_pem",
+    "fullchain.pem": "fullchain_pem",
+    "privkey.pem": "private_key_pem",
+}.items():
+    Path("/etc/ssl/certs/api", name).write_text(bundle[key])
 ```
+
+The same JSON response shape can be consumed directly by Ansible's `uri` module or Salt's HTTP helpers without unpacking an archive.
 
 #### Infrastructure as Code Examples
 
@@ -997,8 +996,8 @@ download_certificate() {
  # Download with retry logic
  for i in {1..3}; do
  if curl -f -H "Authorization: Bearer $API_TOKEN" \
- -o "${DOMAIN}-tls.zip" \
- "$CERTMATE_URL/$DOMAIN/tls"; then
+ -o "${DOMAIN}-tls.json" \
+ "$CERTMATE_URL/api/certificates/$DOMAIN/download?format=json"; then
  log "Certificate downloaded successfully"
  return 0
  else
@@ -1014,7 +1013,10 @@ download_certificate() {
 extract_certificate() {
  log "Extracting certificate to ${CERT_DIR}"
  mkdir -p "$CERT_DIR"
- unzip -o "${DOMAIN}-tls.zip" -d "$CERT_DIR"
+ jq -r '.cert_pem' "${DOMAIN}-tls.json" > "$CERT_DIR/cert.pem"
+ jq -r '.chain_pem' "${DOMAIN}-tls.json" > "$CERT_DIR/chain.pem"
+ jq -r '.fullchain_pem' "${DOMAIN}-tls.json" > "$CERT_DIR/fullchain.pem"
+ jq -r '.private_key_pem' "${DOMAIN}-tls.json" > "$CERT_DIR/privkey.pem"
  
  # Set proper permissions
  chmod 600 "$CERT_DIR"/*.pem
@@ -1029,7 +1031,7 @@ reload_services() {
 }
 
 cleanup() {
- rm -f "${DOMAIN}-tls.zip"
+ rm -f "${DOMAIN}-tls.json"
 }
 
 # Main execution
@@ -1111,21 +1113,28 @@ main "$@"
  
  - name: Download and deploy certificates
  block:
- - name: Download certificate
+ - name: Download certificate bundle as JSON
  uri:
- url: "{{ certmate_url }}/{{ item }}/tls"
+ url: "{{ certmate_url }}/api/certificates/{{ item }}/download?format=json"
  headers:
  Authorization: "Bearer {{ certmate_token }}"
- dest: "/tmp/{{ item }}-tls.zip"
+ return_content: yes
+ register: cert_bundle
  
- - name: Extract certificate
- unarchive:
- src: "/tmp/{{ item }}-tls.zip"
- dest: "/etc/ssl/certs/{{ item }}/"
- remote_src: yes
+ - name: Write certificate files
+ copy:
+ dest: "/etc/ssl/certs/{{ item.0.item }}/{{ item.1.name }}"
+ content: "{{ item.0.json[item.1.key] }}"
  owner: root
  group: ssl-cert
- mode: '0640'
+ mode: "{{ item.1.mode }}"
+ loop: "{{ cert_bundle.results | product(cert_files) | list }}"
+ vars:
+ cert_files:
+ - { name: "cert.pem", key: "cert_pem", mode: "0644" }
+ - { name: "chain.pem", key: "chain_pem", mode: "0644" }
+ - { name: "fullchain.pem", key: "fullchain_pem", mode: "0644" }
+ - { name: "privkey.pem", key: "private_key_pem", mode: "0600" }
  loop:
  - "api.company.com"
  - "staging.company.com"
@@ -1186,23 +1195,28 @@ main "$@"
  
  - name: Download certificates
  uri:
- url: "{{ certmate_url }}/{{ item.name }}/tls"
+ url: "{{ certmate_url }}/api/certificates/{{ item.name }}/download?format=json"
  method: GET
  headers:
  Authorization: "Bearer {{ api_token }}"
- dest: "/tmp/{{ item.name }}-tls.zip"
- creates: "/tmp/{{ item.name }}-tls.zip"
+ return_content: yes
+ register: cert_bundle
  loop: "{{ certificate_domains }}"
  
- - name: Extract certificates
- unarchive:
- src: "/tmp/{{ item.name }}-tls.zip"
- dest: "/etc/ssl/certs/{{ item.name }}/"
+ - name: Write certificates
+ copy:
+ dest: "/etc/ssl/certs/{{ item.0.item.name }}/{{ item.1.name }}"
+ content: "{{ item.0.json[item.1.key] }}"
  owner: root
  group: ssl-cert
- mode: '0640'
- remote_src: yes
- loop: "{{ certificate_domains }}"
+ mode: "{{ item.1.mode }}"
+ loop: "{{ cert_bundle.results | product(cert_files) | list }}"
+ vars:
+ cert_files:
+ - { name: "cert.pem", key: "cert_pem", mode: "0644" }
+ - { name: "chain.pem", key: "chain_pem", mode: "0644" }
+ - { name: "fullchain.pem", key: "fullchain_pem", mode: "0644" }
+ - { name: "privkey.pem", key: "private_key_pem", mode: "0600" }
  notify: 
  - reload nginx
  - reload haproxy
@@ -1226,7 +1240,7 @@ main "$@"
  
  - name: Cleanup temporary files
  file:
- path: "/tmp/{{ item.name }}-tls.zip"
+ path: "/tmp/{{ item.name }}-tls.json"
  state: absent
  loop: "{{ certificate_domains }}"
  

--- a/docs/api.md
+++ b/docs/api.md
@@ -479,16 +479,20 @@ curl http://localhost:5000/api/crl/download/info \
 
 **Endpoint**: `GET /certificates/<domain>/download`
 
-Download certificate files for a specific domain. By default, this endpoint returns a ZIP archive containing all certificate components. A specific file can be requested using the `file` query parameter.
+Download certificate files for a specific domain. By default, this endpoint returns a ZIP archive containing all certificate components. A specific file can be requested using the `file` query parameter. JSON mode is also available for automation that wants all PEMs in one response.
 
 **Parameters**:
 - `domain` (Path) - The domain name associated with the certificate.
 - `file` (Query, Optional) - Specify a single file to download. 
   - Supported values: `fullchain.pem`, `privkey.pem`, `combined.pem`
+- `format` (Query, Optional) - Set to `json` to return all certificate files in a JSON object.
 
 **Response** (200 OK):
 - **Default**: `application/zip` (A ZIP file containing all PEM files)
 - **With `file` param**: `application/x-pem-file` (The raw content of the requested file)
+- **With `format=json`**: `application/json` with `domain`, `cert_pem`, `chain_pem`, `fullchain_pem`, and `private_key_pem`
+
+The JSON form is the preferred automation shape for Ansible, Salt, or any other client that wants to write PEM files directly.
 
 **Examples**:
 
@@ -507,6 +511,11 @@ curl "http://localhost:5000/api/certificates/example.com/download?file=fullchain
 curl "http://localhost:5000/api/certificates/example.com/download?file=privkey.pem" \
  -H "Authorization: Bearer TOKEN" \
  -o privkey.pem
+
+# Download the full certificate bundle as JSON
+curl "http://localhost:5000/api/certificates/example.com/download?format=json" \
+ -H "Authorization: Bearer TOKEN" \
+ -o example_com_bundle.json
 
 ```
 

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -10,7 +10,7 @@ import zipfile
 import os
 import io
 from pathlib import Path
-from flask import send_file, after_this_request, current_app, request
+from flask import send_file, after_this_request, current_app, request, jsonify
 from flask_restx import Resource, fields
 
 from ..core.metrics import get_metrics_summary, is_prometheus_available
@@ -527,7 +527,7 @@ def create_api_resources(api, models, managers):
         @api.doc(security='Bearer')
         @auth_manager.require_role('viewer')
         def get(self, domain):
-            """Download certificate files as ZIP or individual file"""
+            """Download certificate files as ZIP, JSON, or individual file"""
             try:
                 cert_dir, err = _validate_domain_path(domain, file_ops.cert_dir)
                 if err:
@@ -535,8 +535,35 @@ def create_api_resources(api, models, managers):
                 if not cert_dir.exists():
                     return {'error': f'Certificate not found for domain: {domain}'}, 404
 
+                download_format = request.args.get('format')
                 # Check for the optional 'file' parameter
                 requested_file = request.args.get('file')
+
+                if download_format and download_format not in ['json']:
+                    return {'error': 'Invalid format requested.'}, 400
+
+                if download_format == 'json':
+                    if requested_file:
+                        return {'error': 'format=json cannot be combined with file.'}, 400
+
+                    required_files = {
+                        'cert_pem': 'cert.pem',
+                        'chain_pem': 'chain.pem',
+                        'fullchain_pem': 'fullchain.pem',
+                        'private_key_pem': 'privkey.pem',
+                    }
+
+                    try:
+                        payload = {'domain': domain}
+                        for response_key, filename in required_files.items():
+                            file_path = cert_dir / filename
+                            if not file_path.exists():
+                                return {'error': f'Required cert file not found for domain {domain}: {filename}'}, 404
+                            payload[response_key] = file_path.read_text(encoding='utf-8')
+
+                        return jsonify(payload)
+                    except FileNotFoundError:
+                        return {'error': f'Required cert file not found for domain {domain}'}, 404
 
                 if requested_file:
                     # Security check: only allow specific certificate files
@@ -546,8 +573,8 @@ def create_api_resources(api, models, managers):
                     if requested_file == 'combined.pem':
                         try:
                             # Read both files and join them
-                            fullchain = (cert_dir / 'fullchain.pem').read_text()
-                            privkey = (cert_dir / 'privkey.pem').read_text()
+                            fullchain = (cert_dir / 'fullchain.pem').read_text(encoding='utf-8')
+                            privkey = (cert_dir / 'privkey.pem').read_text(encoding='utf-8')
                             combined_data = io.BytesIO(f"{fullchain}{privkey}".encode())
 
                             return send_file(

--- a/tests/test_cert_lifecycle.py
+++ b/tests/test_cert_lifecycle.py
@@ -97,7 +97,30 @@ class TestCertificateDownload:
         assert any("cert" in n.lower() or "fullchain" in n.lower() for n in names), \
             f"No cert file in ZIP: {names}"
 
-    def test_05_download_tls_components(self, api):
+    def test_05_download_json_bundle(self, api):
+        r = api.get(f"/api/certificates/{TEST_DOMAIN}/download?format=json")
+        assert r.status_code == 200
+        assert r.headers["Content-Type"].startswith("application/json")
+
+        payload = r.json()
+        assert payload["domain"] == TEST_DOMAIN
+        assert set(payload.keys()) >= {
+            "domain",
+            "cert_pem",
+            "chain_pem",
+            "fullchain_pem",
+            "private_key_pem",
+        }
+        assert "-----BEGIN CERTIFICATE-----" in payload["cert_pem"]
+        assert "-----BEGIN CERTIFICATE-----" in payload["chain_pem"]
+        assert "-----BEGIN CERTIFICATE-----" in payload["fullchain_pem"]
+        assert "-----BEGIN" in payload["private_key_pem"]
+
+    def test_06_invalid_format_returns_400(self, api):
+        r = api.get(f"/api/certificates/{TEST_DOMAIN}/download?format=tar")
+        assert r.status_code == 400
+
+    def test_07_download_tls_components(self, api):
         """Download individual TLS components."""
         for component in ("cert", "key", "chain", "fullchain"):
             r = api.get(f"/{TEST_DOMAIN}/tls/{component}")
@@ -108,7 +131,7 @@ class TestCertificateDownload:
 class TestCertificateRenewal:
     """Renew the certificate."""
 
-    def test_06_renew_certificate(self, api):
+    def test_08_renew_certificate(self, api):
         r = api.post_json(f"/api/certificates/{TEST_DOMAIN}/renew", {})
         # Renewal may succeed or say "not due for renewal" — both are OK
         assert r.status_code in (200, 400), f"Renew failed: {r.status_code} {r.text[:200]}"

--- a/tests/test_download_file_param.py
+++ b/tests/test_download_file_param.py
@@ -25,6 +25,11 @@ class TestDownloadFileParamMissingDomain:
         r = api.get(f"/api/certificates/{NONEXISTENT_DOMAIN}/download")
         assert r.status_code == 404
 
+    def test_json_format_still_returns_404_for_missing_domain(self, api):
+        """The JSON mode must not change the missing-domain response."""
+        r = api.get(f"/api/certificates/{NONEXISTENT_DOMAIN}/download?format=json")
+        assert r.status_code == 404
+
     @pytest.mark.parametrize("filename", [
         "fullchain.pem",
         "privkey.pem",


### PR DESCRIPTION
**Summary**

This adds a JSON response mode to GET /api/certificates/<domain>/download so automation can fetch all certificate artifacts in one request without handling ZIP extraction. The new mode returns the certificate components as raw PEM text in JSON fields:

cert_pem
chain_pem
fullchain_pem
private_key_pem
The existing ZIP download behavior and ?file= single-file behavior remain unchanged.

**Why**

The goal is to make CertMate easier to consume from tools like Ansible and Salt, where it is more convenient to receive structured JSON and write the PEM files directly than to download and unpack an archive.

**What changed**

Added ?format=json support to the certificate download endpoint.
Kept ZIP as the default response format.
Kept ?file= support intact for single-file downloads.
Added validation for invalid format values.
Added 404 handling when required certificate files are missing.
Updated API docs and README automation examples to use the JSON flow.
Added regression tests for:
JSON download success
invalid format
missing-domain behavior for JSON mode
Testing


**Notes**

The JSON payload uses raw PEM strings rather than base64. That keeps the consumer side simple: Ansible and Salt can write the returned strings straight to files without a decode step.