### PR TITLE
fix: APScheduler app_context for background renewal jobs

### DIFF
--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -33,6 +33,11 @@ from modules.web import register_web_routes
 logger = get_certmate_logger('factory')
 request_logger = get_certmate_logger('request-watchdog')
 
+# APScheduler jobs run in background threads where Flask's thread-local
+# current_app proxy is unbound.  We keep a module-level reference so we
+# can explicitly push an app context inside those jobs.
+_flask_app = None
+
 
 class AppContainer:
     """DI Container holding all managers and application state"""
@@ -458,28 +463,53 @@ def initialize_managers(container: AppContainer, app):
     }
 
 
+def _run_manager_job(manager_key: str, method_name: str):
+    """Execute a manager method inside a Flask app context.
+
+    APScheduler jobs run in background threads where the thread-local
+    `current_app` proxy is unbound.  We keep a module-level reference to
+    the app instance so we can push an explicit app context before
+    touching any Flask-bound code.
+    """
+    if _flask_app is None:
+        logger.warning(
+            "Background job skipped: Flask app not yet initialised "
+            "(manager_key=%s, method=%s)",
+            manager_key,
+            method_name,
+        )
+        return
+    with _flask_app.app_context():
+        managers = _flask_app.config.get('MANAGERS')
+        manager = managers.get(manager_key) if managers else None
+        if manager is None:
+            logger.warning(
+                "Background job skipped: manager '%s' not found", manager_key
+            )
+            return
+        try:
+            getattr(manager, method_name)()
+        except Exception:
+            logger.exception(
+                "Background job failed: manager_key=%s, method=%s",
+                manager_key,
+                method_name,
+            )
+
+
 def _certificate_renewal_job():
     """Picklable wrapper for certificate renewal check"""
-    from flask import current_app
-    managers = current_app.config.get('MANAGERS')
-    if managers and 'certificates' in managers:
-        managers['certificates'].check_renewals()
+    _run_manager_job('certificates', 'check_renewals')
 
 
 def _client_certificate_renewal_job():
     """Picklable wrapper for client certificate renewal check"""
-    from flask import current_app
-    managers = current_app.config.get('MANAGERS')
-    if managers and 'client_certificates' in managers:
-        managers['client_certificates'].check_renewals()
+    _run_manager_job('client_certificates', 'check_renewals')
 
 
 def _weekly_digest_job():
     """Picklable wrapper for weekly digest"""
-    from flask import current_app
-    managers = current_app.config.get('MANAGERS')
-    if managers and 'digest' in managers:
-        managers['digest'].send()
+    _run_manager_job('digest', 'send')
 
 
 def setup_scheduler(container: AppContainer):
@@ -768,12 +798,17 @@ def create_app(test_config=None):
 
     configure_app(container, app, test_config)
     initialize_managers(container, app)
+    app.config['MANAGERS'] = container.managers
     setup_api(container, app)
     register_web_routes(app, container.managers)
     setup_csrf_protection(app)
     setup_security_headers(app)
     setup_rate_limiting(app, container)
     setup_slow_request_logging(app, container)
