### PR TITLE
Sprint 1.5: API auth audit follow-up (F-1, F-2, privkey download, audit matrix gaps)

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -15,6 +15,7 @@ from flask_restx import Resource, fields
 
 from ..core.metrics import get_metrics_summary, is_prometheus_available
 from ..core.constants import CERTIFICATE_FILES, iter_cert_domain_dirs
+from ..core.auth import ROLE_HIERARCHY
 
 _DOMAIN_RE = re.compile(r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$')
 
@@ -742,6 +743,17 @@ def create_api_resources(api, models, managers):
                 event_bus = current_app.config.get('EVENT_BUS')
                 if event_bus:
                     event_bus.publish('certificate_deleted', {'domain': domain})
+
+                if audit_logger:
+                    user = getattr(request, 'current_user', None) or {}
+                    audit_logger.log_operation(
+                        operation='delete',
+                        resource_type='certificate',
+                        resource_id=domain,
+                        status='success',
+                        user=user.get('username'),
+                        ip_address=request.remote_addr,
+                    )
                 return {'message': f'Certificate deleted for {domain}', 'domain': domain}, 200
             except RuntimeError as e:
                 return {'error': str(e)}, 409
@@ -749,11 +761,32 @@ def create_api_resources(api, models, managers):
                 logger.error(f"Certificate deletion failed for {domain}: {e}")
                 return {'error': 'Certificate deletion failed'}, 500
 
+    # Files containing private-key material. A viewer-role caller is
+    # permitted to download public certificate material (cert, chain,
+    # fullchain) but anything that exposes the private key requires
+    # operator role. The default ZIP includes privkey.pem and is
+    # therefore also operator-gated. (2026-05-12 API auth audit
+    # follow-up: viewer-can-pull-privkey was an information-disclosure
+    # surface that the original endpoint exposed.)
+    _PRIVATE_KEY_FILES = frozenset({'privkey.pem', 'combined.pem'})
+    _PUBLIC_DOWNLOAD_FILES = frozenset({'cert.pem', 'chain.pem', 'fullchain.pem'})
+
+    def _user_has_role(user, min_role):
+        level = ROLE_HIERARCHY.get((user or {}).get('role'), -1)
+        return level >= ROLE_HIERARCHY.get(min_role, 999)
+
     class DownloadCertificate(Resource):
         @api.doc(security='Bearer')
         @auth_manager.require_role('viewer')
         def get(self, domain):
-            """Download certificate files as ZIP, JSON, or individual file"""
+            """Download certificate files as ZIP, JSON, or individual file.
+
+            Role gating is per-file: viewers can pull public material
+            (cert.pem, chain.pem, fullchain.pem) and the public-only ZIP
+            (?include_private=0); anything that exposes the private key
+            (privkey.pem, combined.pem, format=json, default ZIP)
+            requires operator role.
+            """
             try:
                 scope_err = _check_domain_scope(domain, 'download')
                 if scope_err:
@@ -764,14 +797,38 @@ def create_api_resources(api, models, managers):
                 if not cert_dir.exists():
                     return {'error': f'Certificate not found for domain: {domain}'}, 404
 
+                user = getattr(request, 'current_user', None) or {}
                 download_format = request.args.get('format')
                 # Check for the optional 'file' parameter
                 requested_file = request.args.get('file')
+                include_private = str(request.args.get('include_private', '1')).lower() not in ('0', 'false', 'no', 'off')
 
                 if download_format and download_format not in ['json']:
                     return {'error': 'Invalid format requested.'}, 400
 
+                def _privkey_denied(file_label):
+                    """Emit audit + return 403 for viewer trying to pull privkey."""
+                    if audit_logger:
+                        audit_logger.log_authz_denied(
+                            operation='download',
+                            resource_type='certificate',
+                            resource_id=domain,
+                            reason=f'viewer cannot download private-key material ({file_label})',
+                            user=user.get('username'),
+                            ip_address=request.remote_addr,
+                        )
+                    return {
+                        'error': 'operator role required to download private key material',
+                        'code': 'PRIVKEY_REQUIRES_OPERATOR',
+                        'hint': f'Use ?file=fullchain.pem or ?include_private=0 to download public material as a viewer.',
+                    }, 403
+
                 if download_format == 'json':
+                    # format=json always returns private_key_pem inline.
+                    # Restrict to operator+; viewer must use ?file=... for
+                    # the specific public-material file they need.
+                    if not _user_has_role(user, 'operator'):
+                        return _privkey_denied('format=json')
                     if requested_file:
                         return {'error': 'format=json cannot be combined with file.'}, 400
 
@@ -796,8 +853,14 @@ def create_api_resources(api, models, managers):
 
                 if requested_file:
                     # Security check: only allow specific certificate files
-                    if requested_file not in ['fullchain.pem', 'privkey.pem', 'combined.pem']:
+                    allowed_files = _PUBLIC_DOWNLOAD_FILES | _PRIVATE_KEY_FILES
+                    if requested_file not in allowed_files:
                         return {'error': 'Invalid file requested.'}, 400
+
+                    # Private-key files require operator+; public files
+                    # remain viewer-accessible.
+                    if requested_file in _PRIVATE_KEY_FILES and not _user_has_role(user, 'operator'):
+                        return _privkey_denied(requested_file)
 
                     if requested_file == 'combined.pem':
                         try:
@@ -826,13 +889,24 @@ def create_api_resources(api, models, managers):
                         mimetype='application/x-pem-file'
                     )
 
