### PR TITLE
Improve deployment status checks and dashboard clarity

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -223,6 +223,13 @@ def create_api_models(api):
         'cleared_entries': fields.Integer(description='Number of entries that were cleared')
     })
 
+    browser_deployment_model = api.model('BrowserDeploymentStatus', {
+        'reachable': fields.Boolean(description='Whether the browser could reach the domain'),
+        'checked_at': fields.String(description='When the browser check happened'),
+        'method': fields.String(description='How the browser check was performed'),
+        'source': fields.String(description='Source of the browser report')
+    })
+
     deployment_status_model = api.model('DeploymentStatus', {
         'domain': fields.String(description='Domain name'),
         'deployed': fields.Boolean(description='Whether the domain is serving a certificate'),
@@ -230,7 +237,20 @@ def create_api_models(api):
         'certificate_match': fields.Raw(description='Whether the served certificate matches the local certificate'),
         'method': fields.String(description='Check method'),
         'timestamp': fields.String(description='Check timestamp'),
-        'error': fields.String(description='Optional error message')
+        'error': fields.String(description='Optional error message'),
+        'browser': fields.Nested(browser_deployment_model, description='Browser-reported reachability')
+    })
+
+    browser_deployment_report_model = api.model('BrowserDeploymentReport', {
+        'domain': fields.String(required=True, description='Domain name'),
+        'reachable': fields.Boolean(required=True, description='Whether the browser could reach the domain'),
+        'checked_at': fields.String(description='When the browser check happened'),
+        'method': fields.String(description='How the browser check was performed'),
+        'source': fields.String(description='Source of the browser report')
+    })
+
+    browser_deployment_reports_model = api.model('BrowserDeploymentReports', {
+        'reports': fields.List(fields.Nested(browser_deployment_report_model), required=True, description='Batch of browser deployment reports')
     })
 
     # Backup models
@@ -348,6 +368,9 @@ def create_api_models(api):
         'dns_providers_model': dns_providers_model,
         'cache_stats_model': cache_stats_model,
         'cache_clear_response_model': cache_clear_response_model,
+        'browser_deployment_model': browser_deployment_model,
+        'browser_deployment_report_model': browser_deployment_report_model,
+        'browser_deployment_reports_model': browser_deployment_reports_model,
         'deployment_status_model': deployment_status_model,
         'certificate_model': certificate_model,
         'create_cert_model': create_cert_model,

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -223,6 +223,16 @@ def create_api_models(api):
         'cleared_entries': fields.Integer(description='Number of entries that were cleared')
     })
 
+    deployment_status_model = api.model('DeploymentStatus', {
+        'domain': fields.String(description='Domain name'),
+        'deployed': fields.Boolean(description='Whether the domain is serving a certificate'),
+        'reachable': fields.Boolean(description='Whether the domain responds over HTTPS'),
+        'certificate_match': fields.Raw(description='Whether the served certificate matches the local certificate'),
+        'method': fields.String(description='Check method'),
+        'timestamp': fields.String(description='Check timestamp'),
+        'error': fields.String(description='Optional error message')
+    })
+
     # Backup models
     backup_metadata_model = api.model('BackupMetadata', {
         'filename': fields.String(description='Backup filename'),
@@ -338,6 +348,7 @@ def create_api_models(api):
         'dns_providers_model': dns_providers_model,
         'cache_stats_model': cache_stats_model,
         'cache_clear_response_model': cache_clear_response_model,
+        'deployment_status_model': deployment_status_model,
         'certificate_model': certificate_model,
         'create_cert_model': create_cert_model,
         'cache_entry_model': cache_entry_model,

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -238,6 +238,10 @@ def create_api_models(api):
         'method': fields.String(description='Check method'),
         'timestamp': fields.String(description='Check timestamp'),
         'error': fields.String(description='Optional error message'),
+        # Machine-readable error code surfaced when _check_domain_scope denies
+        # a scoped API key (e.g. 'DOMAIN_OUT_OF_SCOPE'). Without listing it
+        # here, @api.marshal_with would silently strip it from the 403 body.
+        'code': fields.String(description='Optional machine-readable error code'),
         'browser': fields.Nested(browser_deployment_model, description='Browser-reported reachability')
     })
 

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -4,7 +4,10 @@ Defines Flask-RESTX Resource classes for REST API endpoints
 """
 
 import logging
+import hashlib
 import re
+import socket
+import ssl
 import tempfile
 import zipfile
 import os
@@ -16,6 +19,7 @@ from flask_restx import Resource, fields
 from ..core.metrics import get_metrics_summary, is_prometheus_available
 from ..core.constants import CERTIFICATE_FILES, iter_cert_domain_dirs
 from ..core.auth import ROLE_HIERARCHY
+from ..core.utils import utc_now_iso
 
 _DOMAIN_RE = re.compile(r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$')
 
@@ -46,6 +50,38 @@ def _validate_domain_path(domain, cert_base_dir):
     except (OSError, ValueError):
         return None, 'Invalid domain path'
     return cert_dir, None
+
+
+def _certificate_fingerprint(cert_bytes):
+    """Return a stable SHA-256 fingerprint for a PEM or DER certificate."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes
+
+    cert_bytes = cert_bytes or b''
+    if not cert_bytes:
+        return None
+
+    try:
+        cert = x509.load_pem_x509_certificate(cert_bytes)
+    except ValueError:
+        cert = x509.load_der_x509_certificate(cert_bytes)
+    return cert.fingerprint(hashes.SHA256()).hex()
+
+
+def _probe_https_certificate(domain, timeout=5):
+    """Return the live TLS certificate for a domain, if reachable."""
+    host = domain[2:] if domain.startswith('*.') else domain
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+
+    with socket.create_connection((host, 443), timeout=timeout) as raw_sock:
+        with context.wrap_socket(raw_sock, server_hostname=host) as tls_sock:
+            cert_bytes = tls_sock.getpeercert(binary_form=True)
+            return {
+                'reachable': True,
+                'certificate_bytes': cert_bytes,
+            }
 
 
 logger = logging.getLogger(__name__)
@@ -879,6 +915,69 @@ def create_api_resources(api, models, managers):
     def _user_has_role(user, min_role):
         level = ROLE_HIERARCHY.get((user or {}).get('role'), -1)
         return level >= ROLE_HIERARCHY.get(min_role, 999)
+
+    class CertificateDeploymentStatus(Resource):
+        @api.doc(security='Bearer')
+        @auth_manager.require_role('viewer')
+        @api.marshal_with(models['deployment_status_model'])
+        def get(self, domain):
+            """Check whether the domain is serving the expected certificate."""
+            _, err = _validate_domain_path(domain, file_ops.cert_dir)
+            if err:
+                return {'error': err}, 400
+
+            cert_info = certificate_manager.get_certificate_info(domain)
+            if not cert_info or not cert_info.get('exists'):
+                return {'error': f'Certificate not found for domain: {domain}'}, 404
+
+            cached_result = cache_manager.get_deployment_status(domain)
+            if isinstance(cached_result, dict) and cached_result.get('domain') == domain:
+                return cached_result, 200
+
+            expected_bytes = None
+            storage_manager = getattr(certificate_manager, 'storage_manager', None)
+            if storage_manager is not None:
+                try:
+                    storage_result = storage_manager.retrieve_certificate(domain)
+                    if storage_result:
+                        cert_files, _metadata = storage_result
+                        expected_bytes = cert_files.get('cert.pem')
+                except Exception as e:
+                    logger.warning(f"Could not read stored certificate for {domain}: {e}")
+
+            if expected_bytes is None:
+                cert_path = Path(file_ops.cert_dir) / domain / 'cert.pem'
+                if cert_path.exists():
+                    expected_bytes = cert_path.read_bytes()
+
+            if not expected_bytes:
+                return {'error': f'Certificate file not found for domain: {domain}'}, 404
+
+            expected_fingerprint = _certificate_fingerprint(expected_bytes)
+            if not expected_fingerprint:
+                return {'error': f'Could not parse certificate for domain: {domain}'}, 500
+
+            result = {
+                'domain': domain,
+                'deployed': False,
+                'reachable': False,
+                'certificate_match': False,
+                'method': 'https-tls',
+                'timestamp': utc_now_iso(),
+            }
+
+            try:
+                probe = _probe_https_certificate(domain)
+                result['reachable'] = True
+                result['deployed'] = True
+                result['certificate_match'] = (
+                    _certificate_fingerprint(probe.get('certificate_bytes')) == expected_fingerprint
+                )
+            except Exception as e:
+                result['error'] = str(e)
+
+            cache_manager.set_deployment_status(domain, result)
+            return result, 200
 
     class DownloadCertificate(Resource):
         @api.doc(security='Bearer')
