### PR TITLE
build: EXTRA_REQUIREMENTS build-arg + certbot-dns-azure baked in

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,10 @@ RUN apt-get update && \
     apt-get install -y -o Acquire::Retries=3 gcc && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy requirements first for better caching
-COPY requirements.txt requirements-minimal.txt ./
+# Copy every requirements*.txt so REQUIREMENTS_FILE and EXTRA_REQUIREMENTS
+# can point at any of the optional sets (storage backends, cloud DNS,
+# extended providers, …) without rebuilding the COPY layer for each one.
+COPY requirements*.txt ./
 
 # Create virtual environment and install dependencies
 RUN python -m venv /opt/venv
@@ -19,8 +21,17 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Install minimal requirements by default (fastest build)
 # Override with --build-arg REQUIREMENTS_FILE=requirements.txt for full install
 ARG REQUIREMENTS_FILE=requirements.txt
+# Optional second pip install for storage backends or extra DNS plugins.
+# Examples:
+#   --build-arg EXTRA_REQUIREMENTS=requirements-storage-all.txt
+#   --build-arg EXTRA_REQUIREMENTS=requirements-azure-storage.txt
+# Empty by default → no second install, layer cached.
+ARG EXTRA_REQUIREMENTS=
 RUN pip install -U pip setuptools wheel && \
-    pip install --no-cache-dir -r ${REQUIREMENTS_FILE}
+    pip install --no-cache-dir -r ${REQUIREMENTS_FILE} && \
+    if [ -n "${EXTRA_REQUIREMENTS}" ]; then \
+        pip install --no-cache-dir -r ${EXTRA_REQUIREMENTS}; \
+    fi
 
 # Production stage
 FROM python:3.12-slim-trixie

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,16 +21,25 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Install minimal requirements by default (fastest build)
 # Override with --build-arg REQUIREMENTS_FILE=requirements.txt for full install
 ARG REQUIREMENTS_FILE=requirements.txt
-# Optional second pip install for storage backends or extra DNS plugins.
-# Examples:
-#   --build-arg EXTRA_REQUIREMENTS=requirements-storage-all.txt
-#   --build-arg EXTRA_REQUIREMENTS=requirements-azure-storage.txt
+# Optional extra pip installs layered on top of the main requirements.
+# Accepts a SPACE-SEPARATED list so a single image can bundle e.g. the
+# Azure DNS plugin AND every remote storage backend at once. Quote the
+# value when invoking buildx so the shell preserves the spaces:
+#
+#   --build-arg EXTRA_REQUIREMENTS="requirements-azure.txt requirements-storage-all.txt"
+#   --build-arg EXTRA_REQUIREMENTS="requirements-aws.txt requirements-gcp.txt"
+#   --build-arg EXTRA_REQUIREMENTS=requirements-storage-all.txt   (single file)
+#
 # Empty by default → no second install, layer cached.
 ARG EXTRA_REQUIREMENTS=
+# shellcheck disable=SC2086 — intentional word-splitting to iterate the list.
 RUN pip install -U pip setuptools wheel && \
     pip install --no-cache-dir -r ${REQUIREMENTS_FILE} && \
     if [ -n "${EXTRA_REQUIREMENTS}" ]; then \
-        pip install --no-cache-dir -r ${EXTRA_REQUIREMENTS}; \
+        for req in ${EXTRA_REQUIREMENTS}; do \
+            echo "==> Installing extras from ${req}"; \
+            pip install --no-cache-dir -r "${req}"; \
+        done; \
     fi
 
 # Production stage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,13 @@ services:
       args:
         REQUIREMENTS_FILE: requirements.txt
         # Optional extras layered on top of the main requirements.
-        # Defaults to empty (skipped). Set in .env to bake in storage
-        # backends or other optional deps at image build time:
+        # Accepts a SPACE-SEPARATED list of requirements files so one
+        # image can carry both DNS plugins and remote storage backends.
+        # Set in .env to bake them in at image build time, e.g.:
+        #   EXTRA_REQUIREMENTS=requirements-azure.txt requirements-storage-all.txt
         #   EXTRA_REQUIREMENTS=requirements-storage-all.txt
