### PR TITLE
fix(api): align /api/deploy/history with bare-list convention (#152)

### DIFF
--- a/modules/web/settings_routes.py
+++ b/modules/web/settings_routes.py
@@ -448,7 +448,15 @@ def register_settings_routes(app, managers, require_web_auth, auth_manager,
     @app.route('/api/deploy/history', methods=['GET'])
     @auth_manager_ref.require_role('admin')
     def api_deploy_history():
-        """Get deploy hook execution history"""
+        """Get deploy hook execution history.
+
+        Returns a bare list ``[...]`` — matches the sibling event-log
+        endpoint ``/api/webhooks/deliveries`` (modules/web/misc_routes.py)
+        and the convention the UI (``static/js/settings-deploy.js``,
+        ``static/js/settings-notifications.js``) was originally written
+        against. The error path keeps the ``{"error": ...}`` envelope so
+        the frontend's catch branch can surface a real reason.
+        """
         if not deploy_manager:
             return jsonify({'error': 'Deploy manager not available'}), 503
 
@@ -456,7 +464,7 @@ def register_settings_routes(app, managers, require_web_auth, auth_manager,
             limit = min(int(request.args.get('limit', 50)), 200)
             domain = request.args.get('domain')
             history = deploy_manager.get_history(limit=limit, domain=domain)
-            return jsonify({'history': history})
+            return jsonify(history)
         except Exception as e:
             logger.error(f"Failed to get deploy history: {e}")
             return jsonify({'error': 'Failed to get deploy history'}), 500

--- a/tests/test_issue152_deploy_history.py
+++ b/tests/test_issue152_deploy_history.py
@@ -1,0 +1,142 @@
+"""Contract test for issue #152 — align ``GET /api/deploy/history`` with
+the bare-list convention already used by ``GET /api/webhooks/deliveries``
+(``modules/web/misc_routes.py``).
+
+The two endpoints serve the same role for their respective UI panels
+(Settings → Deploy → "Recent Executions" and Settings → Notifications →
+"Recent Deliveries"), yet they returned different shapes: the deliveries
+endpoint returned a bare list, the deploy history endpoint wrapped it in
+``{"history": [...]}``. The original frontend was written to the bare-list
+convention; the v2.4.12 hotfix made it accept both shapes defensively
+(see ``static/js/settings-deploy.js``) so flipping the backend to a bare
+list is a no-op for the UI but removes the asymmetry the maintainer
+flagged in pull/142#issuecomment-4430183618.
+
+These four cases pin the post-#152 contract so a future maintainer
+doesn't "tidy" the bare list back into an envelope and silently
+re-introduce the divergence.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from modules.web.settings_routes import register_settings_routes
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def _passthrough_decorator(_min_role):
+    """Stand in for ``auth_manager.require_role(...)`` so the view runs
+    without a real session."""
+    def deco(fn):
+        return fn
+    return deco
+
+
+def _build_app(history_entries):
+    app = Flask(__name__)
+    app.secret_key = 'test'
+
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_decorator)
+
+    deploy_manager = MagicMock()
+    deploy_manager.get_history.return_value = history_entries
+
+    register_settings_routes(
+        app,
+        managers={'deployer': deploy_manager},
+        require_web_auth=lambda f: f,
+        auth_manager=auth_manager,
+        settings_manager=MagicMock(),
+        dns_manager=MagicMock(),
+    )
+    return app, deploy_manager
+
+
+def test_deploy_history_returns_bare_array():
+    """Happy path: the response body is the list itself, in the order
+    ``deploy_manager.get_history`` returned it. Matches the shape
+    ``/api/webhooks/deliveries`` already uses and the bare-list predicate
+    in ``static/js/settings-notifications.js`` (``Array.isArray(data)``).
+    """
+    entries = [
+        {'domain': 'a.example.com', 'hook_id': 'k8s', 'status': 'ok',
+         'timestamp': '2026-05-10T10:00:00Z'},
+        {'domain': 'b.example.com', 'hook_id': 'k8s', 'status': 'failed',
+         'timestamp': '2026-05-09T09:00:00Z'},
+    ]
+    app, _ = _build_app(entries)
+    client = app.test_client()
+
+    r = client.get('/api/deploy/history')
+    assert r.status_code == 200
+    body = r.get_json()
+    assert isinstance(body, list)
+    assert body == entries
+
+
+def test_deploy_history_empty_returns_empty_array_not_envelope():
+    """First-run / no-deploys case. The body must be ``[]`` — not
+    ``{"history": []}``. Locks the contract against an accidental
+    re-wrap; the empty case was historically the most visible symptom
+    when the wrap was in place (#137).
+    """
+    app, _ = _build_app([])
+    client = app.test_client()
+
+    r = client.get('/api/deploy/history')
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body == []
+    assert not isinstance(body, dict)
+
+
+def test_deploy_history_forwards_limit_and_domain_filters():
+    """Shape change must not regress the query-string contract. The
+    endpoint still parses ``?limit=N`` (capped at 200) and ``?domain=...``
+    and forwards them verbatim to ``DeployManager.get_history``.
+    """
+    app, deploy_manager = _build_app([])
+    client = app.test_client()
+
+    client.get('/api/deploy/history?limit=10&domain=foo.example.com')
+    deploy_manager.get_history.assert_called_with(
+        limit=10, domain='foo.example.com'
+    )
+
+    # Cap at 200 even if the caller asks for more.
+    deploy_manager.get_history.reset_mock()
+    client.get('/api/deploy/history?limit=10000')
+    deploy_manager.get_history.assert_called_with(limit=200, domain=None)
+
+
+def test_deploy_history_503_when_deploy_manager_missing():
+    """Error path keeps the ``{"error": "..."}`` envelope. The success
+    contract switched to a bare list, but errors still need a key the
+    frontend's catch branch can read (``res.body.error``) instead of the
+    generic 'unexpected response' literal.
+    """
+    app = Flask(__name__)
+    app.secret_key = 'test'
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_decorator)
+
+    register_settings_routes(
+        app,
+        managers={},  # no 'deployer' key — deploy_manager will be None
+        require_web_auth=lambda f: f,
+        auth_manager=auth_manager,
+        settings_manager=MagicMock(),
+        dns_manager=MagicMock(),
+    )
+    client = app.test_client()
+
+    r = client.get('/api/deploy/history')
+    assert r.status_code == 503
+    body = r.get_json()
+    assert isinstance(body, dict)
+    assert 'error' in body


### PR DESCRIPTION
Closes #152. Follow-up to #137 / #142, per the maintainer's ask in [pull/142#issuecomment-4430183618](https://github.com/fabriziosalmi/certmate/pull/142#issuecomment-4430183618).

## Summary

`GET /api/deploy/history` returned `{"history": [...]}` while the sibling event-log endpoint `GET /api/webhooks/deliveries` (`modules/web/misc_routes.py`) already returned a bare `[...]`. The matching frontend `static/js/settings-notifications.js` reads its sibling with `Array.isArray(data)` directly — that's the established convention for delivery/history endpoints in this codebase. The deploy panel was originally written to it too; v2.4.12 added a dual-shape handler so the panel kept working while a backend flip was pending. This PR completes that flip.

One functional line of change:

```diff
-            return jsonify({'history': history})
+            return jsonify(history)
```

Plus a short docstring callout explaining *why* it's a bare list, so a future maintainer doesn't envelope it back and silently re-introduce the asymmetry.

## Backward compatibility

Safe. The v2.4.12 frontend handler (`static/js/settings-deploy.js:184-201`) is explicitly dual-shape:

```javascript
if (Array.isArray(res.body)) {
    entries = res.body;
} else if (Array.isArray(res.body.history)) {
    entries = res.body.history;
}
```

and its inline comment names this flip as the expected migration path. The error path keeps the `{"error": "..."}` envelope so the frontend's catch branch can still surface a real reason instead of the generic `'unexpected response'` literal.

## Tests

`tests/test_issue152_deploy_history.py` — four cases, all pass, pinning the post-#152 contract:

- `test_deploy_history_returns_bare_array` — populated history comes back as a list, entries in order.
- `test_deploy_history_empty_returns_empty_array_not_envelope` — empty history returns `[]`, not `{"history": []}` (the original visible symptom of #137).
- `test_deploy_history_forwards_limit_and_domain_filters` — `?limit=N` (capped at 200) and `?domain=...` are still parsed and forwarded to `DeployManager.get_history` verbatim. Shape change does not regress the query-string contract.
- `test_deploy_history_503_when_deploy_manager_missing` — error path keeps the `{"error": "..."}` envelope.

Existing `tests/test_deployer.py` (35 cases on `DeployManager.get_history` directly) still passes — the underlying function's return shape was always a list, only the HTTP envelope changed.

## Verification

- [x] `pytest tests/test_issue152_deploy_history.py tests/test_deployer.py -v` → 39/39 pass.
- [ ] Manual: Settings → Deploy → Recent Executions on a fresh install (empty history) renders the empty state, not the red error toast. With one or more deploy events, entries show newest-first.

## Non-goals

- No frontend change. The v2.4.12 dual-shape handler stays as-is (defensive, forward/backward compatible).
- No other endpoint touched. Strictly the `/api/deploy/history` alignment per #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)