@@ -1946,6 +2045,7 @@ def create_api_resources(api, models, managers):
         'CheckDNSAlias': CheckDNSAlias,
         'CertificateDNSAliasCheck': CertificateDNSAliasCheck,
         'CertificateDetail': CertificateDetail,
+        'CertificateDeploymentStatus': CertificateDeploymentStatus,
         'DownloadCertificate': DownloadCertificate,
         'RenewCertificate': RenewCertificate,
         'CertificateAutoRenew': CertificateAutoRenew,

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -922,6 +922,7 @@ def create_api_resources(api, models, managers):
         @api.marshal_with(models['deployment_status_model'])
         def get(self, domain):
             """Check whether the domain is serving the expected certificate."""
+            refresh_requested = str(request.args.get('refresh', '')).lower() in {'1', 'true', 'yes', 'on'}
             _, err = _validate_domain_path(domain, file_ops.cert_dir)
             if err:
                 return {'error': err}, 400
@@ -930,9 +931,12 @@ def create_api_resources(api, models, managers):
             if not cert_info or not cert_info.get('exists'):
                 return {'error': f'Certificate not found for domain: {domain}'}, 404
 
-            cached_result = cache_manager.get_deployment_status(domain)
-            if isinstance(cached_result, dict) and cached_result.get('domain') == domain:
-                return cached_result, 200
+            if refresh_requested:
+                cache_manager.remove_from_cache(domain)
+            else:
+                cached_result = cache_manager.get_deployment_status(domain)
+                if isinstance(cached_result, dict) and cached_result.get('domain') == domain:
+                    return cached_result, 200
 
             expected_bytes = None
             storage_manager = getattr(certificate_manager, 'storage_manager', None)

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -980,8 +980,63 @@ def create_api_resources(api, models, managers):
             except Exception as e:
                 result['error'] = str(e)
 
+            persisted_status = certificate_manager.get_deployment_status_record(domain)
+            if isinstance(persisted_status, dict) and persisted_status.get('browser'):
+                result['browser'] = persisted_status.get('browser')
+
+            certificate_manager.record_backend_deployment_status(domain, result)
             cache_manager.set_deployment_status(domain, result)
             return result, 200
+
+    class CertificateDeploymentBrowserReports(Resource):
+        @api.doc(security='Bearer')
+        @auth_manager.require_role('viewer')
+        @api.expect(models['browser_deployment_reports_model'])
+        def post(self):
+            """Persist browser-reported reachability for one or more domains."""
+            payload = request.get_json(silent=True) or {}
+            reports = payload.get('reports')
+            if not isinstance(reports, list) or not reports:
+                return {'error': 'reports must be a non-empty array'}, 400
+
+            updated = []
+            skipped = []
+            for report in reports:
+                if not isinstance(report, dict):
+                    skipped.append({'error': 'invalid report payload'})
+                    continue
+
+                domain = (report.get('domain') or '').strip()
+                if not domain:
+                    skipped.append({'error': 'missing domain'})
+                    continue
+
+                _, err = _validate_domain_path(domain, file_ops.cert_dir)
+                if err:
+                    skipped.append({'domain': domain, 'error': err})
+                    continue
+
+                browser_status = certificate_manager.record_browser_deployment_status(domain, report)
+                persisted = certificate_manager.get_deployment_status_record(domain)
+                backend = persisted.get('backend') if isinstance(persisted, dict) else None
+                merged = {
+                    'domain': domain,
+                    'deployed': bool(backend.get('deployed')) if isinstance(backend, dict) else False,
+                    'reachable': bool(backend.get('reachable')) if isinstance(backend, dict) else False,
+                    'certificate_match': backend.get('certificate_match') if isinstance(backend, dict) else False,
+                    'method': backend.get('method') if isinstance(backend, dict) else 'browser-report',
+                    'timestamp': backend.get('timestamp') if isinstance(backend, dict) else None,
+                    'error': backend.get('error') if isinstance(backend, dict) else None,
+                    'browser': browser_status.get('browser') if isinstance(browser_status, dict) else None,
+                }
+                cache_manager.set_deployment_status(domain, merged)
+                updated.append(domain)
+
+            return {
+                'updated': updated,
+                'skipped': skipped,
+                'count': len(updated),
+            }, 200
 
     class DownloadCertificate(Resource):
         @api.doc(security='Bearer')
@@ -2050,6 +2105,7 @@ def create_api_resources(api, models, managers):
         'CertificateDNSAliasCheck': CertificateDNSAliasCheck,
         'CertificateDetail': CertificateDetail,
         'CertificateDeploymentStatus': CertificateDeploymentStatus,