+
+    # Make the app instance available to background APScheduler jobs before
+    # starting the scheduler so recovered misfired jobs can push an app context.
+    _flask_app = app
     setup_scheduler(container)
 
     return app, container

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -473,10 +473,9 @@ def _run_manager_job(manager_key: str, method_name: str):
     """
     if _flask_app is None:
         logger.warning(
-            "Background job skipped: Flask app not yet initialised "
-            "(manager_key=%s, method=%s)",
-            manager_key,
-            method_name,
+            "Background job skipped: Flask app not yet initialised",
+            manager_key=manager_key,
+            method_name=method_name,
         )
         return
     from flask import current_app
@@ -485,16 +484,17 @@ def _run_manager_job(manager_key: str, method_name: str):
         manager = managers.get(manager_key) if managers else None
         if manager is None:
             logger.warning(
-                "Background job skipped: manager '%s' not found", manager_key
+                "Background job skipped: manager not found",
+                manager_key=manager_key,
             )
             return
         try:
             getattr(manager, method_name)()
         except Exception:
             logger.exception(
-                "Background job failed: manager_key=%s, method=%s",
-                manager_key,
-                method_name,
+                "Background job failed",
+                manager_key=manager_key,
+                method_name=method_name,
             )
 
 

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -479,8 +479,9 @@ def _run_manager_job(manager_key: str, method_name: str):
             method_name,
         )
         return
+    from flask import current_app
     with _flask_app.app_context():
-        managers = _flask_app.config.get('MANAGERS')
+        managers = current_app.config.get('MANAGERS')
         manager = managers.get(manager_key) if managers else None
         if manager is None:
             logger.warning(
@@ -514,6 +515,7 @@ def _weekly_digest_job():
 
 def setup_scheduler(container: AppContainer):
     """Set up APScheduler for background tasks with persistent store."""
+    assert _flask_app is not None, "setup_scheduler called before _flask_app was set"
     try:
         from sqlalchemy import create_engine, event as _sa_event
         _db_path = container.data_dir / 'scheduler_jobs.sqlite'
@@ -774,6 +776,7 @@ def setup_rate_limiting(app, container: AppContainer):
 
 def create_app(test_config=None):
     """Application Factory for CertMate"""
+    global _flask_app
     container = AppContainer()
     setup_directories(container, test_config)
 

--- a/tests/test_factory_scheduler.py
+++ b/tests/test_factory_scheduler.py
@@ -15,3 +15,33 @@ def test_create_app_populates_module_level_flask_app(monkeypatch, tmp_path):
     factory._flask_app = None
     app, _ = factory.create_app(test_config={'TESTING': True})
     assert factory._flask_app is app
+
+
+def test_run_manager_job_handles_uninitialised_app_without_crash():
+    """Branch with _flask_app == None must skip silently, not crash logger."""
+    factory._flask_app = None
+    # Should not raise
+    factory._run_manager_job('certificates', 'check_renewals')
+
+
+def test_run_manager_job_handles_missing_manager_without_crash(monkeypatch, tmp_path):
+    """Branch with manager missing from MANAGERS must skip silently."""
+    monkeypatch.setenv('DATA_DIR', str(tmp_path))
+    factory._flask_app = None
+    app, _ = factory.create_app(test_config={'TESTING': True})
+    app.config['MANAGERS'] = {}
+    # Should not raise
+    factory._run_manager_job('certificates', 'check_renewals')
+
+
+def test_run_manager_job_swallows_manager_exception_without_crash(monkeypatch, tmp_path):
+    """Branch with manager method raising must log, not propagate."""
+    class Boom:
+        def check_renewals(self): raise RuntimeError('simulated')
+
+    monkeypatch.setenv('DATA_DIR', str(tmp_path))
+    factory._flask_app = None
+    app, _ = factory.create_app(test_config={'TESTING': True})
+    app.config['MANAGERS'] = {'certificates': Boom()}
+    # Should not raise
+    factory._run_manager_job('certificates', 'check_renewals')

--- a/tests/test_factory_scheduler.py
+++ b/tests/test_factory_scheduler.py
@@ -1,0 +1,17 @@
+"""
+Regresión test: create_app debe asignar el módulo-level _flask_app
+antes de llamar setup_scheduler.  Sin esto, los jobs de background
+de APScheduler se saltan silenciosamente.
+"""
+import pytest
+
+from modules.core import factory
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_create_app_populates_module_level_flask_app(monkeypatch, tmp_path):
+    monkeypatch.setenv('DATA_DIR', str(tmp_path))
+    factory._flask_app = None
+    app, _ = factory.create_app(test_config={'TESTING': True})
+    assert factory._flask_app is app


### PR DESCRIPTION
## Summary

APScheduler background jobs run in worker threads where Flask's thread-local `current_app` proxy is unbound. Every renewal cycle, cron-triggered cleanup, and digest job that tried to access `current_app.config` failed with:

```
RuntimeError: Working outside of application context.
```

Symptoms in the wild were intermittent renewal failures that didn't reproduce from the UI.

## Fix

- Keeps a module-level `_flask_app` reference in `factory.py`
- Extracts a shared `_run_manager_job(manager_key, method_name)` helper that pushes `app.app_context()` before dispatching
- All three scheduler wrappers (`_certificate_renewal_job`, `_client_certificate_renewal_job`, `_weekly_digest_job`) delegate to the helper
- The helper includes defensive logging for edge cases (app not yet initialised, manager not found, unhandled exception)
- `create_app()` sets `_flask_app = app` before `setup_scheduler()` so recovered misfired jobs from the SQLite jobstore can push the context immediately

## Behaviour change

None. Existing installs see no change — if a job was already working without hitting `current_app`, the `app_context()` push is transparent.

## Files

- `modules/core/factory.py`

## Test plan

- [ ] `pytest tests/ -m unit -q` — all pass
- [ ] Restart scheduler with `RENEWAL_THRESHOLD_DAYS=999` so every cert is "due"; confirm no `RuntimeError` in logs