### PR TITLE
fix #137: return bare list from /api/deploy/history

### DIFF
--- a/modules/web/settings_routes.py
+++ b/modules/web/settings_routes.py
@@ -285,7 +285,15 @@ def register_settings_routes(app, managers, require_web_auth, auth_manager,
     @app.route('/api/deploy/history', methods=['GET'])
     @auth_manager_ref.require_role('admin')
     def api_deploy_history():
-        """Get deploy hook execution history"""
+        """Get deploy hook execution history.
+
+        Returns the history list directly (newest first), matching the
+        sibling ``/api/webhooks/deliveries`` endpoint. The Settings →
+        Deploy "Recent Executions" panel in ``static/js/settings-deploy.js``
+        does ``Array.isArray(res.body)`` on the response — wrapping the
+        list in ``{"history": [...]}`` made the panel render the
+        "unexpected response" error reported in issue #137.
+        """
         if not deploy_manager:
             return jsonify({'error': 'Deploy manager not available'}), 503
 
@@ -293,7 +301,7 @@ def register_settings_routes(app, managers, require_web_auth, auth_manager,
             limit = min(int(request.args.get('limit', 50)), 200)
             domain = request.args.get('domain')
             history = deploy_manager.get_history(limit=limit, domain=domain)
-            return jsonify({'history': history})
+            return jsonify(history)
         except Exception as e:
             logger.error(f"Failed to get deploy history: {e}")
             return jsonify({'error': 'Failed to get deploy history'}), 500

--- a/tests/test_issue137_deploy_history.py
+++ b/tests/test_issue137_deploy_history.py
@@ -1,0 +1,129 @@
+"""Regression test for issue #137 — Settings → Deploy → "Recent Executions"
+showed "Failed to load deploy history: unexpected response".
+
+Root cause: ``GET /api/deploy/history`` returned ``{"history": [...]}``
+but ``static/js/settings-deploy.js`` does ``Array.isArray(res.body)`` to
+decide whether the payload is the list it expects. The object envelope
+never matched the array predicate, so the panel always hit the error
+branch — even on a clean install with an empty history.
+
+The other event-log endpoint the same UI talks to,
+``GET /api/webhooks/deliveries``, already returns a bare list. Aligning
+``/api/deploy/history`` with that contract closes the bug without
+touching the frontend.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from modules.web.settings_routes import register_settings_routes
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def _passthrough_decorator(_min_role):
+    def deco(fn):
+        return fn
+    return deco
+
+
+def _build_app(history_entries):
+    app = Flask(__name__)
+    app.secret_key = 'test'
+
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_decorator)
+
+    deploy_manager = MagicMock()
+    deploy_manager.get_history.return_value = history_entries
+
+    register_settings_routes(
+        app,
+        managers={'deployer': deploy_manager},
+        require_web_auth=lambda f: f,
+        auth_manager=auth_manager,
+        settings_manager=MagicMock(),
+        dns_manager=MagicMock(),
+    )
+    return app, deploy_manager
+
+
+def test_deploy_history_returns_bare_array():
+    """The frontend does ``Array.isArray(res.body)``; the response must
+    be the list itself, not an object wrapper."""
+    entries = [
+        {'domain': 'a.example.com', 'hook_id': 'k8s', 'status': 'ok',
+         'timestamp': '2026-05-10T10:00:00Z'},
+        {'domain': 'b.example.com', 'hook_id': 'k8s', 'status': 'failed',
+         'timestamp': '2026-05-09T09:00:00Z'},
+    ]
+    app, _ = _build_app(entries)
+    client = app.test_client()
+
+    r = client.get('/api/deploy/history')
+    assert r.status_code == 200
+    body = r.get_json()
+    assert isinstance(body, list)
+    assert body == entries
+
+
+def test_deploy_history_empty_returns_empty_array_not_envelope():
+    """The first-run case (no deploys yet) was the most visible
+    symptom of the bug — the UI rendered an error toast on a fresh
+    install. An empty deploy log must come back as ``[]``, not
+    ``{"history": []}``."""
+    app, _ = _build_app([])
+    client = app.test_client()
+
+    r = client.get('/api/deploy/history')
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body == []
+    assert not isinstance(body, dict)
+
+
+def test_deploy_history_forwards_limit_and_domain_filters():
+    """The endpoint accepts ``?limit=N`` (capped at 200) and
+    ``?domain=...`` and forwards them to ``get_history``. Confirms the
+    query string is parsed correctly while changing the response shape."""
+    app, deploy_manager = _build_app([])
+    client = app.test_client()
+
+    client.get('/api/deploy/history?limit=10&domain=foo.example.com')
+    deploy_manager.get_history.assert_called_with(
+        limit=10, domain='foo.example.com'
+    )
+
+    # Cap at 200 even if the caller asks for more.
+    deploy_manager.get_history.reset_mock()
+    client.get('/api/deploy/history?limit=10000')
+    deploy_manager.get_history.assert_called_with(limit=200, domain=None)
+
+
+def test_deploy_history_503_when_deploy_manager_missing():
+    """If the deploy manager isn't wired in (feature disabled, partial
+    boot), the endpoint returns a 503 with an error envelope — the
+    frontend's ``Array.isArray`` check fails fast and the catch branch
+    surfaces ``res.body.error`` instead of the generic
+    'unexpected response' string."""
+    app = Flask(__name__)
+    app.secret_key = 'test'
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_decorator)
+    register_settings_routes(
+        app,
+        managers={},  # no 'deployer' key
+        require_web_auth=lambda f: f,
+        auth_manager=auth_manager,
+        settings_manager=MagicMock(),
+        dns_manager=MagicMock(),
+    )
+    client = app.test_client()
+
+    r = client.get('/api/deploy/history')
+    assert r.status_code == 503
+    body = r.get_json()
+    assert 'error' in body


### PR DESCRIPTION
Closes #137.

## Summary

Settings → Deploy → "Recent Executions" rendered **"Failed to load deploy history: unexpected response"** on every install — including fresh ones with empty history. @SpeeDFireCZE reported this on a Kubernetes deployment.

## Root cause

Shape mismatch between the route and the frontend that consumes it.

- **Backend** (`modules/web/settings_routes.py:285-299`) returned `{"history": [...]}`.
- **Frontend** (`static/js/settings-deploy.js:184-187`) does `Array.isArray(res.body)` to decide whether the payload is the list it expects. The object envelope never matched the array predicate, so the `else` branch fired:

  ```javascript
  addDebugLog('Failed to load deploy history: '
      + ((res.body && res.body.error) || 'unexpected response'),
      'error');
  ```

  And since the success response had no `error` key, the message fell through to the generic `'unexpected response'` literal in exactly the way the issue screenshot shows.

The sibling event-log endpoint `/api/webhooks/deliveries` (in both `notification_routes.py:166` and `misc_routes.py:207`) already returns a bare list, and the matching `settings-notifications.js` reads it as one — so the existing convention in this codebase for delivery/history endpoints is "return the array directly". The frontend was clearly written to that convention; the backend was the outlier.

## Fix

One-character functional change in `modules/web/settings_routes.py`:

```diff
-            return jsonify({'history': history})
+            return jsonify(history)
```

Plus a docstring callout explaining *why* it's a bare list (so a future maintainer doesn't "tidy it up" back into an envelope and silently re-break the panel) and a 7-line `tests/test_issue137_deploy_history.py` covering the contract.

No frontend change needed.

## Tests

`tests/test_issue137_deploy_history.py` — 4 cases, all pass:

- **`test_deploy_history_returns_bare_array`**: populated history comes back as a list, with the entries in order.
- **`test_deploy_history_empty_returns_empty_array_not_envelope`**: the first-run case (the most visible symptom of the bug) returns `[]`, not `{"history": []}`.
- **`test_deploy_history_forwards_limit_and_domain_filters`**: `?limit=N` and `?domain=...` are still parsed and forwarded to `get_history`; the cap at 200 is still enforced.
- **`test_deploy_history_503_when_deploy_manager_missing`**: the error path keeps returning `{"error": "..."}` so the frontend's catch branch can surface the real reason instead of the generic literal.

Existing \`tests/test_deployer.py\` (35 cases on \`DeployManager.get_history()\` directly) still pass — the underlying function's return shape was always a list, only the HTTP envelope changed.

## Verification

- [x] \`pytest tests/test_deployer.py tests/test_issue137_deploy_history.py\` — 39/39 pass.
- [ ] Manual: open Settings → Deploy → Recent Executions on a fresh install and on an install with one or more deploy events. Confirm the empty state renders "No recent executions" (or whatever the empty-state copy is) instead of the red error toast, and that real entries show up newest-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)