+        'CertificateDeploymentBrowserReports': CertificateDeploymentBrowserReports,
         'DownloadCertificate': DownloadCertificate,
         'RenewCertificate': RenewCertificate,
         'CertificateAutoRenew': CertificateAutoRenew,

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -4,7 +4,6 @@ Defines Flask-RESTX Resource classes for REST API endpoints
 """
 
 import logging
-import hashlib
 import re
 import socket
 import ssl
@@ -72,6 +71,9 @@ def _probe_https_certificate(domain, timeout=5):
     """Return the live TLS certificate for a domain, if reachable."""
     host = domain[2:] if domain.startswith('*.') else domain
     context = ssl.create_default_context()
+    # We intentionally disable PKI validation here. The goal is to compare the
+    # served certificate fingerprint against the stored certificate, even when
+    # the live cert is invalid or otherwise not trusted.
     context.check_hostname = False
     context.verify_mode = ssl.CERT_NONE
 
@@ -926,6 +928,9 @@ def create_api_resources(api, models, managers):
             _, err = _validate_domain_path(domain, file_ops.cert_dir)
             if err:
                 return {'error': err}, 400
+            scope_err = _check_domain_scope(domain, 'deployment_status')
+            if scope_err:
+                return scope_err
 
             cert_info = certificate_manager.get_certificate_info(domain)
             if not cert_info or not cert_info.get('exists'):
@@ -1014,6 +1019,10 @@ def create_api_resources(api, models, managers):
                 _, err = _validate_domain_path(domain, file_ops.cert_dir)
                 if err:
                     skipped.append({'domain': domain, 'error': err})
+                    continue
+                scope_err = _check_domain_scope(domain, 'browser_report')
+                if scope_err:
+                    skipped.append({'domain': domain, 'error': 'out of scope'})
                     continue
 
                 browser_status = certificate_manager.record_browser_deployment_status(domain, report)

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta
 from .shell import ShellExecutor
 from .dns_strategies import DNSStrategyFactory, HTTP01Strategy, check_certbot_plugin_installed
 from .constants import CERTIFICATE_FILES, get_domain_name
-from .utils import validate_domain, utc_now
+from .utils import validate_domain, utc_now, utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +105,72 @@ class CertificateManager:
             if domain not in self._domain_locks:
                 self._domain_locks[domain] = threading.Lock()
             return self._domain_locks[domain]
+
+    def _metadata_path(self, domain: str) -> Path:
+        return self.cert_dir / domain / 'metadata.json'
+
+    def _load_metadata(self, domain: str) -> dict:
+        metadata_file = self._metadata_path(domain)
+        if not metadata_file.exists():
+            return {}
+        try:
+            with open(metadata_file, 'r', encoding='utf-8') as f:
+                metadata = json.load(f)
+                return metadata if isinstance(metadata, dict) else {}
+        except Exception as e:
+            logger.warning(f"Failed to read metadata for {domain}: {e}")
+            return {}
+
+    def _save_metadata(self, domain: str, metadata: dict) -> bool:
+        metadata_file = self._metadata_path(domain)
+        try:
+            self._atomic_json_write(metadata_file, metadata)
+            return True
+        except Exception as e:
+            logger.warning(f"Failed to save metadata for {domain}: {e}")
+            return False
+
+    def get_deployment_status_record(self, domain: str) -> dict:
+        metadata = self._load_metadata(domain)
+        status = metadata.get('deployment_status')
+        return status if isinstance(status, dict) else {}
+
+    def record_backend_deployment_status(self, domain: str, backend_status: dict) -> dict:
+        metadata = self._load_metadata(domain)
+        deployment_status = metadata.get('deployment_status')
+        if not isinstance(deployment_status, dict):
+            deployment_status = {}
+
+        deployment_status['backend'] = {
+            'domain': backend_status.get('domain', domain),
+            'deployed': bool(backend_status.get('deployed', False)),
+            'reachable': bool(backend_status.get('reachable', False)),
+            'certificate_match': backend_status.get('certificate_match'),
+            'method': backend_status.get('method'),
+            'timestamp': backend_status.get('timestamp') or utc_now_iso(),
+            'error': backend_status.get('error'),
+        }
+
+        metadata['deployment_status'] = deployment_status
+        self._save_metadata(domain, metadata)
+        return deployment_status
+
+    def record_browser_deployment_status(self, domain: str, browser_status: dict) -> dict:
+        metadata = self._load_metadata(domain)
+        deployment_status = metadata.get('deployment_status')
+        if not isinstance(deployment_status, dict):
+            deployment_status = {}
+
+        deployment_status['browser'] = {
+            'reachable': bool(browser_status.get('reachable', False)),
+            'checked_at': browser_status.get('checked_at') or utc_now_iso(),
+            'method': browser_status.get('method') or 'browser-fallback',
+            'source': browser_status.get('source') or 'browser',
+        }
+
+        metadata['deployment_status'] = deployment_status
+        self._save_metadata(domain, metadata)
+        return deployment_status
 
     @staticmethod
     def _create_dns_alias_hook_config(dns_provider, dns_config, domain_alias, propagation_seconds):

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -576,6 +576,7 @@ def setup_api(container: AppContainer, app):
     ns_certificates.add_resource(api_resources['CheckDNSAlias'], '/check-dns-alias')
     ns_certificates.add_resource(api_resources['CertificateDetail'], '/<string:domain>')
     ns_certificates.add_resource(api_resources['CertificateDeploymentStatus'], '/<string:domain>/deployment-status')
+    ns_certificates.add_resource(api_resources['CertificateDeploymentBrowserReports'], '/deployment-status/browser')
     ns_certificates.add_resource(api_resources['CertificateDNSAliasCheck'], '/<string:domain>/dns-alias-check')
     ns_certificates.add_resource(api_resources['DownloadCertificate'], '/<string:domain>/download')
     ns_certificates.add_resource(api_resources['RenewCertificate'], '/<string:domain>/renew')

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -575,6 +575,7 @@ def setup_api(container: AppContainer, app):
     ns_certificates.add_resource(api_resources['CreateCertificate'], '/create')
     ns_certificates.add_resource(api_resources['CheckDNSAlias'], '/check-dns-alias')
     ns_certificates.add_resource(api_resources['CertificateDetail'], '/<string:domain>')
+    ns_certificates.add_resource(api_resources['CertificateDeploymentStatus'], '/<string:domain>/deployment-status')
     ns_certificates.add_resource(api_resources['CertificateDNSAliasCheck'], '/<string:domain>/dns-alias-check')
     ns_certificates.add_resource(api_resources['DownloadCertificate'], '/<string:domain>/download')
     ns_certificates.add_resource(api_resources['RenewCertificate'], '/<string:domain>/renew')

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -848,6 +848,18 @@
         }).then(function (response) {
             if (response.ok) {
                 return response.json().then(function (result) {
+                    if (result && result.reachable === false) {
+                        return checkDeploymentViaBrowser(domain).then(function (browserResult) {
+                            if (browserResult) {
+                                deploymentCache.set(domain, browserResult);
+                                updateDeploymentUI(domain, browserResult);
+                                return;
+                            }
+                            deploymentCache.set(domain, result);
+                            updateDeploymentUI(domain, result);
+                        });
+                    }
+
                     deploymentCache.set(domain, result);
                     updateDeploymentUI(domain, result);
                 });

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -837,7 +837,12 @@
             statusElement.innerHTML = '<i class="fas fa-spinner fa-spin mr-1"></i>Checking...';
         });
 
-        return fetch('/api/certificates/' + encodeURIComponent(domain) + '/deployment-status', {
+        var deploymentUrl = '/api/certificates/' + encodeURIComponent(domain) + '/deployment-status';
+        if (forceRefresh) {
+            deploymentUrl += '?refresh=1';
+        }
+
+        return fetch(deploymentUrl, {
             method: 'GET',
             headers: API_HEADERS
         }).then(function (response) {

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -301,7 +301,7 @@
             } else if (cachedStatus.reachable && !cachedStatus.certificate_match) {
                 sc = 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400'; si = 'fa-exclamation-triangle'; st = 'Wrong Cert';
             } else if (!cachedStatus.reachable) {
-                sc = 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400'; si = 'fa-times-circle'; st = 'Not Deployed';
+                sc = 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400'; si = 'fa-times-circle'; st = 'Unreachable';
             } else {
                 sc = 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'; si = 'fa-question-circle'; st = 'Unknown';
             }
@@ -560,7 +560,7 @@
                     : '') +
                 '<button type="button" onclick="downloadCertificate(\'' + safeDomain + '\')" class="w-full inline-flex items-center justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600"><i class="fas fa-download mr-2 text-blue-600"></i>Download Certificate</button>' +
                 '<button type="button" onclick="copyCurlCommand(\'' + safeDomain + '\')" class="w-full inline-flex items-center justify-center px-4 py-2 border border-blue-300 dark:border-blue-600 shadow-sm text-sm font-medium rounded-md text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50"><i class="fas fa-code mr-2"></i>Show API Command</button>' +
-                '<button type="button" onclick="checkDeploymentStatus(\'' + safeDomain + '\')" class="w-full inline-flex items-center justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600"><i class="fas fa-globe mr-2 text-indigo-600"></i>Check Deployment</button>' +
+                '<button type="button" onclick="checkDeploymentStatus(\'' + safeDomain + '\', this)" class="w-full inline-flex items-center justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600"><i class="fas fa-globe mr-2 text-indigo-600"></i>Check Deployment</button>' +
                 (safeDomainAlias ? '<button type="button" onclick="checkDnsAliasForCertificate(\'' + safeDomain + '\')" class="w-full inline-flex items-center justify-center px-4 py-2 border border-blue-300 dark:border-blue-600 shadow-sm text-sm font-medium rounded-md text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50"><i class="fas fa-search mr-2"></i>Check DNS-01 Alias</button>' : '') +
                 '<div id="cert_dns_alias_check_result" class="hidden"></div>' +
                 (roleAtLeast('admin')
@@ -793,7 +793,24 @@
     }
 
     // Check deployment status for a specific domain
-    function checkDeploymentStatus(domain) {
+    function checkDeploymentStatus(domain, triggerButton) {
+        var restoreButton = function () {
+            if (!triggerButton) {
+                return;
+            }
+            triggerButton.disabled = false;
+            if (triggerButton.dataset.originalHtml) {
+                triggerButton.innerHTML = triggerButton.dataset.originalHtml;
+                delete triggerButton.dataset.originalHtml;
+            }
+        };
+
+        if (triggerButton) {
+            triggerButton.dataset.originalHtml = triggerButton.innerHTML;
+            triggerButton.disabled = true;
+            triggerButton.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Checking...';
+        }
+
         var statusElements = Array.prototype.filter.call(
             document.querySelectorAll('[data-deployment-domain]'),
             function (el) {
@@ -802,6 +819,7 @@
         );
 
         if (!statusElements.length) {
+            restoreButton();
             return Promise.resolve();
         }
 
@@ -809,6 +827,7 @@
         var cachedResult = deploymentCache.get(domain);
         if (cachedResult) {
             updateDeploymentUI(domain, cachedResult);
+            restoreButton();
             return Promise.resolve();
         }
 
@@ -850,6 +869,8 @@
                 statusElement.className = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300';
                 statusElement.innerHTML = '<i class="fas fa-question-circle mr-1"></i>Error';
             });
+        }).finally(function () {
+            restoreButton();
         });
     }
 
@@ -914,7 +935,7 @@
         } else {
             statusClass = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400';
             statusIcon = 'fa-times-circle';
-            statusText = 'Not Deployed';
+            statusText = 'Unreachable';
         }
 
         statusElements.forEach(function (statusElement) {

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -14,6 +14,8 @@
     };
 
     var escapeHtml = CertMate.escapeHtml;
+    var browserDeploymentReportQueue = {};
+    var browserDeploymentReportTimer = null;
 
     // --- Role-aware UI gating (audit punch-list M2) -----------------------
     // Default to viewer until /api/auth/me responds. The server is the
@@ -84,6 +86,45 @@
         document.getElementById('certificateSearch').value = '';
         document.getElementById('statusFilter').value = 'all';
         filterCertificates();
+    }
+
+    function queueBrowserDeploymentReport(domain, result) {
+        if (!domain || !result || !result.reachable) {
+            return;
+        }
+
+        browserDeploymentReportQueue[domain] = {
+            domain: domain,
+            reachable: true,
+            checked_at: result.timestamp || new Date().toISOString(),
+            method: result.method || 'browser-fallback',
+            source: 'browser'
+        };
+
+        if (!browserDeploymentReportTimer) {
+            browserDeploymentReportTimer = setTimeout(flushBrowserDeploymentReports, 250);
+        }
+    }
+
+    function flushBrowserDeploymentReports() {
+        browserDeploymentReportTimer = null;
+        var reports = Object.keys(browserDeploymentReportQueue).map(function (domain) {
+            return browserDeploymentReportQueue[domain];
+        });
+        browserDeploymentReportQueue = {};
+
+        if (!reports.length) {
+            return Promise.resolve();
+        }
+
+        return fetch('/api/certificates/deployment-status/browser', {
+            method: 'POST',
+            headers: API_HEADERS,
+            credentials: 'same-origin',
+            body: JSON.stringify({ reports: reports })
+        }).catch(function (error) {
+            console.warn('Failed to send browser deployment reports:', error);
+        });
     }
 
     // Update statistics cards with deployment info
@@ -851,6 +892,7 @@
                     if (result && result.reachable === false) {
                         return checkDeploymentViaBrowser(domain).then(function (browserResult) {
                             if (browserResult) {
+                                queueBrowserDeploymentReport(domain, browserResult);
                                 deploymentCache.set(domain, browserResult);
                                 updateDeploymentUI(domain, browserResult);
                                 return;
@@ -877,6 +919,9 @@
                         error: 'all_methods_failed',
                         timestamp: new Date().toISOString()
                     };
+                }
+                if (result.reachable) {
+                    queueBrowserDeploymentReport(domain, result);
                 }
                 deploymentCache.set(domain, result);
                 updateDeploymentUI(domain, result);

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -289,9 +289,10 @@
     }
 
     // Build deployment status badge HTML
-    function deploymentBadgeHtml(cert) {
+    function deploymentBadgeHtml(cert, context) {
         var safeDomain = escapeHtml(cert.domain);
         var domainId = safeDomain.replace(/\./g, '-');
+        var badgeId = context === 'detail' ? '' : ' id="deployment-status-' + domainId + '"';
         var cachedStatus = deploymentCache.get(cert.domain);
         if (cachedStatus) {
             var sc, si, st;
@@ -304,9 +305,9 @@
             } else {
                 sc = 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'; si = 'fa-question-circle'; st = 'Unknown';
             }
-            return '<span id="deployment-status-' + domainId + '" class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ' + sc + '"><i class="fas ' + si + ' mr-1"></i>' + st + '</span>';
+            return '<span data-deployment-domain="' + safeDomain + '"' + badgeId + ' class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ' + sc + '"><i class="fas ' + si + ' mr-1"></i>' + st + '</span>';
         }
-        return '<span id="deployment-status-' + domainId + '" class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"><i class="fas fa-spinner fa-spin mr-1"></i>Checking...</span>';
+        return '<span data-deployment-domain="' + safeDomain + '"' + badgeId + ' class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"><i class="fas fa-spinner fa-spin mr-1"></i>Checking...</span>';
     }
 
     function providerDisplayName(provider) {
@@ -450,7 +451,7 @@
                 <td class="px-4 py-4 whitespace-nowrap"><span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${rowRaw(statusClass)}"><i class="fas ${rowRaw(statusIcon)} mr-1"></i>${statusText}</span></td>
                 <td class="px-4 py-4 whitespace-nowrap hidden md:table-cell"><div class="text-sm text-gray-900 dark:text-white">${expiryStr}</div><div class="text-xs ${rowRaw(daysClass)}">${cert.days_until_expiry} days</div></td>
                 <td class="px-4 py-4 whitespace-nowrap hidden lg:table-cell text-sm text-gray-500 dark:text-gray-400">${rowRaw(providerLabel) || '—'}</td>
-                <td class="px-4 py-4 whitespace-nowrap hidden lg:table-cell">${rowRaw(deploymentBadgeHtml(cert))}</td>
+                <td class="px-4 py-4 whitespace-nowrap hidden lg:table-cell">${rowRaw(deploymentBadgeHtml(cert, 'row'))}</td>
                 <td class="px-4 py-4 whitespace-nowrap text-right">
                     <div class="flex items-center justify-end gap-1">
                         ${roleAtLeast('operator') ? actionBtn('renew', cert.domain, 'green', 'Renew', 'fa-sync-alt') : false}
@@ -547,7 +548,7 @@
                 (safeDomainAlias ? '<div class="flex justify-between gap-4 py-2 border-b dark:border-gray-700"><dt class="text-sm text-gray-500 dark:text-gray-400">DNS-01 Alias</dt><dd class="text-sm font-medium text-right break-all text-blue-600 dark:text-blue-300">' + safeDomainAlias + '</dd></div>' : '') +
                 (safeDomainAlias && aliasProviderLabel ? '<div class="flex justify-between gap-4 py-2 border-b dark:border-gray-700"><dt class="text-sm text-gray-500 dark:text-gray-400">Alias Provider</dt><dd class="text-sm font-medium text-right text-gray-900 dark:text-white">' + aliasProviderLabel + '</dd></div>' : '') +
                 '<div class="flex justify-between gap-4 py-2 border-b dark:border-gray-700"><dt class="text-sm text-gray-500 dark:text-gray-400">Auto-Renew</dt><dd class="text-sm font-medium text-right ' + (cert.auto_renew !== false ? 'text-green-600 dark:text-green-400' : 'text-amber-600 dark:text-amber-400') + '">' + (cert.auto_renew !== false ? 'Enabled' : 'Disabled') + '</dd></div>' +
-                '<div class="flex justify-between gap-4 py-2 border-b dark:border-gray-700"><dt class="text-sm text-gray-500 dark:text-gray-400">Deployment</dt><dd>' + deploymentBadgeHtml(cert) + '</dd></div>' +
+                '<div class="flex justify-between gap-4 py-2 border-b dark:border-gray-700"><dt class="text-sm text-gray-500 dark:text-gray-400">Deployment</dt><dd>' + deploymentBadgeHtml(cert, 'detail') + '</dd></div>' +
                 '</dl>' +
                 '</div>' +
                 // Actions
@@ -793,27 +794,29 @@
 
     // Check deployment status for a specific domain
     function checkDeploymentStatus(domain) {
-        var statusElement = document.getElementById('deployment-status-' + domain.replace(/\./g, '-'));
-        var textElement = document.getElementById('deployment-text-' + domain.replace(/\./g, '-'));
+        var statusElements = Array.prototype.filter.call(
+            document.querySelectorAll('[data-deployment-domain]'),
+            function (el) {
+                return el.getAttribute('data-deployment-domain') === domain;
+            }
+        );
 
-        if (!statusElement) {
+        if (!statusElements.length) {
             return Promise.resolve();
         }
 
         // Check cache first
         var cachedResult = deploymentCache.get(domain);
         if (cachedResult) {
-            updateDeploymentUI(domain, cachedResult, statusElement);
+            updateDeploymentUI(domain, cachedResult);
             return Promise.resolve();
         }
 
         // Update UI to show checking state
-        statusElement.className = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-600';
-        statusElement.innerHTML = '<i class="fas fa-spinner fa-spin mr-1"></i>Checking...';
-        if (textElement) {
-            textElement.textContent = 'Checking...';
-            textElement.className = 'text-sm font-medium text-blue-600';
-        }
+        statusElements.forEach(function (statusElement) {
+            statusElement.className = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-600';
+            statusElement.innerHTML = '<i class="fas fa-spinner fa-spin mr-1"></i>Checking...';
+        });
 
         return fetch('/api/certificates/' + encodeURIComponent(domain) + '/deployment-status', {
             method: 'GET',
@@ -822,7 +825,7 @@
             if (response.ok) {
                 return response.json().then(function (result) {
                     deploymentCache.set(domain, result);
-                    updateDeploymentUI(domain, result, statusElement);
+                    updateDeploymentUI(domain, result);
                 });
             }
             throw new Error('API failed');
@@ -840,11 +843,13 @@
                     };
                 }
                 deploymentCache.set(domain, result);
-                updateDeploymentUI(domain, result, statusElement);
+                updateDeploymentUI(domain, result);
             });
         }).catch(function () {
-            statusElement.className = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300';
-            statusElement.innerHTML = '<i class="fas fa-question-circle mr-1"></i>Error';
+            statusElements.forEach(function (statusElement) {
+                statusElement.className = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300';
+                statusElement.innerHTML = '<i class="fas fa-question-circle mr-1"></i>Error';
+            });
         });
     }
 
@@ -883,49 +888,42 @@
     }
 
     // Update deployment UI based on check result
-    function updateDeploymentUI(domain, result, statusElement) {
-        var textElement = document.getElementById('deployment-text-' + domain.replace(/\./g, '-'));
+    function updateDeploymentUI(domain, result) {
+        var statusElements = Array.prototype.filter.call(
+            document.querySelectorAll('[data-deployment-domain]'),
+            function (el) {
+                return el.getAttribute('data-deployment-domain') === domain;
+            }
+        );
 
+        var statusText;
+        var statusClass;
+        var statusIcon;
         if (result.deployed && result.certificate_match !== false) {
-            statusElement.className = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400';
-            statusElement.innerHTML = '<i class="fas fa-check-circle mr-1"></i>Deployed';
-            if (textElement) {
-                textElement.textContent = 'Active';
-                textElement.className = 'text-sm font-medium text-green-600 dark:text-green-400';
-            }
-
+            statusClass = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400';
+            statusIcon = 'fa-check-circle';
+            statusText = 'Deployed';
         } else if (result.reachable && result.certificate_match === false) {
-            statusElement.className = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400';
-            statusElement.innerHTML = '<i class="fas fa-exclamation-triangle mr-1"></i>Mismatch';
-            if (textElement) {
-                textElement.textContent = 'Mismatch';
-                textElement.className = 'text-sm font-medium text-yellow-600 dark:text-yellow-400';
-            }
-
+            statusClass = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400';
+            statusIcon = 'fa-exclamation-triangle';
+            statusText = 'Wrong Cert';
         } else if (result.reachable) {
-            statusElement.className = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400';
-            statusElement.innerHTML = '<i class="fas fa-info-circle mr-1"></i>Unknown';
-            if (textElement) {
-                textElement.textContent = 'Unknown';
-                textElement.className = 'text-sm font-medium text-blue-600 dark:text-blue-400';
-            }
-
+            statusClass = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400';
+            statusIcon = 'fa-info-circle';
+            statusText = 'Unknown';
         } else {
-            statusElement.className = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400';
-            statusElement.innerHTML = '<i class="fas fa-times-circle mr-1"></i>Unreachable';
-            if (textElement) {
-                textElement.textContent = 'Unreachable';
-                textElement.className = 'text-sm font-medium text-red-600 dark:text-red-400';
-            }
+            statusClass = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400';
+            statusIcon = 'fa-times-circle';
+            statusText = 'Not Deployed';
         }
 
-        // Add method info to title for debugging
-        if (result.method) {
-            statusElement.title = 'Checked via: ' + result.method + ' at ' + result.timestamp;
-            if (textElement) {
-                textElement.title = statusElement.title;
+        statusElements.forEach(function (statusElement) {
+            statusElement.className = statusClass;
+            statusElement.innerHTML = '<i class="fas ' + statusIcon + ' mr-1"></i>' + statusText;
+            if (result.method) {
+                statusElement.title = 'Checked via: ' + result.method + ' at ' + result.timestamp;
             }
-        }
+        });
     }
 
     // Load certificates with deployment status

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -329,6 +329,40 @@
             'title="' + title + '"><i class="fas ' + icon + '"></i></button>';
     }
 
+    function deploymentStatusDisplay(result) {
+        var statusClass;
+        var statusIcon;
+        var statusText;
+
+        if (result && result.deployed && result.certificate_match === true) {
+            statusClass = 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400';
+            statusIcon = 'fa-check-circle';
+            statusText = 'Deployed';
+        } else if (result && result.reachable && result.certificate_match === false) {
+            statusClass = 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400';
+            statusIcon = 'fa-exclamation-triangle';
+            statusText = 'Wrong Cert';
+        } else if (result && result.reachable && result.certificate_match === null) {
+            statusClass = 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400';
+            statusIcon = 'fa-info-circle';
+            statusText = 'Reachable';
+        } else if (result && !result.reachable) {
+            statusClass = 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400';
+            statusIcon = 'fa-times-circle';
+            statusText = 'Unreachable';
+        } else {
+            statusClass = 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300';
+            statusIcon = 'fa-question-circle';
+            statusText = 'Unknown';
+        }
+
+        return {
+            className: 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ' + statusClass,
+            icon: statusIcon,
+            text: statusText
+        };
+    }
+
     // Build deployment status badge HTML
     function deploymentBadgeHtml(cert, context) {
         var safeDomain = escapeHtml(cert.domain);
@@ -336,17 +370,8 @@
         var badgeId = context === 'detail' ? '' : ' id="deployment-status-' + domainId + '"';
         var cachedStatus = deploymentCache.get(cert.domain);
         if (cachedStatus) {
-            var sc, si, st;
-            if (cachedStatus.deployed && cachedStatus.certificate_match) {
-                sc = 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400'; si = 'fa-check-circle'; st = 'Deployed';
-            } else if (cachedStatus.reachable && !cachedStatus.certificate_match) {
-                sc = 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400'; si = 'fa-exclamation-triangle'; st = 'Wrong Cert';
-            } else if (!cachedStatus.reachable) {
-                sc = 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400'; si = 'fa-times-circle'; st = 'Unreachable';
-            } else {
-                sc = 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'; si = 'fa-question-circle'; st = 'Unknown';
-            }
-            return '<span data-deployment-domain="' + safeDomain + '"' + badgeId + ' class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ' + sc + '"><i class="fas ' + si + ' mr-1"></i>' + st + '</span>';
+            var display = deploymentStatusDisplay(cachedStatus);
+            return '<span data-deployment-domain="' + safeDomain + '"' + badgeId + ' class="' + display.className + '"><i class="fas ' + display.icon + ' mr-1"></i>' + display.text + '</span>';
         }
         return '<span data-deployment-domain="' + safeDomain + '"' + badgeId + ' class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"><i class="fas fa-spinner fa-spin mr-1"></i>Checking...</span>';
     }
@@ -979,30 +1004,11 @@
             }
         );
 
-        var statusText;
-        var statusClass;
-        var statusIcon;
-        if (result.deployed && result.certificate_match !== false) {
-            statusClass = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400';
-            statusIcon = 'fa-check-circle';
-            statusText = 'Deployed';
-        } else if (result.reachable && result.certificate_match === false) {
-            statusClass = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400';
-            statusIcon = 'fa-exclamation-triangle';
-            statusText = 'Wrong Cert';
-        } else if (result.reachable) {
-            statusClass = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400';
-            statusIcon = 'fa-info-circle';
-            statusText = 'Unknown';
-        } else {
-            statusClass = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400';
-            statusIcon = 'fa-times-circle';
-            statusText = 'Unreachable';
-        }
+        var display = deploymentStatusDisplay(result);
 
         statusElements.forEach(function (statusElement) {
-            statusElement.className = statusClass;
-            statusElement.innerHTML = '<i class="fas ' + statusIcon + ' mr-1"></i>' + statusText;
+            statusElement.className = display.className;
+            statusElement.innerHTML = '<i class="fas ' + display.icon + ' mr-1"></i>' + display.text;
             if (result.method) {
                 statusElement.title = 'Checked via: ' + result.method + ' at ' + result.timestamp;
             }

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -918,9 +918,7 @@
                         return checkDeploymentViaBrowser(domain).then(function (browserResult) {
                             if (browserResult) {
                                 queueBrowserDeploymentReport(domain, browserResult);
-                                deploymentCache.set(domain, browserResult);
-                                updateDeploymentUI(domain, browserResult);
-                                return;
+                                result.browser = browserResult;
                             }
                             deploymentCache.set(domain, result);
                             updateDeploymentUI(domain, result);
@@ -948,8 +946,19 @@
                 if (result.reachable) {
                     queueBrowserDeploymentReport(domain, result);
                 }
-                deploymentCache.set(domain, result);
-                updateDeploymentUI(domain, result);
+                // Keep the server-side result as the primary status. The browser
+                // probe is supplemental and may be useful for diagnostics, but it
+                // should not replace the backend's deployed/reachable verdict.
+                deploymentCache.set(domain, {
+                    deployed: false,
+                    reachable: false,
+                    certificate_match: false,
+                    method: 'browser-fallback',
+                    error: 'backend-unavailable',
+                    timestamp: result.timestamp || new Date().toISOString(),
+                    browser: result
+                });
+                updateDeploymentUI(domain, deploymentCache.get(domain));
             });
         }).catch(function () {
             statusElements.forEach(function (statusElement) {

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -560,7 +560,7 @@
                     : '') +
                 '<button type="button" onclick="downloadCertificate(\'' + safeDomain + '\')" class="w-full inline-flex items-center justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600"><i class="fas fa-download mr-2 text-blue-600"></i>Download Certificate</button>' +
                 '<button type="button" onclick="copyCurlCommand(\'' + safeDomain + '\')" class="w-full inline-flex items-center justify-center px-4 py-2 border border-blue-300 dark:border-blue-600 shadow-sm text-sm font-medium rounded-md text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50"><i class="fas fa-code mr-2"></i>Show API Command</button>' +
-                '<button type="button" onclick="checkDeploymentStatus(\'' + safeDomain + '\', this)" class="w-full inline-flex items-center justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600"><i class="fas fa-globe mr-2 text-indigo-600"></i>Check Deployment</button>' +
+                '<button type="button" onclick="checkDeploymentStatus(\'' + safeDomain + '\', this, true)" class="w-full inline-flex items-center justify-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600"><i class="fas fa-globe mr-2 text-indigo-600"></i>Check Deployment</button>' +
                 (safeDomainAlias ? '<button type="button" onclick="checkDnsAliasForCertificate(\'' + safeDomain + '\')" class="w-full inline-flex items-center justify-center px-4 py-2 border border-blue-300 dark:border-blue-600 shadow-sm text-sm font-medium rounded-md text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50"><i class="fas fa-search mr-2"></i>Check DNS-01 Alias</button>' : '') +
                 '<div id="cert_dns_alias_check_result" class="hidden"></div>' +
                 (roleAtLeast('admin')
@@ -793,7 +793,7 @@
     }
 
     // Check deployment status for a specific domain
-    function checkDeploymentStatus(domain, triggerButton) {
+    function checkDeploymentStatus(domain, triggerButton, forceRefresh) {
         var restoreButton = function () {
             if (!triggerButton) {
                 return;
@@ -824,7 +824,7 @@
         }
 
         // Check cache first
-        var cachedResult = deploymentCache.get(domain);
+        var cachedResult = forceRefresh ? null : deploymentCache.get(domain);
         if (cachedResult) {
             updateDeploymentUI(domain, cachedResult);
             restoreButton();

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -329,51 +329,75 @@
             'title="' + title + '"><i class="fas ' + icon + '"></i></button>';
     }
 
-    function deploymentStatusDisplay(result) {
+    function deploymentStatusDisplay(role, result) {
+        var isBrowser = role === 'browser';
+        var roleLabel = isBrowser ? 'Browser' : 'Backend';
+        var roleIcon = isBrowser ? 'fa-globe' : 'fa-server';
         var statusClass;
-        var statusIcon;
+        var statusIcon = roleIcon;
         var statusText;
 
-        if (result && result.deployed && result.certificate_match === true) {
-            statusClass = 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400';
-            statusIcon = 'fa-check-circle';
-            statusText = 'Deployed';
-        } else if (result && result.reachable && result.certificate_match === false) {
-            statusClass = 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400';
-            statusIcon = 'fa-exclamation-triangle';
-            statusText = 'Wrong Cert';
-        } else if (result && result.reachable && result.certificate_match === null) {
-            statusClass = 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400';
-            statusIcon = 'fa-info-circle';
-            statusText = 'Reachable';
-        } else if (result && !result.reachable) {
-            statusClass = 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400';
-            statusIcon = 'fa-times-circle';
-            statusText = 'Unreachable';
+        if (isBrowser) {
+            if (result && result.reachable) {
+                statusClass = 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400';
+                statusText = 'Reachable';
+            } else if (result && result.reachable === false) {
+                statusClass = 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400';
+                statusText = 'Unreachable';
+            } else {
+                statusClass = 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300';
+                statusText = 'Not Checked';
+            }
         } else {
-            statusClass = 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300';
-            statusIcon = 'fa-question-circle';
-            statusText = 'Unknown';
+            if (result && result.error === 'backend-unavailable') {
+                statusClass = 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300';
+                statusIcon = 'fa-exclamation-circle';
+                statusText = 'Unavailable';
+            } else if (result && result.deployed && result.certificate_match === true) {
+                statusClass = 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400';
+                statusText = 'Deployed';
+            } else if (result && result.reachable && result.certificate_match === false) {
+                statusClass = 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400';
+                statusText = 'Wrong Cert';
+            } else if (result && result.reachable === false) {
+                statusClass = 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400';
+                statusText = 'Unreachable';
+            } else {
+                statusClass = 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300';
+                statusText = 'Unknown';
+            }
         }
 
         return {
             className: 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ' + statusClass,
             icon: statusIcon,
-            text: statusText
+            text: roleLabel + ': ' + statusText
         };
     }
 
-    // Build deployment status badge HTML
-    function deploymentBadgeHtml(cert, context) {
+    function deploymentBadgeHtml(role, result, safeDomain, domainId) {
+        var badgeId = 'deployment-status-' + domainId + '-' + role;
+        var display = deploymentStatusDisplay(role, result);
+        var title = display.text;
+        if (result && result.method) {
+            title += ' via ' + result.method;
+        }
+        if (result && result.timestamp) {
+            title += ' at ' + result.timestamp;
+        }
+        return '<span data-deployment-domain="' + safeDomain + '" data-deployment-role="' + role + '" id="' + badgeId + '" title="' + escapeHtml(title) + '" class="' + display.className + '"><i class="fas ' + display.icon + ' mr-1"></i>' + display.text + '</span>';
+    }
+
+    // Build deployment status badges HTML
+    function deploymentBadgesHtml(cert) {
         var safeDomain = escapeHtml(cert.domain);
         var domainId = safeDomain.replace(/\./g, '-');
-        var badgeId = context === 'detail' ? '' : ' id="deployment-status-' + domainId + '"';
-        var cachedStatus = deploymentCache.get(cert.domain);
-        if (cachedStatus) {
-            var display = deploymentStatusDisplay(cachedStatus);
-            return '<span data-deployment-domain="' + safeDomain + '"' + badgeId + ' class="' + display.className + '"><i class="fas ' + display.icon + ' mr-1"></i>' + display.text + '</span>';
-        }
-        return '<span data-deployment-domain="' + safeDomain + '"' + badgeId + ' class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"><i class="fas fa-spinner fa-spin mr-1"></i>Checking...</span>';
+        var cachedStatus = deploymentCache.get(cert.domain) || {};
+        var browserStatus = cachedStatus.browser || null;
+        return '<div class="flex flex-wrap items-center gap-2">' +
+            deploymentBadgeHtml('backend', cachedStatus, safeDomain, domainId) +
+            deploymentBadgeHtml('browser', browserStatus, safeDomain, domainId) +
+            '</div>';
     }
 
     function providerDisplayName(provider) {
@@ -517,7 +541,7 @@
                 <td class="px-4 py-4 whitespace-nowrap"><span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${rowRaw(statusClass)}"><i class="fas ${rowRaw(statusIcon)} mr-1"></i>${statusText}</span></td>
                 <td class="px-4 py-4 whitespace-nowrap hidden md:table-cell"><div class="text-sm text-gray-900 dark:text-white">${expiryStr}</div><div class="text-xs ${rowRaw(daysClass)}">${cert.days_until_expiry} days</div></td>
                 <td class="px-4 py-4 whitespace-nowrap hidden lg:table-cell text-sm text-gray-500 dark:text-gray-400">${rowRaw(providerLabel) || '—'}</td>
-                <td class="px-4 py-4 whitespace-nowrap hidden lg:table-cell">${rowRaw(deploymentBadgeHtml(cert, 'row'))}</td>
+                <td class="px-4 py-4 whitespace-nowrap hidden lg:table-cell">${rowRaw(deploymentBadgesHtml(cert))}</td>
                 <td class="px-4 py-4 whitespace-nowrap text-right">
                     <div class="flex items-center justify-end gap-1">
                         ${roleAtLeast('operator') ? actionBtn('renew', cert.domain, 'green', 'Renew', 'fa-sync-alt') : false}
@@ -614,7 +638,7 @@
                 (safeDomainAlias ? '<div class="flex justify-between gap-4 py-2 border-b dark:border-gray-700"><dt class="text-sm text-gray-500 dark:text-gray-400">DNS-01 Alias</dt><dd class="text-sm font-medium text-right break-all text-blue-600 dark:text-blue-300">' + safeDomainAlias + '</dd></div>' : '') +
                 (safeDomainAlias && aliasProviderLabel ? '<div class="flex justify-between gap-4 py-2 border-b dark:border-gray-700"><dt class="text-sm text-gray-500 dark:text-gray-400">Alias Provider</dt><dd class="text-sm font-medium text-right text-gray-900 dark:text-white">' + aliasProviderLabel + '</dd></div>' : '') +
                 '<div class="flex justify-between gap-4 py-2 border-b dark:border-gray-700"><dt class="text-sm text-gray-500 dark:text-gray-400">Auto-Renew</dt><dd class="text-sm font-medium text-right ' + (cert.auto_renew !== false ? 'text-green-600 dark:text-green-400' : 'text-amber-600 dark:text-amber-400') + '">' + (cert.auto_renew !== false ? 'Enabled' : 'Disabled') + '</dd></div>' +
-                '<div class="flex justify-between gap-4 py-2 border-b dark:border-gray-700"><dt class="text-sm text-gray-500 dark:text-gray-400">Deployment</dt><dd>' + deploymentBadgeHtml(cert, 'detail') + '</dd></div>' +
+                '<div class="flex justify-between gap-4 py-2 border-b dark:border-gray-700"><dt class="text-sm text-gray-500 dark:text-gray-400">Deployment</dt><dd>' + deploymentBadgesHtml(cert) + '</dd></div>' +
                 '</dl>' +
                 '</div>' +
                 // Actions
@@ -1006,21 +1030,30 @@
 
     // Update deployment UI based on check result
     function updateDeploymentUI(domain, result) {
-        var statusElements = Array.prototype.filter.call(
-            document.querySelectorAll('[data-deployment-domain]'),
-            function (el) {
-                return el.getAttribute('data-deployment-domain') === domain;
-            }
-        );
+        var backendResult = result || null;
+        var browserResult = result && result.browser ? result.browser : null;
 
-        var display = deploymentStatusDisplay(result);
-
-        statusElements.forEach(function (statusElement) {
-            statusElement.className = display.className;
-            statusElement.innerHTML = '<i class="fas ' + display.icon + ' mr-1"></i>' + display.text;
-            if (result.method) {
-                statusElement.title = 'Checked via: ' + result.method + ' at ' + result.timestamp;
-            }
+        ['backend', 'browser'].forEach(function (role) {
+            var roleResult = role === 'browser' ? browserResult : backendResult;
+            var display = deploymentStatusDisplay(role, roleResult);
+            Array.prototype.filter.call(
+                document.querySelectorAll('[data-deployment-domain][data-deployment-role="' + role + '"]'),
+                function (el) {
+                    return el.getAttribute('data-deployment-domain') === domain;
+                }
+            ).forEach(function (statusElement) {
+                statusElement.className = display.className;
+                statusElement.innerHTML = '<i class="fas ' + display.icon + ' mr-1"></i>' + display.text;
+                if (roleResult && roleResult.method) {
+                    var title = display.text + ' via ' + roleResult.method;
+                    if (roleResult.timestamp) {
+                        title += ' at ' + roleResult.timestamp;
+                    }
+                    statusElement.title = title;
+                } else {
+                    statusElement.removeAttribute('title');
+                }
+            });
         });
     }
 

--- a/tests/test_deployment_status_route.py
+++ b/tests/test_deployment_status_route.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -29,6 +30,7 @@ def _build_app(managers):
     ns_certificates = Namespace('certificates', description='Certificate operations')
     api.add_namespace(ns_certificates)
     ns_certificates.add_resource(resources['CertificateDeploymentStatus'], '/<string:domain>/deployment-status')
+    ns_certificates.add_resource(resources['CertificateDeploymentBrowserReports'], '/deployment-status/browser')
     return app
 
 
@@ -136,3 +138,113 @@ def test_deployment_status_refresh_bypasses_cache(tmp_path, monkeypatch):
     assert body['certificate_match'] is True
     cache_manager.remove_from_cache.assert_called_once_with(domain)
     cache_manager.get_deployment_status.assert_not_called()
+
+
+def test_browser_report_is_persisted_separately(tmp_path, monkeypatch):
+    domain = 'example.com'
+    cert_dir = tmp_path / domain
+    cert_dir.mkdir(parents=True)
+    (cert_dir / 'cert.pem').write_bytes(b'expected-cert-bytes')
+
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_decorator)
+
+    cache_manager = MagicMock(
+        get_deployment_status=MagicMock(return_value=None),
+        set_deployment_status=MagicMock(),
+        remove_from_cache=MagicMock(),
+    )
+
+    certificate_manager = MagicMock()
+    certificate_manager.cert_dir = Path(tmp_path)
+    certificate_manager.storage_manager = None
+    certificate_manager.get_certificate_info.return_value = {'exists': True}
+
+    def _metadata_path():
+        return cert_dir / 'metadata.json'
+
+    def _load_metadata():
+        if _metadata_path().exists():
+            return json.loads(_metadata_path().read_text())
+        return {}
+
+    def _write_metadata(metadata):
+        _metadata_path().write_text(json.dumps(metadata, indent=2))
+
+    def record_browser(_domain, report):
+        metadata = _load_metadata()
+        deployment_status = metadata.get('deployment_status', {})
+        deployment_status['browser'] = {
+            'reachable': bool(report.get('reachable', False)),
+            'checked_at': report.get('checked_at'),
+            'method': report.get('method'),
+            'source': report.get('source'),
+        }
+        metadata['deployment_status'] = deployment_status
+        _write_metadata(metadata)
+        return deployment_status
+
+    def record_backend(_domain, status):
+        metadata = _load_metadata()
+        deployment_status = metadata.get('deployment_status', {})
+        deployment_status['backend'] = {
+            'domain': status.get('domain', domain),
+            'deployed': bool(status.get('deployed', False)),
+            'reachable': bool(status.get('reachable', False)),
+            'certificate_match': status.get('certificate_match'),
+            'method': status.get('method'),
+            'timestamp': status.get('timestamp'),
+            'error': status.get('error'),
+        }
+        metadata['deployment_status'] = deployment_status
+        _write_metadata(metadata)
+        return deployment_status
+
+    certificate_manager.get_deployment_status_record.side_effect = lambda _domain: _load_metadata().get('deployment_status', {})
+    certificate_manager.record_browser_deployment_status.side_effect = record_browser
+    certificate_manager.record_backend_deployment_status.side_effect = record_backend
+
+    managers = {
+        'auth': auth_manager,
+        'settings': MagicMock(),
+        'certificates': certificate_manager,
+        'file_ops': MagicMock(cert_dir=Path(tmp_path)),
+        'cache': cache_manager,
+        'dns': MagicMock(),
+    }
+
+    app = _build_app(managers)
+    client = app.test_client()
+
+    response = client.post('/api/certificates/deployment-status/browser', json={
+        'reports': [{
+            'domain': domain,
+            'reachable': True,
+            'checked_at': '2026-05-12T09:45:31.540941',
+            'method': 'browser-fallback',
+            'source': 'browser',
+        }]
+    })
+
+    assert response.status_code == 200
+    metadata = json.loads((cert_dir / 'metadata.json').read_text())
+    assert metadata['deployment_status']['browser']['reachable'] is True
+    assert metadata['deployment_status']['browser']['checked_at'] == '2026-05-12T09:45:31.540941'
+
+    monkeypatch.setattr(
+        api_resources_module,
+        '_certificate_fingerprint',
+        lambda cert_bytes: 'expected' if cert_bytes == b'expected-cert-bytes' else 'other',
+    )
+    monkeypatch.setattr(
+        api_resources_module,
+        '_probe_https_certificate',
+        lambda _domain: (_ for _ in ()).throw(ConnectionRefusedError('[Errno 111] Connection refused')),
+    )
+
+    response = client.get(f'/api/certificates/{domain}/deployment-status?refresh=1')
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body['reachable'] is False
+    assert body['browser']['reachable'] is True
+    assert body['browser']['checked_at'] == '2026-05-12T09:45:31.540941'

--- a/tests/test_deployment_status_route.py
+++ b/tests/test_deployment_status_route.py
@@ -140,6 +140,45 @@ def test_deployment_status_refresh_bypasses_cache(tmp_path, monkeypatch):
     cache_manager.get_deployment_status.assert_not_called()
 
 
+def test_deployment_status_denies_out_of_scope_domain(tmp_path, monkeypatch):
+    domain = 'example.com'
+    cert_dir = tmp_path / domain
+    cert_dir.mkdir(parents=True)
+    (cert_dir / 'cert.pem').write_bytes(b'expected-cert-bytes')
+
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_decorator)
+    auth_manager.user_can_access_domain = MagicMock(return_value=False)
+
+    certificate_manager = MagicMock(
+        cert_dir=Path(tmp_path),
+        storage_manager=None,
+        get_certificate_info=MagicMock(return_value={'exists': True}),
+    )
+
+    managers = {
+        'auth': auth_manager,
+        'settings': MagicMock(),
+        'certificates': certificate_manager,
+        'file_ops': MagicMock(cert_dir=Path(tmp_path)),
+        'cache': MagicMock(
+            get_deployment_status=MagicMock(return_value=None),
+            set_deployment_status=MagicMock(),
+            remove_from_cache=MagicMock(),
+        ),
+        'dns': MagicMock(),
+    }
+
+    app = _build_app(managers)
+    client = app.test_client()
+
+    response = client.get(f'/api/certificates/{domain}/deployment-status')
+
+    assert response.status_code == 403
+    assert response.get_json()['code'] == 'DOMAIN_OUT_OF_SCOPE'
+    certificate_manager.get_certificate_info.assert_not_called()
+
+
 def test_browser_report_is_persisted_separately(tmp_path, monkeypatch):
     domain = 'example.com'
     cert_dir = tmp_path / domain
@@ -248,3 +287,53 @@ def test_browser_report_is_persisted_separately(tmp_path, monkeypatch):
     assert body['reachable'] is False
     assert body['browser']['reachable'] is True
     assert body['browser']['checked_at'] == '2026-05-12T09:45:31.540941'
+
+
+def test_browser_report_skips_out_of_scope_domains(tmp_path):
+    domain = 'example.com'
+    cert_dir = tmp_path / domain
+    cert_dir.mkdir(parents=True)
+    (cert_dir / 'cert.pem').write_bytes(b'expected-cert-bytes')
+
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_decorator)
+    auth_manager.user_can_access_domain = MagicMock(return_value=False)
+
+    certificate_manager = MagicMock()
+    certificate_manager.cert_dir = Path(tmp_path)
+    certificate_manager.storage_manager = None
+    certificate_manager.get_certificate_info.return_value = {'exists': True}
+
+    managers = {
+        'auth': auth_manager,
+        'settings': MagicMock(),
+        'certificates': certificate_manager,
+        'file_ops': MagicMock(cert_dir=Path(tmp_path)),
+        'cache': MagicMock(
+            get_deployment_status=MagicMock(return_value=None),
+            set_deployment_status=MagicMock(),
+            remove_from_cache=MagicMock(),
+        ),
+        'dns': MagicMock(),
+    }
+
+    app = _build_app(managers)
+    client = app.test_client()
+
+    response = client.post('/api/certificates/deployment-status/browser', json={
+        'reports': [{
+            'domain': domain,
+            'reachable': True,
+            'checked_at': '2026-05-12T09:45:31.540941',
+            'method': 'browser-fallback',
+            'source': 'browser',
+        }]
+    })
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body['updated'] == []
+    assert body['count'] == 0
+    assert body['skipped'][0]['domain'] == domain
+    assert body['skipped'][0]['error'] == 'out of scope'
+    certificate_manager.record_browser_deployment_status.assert_not_called()

--- a/tests/test_deployment_status_route.py
+++ b/tests/test_deployment_status_route.py
@@ -80,3 +80,59 @@ def test_deployment_status_route_exists_and_returns_match(tmp_path, monkeypatch)
     assert body['reachable'] is True
     assert body['certificate_match'] is True
     assert body['method'] == 'https-tls'
+
+
+def test_deployment_status_refresh_bypasses_cache(tmp_path, monkeypatch):
+    domain = 'example.com'
+    cert_dir = tmp_path / domain
+    cert_dir.mkdir(parents=True)
+    (cert_dir / 'cert.pem').write_bytes(b'expected-cert-bytes')
+
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_decorator)
+
+    cache_manager = MagicMock(
+        get_deployment_status=MagicMock(return_value={
+            'domain': domain,
+            'deployed': True,
+            'reachable': True,
+            'certificate_match': True,
+        }),
+        set_deployment_status=MagicMock(),
+        remove_from_cache=MagicMock(),
+    )
+
+    managers = {
+        'auth': auth_manager,
+        'settings': MagicMock(),
+        'certificates': MagicMock(
+            cert_dir=Path(tmp_path),
+            storage_manager=None,
+            get_certificate_info=MagicMock(return_value={'exists': True}),
+        ),
+        'file_ops': MagicMock(cert_dir=Path(tmp_path)),
+        'cache': cache_manager,
+        'dns': MagicMock(),
+    }
+
+    monkeypatch.setattr(
+        api_resources_module,
+        '_certificate_fingerprint',
+        lambda cert_bytes: 'expected' if cert_bytes == b'expected-cert-bytes' else 'other',
+    )
+    monkeypatch.setattr(
+        api_resources_module,
+        '_probe_https_certificate',
+        lambda _domain: {'reachable': True, 'certificate_bytes': b'expected-cert-bytes'},
+    )
+
+    app = _build_app(managers)
+    client = app.test_client()
+
+    response = client.get(f'/api/certificates/{domain}/deployment-status?refresh=1')
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body['certificate_match'] is True
+    cache_manager.remove_from_cache.assert_called_once_with(domain)
+    cache_manager.get_deployment_status.assert_not_called()

--- a/tests/test_deployment_status_route.py
+++ b/tests/test_deployment_status_route.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+from flask_restx import Api, Namespace
+
+from modules.api.models import create_api_models
+from modules.api.resources import create_api_resources
+import modules.api.resources as api_resources_module
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def _passthrough_decorator(_min_role):
+    def deco(fn):
+        return fn
+    return deco
+
+
+def _build_app(managers):
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    api = Api(app, prefix='/api')
+    models = create_api_models(api)
+    resources = create_api_resources(api, models, managers)
+
+    ns_certificates = Namespace('certificates', description='Certificate operations')
+    api.add_namespace(ns_certificates)
+    ns_certificates.add_resource(resources['CertificateDeploymentStatus'], '/<string:domain>/deployment-status')
+    return app
+
+
+def test_deployment_status_route_exists_and_returns_match(tmp_path, monkeypatch):
+    domain = 'example.com'
+    cert_dir = tmp_path / domain
+    cert_dir.mkdir(parents=True)
+    (cert_dir / 'cert.pem').write_bytes(b'expected-cert-bytes')
+
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_decorator)
+
+    managers = {
+        'auth': auth_manager,
+        'settings': MagicMock(),
+        'certificates': MagicMock(
+            cert_dir=Path(tmp_path),
+            storage_manager=None,
+            get_certificate_info=MagicMock(return_value={'exists': True}),
+        ),
+        'file_ops': MagicMock(cert_dir=Path(tmp_path)),
+        'cache': MagicMock(
+            get_deployment_status=MagicMock(return_value=None),
+            set_deployment_status=MagicMock(),
+        ),
+        'dns': MagicMock(),
+    }
+
+    monkeypatch.setattr(
+        api_resources_module,
+        '_certificate_fingerprint',
+        lambda cert_bytes: 'expected' if cert_bytes == b'expected-cert-bytes' else 'other',
+    )
+    monkeypatch.setattr(
+        api_resources_module,
+        '_probe_https_certificate',
+        lambda _domain: {'reachable': True, 'certificate_bytes': b'expected-cert-bytes'},
+    )
+
+    app = _build_app(managers)
+    client = app.test_client()
+
+    response = client.get(f'/api/certificates/{domain}/deployment-status')
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body['domain'] == domain
+    assert body['deployed'] is True
+    assert body['reachable'] is True
+    assert body['certificate_match'] is True
+    assert body['method'] == 'https-tls'


### PR DESCRIPTION
the ui was reaching out to a url in certmate that did not exist
/api/certificates/{domain}/deployment-status

i fleshed out the backend to support this url
i also made it more understandable to which reachability check was used (backend or browser)