-                # Fallback to original ZIP logic if no file parameter is provided
+                # Fallback ZIP. Two flavors:
+                #   include_private=1 (default)  -> all 4 PEMs, operator+
+                #   include_private=0            -> public material only,
+                #                                   safe for viewer
+                if include_private and not _user_has_role(user, 'operator'):
+                    return _privkey_denied('default ZIP')
+
+                files_to_zip = (
+                    CERTIFICATE_FILES if include_private
+                    else tuple(f for f in CERTIFICATE_FILES if f not in _PRIVATE_KEY_FILES)
+                )
+                zip_suffix = 'certificates' if include_private else 'certificates_public'
 
                 # Create temporary ZIP file
                 with tempfile.NamedTemporaryFile(delete=False, suffix='.zip') as tmp_file:
                     tmp_path = tmp_file.name
                     with zipfile.ZipFile(tmp_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
-                        for cert_file in CERTIFICATE_FILES:
+                        for cert_file in files_to_zip:
                             file_path = cert_dir / cert_file
                             if file_path.exists():
                                 zipf.write(file_path, cert_file)
@@ -848,7 +922,7 @@ def create_api_resources(api, models, managers):
                     return send_file(
                         tmp_path,
                         as_attachment=True,
-                        download_name=f'{domain}_certificates.zip',
+                        download_name=f'{domain}_{zip_suffix}.zip',
                         mimetype='application/zip'
                     )
 
@@ -1010,6 +1084,17 @@ def create_api_resources(api, models, managers):
                     logger.info(f"Created unified backup: {filename}")
 
                 if created_backups:
+                    if audit_logger:
+                        user = getattr(request, 'current_user', None) or {}
+                        audit_logger.log_operation(
+                            operation='create',
+                            resource_type='backup',
+                            resource_id=created_backups[0].get('filename', 'unknown'),
+                            status='success',
+                            details={'type': 'unified', 'reason': reason},
+                            user=user.get('username'),
+                            ip_address=request.remote_addr,
+                        )
                     return {
                         'message': 'Backup created successfully',
                         'backups': created_backups,
@@ -1178,6 +1263,24 @@ def create_api_resources(api, models, managers):
                 restore_msg = "Settings and certificates restored atomically"
 
                 if success:
+                    if audit_logger:
+                        user = getattr(request, 'current_user', None) or {}
+                        # Restore wholesale-replaces settings + certificates;
+                        # the audit entry must surface both source filename
+                        # and the pre-restore backup (if one was created) so
+                        # an admin can roll back via the audit trail alone.
+                        audit_logger.log_operation(
+                            operation='restore',
+                            resource_type='backup',
+                            resource_id=filename,
+                            status='success',
+                            details={
+                                'backup_type': 'unified',
+                                'pre_restore_backup': pre_restore_backup,
+                            },
+                            user=user.get('username'),
+                            ip_address=request.remote_addr,
+                        )
                     response = {
                         'message': f'{restore_msg} successfully from {filename}',
                         'restored_from': filename,
@@ -1231,6 +1334,17 @@ def create_api_resources(api, models, managers):
                 backup_path.unlink()
 
                 logger.info(f"Backup deleted: {backup_type}/{filename}")
+                if audit_logger:
+                    user = getattr(request, 'current_user', None) or {}
+                    audit_logger.log_operation(
+                        operation='delete',
+                        resource_type='backup',
+                        resource_id=filename,
+                        status='success',
+                        details={'backup_type': backup_type},
+                        user=user.get('username'),
+                        ip_address=request.remote_addr,
+                    )
                 return {
                     'message': f'Backup {filename} deleted successfully',
                     'deleted_file': filename,

--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -35,11 +35,19 @@ class AuthManager:
         self._sessions = {}  # In-memory session store: {session_id: {user, expires, created}}
         self._session_lock = threading.Lock()  # Thread-safe session access
         self._hmac_key = None  # Set by set_hmac_key() after app init
+        self._audit_logger = None  # Set by set_audit_logger() after AuditLogger constructed
         import os
         _timeout_hours = int(os.getenv('SESSION_TIMEOUT_HOURS', '8'))
         self._session_timeout = max(1, _timeout_hours) * 60 * 60
         if not BCRYPT_AVAILABLE:
             logger.warning("bcrypt not available, falling back to SHA-256 (less secure)")
+
+    def set_audit_logger(self, audit_logger):
+        """Inject the AuditLogger so authorization denials emit a real audit
+        entry instead of a stderr-only warning. Optional — when unset, the
+        decorator falls back to logger.warning so role/scope denials are at
+        least surfaced in the application log."""
+        self._audit_logger = audit_logger
 
     def set_hmac_key(self, key):
         """Set the server-side secret used for HMAC-based API token hashing.
@@ -601,53 +609,81 @@ class AuthManager:
         """Check if any users exist"""
         return len(self._get_users()) > 0
     
+    def _authenticate_request(self):
+        """Resolve the caller's identity for the current Flask request.
+
+        Single source of truth for authentication. Both ``require_auth`` and
+        ``require_role`` delegate here instead of chaining decorators or
+        relying on cross-decorator side effects on ``request.current_user``
+        (the previous implementation called ``self.require_auth(lambda:
+        None)()`` to populate the request, then read the side-effect — an
+        architecture flagged as fragile by the 2026-05-12 API auth audit
+        finding F-1).
+
+        Returns:
+            (user_dict, None)            on success
+            (None, (error_dict, status)) on failure
+
+        Side effects: none. The caller is responsible for assigning
+        ``request.current_user`` once it knows the request is allowed to
+        proceed. That keeps the side effect localized to the decorator that
+        owns it, instead of leaking across two helpers.
+        """
+        try:
+            # Allow unauthenticated access during initial setup
+            # (matches require_web_auth: bypass if auth disabled OR no users)
+            if not self.is_local_auth_enabled() or not self.has_any_users():
+                return {'username': 'setup_user', 'role': 'admin'}, None
+
+            # Check for session-based auth first (for web UI)
+            session_id = request.cookies.get('certmate_session')
+            if session_id:
+                user_info = self.validate_session(session_id)
+                if user_info:
+                    return user_info, None
+
+            # Fall back to bearer token auth (for API)
+            auth_header = request.headers.get('Authorization')
+            if not auth_header:
+                return None, ({'error': 'Authorization header required',
+                               'code': 'AUTH_HEADER_MISSING'}, 401)
+
+            try:
+                scheme, token = auth_header.split(' ', 1)
+                if scheme.lower() != 'bearer':
+                    return None, ({'error': 'Invalid authorization scheme. Use Bearer token',
+                                   'code': 'INVALID_AUTH_SCHEME'}, 401)
+                if not token.strip():
+                    return None, ({'error': 'Invalid authorization header format. Use: Bearer <token>',
+                                   'code': 'INVALID_AUTH_FORMAT'}, 401)
+            except ValueError:
+                return None, ({'error': 'Invalid authorization header format. Use: Bearer <token>',
+                               'code': 'INVALID_AUTH_FORMAT'}, 401)
+
+            # Authenticate against legacy token and scoped API keys
+            user_info = self.authenticate_api_token(token)
+            if not user_info:
+                logger.warning(f"Invalid API token attempt from {request.remote_addr}")
+                return None, ({'error': 'Invalid or expired token',
+                               'code': 'INVALID_TOKEN'}, 401)
+
+            return user_info, None
+        except Exception as e:
+            logger.error(f"Authentication error: {e}")
+            return None, ({'error': 'Authentication failed',
+                           'code': 'AUTH_ERROR'}, 401)
+
     def require_auth(self, f):
-        """Enhanced decorator to require authentication (API token or session)"""
+        """Decorator: require authentication (API token or session)."""
         @wraps(f)
         def decorated_function(*args, **kwargs):
-            try:
-                # Allow unauthenticated access during initial setup
-                # (matches require_web_auth: bypass if auth disabled OR no users)
-                if not self.is_local_auth_enabled() or not self.has_any_users():
-                    request.current_user = {'username': 'setup_user', 'role': 'admin'}
-                    return f(*args, **kwargs)
-
-                # Check for session-based auth first (for web UI)
-                session_id = request.cookies.get('certmate_session')
-                if session_id:
-                    user_info = self.validate_session(session_id)
-                    if user_info:
-                        request.current_user = user_info
-                        return f(*args, **kwargs)
-                
-                # Fall back to bearer token auth (for API)
-                auth_header = request.headers.get('Authorization')
-                if not auth_header:
-                    return {'error': 'Authorization header required', 'code': 'AUTH_HEADER_MISSING'}, 401
-                
-                try:
-                    scheme, token = auth_header.split(' ', 1)
-                    if scheme.lower() != 'bearer':
-                        return {'error': 'Invalid authorization scheme. Use Bearer token', 'code': 'INVALID_AUTH_SCHEME'}, 401
-                    if not token.strip():
-                        return {'error': 'Invalid authorization header format. Use: Bearer <token>', 'code': 'INVALID_AUTH_FORMAT'}, 401
-                except ValueError:
-                    return {'error': 'Invalid authorization header format. Use: Bearer <token>', 'code': 'INVALID_AUTH_FORMAT'}, 401
-                
-                # Authenticate against legacy token and scoped API keys
-                user_info = self.authenticate_api_token(token)
-                if not user_info:
-                    logger.warning(f"Invalid API token attempt from {request.remote_addr}")
-                    return {'error': 'Invalid or expired token', 'code': 'INVALID_TOKEN'}, 401
-
-                request.current_user = user_info
-                return f(*args, **kwargs)
-            except Exception as e:
-                logger.error(f"Authentication error: {e}")
-                return {'error': 'Authentication failed', 'code': 'AUTH_ERROR'}, 401
-        
+            user, err = self._authenticate_request()
+            if err is not None:
+                return err
+            request.current_user = user
+            return f(*args, **kwargs)
         return decorated_function
-    
+
     def require_role(self, min_role):
         """Decorator factory requiring a minimum role level.
 
@@ -659,24 +695,67 @@ class AuthManager:
         def decorator(f):
             @wraps(f)
             def decorated_function(*args, **kwargs):
-                # Authenticate first (sets request.current_user)
-                auth_result = self.require_auth(lambda: None)()
-                if isinstance(auth_result, tuple) and len(auth_result) == 2:
-                    return auth_result  # Return auth error
+                user, err = self._authenticate_request()
+                if err is not None:
+                    return err
 
-                # Check role level
-                user = getattr(request, 'current_user', None)
-                if not user:
-                    return {'error': 'Authentication required', 'code': 'AUTH_REQUIRED'}, 401
+                # current_user is set here only after auth is known to
+                # have succeeded; downstream code that reads it can trust
+                # the value is fresh from this request, not a leftover.
+                request.current_user = user
 
                 user_level = ROLE_HIERARCHY.get(user.get('role'), -1)
                 required_level = ROLE_HIERARCHY.get(min_role, 999)
                 if user_level < required_level:
-                    return {'error': f'{min_role} privileges required', 'code': 'INSUFFICIENT_ROLE'}, 403
+                    # Audit + log every role denial so privilege-enumeration
+                    # attempts surface in the audit trail instead of vanishing
+                    # behind a silent 403 (2026-05-12 API auth audit, F-2).
+                    self._log_rbac_denial(
+                        user=user,
+                        required_role=min_role,
+                        endpoint=request.path,
+                    )
+                    return {'error': f'{min_role} privileges required',
+                            'code': 'INSUFFICIENT_ROLE'}, 403
 
                 return f(*args, **kwargs)
             return decorated_function
         return decorator
+
+    def _log_rbac_denial(self, user, required_role, endpoint):
+        """Record an RBAC role-level denial.
+
+        Always emits a structured warning on the application logger so the
+        signal is present even when no AuditLogger is wired. When one IS
+        wired (the production path), also writes a tamper-evident audit
+        entry via log_authz_denied so the denial sits in the same log
+        admins already scan.
+        """
+        username = (user or {}).get('username')
+        actual_role = (user or {}).get('role')
+        try:
+            from flask import request as _request
+            ip = _request.remote_addr
+        except Exception:
+            ip = None
+
+        logger.warning(
+            "RBAC denial: user=%s role=%s required=%s endpoint=%s ip=%s",
+            username, actual_role, required_role, endpoint, ip,
+        )
+
+        if self._audit_logger is not None:
+            try:
+                self._audit_logger.log_authz_denied(
+                    operation='access',
+                    resource_type='endpoint',
+                    resource_id=endpoint,
+                    reason=f'role={actual_role} below required {required_role}',
+                    user=username,
+                    ip_address=ip,
+                )
+            except Exception as e:
+                logger.debug(f"Failed to write RBAC denial audit entry: {e}")
 
     def require_admin(self, f):
         """Decorator to require admin role (backward compat wrapper)."""

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -395,6 +395,9 @@ def initialize_managers(container: AppContainer, app):
 
     audit_dir = container.logs_dir / "audit"
     audit_logger = AuditLogger(audit_dir)
+    # Let AuthManager emit RBAC + scope denials through the same audit
+    # surface the rest of the app uses (2026-05-12 API auth audit, F-2).
+    auth_manager.set_audit_logger(audit_logger)
 
     rate_limit_config = RateLimitConfig()
     rate_limiter = SimpleRateLimiter(rate_limit_config)

--- a/modules/web/misc_routes.py
+++ b/modules/web/misc_routes.py
@@ -151,6 +151,22 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
                 return s
 
             settings_manager.update(_mutator)
+            audit_logger = managers.get('audit')
+            if audit_logger:
+                actor = getattr(request, 'current_user', {}) or {}
+                # Channel credentials (Slack/Discord webhook URLs, SMTP
+                # passwords) ride inside `data`; record only the set of
+                # configured channels, not their secrets.
+                channels = sorted(k for k in data.keys() if isinstance(data.get(k), dict))
+                audit_logger.log_operation(
+                    operation='update',
+                    resource_type='notifications_config',
+                    resource_id='notifications',
+                    status='success',
+                    details={'channels_present': channels},
+                    user=actor.get('username'),
+                    ip_address=request.remote_addr,
+                )
             return jsonify({'message': 'Notification settings saved'})
         except Exception as e:
             logger.error(f"Failed to save notifications config: {e}")

--- a/modules/web/settings_routes.py
+++ b/modules/web/settings_routes.py
@@ -410,6 +410,19 @@ def register_settings_routes(app, managers, require_web_auth, auth_manager,
             data = request.json or {}
             domain = data.get('domain', 'test.example.com')
             result = deploy_manager.test_hook(hook_id, domain=domain)
+            if audit_logger:
+                actor = getattr(request, 'current_user', {}) or {}
+                # We audit the *attempt* (success or failure of the dry-run)
+                # because the test path executes the hook command end-to-end
+                # against a test domain — admins need a trail of who poked
+                # what, even on a successful no-op test.
+                audit_logger.log_deploy_hook_changed(
+                    scope=domain,
+                    hook_id=hook_id,
+                    operation='test',
+                    user=actor.get('username'),
+                    ip_address=request.remote_addr,
+                )
             if 'error' in result:
                 return jsonify(result), 404
             return jsonify(result)

--- a/tests/test_sprint1_5_audit_followup.py
+++ b/tests/test_sprint1_5_audit_followup.py
@@ -1,0 +1,410 @@
+"""Sprint 1.5 (security audit follow-up) — pure unit tests.
+
+Covers:
+- AuthManager._authenticate_request returns (user, None) on success and
+  (None, error) on failure, without touching request.current_user as a
+  side effect (audit F-1 refactor).
+- AuthManager._log_rbac_denial both emits an application log warning and
+  writes audit_logger.log_authz_denied when audit_logger is wired
+  (audit F-2).
+- AuthManager.set_audit_logger plumbs the logger through correctly.
+
+The download-endpoint role split (viewer cannot pull privkey material) is
+exercised end-to-end and lives in a separate Flask test client class.
+
+No Docker; runs in-process.
+"""
+
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from flask import Flask, request
+from flask_restx import Api, Namespace
+
+from modules.core.auth import AuthManager, ROLE_HIERARCHY
+from modules.api.models import create_api_models
+from modules.api.resources import create_api_resources
+import modules.api.resources as api_resources_module
+
+
+# --- _authenticate_request (F-1 refactor) -----------------------------------
+
+@pytest.fixture
+def base_settings():
+    return {
+        'local_auth_enabled': False,
+        'users': {},
+        'api_keys': {},
+        'api_bearer_token': 'legacy_test_token_abc123',
+    }
+
+
+@pytest.fixture
+def auth(base_settings):
+    sm = MagicMock()
+    sm.load_settings.side_effect = lambda: base_settings
+    sm.save_settings.side_effect = lambda s, reason=None: True
+
+    def _update(mutator, reason=None):
+        s = sm.load_settings()
+        mutator(s)
+        return sm.save_settings(s, reason)
+    sm.update.side_effect = _update
+    return AuthManager(sm)
+
+
+@pytest.fixture
+def flask_app():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    return app
+
+
+class TestAuthenticateRequestBypassMode:
+    """When local_auth is off and no users exist, every request is admin."""
+
+    def test_returns_setup_admin_no_error(self, auth, flask_app):
+        with flask_app.test_request_context('/some/path'):
+            user, err = auth._authenticate_request()
+        assert err is None
+        assert user == {'username': 'setup_user', 'role': 'admin'}
+
+    def test_does_not_touch_request_current_user(self, auth, flask_app):
+        # The whole point of F-1: side effects must not leak from the
+        # authentication helper. The caller (decorator) owns the
+        # request.current_user assignment.
+        with flask_app.test_request_context('/some/path'):
+            user, err = auth._authenticate_request()
+            assert not hasattr(request, 'current_user')
+        assert user is not None
+
+
+class TestAuthenticateRequestBearerToken:
+    """With local_auth on + users present, bearer token is required."""
+
+    def test_missing_header_returns_401(self, auth, base_settings, flask_app):
+        base_settings['local_auth_enabled'] = True
+        base_settings['users'] = {'admin': {'password_hash': 'x', 'role': 'admin', 'enabled': True}}
+        with flask_app.test_request_context('/api/x'):
+            user, err = auth._authenticate_request()
+        assert user is None
+        body, status = err
+        assert status == 401
+        assert body['code'] == 'AUTH_HEADER_MISSING'
+
+    def test_wrong_scheme_returns_401(self, auth, base_settings, flask_app):
+        base_settings['local_auth_enabled'] = True
+        base_settings['users'] = {'admin': {'password_hash': 'x', 'role': 'admin', 'enabled': True}}
+        with flask_app.test_request_context('/api/x', headers={'Authorization': 'Basic abc'}):
+            user, err = auth._authenticate_request()
+        body, status = err
+        assert status == 401
+        assert body['code'] == 'INVALID_AUTH_SCHEME'
+
+    def test_invalid_token_returns_401(self, auth, base_settings, flask_app):
+        base_settings['local_auth_enabled'] = True
+        base_settings['users'] = {'admin': {'password_hash': 'x', 'role': 'admin', 'enabled': True}}
+        with flask_app.test_request_context('/api/x', headers={'Authorization': 'Bearer wrong'}):
+            user, err = auth._authenticate_request()
+        body, status = err
+        assert status == 401
+        assert body['code'] == 'INVALID_TOKEN'
+
+    def test_legacy_token_returns_admin(self, auth, base_settings, flask_app):
+        base_settings['local_auth_enabled'] = True
+        base_settings['users'] = {'admin': {'password_hash': 'x', 'role': 'admin', 'enabled': True}}
+        with flask_app.test_request_context('/api/x',
+                                            headers={'Authorization': 'Bearer legacy_test_token_abc123'}):
+            user, err = auth._authenticate_request()
+        assert err is None
+        assert user['role'] == 'admin'
+
+    def test_scoped_key_propagates_allowed_domains(self, auth, base_settings, flask_app):
+        base_settings['local_auth_enabled'] = True
+        base_settings['users'] = {'admin': {'password_hash': 'x', 'role': 'admin', 'enabled': True}}
+        # Create a scoped key through the manager (will go via mocked update).
+        ok, created = auth.create_api_key('ci', role='operator',
+                                          allowed_domains=['*.ci.example.com'])
+        assert ok
+        token = created['token']
+        with flask_app.test_request_context('/api/x',
+                                            headers={'Authorization': f'Bearer {token}'}):
+            user, err = auth._authenticate_request()
+        assert err is None
+        assert user['role'] == 'operator'
+        assert user['allowed_domains'] == ['*.ci.example.com']
+
+
+class TestRequireRoleDelegation:
+    """The decorators are now thin wrappers over _authenticate_request."""
+
+    def test_require_auth_assigns_current_user_on_success(self, auth, flask_app):
+        @auth.require_auth
+        def view():
+            return {'user': request.current_user['username']}, 200
+
+        with flask_app.test_request_context('/api/x'):
+            response = view()
+        assert response == ({'user': 'setup_user'}, 200)
+
+    def test_require_role_assigns_current_user_only_after_success(self, auth, flask_app):
+        # In bypass mode role=admin so this should pass.
+        @auth.require_role('admin')
+        def view():
+            return {'ok': True, 'role': request.current_user['role']}, 200
+
+        with flask_app.test_request_context('/api/x'):
+            response = view()
+        assert response == ({'ok': True, 'role': 'admin'}, 200)
+
+    def test_require_role_returns_403_for_insufficient_role(self, auth, base_settings, flask_app):
+        # Set up: local auth on, scoped viewer key.
+        base_settings['local_auth_enabled'] = True
+        base_settings['users'] = {'admin': {'password_hash': 'x', 'role': 'admin', 'enabled': True}}
+        ok, created = auth.create_api_key('readonly', role='viewer')
+        token = created['token']
+
+        @auth.require_role('admin')
+        def view():
+            return {'ok': True}, 200
+
+        with flask_app.test_request_context('/api/x',
+                                            headers={'Authorization': f'Bearer {token}'}):
+            response = view()
+        body, status = response
+        assert status == 403
+        assert body['code'] == 'INSUFFICIENT_ROLE'
+
+
+# --- RBAC denial audit emission (F-2) ---------------------------------------
+
+class TestRbacDenialAudit:
+    def test_audit_log_authz_denied_emitted_when_wired(self, auth, base_settings, flask_app):
+        # Enable local auth + create a viewer key + wire audit logger.
+        base_settings['local_auth_enabled'] = True
+        base_settings['users'] = {'admin': {'password_hash': 'x', 'role': 'admin', 'enabled': True}}
+        ok, created = auth.create_api_key('readonly', role='viewer')
+        token = created['token']
+        audit_logger = MagicMock()
+        auth.set_audit_logger(audit_logger)
+
+        @auth.require_role('admin')
+        def view():
+            return {'ok': True}, 200
+
+        with flask_app.test_request_context('/api/admin/thing',
+                                            headers={'Authorization': f'Bearer {token}'}):
+            response = view()
+
+        assert response[1] == 403
+        audit_logger.log_authz_denied.assert_called_once()
+        kwargs = audit_logger.log_authz_denied.call_args.kwargs
+        assert kwargs['operation'] == 'access'
+        assert kwargs['resource_type'] == 'endpoint'
+        assert kwargs['resource_id'] == '/api/admin/thing'
+        assert 'role=viewer' in kwargs['reason']
+        assert 'required admin' in kwargs['reason']
+        assert kwargs['user'] == 'api_key:readonly'
+
+    def test_no_crash_when_audit_logger_not_wired(self, auth, base_settings, flask_app):
+        # The default state (audit not wired) must still log a warning
+        # and emit a clean 403 — never raise.
+        base_settings['local_auth_enabled'] = True
+        base_settings['users'] = {'admin': {'password_hash': 'x', 'role': 'admin', 'enabled': True}}
+        ok, created = auth.create_api_key('readonly', role='viewer')
+        token = created['token']
+
+        @auth.require_role('admin')
+        def view():
+            return {'ok': True}, 200
+
+        with flask_app.test_request_context('/api/x',
+                                            headers={'Authorization': f'Bearer {token}'}):
+            response = view()
+        assert response[1] == 403
+
+
+# --- PRIVKEY-DOWNLOAD: split role per-file ----------------------------------
+
+def _passthrough_decorator(_min_role):
+    def deco(fn):
+        return fn
+    return deco
+
+
+@pytest.fixture
+def cert_dir(tmp_path):
+    d = tmp_path / 'example.com'
+    d.mkdir()
+    (d / 'cert.pem').write_text('PUBLIC-cert')
+    (d / 'chain.pem').write_text('PUBLIC-chain')
+    (d / 'fullchain.pem').write_text('PUBLIC-fullchain')
+    (d / 'privkey.pem').write_text('PRIVATE-key')
+    return tmp_path
+
+
+@pytest.fixture
+def download_app(cert_dir, monkeypatch):
+    # We bypass require_role to test the per-file gate independently of
+    # the decorator. The role check the handler performs comes from
+    # request.current_user, which we set via a before_request hook
+    # below per test case.
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_decorator)
+    # user_can_access_domain returns True (no scope filtering in this test)
+    auth_manager.user_can_access_domain.return_value = True
+    auth_manager.domain_matches_scope.return_value = True
+
+    file_ops = MagicMock(cert_dir=Path(cert_dir))
+    settings_manager = MagicMock()
+    settings_manager.load_settings.return_value = {}
+    certificate_manager = MagicMock(cert_dir=Path(cert_dir))
+    cache_manager = MagicMock()
+    dns_manager = MagicMock()
+    audit_logger = MagicMock()
+
+    managers = {
+        'auth': auth_manager,
+        'settings': settings_manager,
+        'certificates': certificate_manager,
+        'file_ops': file_ops,
+        'cache': cache_manager,
+        'dns': dns_manager,
+        'audit': audit_logger,
+    }
+
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    api = Api(app, prefix='/api')
+    models = create_api_models(api)
+    resources = create_api_resources(api, models, managers)
+
+    ns = Namespace('certificates', description='certs')
+    api.add_namespace(ns)
+    ns.add_resource(resources['DownloadCertificate'], '/<string:domain>/download')
+
+    return app, managers
+
+
+def _attach_user(app, role):
+    """Before-request hook that sets request.current_user to a fake of
+    the given role. Equivalent to a successful auth path."""
+    @app.before_request
+    def _set_user():
+        from flask import g, request as _r
+        _r.current_user = {'username': f'fake_{role}', 'role': role,
+                           'allowed_domains': None}
+
+
+class TestDownloadRoleSplit:
+    """Viewer can pull public material; private-key material requires operator."""
+
+    def test_viewer_can_pull_public_fullchain(self, download_app):
+        app, _ = download_app
+        _attach_user(app, 'viewer')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download?file=fullchain.pem')
+        assert r.status_code == 200
+        assert b'PUBLIC-fullchain' in r.data
+
+    def test_viewer_can_pull_public_cert(self, download_app):
+        app, _ = download_app
+        _attach_user(app, 'viewer')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download?file=cert.pem')
+        assert r.status_code == 200
+        assert b'PUBLIC-cert' in r.data
+
+    def test_viewer_can_pull_public_chain(self, download_app):
+        app, _ = download_app
+        _attach_user(app, 'viewer')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download?file=chain.pem')
+        assert r.status_code == 200
+        assert b'PUBLIC-chain' in r.data
+
+    def test_viewer_cannot_pull_privkey(self, download_app):
+        app, managers = download_app
+        _attach_user(app, 'viewer')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download?file=privkey.pem')
+        assert r.status_code == 403
+        body = r.get_json()
+        assert body['code'] == 'PRIVKEY_REQUIRES_OPERATOR'
+        # And the denial is audited.
+        managers['audit'].log_authz_denied.assert_called()
+
+    def test_viewer_cannot_pull_combined_pem(self, download_app):
+        app, _ = download_app
+        _attach_user(app, 'viewer')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download?file=combined.pem')
+        assert r.status_code == 403
+        assert r.get_json()['code'] == 'PRIVKEY_REQUIRES_OPERATOR'
+
+    def test_viewer_cannot_pull_format_json(self, download_app):
+        # format=json bundles the private key inline; must be operator+.
+        app, _ = download_app
+        _attach_user(app, 'viewer')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download?format=json')
+        assert r.status_code == 403
+        assert r.get_json()['code'] == 'PRIVKEY_REQUIRES_OPERATOR'
+
+    def test_viewer_cannot_pull_default_zip(self, download_app):
+        # The default ZIP includes privkey.pem; viewer must opt out.
+        app, _ = download_app
+        _attach_user(app, 'viewer')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download')
+        assert r.status_code == 403
+        assert r.get_json()['code'] == 'PRIVKEY_REQUIRES_OPERATOR'
+
+    def test_viewer_can_pull_public_zip_via_include_private_0(self, download_app):
+        # The new opt-out path keeps the ZIP UX for monitoring callers.
+        app, _ = download_app
+        _attach_user(app, 'viewer')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download?include_private=0')
+        assert r.status_code == 200
+        # Disposition should reflect the public-only suffix.
+        assert 'certificates_public.zip' in r.headers.get('Content-Disposition', '')
+        # And the ZIP must not contain privkey.pem.
+        import zipfile
+        import io as _io
+        with zipfile.ZipFile(_io.BytesIO(r.data)) as zf:
+            names = set(zf.namelist())
+        assert 'privkey.pem' not in names
+        assert 'fullchain.pem' in names
+
+    def test_operator_can_pull_privkey(self, download_app):
+        app, _ = download_app
+        _attach_user(app, 'operator')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download?file=privkey.pem')
+        assert r.status_code == 200
+        assert b'PRIVATE-key' in r.data
+
+    def test_operator_can_pull_format_json(self, download_app):
+        app, _ = download_app
+        _attach_user(app, 'operator')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download?format=json')
+        assert r.status_code == 200
+        payload = r.get_json()
+        assert payload['private_key_pem'] == 'PRIVATE-key'
+        assert payload['fullchain_pem'] == 'PUBLIC-fullchain'
+
+    def test_operator_can_pull_default_zip(self, download_app):
+        app, _ = download_app
+        _attach_user(app, 'operator')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download')
+        assert r.status_code == 200
+        import zipfile
+        import io as _io
+        with zipfile.ZipFile(_io.BytesIO(r.data)) as zf:
+            names = set(zf.namelist())
+        assert 'privkey.pem' in names


### PR DESCRIPTION
## Summary

Follow-up to the [2026-05-12 draconian API auth audit](https://github.com/fabriziosalmi/certmate/releases/tag/v2.4.12) and the coverage matrix it produced. Four atomic commits, 23 new unit tests (112 pass total, 0 regressions), no breaking changes for the happy path.

Picks up everything the audit rated MEDIUM that was actionable in one sprint:
- F-1 (architecture): `require_role` no longer leans on a cross-decorator side effect.
- F-2 (observability): RBAC role denials are audit-logged with the same surface that already covered domain-scope denials in v2.4.12.
- One MEDIUM finding the audit weighted as ⚠️ but escalated here: viewer role could pull the private key from `/api/certificates/<d>/download` via four code paths. Now per-file role-gated.
- Four mutating endpoints flagged in the audit's coverage matrix as missing audit-log entries: cert DELETE, backup create / restore / delete, deploy hook test, notifications config update.

Out of scope for this PR (deferred to Sprint 2):
- F-3 (legacy bearer token deprecation flag + UI warning + dedicated rotation endpoint) — structural feature, needs design.
- F-4 (UI warning when `allowed_domains` left empty on key creation) — UX nudge.
- F-5 (in-memory sessions) — accepted trade-off; not a fix target.
- F-6 (self-host ReDoc bundle) — INFO; air-gapped polish.
- F-7 (per-username login rate limit) — INFO; complements existing per-IP limit.

## Changes

### `refactor(authz): drop require_role side-effect dependency + audit RBAC denials`

**F-1 (MEDIUM, fragility).** `require_role` previously called `self.require_auth(lambda: None)()` and then read `request.current_user` back as a side effect. Any middleware that cleared `current_user` between the lambda call and the role-check line would silently downgrade the call to None. Not exploitable today; fragile as a foundation. The new `AuthManager._authenticate_request()` is the single source of truth — it evaluates bypass mode -> session cookie -> bearer token in order and returns `(user, None)` on success or `(None, (error_dict, status))` on failure, **without** touching `request.current_user`. Both decorators are now thin wrappers that call it, assign `request.current_user` exactly when they know the request is allowed to proceed, and dispatch.

**F-2 (MEDIUM, observability).** Domain-scope denials already audited via `log_authz_denied` since v2.4.12; role-level denials did not. `AuthManager` gains `set_audit_logger(audit_logger)` (wired in `factory.py`) and `_log_rbac_denial(user, required_role, endpoint)`. The helper always emits a structured `logger.warning` so the signal is present even when no AuditLogger is wired; when one is wired (the production path), it also writes `log_authz_denied` with `operation='access'`, `resource_type='endpoint'`, `resource_id=request.path`, `reason='role=X below required Y'`.

### `fix(api): split certificate download role + close audit gaps`

**Privkey download (escalated MEDIUM).** `DownloadCertificate.get` required only `viewer`. Four code paths returned private-key material: `?format=json`, `?file=privkey.pem`, `?file=combined.pem`, default ZIP. A scoped viewer key could pull the private key for every cert in its scope — information disclosure surface. The audit rated this ⚠️/INFO; treating it as MEDIUM here since viewer is meant for read-only monitoring, not key material exfiltration.

The decorator stays `viewer` (so the authn check fires) and the handler gates per file:

| Path | Allowed roles |
|---|---|
| `?file=cert.pem`, `?file=chain.pem`, `?file=fullchain.pem` | viewer, operator, admin |
| `?include_private=0` (public-only ZIP) | viewer, operator, admin |
| `?file=privkey.pem`, `?file=combined.pem`, `?format=json`, default ZIP / `?include_private=1` | operator, admin |

Denied calls return `403 PRIVKEY_REQUIRES_OPERATOR` with a `hint` field pointing at the viewer-safe variants, and write `audit_logger.log_authz_denied`. The public-only ZIP gets the suffix `_certificates_public.zip` so triage by filename is unambiguous. `cert.pem` and `chain.pem` are now legal single-file `?file=` values (they were never reachable before; only `fullchain.pem` was on the viewer side).

**Audit matrix gaps.** Four mutating endpoints landed in v2.4.12 without audit wiring; each now emits `audit_logger.log_*` on success:

- `DELETE /api/certificates/<d>` — `log_operation(operation='delete', resource_type='certificate', resource_id=<domain>)`
- `POST /api/backups/create` — `log_operation(operation='create', resource_type='backup', resource_id=<filename>, details={type, reason})`
- `POST /api/backups/restore` — `log_operation(operation='restore', resource_type='backup', resource_id=<filename>, details={backup_type, pre_restore_backup})` — the heaviest of the four since it wholesale-replaces settings + certificates; the audit entry now surfaces both the source filename and the pre-restore backup so an admin can roll back via the audit trail alone.
- `DELETE /api/backups/delete` — `log_operation(operation='delete', resource_type='backup', resource_id=<filename>)`

### `audit: wire log_* on /api/deploy/test/<id> + /api/notifications/config`

Closes the remaining two coverage-matrix gaps. Both endpoints are admin-only but their mutations were silent.

- `POST /api/deploy/test/<id>` — records each hook dry-run via `log_deploy_hook_changed(operation='test', scope=<domain>, hook_id=<id>)`. The dry-run executes the hook command end-to-end against a test domain, so the trail must cover both successful and failed dry-runs. The hook command itself is never logged (consistent with the existing `log_deploy_hook_changed` semantics — log-injection + secret-leak risk).
- `POST /api/notifications/config` — records updates via `log_operation(operation='update', resource_type='notifications_config')`. Channel-level config carries credentials inline (Slack/Discord webhook URLs, SMTP passwords); the `details` field records only the sorted list of channel keys present, never their secrets.

### `test: 23 unit tests for Sprint 1.5 audit follow-up`

`tests/test_sprint1_5_audit_followup.py`, 0.35s in-process runtime, no Docker.

- `TestAuthenticateRequestBypassMode` (2) — bypass returns setup_user without side-effecting `request.current_user`.
- `TestAuthenticateRequestBearerToken` (5) — missing header, wrong scheme, invalid token, legacy token, scoped key allowed_domains propagation.
- `TestRequireRoleDelegation` (3) — both decorators set `current_user` only on success, 403 INSUFFICIENT_ROLE under-roled callers.
- `TestRbacDenialAudit` (2) — `log_authz_denied` emitted with the right fields when wired; no crash when not wired.
- `TestDownloadRoleSplit` (11) — viewer can pull cert/chain/fullchain + public-only ZIP; viewer cannot pull privkey/combined/format=json/default ZIP (403 + audit denial); operator can pull all of them.

## Backward compatibility

- The split download endpoint keeps every previous URL working for operator+ callers — only viewers see new 403s on the four private-key paths. The new `?include_private=0` parameter and `cert.pem` / `chain.pem` single-file paths are additive.
- No change to legacy `api_bearer_token` semantics. F-3 (deprecation flag) is deferred.
- No change to scoped API key creation or matching. F-4 (UI nudge for empty scope) is deferred.
- The `_authenticate_request` refactor is internal to AuthManager; the decorator API surface (`@auth_manager.require_auth`, `@auth_manager.require_role`) is unchanged.
- `set_audit_logger` is optional — when unset, role denials still surface in `logger.warning` so behavior in tests / minimal setups is unchanged.

## Test plan

Unit (in-process, no Docker, 0.83s total):

- [x] `tests/test_sprint1_5_audit_followup.py` — 23 new tests
- [x] `tests/test_sprint1_security.py` + `tests/test_apikeys.py` + `tests/test_settings_atomic_update.py` + `tests/test_audit.py` + `tests/test_factory_logging.py` — 89 pre-existing tests, no regressions

Manual smoke (Docker on `localhost:8000`):

- [ ] Create a scoped viewer API key; `curl -H "Bearer <token>" '/api/certificates/<d>/download?file=privkey.pem'` returns 403 `PRIVKEY_REQUIRES_OPERATOR`; the same call with `?file=fullchain.pem` returns 200; `?include_private=0` returns a ZIP without `privkey.pem`
- [ ] Create a scoped viewer key; `curl -H "Bearer <token>" /api/users` returns 403 `INSUFFICIENT_ROLE`; `data/audit/certificate_audit.log` records the denial with `operation=access`, `resource_type=endpoint`, `reason=role=viewer below required admin`
- [ ] `DELETE /api/certificates/<d>` records `operation=delete, resource_type=certificate`; backup create / restore / delete each record their op; `POST /api/deploy/test/<id>` records `operation=test, resource_type=deploy_hook`; `POST /api/notifications/config` records the sorted channel list without secrets