-        # Other valid values: requirements-azure-storage.txt,
-        # requirements-aws-storage.txt, requirements-vault-storage.txt,
-        # requirements-infisical-storage.txt, requirements-extended.txt.
+        #   EXTRA_REQUIREMENTS=requirements-aws.txt requirements-gcp.txt
+        # Defaults to empty (skipped).
         EXTRA_REQUIREMENTS: ${EXTRA_REQUIREMENTS:-}
     # Uncomment to use pre-built multi-platform image instead of building locally:
     # image: YOUR_DOCKERHUB_USERNAME/certmate:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,14 @@ services:
       context: .
       args:
         REQUIREMENTS_FILE: requirements.txt
+        # Optional extras layered on top of the main requirements.
+        # Defaults to empty (skipped). Set in .env to bake in storage
+        # backends or other optional deps at image build time:
+        #   EXTRA_REQUIREMENTS=requirements-storage-all.txt
+        # Other valid values: requirements-azure-storage.txt,
+        # requirements-aws-storage.txt, requirements-vault-storage.txt,
+        # requirements-infisical-storage.txt, requirements-extended.txt.
+        EXTRA_REQUIREMENTS: ${EXTRA_REQUIREMENTS:-}
     # Uncomment to use pre-built multi-platform image instead of building locally:
     # image: YOUR_DOCKERHUB_USERNAME/certmate:latest
     # platform: linux/amd64  # Optional: force specific platform (linux/amd64, linux/arm64)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,10 @@ certbot-dns-cloudflare==2.10.0
 certbot-dns-route53==2.10.0
 certbot-dns-digitalocean==2.10.0
 certbot-dns-google==2.10.0
+# certbot-dns-azure has independent versioning. 2.5.0 is the latest in
+# the line that still declares certbot<3.0,>=2.0; 2.6.0+ jumps to
+# certbot 3.x and would conflict with our certbot==2.10.0 pin.
+certbot-dns-azure==2.5.0
 
 # DNS provider plugins - Additional providers
 # certbot-dns-powerdns pinned at 0.2.1 (latest) requires dns-lexicon<=3.5.6,


### PR DESCRIPTION
## Summary

Two build/deploy improvements:

1. **`EXTRA_REQUIREMENTS` build-arg** — lets a single `docker build` layer in optional storage backends (Azure KV, AWS SM, Vault, Infisical) without forking the image.
2. **`certbot-dns-azure==2.5.0`** baked into the main `requirements.txt` — Azure DNS is one of the four major providers already in the UI but picking it produced "plugin not installed" errors on default builds.

## What it does

### `EXTRA_REQUIREMENTS` build-arg

Accepts a space-separated list of requirements file paths and runs `pip install -r <file>` for each, after the main `REQUIREMENTS_FILE` install:

```bash
docker build \
  --build-arg EXTRA_REQUIREMENTS="requirements-azure-storage.txt requirements-aws-storage.txt" \
  -t certmate:azure+aws .
```

Defaults to empty, so existing builds are unchanged. Wired through `docker-compose.yml` via env var. The Dockerfile COPY layer was widened to `requirements*.txt` so any optional file is available for pip without rebuild.

### `certbot-dns-azure`

Pinned to 2.5.0 — 2.6.0 jumped to `certbot>=3.0`, which would conflict with the repo-wide `certbot==2.10.0` pin.

## Files

- `Dockerfile`, `docker-compose.yml`, `requirements.txt`

## Test plan

- [ ] `docker build` succeeds with and without `EXTRA_REQUIREMENTS`
- [ ] `docker build --build-arg EXTRA_REQUIREMENTS=requirements-azure-storage.txt` includes Azure KV packages
- [ ] Container boots, selecting "Azure" as DNS provider no longer produces "plugin not installed"