### PR TITLE
Sprint 1.7: diagnostic snapshot endpoint + one-click bug report (closes #150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2230,26 +2230,39 @@ CertMate 2.0 is a major release that adds enterprise-grade access control, a not
 - **Mobile Bottom Tab Bar** - Responsive navigation on small screens
 - **HTTP-01 Challenge Support** - Alternative to DNS-01 for simple setups
 
-### Support Checklist
+### Reporting Bugs
 
-Before seeking help, please provide:
+CertMate ships an in-app bug reporter that produces an actionable issue with one click. When an action fails and you're signed in as admin, the error toast surfaces a **Report this issue** button. Clicking it:
 
-- [] CertMate version/commit hash
-- [] DNS provider being used
-- [] Error messages from logs
-- [] Steps to reproduce the issue
-- [] Environment details (Docker, Python version, OS)
+1. Calls `GET /api/diagnostics/snapshot` (admin-only) to collect sanitised operational state — CertMate version, Python version, OS, scheduler status, certificate count, DNS provider name, CA name, challenge type, storage backend, disk free, and the last 5 audit-log entries with all identifiers (resource_id, user, IP address, details, error) stripped.
+2. Merges the snapshot with browser-side context (user agent, current page, viewport, the specific error envelope `endpoint` / `status` / `code` / `message` / `hint`).
+3. Formats the result as Markdown and copies it to your clipboard.
+4. Opens `github.com/fabriziosalmi/certmate/issues/new?template=bug_report.md` with the title pre-filled as `[Bug] <status> <code> on <method> <endpoint>`.
+
+Paste the clipboard contents into the issue body, edit if you want, submit. The flow is fully manual — nothing leaves the install without your explicit click, and you can read everything before submitting (it's right there in the textarea). If your browser blocks the clipboard write or pop-ups, the reporter falls back to a modal with the markdown in an editable textarea and a clickable GitHub link.
+
+### Support Checklist (manual reporting)
+
+If the in-app reporter is unavailable (you're not signed in as admin, or you hit the bug before reaching the UI), please provide:
+
+- [ ] CertMate version/commit hash
+- [ ] DNS provider being used
+- [ ] Error messages from logs
+- [ ] Steps to reproduce the issue
+- [ ] Environment details (Docker, Python version, OS)
 
 ```bash
-# Collect system information
+# Collect system information manually (equivalent of the in-app snapshot)
 echo "=== CertMate Debug Info ==="
-echo "Version: $(docker exec certmate python -c 'import app; print(getattr(app, "__version__", "unknown"))')"
+echo "Version: $(docker exec certmate python -c 'import modules; print(modules.__version__)')"
 echo "Python: $(docker exec certmate python --version)"
 echo "OS: $(docker exec certmate cat /etc/os-release | head -2)"
 echo "Certbot: $(docker exec certmate certbot --version)"
 echo "DNS Plugins: $(docker exec certmate pip list | grep certbot-dns)"
-echo "Certificates: $(docker exec certmate ls -la /app/certificates)"
-echo "Settings: $(docker exec certmate cat /app/data/settings.json | jq .)"
+# DO NOT paste settings.json verbatim into a public issue — it contains
+# credentials. The /api/diagnostics/snapshot endpoint returns a redacted
+# subset; use it instead:
+curl -sS -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/diagnostics/snapshot | jq .
 ```
 
 ## Documentation

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -145,6 +145,111 @@ def create_api_resources(api, models, managers):
                 logger.error(f"Error getting metrics info: {e}")
                 return {'error': 'Failed to get metrics information'}, 500
 
+    # Diagnostic snapshot endpoint — closes #150. Powers the "Report this
+    # issue" button in the error toast: when an admin hits a recoverable
+    # API error, the UI fetches this snapshot, merges it with the
+    # client-side context (browser, page, error envelope), formats the
+    # whole thing as Markdown, copies it to the clipboard, and opens
+    # github.com/issues/new pre-filled. Operators reading the resulting
+    # issue see an actionable bug report instead of "doesn't work".
+    #
+    # Security stance: admin-only via require_role('admin'). The response
+    # is built from a fixed allowlist of scalar fields plus a sanitized
+    # tail of the audit log — never the full settings tree, never any
+    # secret, never resource identifiers from the audit entries
+    # (resource_id / user / ip_address / details / error are stripped).
+    # Sanitization is enforced inline in this handler, not deferred to a
+    # generic mask helper, so a future contributor adding a field is
+    # forced to think about whether to include it.
+    class DiagnosticsSnapshot(Resource):
+        @api.doc(security='Bearer')
+        @auth_manager.require_role('admin')
+        def get(self):
+            """Build a sanitized diagnostic snapshot for bug-report use."""
+            import platform
+            import shutil
+            import sys
+
+            from .. import __version__ as _certmate_version
+
+            errors = {}
+
+            # --- Application / runtime identity ---
+            payload = {
+                'certmate_version': _certmate_version,
+                'python_version': sys.version.split()[0],
+                'os_platform': platform.platform(),
+                'container': Path('/.dockerenv').exists(),
+            }
+
+            # --- Background scheduler liveness ---
+            scheduler = managers.get('scheduler')
+            payload['scheduler_running'] = bool(
+                scheduler and getattr(scheduler, 'running', False)
+            )
+
+            # --- Certificate inventory cardinality ---
+            try:
+                certs = certificate_manager.list_certificates()
+                payload['certificate_count'] = (
+                    len(certs) if isinstance(certs, list) else None
+                )
+            except Exception as e:
+                logger.warning(f"Diagnostic: failed to count certificates: {e}")
+                payload['certificate_count'] = None
+                errors['certificate_count'] = 'failed_to_enumerate'
+
+            # --- Configuration scalars (names only, never credentials) ---
+            try:
+                settings = settings_manager.load_settings() or {}
+                payload['dns_provider'] = settings.get('dns_provider')
+                payload['default_ca'] = settings.get('default_ca')
+                payload['challenge_type'] = settings.get('challenge_type')
+                cert_storage = settings.get('certificate_storage') or {}
+                payload['storage_backend'] = cert_storage.get('backend')
+            except Exception as e:
+                logger.warning(f"Diagnostic: failed to read settings scalars: {e}")
+                errors['settings'] = 'failed_to_read'
+
+            # --- Free disk on the data partition ---
+            try:
+                data_dir = current_app.config.get('DATA_DIR') or '.'
+                usage = shutil.disk_usage(str(data_dir))
+                payload['disk_free_bytes'] = usage.free
+                payload['disk_total_bytes'] = usage.total
+            except Exception as e:
+                logger.warning(f"Diagnostic: disk_usage failed: {e}")
+                payload['disk_free_bytes'] = None
+                payload['disk_total_bytes'] = None
+                errors['disk_usage'] = 'permission_or_path_unavailable'
+
+            # --- Recent audit (sanitized: identifiers stripped) ---
+            # Only timestamp / operation / resource_type / status survive
+            # the round-trip. Domain names, usernames, IP addresses, and
+            # the audit details payload are all dropped before
+            # serialization. Anyone reading the resulting bug report
+            # sees operational tempo without learning who did what to
+            # which domain from which IP.
+            try:
+                raw_entries = audit_logger.get_recent_entries(limit=5) if audit_logger else []
+                payload['recent_audit'] = [
+                    {
+                        'timestamp': (e or {}).get('timestamp'),
+                        'operation': (e or {}).get('operation'),
+                        'resource_type': (e or {}).get('resource_type'),
+                        'status': (e or {}).get('status'),
+                    }
+                    for e in (raw_entries or [])[:5]
+                ]
+            except Exception as e:
+                logger.warning(f"Diagnostic: audit log read failed: {e}")
+                payload['recent_audit'] = []
+                errors['recent_audit'] = 'failed_to_read'
+
+            if errors:
+                payload['errors'] = errors
+            return payload, 200
+
     # Settings endpoints
     class Settings(Resource):
         @api.doc(security='Bearer')
@@ -1831,6 +1936,7 @@ def create_api_resources(api, models, managers):
     return {
         'HealthCheck': HealthCheck,
         'MetricsList': MetricsList,
+        'DiagnosticsSnapshot': DiagnosticsSnapshot,
         'Settings': Settings,
         'DNSProviders': DNSProviders,
         'CacheStats': CacheStats,

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -430,6 +430,11 @@ def initialize_managers(container: AppContainer, app):
     )
     event_bus.add_listener(deploy_manager.on_certificate_event)
     app.config['EVENT_BUS'] = event_bus
+    # DATA_DIR is the partition the DiagnosticsSnapshot endpoint queries
+    # for disk_free / disk_total. Stored on the Flask app config so the
+    # RESTX resource can resolve it via current_app without holding a
+    # reference to the container.
+    app.config['DATA_DIR'] = str(container.data_dir)
 
     container.managers = {
         'file_ops': file_ops,
@@ -549,16 +554,18 @@ def setup_api(container: AppContainer, app):
     ns_backups = Namespace('backups', description='Backup and restore')
     ns_cache = Namespace('cache', description='Cache management operations')
     ns_metrics = Namespace('metrics', description='Prometheus metrics and monitoring')
+    ns_diagnostics = Namespace('diagnostics', description='Sanitized diagnostic snapshot for bug reports')
 
     namespaces = [
         ns_certificates, ns_client_certs, ns_ocsp, ns_crl, ns_settings,
-        ns_health, ns_backups, ns_cache, ns_metrics
+        ns_health, ns_backups, ns_cache, ns_metrics, ns_diagnostics
     ]
     for ns in namespaces:
         api.add_namespace(ns)
 
     ns_health.add_resource(api_resources['HealthCheck'], '')
     ns_metrics.add_resource(api_resources['MetricsList'], '')
+    ns_diagnostics.add_resource(api_resources['DiagnosticsSnapshot'], '/snapshot')
     ns_settings.add_resource(api_resources['Settings'], '')
     ns_settings.add_resource(api_resources['DNSProviders'], '/dns-providers')
     ns_settings.add_resource(api_resources['CAProviderTest'], '/test-ca-provider')

--- a/static/js/certmate.js
+++ b/static/js/certmate.js
@@ -72,22 +72,73 @@
         info: 'bg-blue-50 dark:bg-blue-900/40 border-blue-300 dark:border-blue-700 text-blue-800 dark:text-blue-200'
     };
 
-    CM.toast = function(message, type, duration) {
+    CM.toast = function(message, type, duration, options) {
         type = type || 'info';
-        duration = duration || 5000;
+        // When an errorContext is supplied, give the user time to find
+        // the Report button before the toast auto-dismisses. 10s vs the
+        // 5s default — still goes away on its own so a chatty page
+        // doesn't grow a pile of toasts.
+        if (duration === undefined || duration === null) {
+            duration = (options && options.errorContext) ? 10000 : 5000;
+        }
         var container = ensureToastContainer();
+        var opts = options || {};
+
+        // Render the "Report this issue" button when (a) the caller
+        // supplied an errorContext (so there's something to report),
+        // (b) the type is error (we don't want to clutter success
+        // toasts with a bug report affordance), and (c) the current
+        // user role is admin — the diagnostics snapshot endpoint
+        // is admin-only and a viewer click would just 403.
+        var canReport = (
+            type === 'error' &&
+            opts.errorContext &&
+            CM.role === 'admin' &&
+            typeof CM.reportIssue === 'function'
+        );
 
         var toast = document.createElement('div');
-        toast.className = 'pointer-events-auto relative border rounded-lg shadow-lg p-4 flex items-start gap-3 transform translate-x-full opacity-0 transition-all duration-300 overflow-hidden ' + (TOAST_COLORS[type] || TOAST_COLORS.info);
+        toast.className = 'pointer-events-auto relative border rounded-lg shadow-lg p-4 flex flex-col gap-2 transform translate-x-full opacity-0 transition-all duration-300 overflow-hidden ' + (TOAST_COLORS[type] || TOAST_COLORS.info);
 
-        toast.innerHTML =
-            '<i class="fas ' + (TOAST_ICONS[type] || TOAST_ICONS.info) + ' text-lg mt-0.5 flex-shrink-0"></i>' +
-            '<div class="flex-1 text-sm font-medium">' + CM.escapeHtml(message) + '</div>' +
-            '<button class="flex-shrink-0 text-current opacity-50 hover:opacity-100" onclick="this.parentElement.remove()">' +
-            '<i class="fas fa-times"></i></button>' +
-            (duration > 0 ? '<div class="toast-progress" style="--toast-duration:' + duration + 'ms"></div>' : '');
+        var headerHtml =
+            '<div class="flex items-start gap-3">' +
+                '<i class="fas ' + (TOAST_ICONS[type] || TOAST_ICONS.info) + ' text-lg mt-0.5 flex-shrink-0"></i>' +
+                '<div class="flex-1 text-sm font-medium">' + CM.escapeHtml(message) + '</div>' +
+                '<button class="flex-shrink-0 text-current opacity-50 hover:opacity-100" data-action="dismiss">' +
+                '<i class="fas fa-times"></i></button>' +
+            '</div>';
+
+        var reportRowHtml = canReport
+            ? '<div class="pl-7 flex justify-start">' +
+                  '<button data-action="report" class="text-xs font-medium underline opacity-80 hover:opacity-100 disabled:opacity-40 disabled:no-underline disabled:cursor-wait">' +
+                      '<i class="fas fa-bug mr-1"></i>Report this issue' +
+                  '</button>' +
+              '</div>'
+            : '';
+
+        var progressHtml = duration > 0
+            ? '<div class="toast-progress" style="--toast-duration:' + duration + 'ms"></div>'
+            : '';
+
+        toast.innerHTML = headerHtml + reportRowHtml + progressHtml;
 
         container.appendChild(toast);
+
+        toast.querySelector('[data-action="dismiss"]').addEventListener('click', function () {
+            toast.remove();
+        });
+
+        if (canReport) {
+            var reportBtn = toast.querySelector('[data-action="report"]');
+            reportBtn.addEventListener('click', function () {
+                reportBtn.disabled = true;
+                reportBtn.innerHTML = '<i class="fas fa-spinner fa-spin mr-1"></i>Preparing…';
+                CM.reportIssue(opts.errorContext)['finally'](function () {
+                    reportBtn.disabled = false;
+                    reportBtn.innerHTML = '<i class="fas fa-bug mr-1"></i>Report this issue';
+                });
+            });
+        }
 
         // Animate in
         requestAnimationFrame(function() {
@@ -105,6 +156,34 @@
 
         return toast;
     };
+
+    // ── Current-user role (cross-page) ───────────────────────────
+    // dashboard.js has had its own currentRole for a while; we mirror it
+    // here on CM.role so report-issue.js (and any future cross-page
+    // helper) can gate UI without depending on dashboard.js being
+    // loaded — e.g. /settings doesn't load it. The two stores converge:
+    // refreshRole() is idempotent and dashboard.js's loadCertificates
+    // continues to drive its own local copy.
+    CM.role = 'viewer';
+    CM.ROLE_LEVELS = { viewer: 0, operator: 1, admin: 2 };
+    CM.roleAtLeast = function (name) {
+        return (CM.ROLE_LEVELS[CM.role] || 0) >= (CM.ROLE_LEVELS[name] || 0);
+    };
+    CM.refreshRole = function () {
+        return fetch('/api/auth/me', { credentials: 'same-origin' })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (data) {
+                if (data && data.user && data.user.role) {
+                    CM.role = data.user.role;
+                }
+            })
+            .catch(function () { /* keep last-known role */ });
+    };
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', CM.refreshRole);
+    } else {
+        CM.refreshRole();
+    }
 
     // ── Styled Confirm Dialog ────────────────────────────────────
     function createOverlay() {

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -73,8 +73,10 @@
     }
 
     // Show message function with improved styling
-    function showMessage(message, type) {
-        CertMate.toast(message, type);
+    function showMessage(message, type, options) {
+        // options.errorContext (when supplied) triggers the "Report
+        // this issue" button in the resulting toast — see report-issue.js.
+        CertMate.toast(message, type, undefined, options);
     }
 
     // Clear filters function
@@ -1414,12 +1416,27 @@
                     if (result.hint) {
                         errorMsg += '\n\n\ud83d\udca1 ' + result.hint;
                     }
-                    showMessage(errorMsg, 'error');
+                    showMessage(errorMsg, 'error', {
+                        errorContext: {
+                            endpoint: 'POST /api/certificates/create',
+                            status: response.status,
+                            code: result.code,
+                            message: result.error || result.message,
+                            hint: result.hint
+                        }
+                    });
                 }
             });
         }).catch(function (error) {
             console.error('Error creating certificate:', error);
-            showMessage('Failed to create certificate. Please check your network connection and try again.', 'error');
+            showMessage('Failed to create certificate. Please check your network connection and try again.', 'error', {
+                errorContext: {
+                    endpoint: 'POST /api/certificates/create',
+                    status: 0,
+                    code: 'NETWORK_ERROR',
+                    message: (error && error.message) || 'network error'
+                }
+            });
         }).then(function () {
             hideLoadingModal(progressInterval);
         });
@@ -1490,7 +1507,15 @@
                 var msg = (data.body && data.body.error)
                     ? data.body.error
                     : ('Deploy hook run failed (HTTP ' + data.status + ')');
-                showMessage(msg, 'error');
+                showMessage(msg, 'error', {
+                    errorContext: {
+                        endpoint: 'POST /api/certificates/' + domain + '/deploy',
+                        status: data.status,
+                        code: data.body && data.body.code,
+                        message: data.body && data.body.error,
+                        hint: data.body && data.body.hint
+                    }
+                });
                 return;
             }
             var s = data.body || {};
@@ -1552,7 +1577,7 @@
             method: 'DELETE'
         }).then(function (response) {
             return response.json().then(function (result) {
-                return { ok: response.ok, result: result };
+                return { ok: response.ok, status: response.status, result: result };
             });
         }).then(function (data) {
             if (data.ok) {
@@ -1560,11 +1585,26 @@
                 closeCertDetail();
                 loadCertificates();
             } else {
-                showMessage(data.result.error || 'Failed to delete certificate', 'error');
+                showMessage(data.result.error || 'Failed to delete certificate', 'error', {
+                    errorContext: {
+                        endpoint: 'DELETE /api/certificates/' + domain,
+                        status: data.status || 0,
+                        code: data.result.code,
+                        message: data.result.error,
+                        hint: data.result.hint
+                    }
+                });
             }
         }).catch(function (error) {
             console.error('Error deleting certificate:', error);
-            showMessage('Failed to delete certificate. Please try again.', 'error');
+            showMessage('Failed to delete certificate. Please try again.', 'error', {
+                errorContext: {
+                    endpoint: 'DELETE /api/certificates/' + domain,
+                    status: 0,
+                    code: 'NETWORK_ERROR',
+                    message: (error && error.message) || 'network error'
+                }
+            });
         });
     }
 
@@ -1579,18 +1619,33 @@
             headers: { 'Content-Type': 'application/json' }
         }).then(function (response) {
             return response.json().then(function (result) {
-                return { ok: response.ok, result: result };
+                return { ok: response.ok, status: response.status, result: result };
             });
         }).then(function (data) {
             if (data.ok) {
                 showMessage('Certificate renewed successfully for ' + domain + '!', 'success');
                 setTimeout(function () { loadCertificates(); }, 2000);
             } else {
-                showMessage(data.result.error || data.result.message || 'Failed to renew certificate', 'error');
+                showMessage(data.result.error || data.result.message || 'Failed to renew certificate', 'error', {
+                    errorContext: {
+                        endpoint: 'POST /api/certificates/' + domain + '/renew',
+                        status: data.status,
+                        code: data.result.code,
+                        message: data.result.error || data.result.message,
+                        hint: data.result.hint
+                    }
+                });
             }
         }).catch(function (error) {
             console.error('Error renewing certificate:', error);
-            showMessage('Failed to renew certificate. Please try again.', 'error');
+            showMessage('Failed to renew certificate. Please try again.', 'error', {
+                errorContext: {
+                    endpoint: 'POST /api/certificates/' + domain + '/renew',
+                    status: 0,
+                    code: 'NETWORK_ERROR',
+                    message: (error && error.message) || 'network error'
+                }
+            });
         }).then(function () {
             hideLoadingModal(progressInterval);
         });

--- a/static/js/report-issue.js
+++ b/static/js/report-issue.js
@@ -1,0 +1,285 @@
+/*
+ * CertMate — one-click bug reporter
+ *
+ * Powers the "Report this issue" button rendered by CertMate.toast when
+ * the caller supplies an errorContext. The button is admin-only (no
+ * snapshot endpoint access otherwise) and fully manual — nothing leaves
+ * the install without an explicit user click.
+ *
+ * Flow:
+ *   1. fetch /api/diagnostics/snapshot                (admin-gated)
+ *   2. merge with client-side context                 (browser, page, error)
+ *   3. format as Markdown                             (renderable on GitHub)
+ *   4. navigator.clipboard.writeText(markdown)        (fallback: modal)
+ *   5. window.open(github/issues/new?...)             (fallback: link in modal)
+ *
+ * The user lands on github.com with the bug template open and the
+ * markdown in their clipboard. They paste, read what they're sending
+ * (it's right there in the textarea), edit if they want, submit.
+ *
+ * Issue: https://github.com/fabriziosalmi/certmate/issues/150
+ */
+(function () {
+    'use strict';
+
+    var CM = window.CertMate = window.CertMate || {};
+    var REPO = 'fabriziosalmi/certmate';
+    var GITHUB_NEW_ISSUE_URL = 'https://github.com/' + REPO + '/issues/new';
+    // GitHub silently truncates ?title= over ~256 chars and the surrounding
+    // querystring caps around 2KB. We trim our title aggressively below.
+    var TITLE_MAX = 200;
+
+    // ──────────────────────────────────────────────────────────────────
+    // Pure helpers (no side effects — testable as a unit)
+    // ──────────────────────────────────────────────────────────────────
+
+    function _humanBytes(n) {
+        if (n === null || n === undefined) return 'unknown';
+        if (n < 1024) return n + ' B';
+        var units = ['KB', 'MB', 'GB', 'TB'];
+        var v = n / 1024, i = 0;
+        while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+        return v.toFixed(1) + ' ' + units[i];
+    }
+
+    function _browserLabel(ua) {
+        // Pure best-effort family + version detection. We don't ship a
+        // full UA parser for a one-line bug-report field; the raw UA
+        // remains visible in the Markdown for forensic accuracy.
+        if (!ua) return 'unknown';
+        var m;
+        if ((m = /Firefox\/([\d.]+)/.exec(ua))) return 'Firefox ' + m[1];
+        if ((m = /Edg\/([\d.]+)/.exec(ua))) return 'Edge ' + m[1];
+        if ((m = /Chrome\/([\d.]+)/.exec(ua))) return 'Chrome ' + m[1];
+        if ((m = /Version\/([\d.]+).+Safari/.exec(ua))) return 'Safari ' + m[1];
+        return ua.length > 80 ? ua.slice(0, 80) + '…' : ua;
+    }
+
+    /**
+     * Build the issue title from the error envelope.
+     * Shape: "[Bug] <status> <code> on <method> <endpoint>"
+     * Falls back gracefully when fields are missing.
+     */
+    function buildTitle(errorContext) {
+        var ec = errorContext || {};
+        var parts = ['[Bug]'];
+        if (ec.status) parts.push(String(ec.status));
+        if (ec.code) parts.push(String(ec.code));
+        if (ec.endpoint) parts.push('on ' + ec.endpoint);
+        var t = parts.join(' ').trim();
+        if (t.length > TITLE_MAX) t = t.slice(0, TITLE_MAX - 1) + '…';
+        return t;
+    }
+
+    /**
+     * Format the merged context as a Markdown body. Pure function — easy to
+     * inspect, easy to unit-test, easy for a maintainer to extend with a
+     * new field without touching the network/clipboard plumbing.
+     */
+    function buildMarkdown(snapshot, errorContext, clientContext) {
+        var snap = snapshot || {};
+        var ec = errorContext || {};
+        var cc = clientContext || {};
+
+        function line(label, value) {
+            return '- **' + label + '**: ' + (value === undefined || value === null || value === '' ? 'unknown' : value);
+        }
+
+        var out = [];
+
+        out.push('### Environment');
+        out.push(line('CertMate', snap.certmate_version ? 'v' + snap.certmate_version : null));
+        out.push(line('Python', snap.python_version));
+        out.push(line('OS', snap.os_platform + (snap.container ? ' (Docker)' : '')));
+        out.push(line('Browser', _browserLabel(cc.userAgent) + (cc.viewport ? ' — ' + cc.viewport : '')));
+        out.push(line('Page', cc.path));
+        out.push('');
+
+        out.push('### Error');
+        out.push(line('Endpoint', ec.endpoint));
+        out.push(line('Status', ec.status));
+        if (ec.code) out.push(line('Code', '`' + ec.code + '`'));
+        if (ec.message) out.push(line('Message', ec.message));
+        if (ec.hint) out.push(line('Hint', ec.hint));
+        out.push('');
+
+        out.push('### Diagnostics');
+        out.push(line('Scheduler', snap.scheduler_running ? 'running' : 'not running'));
+        out.push(line('Certificates', snap.certificate_count));
+        out.push(line('DNS Provider', snap.dns_provider));
+        out.push(line('CA', snap.default_ca));
+        out.push(line('Challenge', snap.challenge_type));
+        out.push(line('Storage', snap.storage_backend));
+        out.push(line('Disk free', _humanBytes(snap.disk_free_bytes) +
+            (snap.disk_total_bytes ? ' / ' + _humanBytes(snap.disk_total_bytes) : '')));
+        out.push('');
+
+        out.push('### Recent activity (sanitized — identifiers stripped)');
+        var entries = Array.isArray(snap.recent_audit) ? snap.recent_audit : [];
+        if (entries.length === 0) {
+            out.push('_(no recent audit entries)_');
+        } else {
+            entries.forEach(function (e, i) {
+                var ts = (e && e.timestamp) ? e.timestamp.replace('T', ' ').replace('Z', '') : '?';
+                out.push((i + 1) + '. ' + ts + ' — ' + (e.operation || '?') + ' / ' + (e.resource_type || '?') + ' / ' + (e.status || '?'));
+            });
+        }
+
+        if (snap.errors && Object.keys(snap.errors).length) {
+            out.push('');
+            out.push('### Snapshot partial failures');
+            Object.keys(snap.errors).forEach(function (k) {
+                out.push('- `' + k + '`: ' + snap.errors[k]);
+            });
+        }
+
+        out.push('');
+        out.push('---');
+        out.push('_Generated by CertMate\'s in-app bug reporter. The author opened this issue from a one-click button in an error toast; the snapshot above was retrieved from `GET /api/diagnostics/snapshot` and sanitized server-side. The author saw and chose to share these fields before submitting._');
+
+        return out.join('\n');
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Clipboard + URL plumbing (with fallbacks)
+    // ──────────────────────────────────────────────────────────────────
+
+    function _writeClipboard(text) {
+        // Modern path. Fails outside HTTPS in some browsers — we
+        // surface the fallback modal in that case.
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            return navigator.clipboard.writeText(text);
+        }
+        return Promise.reject(new Error('clipboard API unavailable'));
+    }
+
+    function _openFallbackModal(markdown, issueUrl) {
+        // Used when clipboard fails OR window.open is blocked. The user
+        // can copy the markdown manually and click the link to open
+        // GitHub themselves.
+        var overlay = document.createElement('div');
+        overlay.className = 'fixed inset-0 z-[10001] flex items-center justify-center p-4';
+        overlay.innerHTML = '<div class="absolute inset-0 bg-black/50 backdrop-blur-sm"></div>';
+
+        var box = document.createElement('div');
+        box.className = 'relative bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-2xl border border-gray-200 dark:border-gray-700';
+        var title = 'Report this issue — manual paste';
+        box.innerHTML =
+            '<div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700">' +
+                '<h3 class="text-lg font-semibold text-gray-900 dark:text-white">' + CM.escapeHtml(title) + '</h3>' +
+                '<p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Your browser blocked the clipboard or new-tab automation. Copy the markdown below and open the issue manually.</p>' +
+            '</div>' +
+            '<div class="px-6 py-4">' +
+                '<textarea readonly class="w-full h-64 p-3 text-xs font-mono bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded text-gray-800 dark:text-gray-200"></textarea>' +
+                '<div class="flex justify-between items-center mt-4">' +
+                    '<a target="_blank" rel="noopener" href="' + CM.escapeHtml(issueUrl) + '" class="text-blue-600 dark:text-blue-400 hover:underline text-sm">Open GitHub issue form &nearr;</a>' +
+                    '<div class="flex gap-2">' +
+                        '<button data-action="copy" class="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 text-white hover:bg-blue-700">Copy markdown</button>' +
+                        '<button data-action="close" class="px-4 py-2 rounded-lg text-sm font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600">Close</button>' +
+                    '</div>' +
+                '</div>' +
+            '</div>';
+        overlay.appendChild(box);
+        document.body.appendChild(overlay);
+
+        var ta = box.querySelector('textarea');
+        ta.value = markdown;
+        ta.focus();
+        ta.select();
+
+        box.querySelector('[data-action="copy"]').addEventListener('click', function () {
+            ta.select();
+            try {
+                document.execCommand('copy');
+                if (CM.toast) CM.toast('Copied to clipboard', 'success', 2000);
+            } catch (e) {
+                if (CM.toast) CM.toast('Copy failed — please select and Cmd/Ctrl+C', 'warning', 4000);
+            }
+        });
+        box.querySelector('[data-action="close"]').addEventListener('click', function () {
+            overlay.remove();
+        });
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Public entry point — wired up by toast button click handler
+    // ──────────────────────────────────────────────────────────────────
+
+    /**
+     * `errorContext` shape (all optional except endpoint+status if you
+     * want the title to be useful):
+     *   {
+     *     endpoint: 'POST /api/certificates/create',
+     *     status: 422,
+     *     code: 'CERTBOT_FAILED',
+     *     message: 'Certificate creation failed: DNS verification timed out',
+     *     hint: 'Check DNS provider credentials and ensure DNS records can be created.'
+     *   }
+     */
+    var _inFlight = false;
+    CM.reportIssue = function (errorContext) {
+        if (_inFlight) return Promise.resolve();   // idempotency: ignore rapid double-clicks
+        _inFlight = true;
+
+        var clientContext = {
+            userAgent: navigator.userAgent,
+            path: window.location.pathname + window.location.search,
+            viewport: window.innerWidth + '×' + window.innerHeight,
+            timestamp: new Date().toISOString()
+        };
+
+        function _finalize() { _inFlight = false; }
+
+        return fetch('/api/diagnostics/snapshot', {
+            credentials: 'same-origin',
+            headers: { 'Accept': 'application/json' }
+        })
+            .then(function (r) {
+                if (!r.ok) {
+                    // 403 (role changed mid-session) or 5xx — degrade
+                    // gracefully: ship a client-only report so the
+                    // user is never stranded with no recovery.
+                    return r.json().catch(function () { return {}; }).then(function (body) {
+                        return { _snapshot_unavailable: true, _snapshot_status: r.status, _snapshot_body: body };
+                    });
+                }
+                return r.json();
+            })
+            .catch(function () {
+                return { _snapshot_unavailable: true };
+            })
+            .then(function (snapshot) {
+                var markdown = buildMarkdown(snapshot, errorContext, clientContext);
+                if (snapshot && snapshot._snapshot_unavailable) {
+                    markdown = '> ⚠️ Server snapshot was unavailable (status ' +
+                        (snapshot._snapshot_status || 'network error') +
+                        '). The report below is client-side only.\n\n' + markdown;
+                }
+                var url = GITHUB_NEW_ISSUE_URL + '?template=bug_report.md&title=' +
+                    encodeURIComponent(buildTitle(errorContext));
+
+                return _writeClipboard(markdown).then(function () {
+                    var tab = window.open(url, '_blank', 'noopener');
+                    if (!tab) {
+                        // popup blocker — fall back to the manual modal
+                        // (which has a clickable link inside it).
+                        _openFallbackModal(markdown, url);
+                    } else if (CM.toast) {
+                        CM.toast('Bug report copied. GitHub opened in a new tab — paste and review before submitting.', 'success', 8000);
+                    }
+                }).catch(function () {
+                    // Clipboard write rejected (HTTP, permission, browser policy)
+                    _openFallbackModal(markdown, url);
+                });
+            })
+            .then(_finalize, _finalize);
+    };
+
+    // Expose pure helpers so they can be unit-tested or reused.
+    CM.reportIssueInternals = {
+        buildTitle: buildTitle,
+        buildMarkdown: buildMarkdown,
+        _humanBytes: _humanBytes,
+        _browserLabel: _browserLabel
+    };
+})();

--- a/static/js/settings-apikeys.js
+++ b/static/js/settings-apikeys.js
@@ -2,9 +2,9 @@
     'use strict';
 
     // Local proxy to core's showMessage (toast + debug log).
-    function showMessage(message, type) {
+    function showMessage(message, type, options) {
         var ns = window.CmSettings;
-        if (ns && typeof ns.showMessage === 'function') ns.showMessage(message, type);
+        if (ns && typeof ns.showMessage === 'function') ns.showMessage(message, type, options);
     }
 
     // Parse the comma-separated allowed_domains input into:
@@ -117,11 +117,28 @@
                                 self.loadKeys();
                                 showMessage('API key "' + data.name + '" created', 'success');
                             } else {
-                                showMessage(data.error || 'Failed to create API key', 'error');
+                                showMessage(data.error || 'Failed to create API key', 'error', {
+                                    errorContext: {
+                                        endpoint: 'POST /api/keys',
+                                        status: r.status,
+                                        code: data.code,
+                                        message: data.error,
+                                        hint: data.hint
+                                    }
+                                });
                             }
                         });
                     })
-                    .catch(function () { showMessage('Failed to create API key', 'error'); });
+                    .catch(function () {
+                        showMessage('Failed to create API key', 'error', {
+                            errorContext: {
+                                endpoint: 'POST /api/keys',
+                                status: 0,
+                                code: 'NETWORK_ERROR',
+                                message: 'network error or unparseable response'
+                            }
+                        });
+                    });
             },
 
             revokeKey: function (keyId, keyName) {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -110,10 +110,12 @@
     // Message display function
     // =============================================
 
-    function showMessage(message, type) {
+    function showMessage(message, type, options) {
         type = type || 'info';
         addDebugLog(message, type);
-        CertMate.toast(message, type);
+        // options.errorContext (when supplied) triggers the "Report this
+        // issue" button in the resulting toast — see report-issue.js.
+        CertMate.toast(message, type, undefined, options);
     }
 
     // =============================================
@@ -267,7 +269,15 @@
                 .then(function (response) {
                     if (!response.ok) {
                         return response.text().then(function (errorData) {
-                            throw new Error('HTTP ' + response.status + ': ' + errorData);
+                            // Parse JSON body when possible so the bug-report
+                            // errorContext can carry the `code`/`hint` the
+                            // backend returned.
+                            var parsed = null;
+                            try { parsed = errorData ? JSON.parse(errorData) : null; } catch (e) { /* not JSON */ }
+                            var err = new Error('HTTP ' + response.status + ': ' + (parsed && parsed.error ? parsed.error : errorData));
+                            err.responseStatus = response.status;
+                            err.responseBody = parsed;
+                            throw err;
                         });
                     }
                     return response.json();
@@ -281,7 +291,15 @@
                 })
                 .catch(function (error) {
                     addDebugLog('Error saving settings: ' + error.message, 'error');
-                    showMessage('Error saving settings: ' + error.message, 'error');
+                    showMessage('Error saving settings: ' + error.message, 'error', {
+                        errorContext: {
+                            endpoint: 'POST /api/web/settings',
+                            status: error.responseStatus || 0,
+                            code: error.responseBody && error.responseBody.code,
+                            message: (error.responseBody && error.responseBody.error) || error.message,
+                            hint: error.responseBody && error.responseBody.hint
+                        }
+                    });
                 })
                 .then(function () {
                     // finally block equivalent
@@ -1320,7 +1338,12 @@
             .then(function (response) {
                 if (!response.ok) {
                     return response.text().then(function (errorData) {
-                        throw new Error('HTTP ' + response.status + ': ' + errorData);
+                        var parsed = null;
+                        try { parsed = errorData ? JSON.parse(errorData) : null; } catch (e) { /* not JSON */ }
+                        var err = new Error('HTTP ' + response.status + ': ' + (parsed && parsed.error ? parsed.error : errorData));
+                        err.responseStatus = response.status;
+                        err.responseBody = parsed;
+                        throw err;
                     });
                 }
                 return response.json();
@@ -1338,12 +1361,22 @@
                     // Refresh backup list
                     return refreshBackupList();
                 } else {
-                    throw new Error(result.error || 'Failed to create backup');
+                    var err = new Error(result.error || 'Failed to create backup');
+                    err.responseBody = result;
+                    throw err;
                 }
             })
             .catch(function (error) {
                 addDebugLog('Error creating backup: ' + error.message, 'error');
-                showMessage('Error creating backup: ' + error.message, 'error');
+                showMessage('Error creating backup: ' + error.message, 'error', {
+                    errorContext: {
+                        endpoint: 'POST /api/backups/create',
+                        status: error.responseStatus || 0,
+                        code: error.responseBody && error.responseBody.code,
+                        message: (error.responseBody && error.responseBody.error) || error.message,
+                        hint: error.responseBody && error.responseBody.hint
+                    }
+                });
             })
             .then(function () {
                 // finally block equivalent - restore button state
@@ -1551,7 +1584,12 @@
                 .then(function (response) {
                     if (!response.ok) {
                         return response.text().then(function (errorData) {
-                            throw new Error('HTTP ' + response.status + ': ' + errorData);
+                            var parsed = null;
+                            try { parsed = errorData ? JSON.parse(errorData) : null; } catch (e) { /* not JSON */ }
+                            var err = new Error('HTTP ' + response.status + ': ' + (parsed && parsed.error ? parsed.error : errorData));
+                            err.responseStatus = response.status;
+                            err.responseBody = parsed;
+                            throw err;
                         });
                     }
                     return response.json();
@@ -1590,7 +1628,15 @@
         })
             .catch(function (error) {
                 addDebugLog('Error during backup restore: ' + error.message, 'error');
-                showMessage('Error restoring backup: ' + error.message, 'error');
+                showMessage('Error restoring backup: ' + error.message, 'error', {
+                    errorContext: {
+                        endpoint: 'POST /api/backups/restore/unified',
+                        status: error.responseStatus || 0,
+                        code: error.responseBody && error.responseBody.code,
+                        message: (error.responseBody && error.responseBody.error) || error.message,
+                        hint: error.responseBody && error.responseBody.hint
+                    }
+                });
             });
     }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -279,6 +279,7 @@
     </script>
     <script defer src="/static/js/alpine.min.js"></script>
     <script src="/static/js/certmate.js"></script>
+    <script defer src="/static/js/report-issue.js"></script>
     <script defer src="/static/js/cmd-palette.js"></script>
     <script defer src="/static/js/shortcuts.js"></script>
     <script defer src="/static/js/setup-wizard.js"></script>

--- a/tests/test_diagnostics_snapshot.py
+++ b/tests/test_diagnostics_snapshot.py
@@ -1,0 +1,259 @@
+"""Unit tests for the DiagnosticsSnapshot resource (closes #150).
+
+The endpoint powers the in-app "Report this issue" button. Its
+correctness contract is:
+
+  - admin-only (viewer/operator 403)
+  - returns a fixed allowlist of operational scalars, never the full
+    settings dict and never any secret
+  - returns at most 5 audit-log entries, each stripped of resource_id,
+    user, ip_address, details, error
+  - tolerates partial failure (disk_usage raising, audit log missing,
+    etc.) by reporting the working fields plus an `errors` map — never
+    500s out the whole response
+
+No Docker; runs in-process via Flask's test client.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+from flask_restx import Api, Namespace
+
+from modules.api.models import create_api_models
+from modules.api.resources import create_api_resources
+import modules.api.resources as api_resources_module
+
+
+def _passthrough_decorator(_min_role):
+    def deco(fn):
+        return fn
+    return deco
+
+
+def _build_app(managers, *, data_dir=None):
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    if data_dir is not None:
+        app.config['DATA_DIR'] = str(data_dir)
+    api = Api(app, prefix='/api')
+    models = create_api_models(api)
+    resources = create_api_resources(api, models, managers)
+
+    ns = Namespace('diagnostics', description='diagnostics')
+    api.add_namespace(ns)
+    ns.add_resource(resources['DiagnosticsSnapshot'], '/snapshot')
+    return app
+
+
+def _audit_entries(*operations):
+    """Build raw audit entries with all the fields the real logger emits
+    so we can verify the sanitizer strips identifiers correctly."""
+    return [
+        {
+            'timestamp': '2026-05-12T14:12:0{}Z'.format(i),
+            'operation': op,
+            'resource_type': 'certificate',
+            'resource_id': 'secret.example.com',
+            'status': 'success',
+            'user': 'admin@example.com',
+            'ip_address': '198.51.100.42',
+            'details': {'common_name': 'secret.example.com',
+                        'private_key_pem': 'should-never-leak'},
+            'error': None,
+        }
+        for i, op in enumerate(operations)
+    ]
+
+
+@pytest.fixture
+def managers(tmp_path):
+    """Standard managers wired up enough to exercise the resource."""
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_decorator)
+
+    cert_manager = MagicMock()
+    cert_manager.cert_dir = Path(tmp_path)
+    cert_manager.list_certificates.return_value = [
+        {'domain': 'a.com'}, {'domain': 'b.com'}, {'domain': 'c.com'}
+    ]
+
+    audit_logger = MagicMock()
+    audit_logger.get_recent_entries.return_value = _audit_entries(
+        'create', 'renew', 'update', 'delete', 'access'
+    )
+
+    settings_manager = MagicMock()
+    settings_manager.load_settings.return_value = {
+        'dns_provider': 'cloudflare',
+        'default_ca': 'letsencrypt',
+        'challenge_type': 'dns-01',
+        'certificate_storage': {'backend': 'local_filesystem'},
+        # Things that MUST NOT appear in the snapshot:
+        'api_bearer_token': 'cm_supersecret_should_not_leak',
+        'api_bearer_token_hash': 'hmac-sha256:should_not_leak',
+        'cloudflare_token': 'cf_should_not_leak',
+        'users': {'admin': {'password_hash': 'should_not_leak'}},
+        'dns_providers': {'cloudflare': {'api_token': 'should_not_leak'}},
+    }
+
+    file_ops = MagicMock(cert_dir=Path(tmp_path))
+
+    return {
+        'auth': auth_manager,
+        'settings': settings_manager,
+        'certificates': cert_manager,
+        'file_ops': file_ops,
+        'cache': MagicMock(),
+        'dns': MagicMock(),
+        'audit': audit_logger,
+    }
+
+
+class TestSnapshotShape:
+    """The response carries the expected top-level fields and never
+    leaks anything outside the allowlist."""
+
+    def test_basic_shape(self, managers, tmp_path):
+        app = _build_app(managers, data_dir=tmp_path)
+        r = app.test_client().get('/api/diagnostics/snapshot')
+        assert r.status_code == 200
+        body = r.get_json()
+
+        # Required scalar fields
+        for k in (
+            'certmate_version', 'python_version', 'os_platform', 'container',
+            'scheduler_running', 'certificate_count',
+            'dns_provider', 'default_ca', 'challenge_type', 'storage_backend',
+            'disk_free_bytes', 'disk_total_bytes', 'recent_audit',
+        ):
+            assert k in body, f"missing field: {k}"
+
+    def test_certificate_count_matches_manager(self, managers, tmp_path):
+        app = _build_app(managers, data_dir=tmp_path)
+        body = app.test_client().get('/api/diagnostics/snapshot').get_json()
+        assert body['certificate_count'] == 3
+
+    def test_settings_scalars_propagated(self, managers, tmp_path):
+        app = _build_app(managers, data_dir=tmp_path)
+        body = app.test_client().get('/api/diagnostics/snapshot').get_json()
+        assert body['dns_provider'] == 'cloudflare'
+        assert body['default_ca'] == 'letsencrypt'
+        assert body['challenge_type'] == 'dns-01'
+        assert body['storage_backend'] == 'local_filesystem'
+
+
+class TestSnapshotSanitization:
+    """The blacklist is the load-bearing security property: no secret
+    field, no resource identifier, no user, no IP, no audit details
+    may appear in any part of the response."""
+
+    def _flatten_to_string(self, obj):
+        """Walk the response and produce a single string of every value
+        encountered. Used to assert 'X never appears anywhere'."""
+        if isinstance(obj, dict):
+            parts = []
+            for k, v in obj.items():
+                parts.append(str(k))
+                parts.append(self._flatten_to_string(v))
+            return ' '.join(parts)
+        if isinstance(obj, list):
+            return ' '.join(self._flatten_to_string(x) for x in obj)
+        return '' if obj is None else str(obj)
+
+    def test_response_has_no_secret_values(self, managers, tmp_path):
+        app = _build_app(managers, data_dir=tmp_path)
+        body = app.test_client().get('/api/diagnostics/snapshot').get_json()
+        blob = self._flatten_to_string(body)
+
+        # Things explicitly planted in settings + audit details that
+        # must NEVER appear in the response.
+        forbidden = [
+            'cm_supersecret_should_not_leak',
+            'hmac-sha256:should_not_leak',
+            'cf_should_not_leak',
+            'should-never-leak',   # audit detail
+            'secret.example.com',  # audit resource_id
+            'admin@example.com',   # audit user
+            '198.51.100.42',       # audit ip_address
+            'password_hash',
+        ]
+        for token in forbidden:
+            assert token not in blob, f"secret/identifier leaked: {token}"
+
+    def test_audit_entries_stripped_of_identifiers(self, managers, tmp_path):
+        app = _build_app(managers, data_dir=tmp_path)
+        body = app.test_client().get('/api/diagnostics/snapshot').get_json()
+
+        entries = body['recent_audit']
+        assert len(entries) == 5
+        for entry in entries:
+            # Only these four keys survive the sanitizer.
+            assert set(entry.keys()) == {
+                'timestamp', 'operation', 'resource_type', 'status'
+            }, f"audit entry leaked extra fields: {set(entry.keys())}"
+
+    def test_audit_entries_capped_at_five(self, managers, tmp_path):
+        # The endpoint passes limit=5 to get_recent_entries.
+        managers['audit'].get_recent_entries.return_value = _audit_entries(
+            *['op' + str(i) for i in range(20)]
+        )
+        app = _build_app(managers, data_dir=tmp_path)
+        body = app.test_client().get('/api/diagnostics/snapshot').get_json()
+        assert len(body['recent_audit']) <= 5
+
+    def test_full_settings_dict_not_exposed(self, managers, tmp_path):
+        # Even the keys of the settings dict (which include 'users',
+        # 'api_keys', 'dns_providers') must not appear as top-level
+        # fields of the response.
+        app = _build_app(managers, data_dir=tmp_path)
+        body = app.test_client().get('/api/diagnostics/snapshot').get_json()
+        for forbidden_key in ('users', 'api_keys', 'dns_providers',
+                              'api_bearer_token', 'api_bearer_token_hash',
+                              'deploy_hooks'):
+            assert forbidden_key not in body, (
+                f"settings field '{forbidden_key}' leaked into snapshot"
+            )
+
+
+class TestSnapshotPartialFailure:
+    """A field that can't be computed must surface in `errors` rather
+    than 500ing the whole call."""
+
+    def test_certificate_count_failure(self, managers, tmp_path):
+        managers['certificates'].list_certificates.side_effect = RuntimeError('disk gone')
+        app = _build_app(managers, data_dir=tmp_path)
+        body = app.test_client().get('/api/diagnostics/snapshot').get_json()
+        assert body['certificate_count'] is None
+        assert body.get('errors', {}).get('certificate_count') == 'failed_to_enumerate'
+        # Other fields still populated.
+        assert body['dns_provider'] == 'cloudflare'
+
+    def test_audit_failure(self, managers, tmp_path):
+        managers['audit'].get_recent_entries.side_effect = OSError('audit log missing')
+        app = _build_app(managers, data_dir=tmp_path)
+        body = app.test_client().get('/api/diagnostics/snapshot').get_json()
+        assert body['recent_audit'] == []
+        assert body.get('errors', {}).get('recent_audit') == 'failed_to_read'
+
+    def test_disk_usage_failure(self, managers, monkeypatch, tmp_path):
+        # Force shutil.disk_usage to raise.
+        def boom(_path):
+            raise PermissionError('denied')
+        monkeypatch.setattr(api_resources_module.__dict__.get('shutil', None)
+                            or __import__('shutil'), 'disk_usage', boom)
+        app = _build_app(managers, data_dir=tmp_path)
+        body = app.test_client().get('/api/diagnostics/snapshot').get_json()
+        assert body['disk_free_bytes'] is None
+        assert body['disk_total_bytes'] is None
+        assert body.get('errors', {}).get('disk_usage') == 'permission_or_path_unavailable'
+
+    def test_no_audit_logger_wired(self, managers, tmp_path):
+        managers['audit'] = None
+        app = _build_app(managers, data_dir=tmp_path)
+        body = app.test_client().get('/api/diagnostics/snapshot').get_json()
+        # No crash, empty list, no spurious error entry.
+        assert body['recent_audit'] == []


### PR DESCRIPTION
## Summary

Implements #150 in full. Four atomic commits, 11 new unit tests on top of v2.4.15's 125 (136 total, 1.14 s runtime, no Docker), zero new external dependencies.

The shipping flow is exactly the one drafted in the issue: when an action fails and you're signed in as admin, the error toast surfaces a **Report this issue** button. One click → fetch `/api/diagnostics/snapshot` → merge with browser context → format Markdown → clipboard + open GitHub with the bug template pre-filled. The user paste-reviews-submits. No automatic upload, no telemetry, no new dependency, no air-gap compromise.

Eight high-impact error toasts are wired in this PR (cert create / renew / delete / deploy, settings save, API key create, backup create / restore). The remaining ~80 error toasts in the codebase still work — they just don't surface the button. The pattern is documented inline so contributors extending coverage know what to pass.

## Changes

### `feat(api): GET /api/diagnostics/snapshot` (commit 6b61e95)

New `DiagnosticsSnapshot` resource under a new `/api/diagnostics/` namespace. Admin-only. Returns an **allowlist** (not a serialiser):

| Field | Source | Sensitivity |
|---|---|---|
| `certmate_version` | `modules.__version__` | public |
| `python_version` | `sys.version.split()[0]` | public |
| `os_platform`, `container` | `platform.platform()`, `/.dockerenv` existence | public |
| `scheduler_running` | `container.scheduler.running` | bool |
| `certificate_count` | `len(certificate_manager.list_certificates())` | int |
| `dns_provider`, `default_ca`, `challenge_type`, `storage_backend` | `settings[...]` scalar reads — provider/CA *names*, never credentials | low |
| `disk_free_bytes`, `disk_total_bytes` | `shutil.disk_usage(app.config['DATA_DIR'])` | low |
| `recent_audit` | last 5 from `audit_logger.get_recent_entries(5)`, sanitised | mid |
| `errors` | only present on partial failure | low |

**Sanitisation is inline in the handler**, not deferred to a generic helper. Every audit entry is reduced to `{timestamp, operation, resource_type, status}` — `resource_id` (often a domain), `user`, `ip_address`, `details` (full operation payload), and `error` are dropped. A future contributor adding a new audit field has to think about whether to expose it.

**Partial-failure tolerance**: if certificate enumeration / settings read / `shutil.disk_usage` / audit read raises, that single field becomes `null` and the response carries an `errors: {field: reason}` map alongside the working data — never 500s the whole call.

### `feat(ui): one-click bug-report helper + role-aware toast button` (commit 072e887)

Three loosely-coupled additions:

1. **`static/js/report-issue.js`** — new file. `CM.reportIssue(errorContext)` is the public entry point:
   - Fetches the snapshot, merges with browser context (userAgent, page, viewport).
   - Formats a structured Markdown body via the pure `buildMarkdown()` (exposed on `CM.reportIssueInternals` for future testing).
   - Copies to clipboard via `navigator.clipboard.writeText`.
   - Opens `github.com/issues/new?template=bug_report.md&title=[Bug] <status> <code> on <method> <endpoint>`.
   - Idempotent (in-flight Promise guards double-clicks).
   - Fallbacks: clipboard reject → modal with editable textarea + clickable GitHub link. Popup blocker → same modal. Snapshot fetch fails → ship a client-only report tagged "Server snapshot was unavailable".

2. **`static/js/certmate.js` — `CM.toast` gains 4th arg `options`**. When `options.errorContext` is supplied and `type === 'error'` and `CM.role === 'admin'`, the toast renders a **Report this issue** button below the message and extends auto-dismiss to 10 s. Backward compatible — every existing call works unchanged.

3. **`static/js/certmate.js` — `CM.role` / `CM.roleAtLeast` / `CM.refreshRole` exposed**. dashboard.js already tracks the role locally for its own UI gating; we mirror it on `CM` so cross-page helpers don't have to depend on dashboard.js being loaded (e.g. `/settings` doesn't load it). Auto-refresh on `DOMContentLoaded`.

### `feat(ui): wire 8 high-impact error sites to the bug-report toast` (commit 00bad43)

Eight error toasts now carry `options.errorContext`:

| Action | File | Endpoint |
|---|---|---|
| Cert create (server error + network) | dashboard.js | `POST /api/certificates/create` |
| Cert renew | dashboard.js | `POST /api/certificates/<d>/renew` |
| Cert delete | dashboard.js | `DELETE /api/certificates/<d>` |
| Run deploy hooks | dashboard.js | `POST /api/certificates/<d>/deploy` |
| Settings save | settings.js | `POST /api/web/settings` |
| API key create | settings-apikeys.js | `POST /api/keys` |
| Backup create | settings.js | `POST /api/backups/create` |
| Backup restore | settings.js | `POST /api/backups/restore/unified` |

Plumbing changes alongside the wires:
- `showMessage(msg, type)` in dashboard.js / settings.js / settings-apikeys.js grew an optional 3rd `options` param that forwards to `CertMate.toast`.
- The cert delete / renew handlers now propagate `response.status` through their `.then()` wrap.
- Settings save / backup create / restore catch paths parse the JSON response body when available and attach it as `error.responseBody` + `error.responseStatus` so the toast can surface `code` and `hint`.
- `status: 0, code: 'NETWORK_ERROR'` is the convention for `.catch` branches that never got an HTTP response.

### `test+docs: DiagnosticsSnapshot contract pinned + README Reporting Bugs` (commit 992c90f)

`tests/test_diagnostics_snapshot.py` — 11 new tests:

- **`TestSnapshotShape` (3)** — every documented field is present; certificate count matches the manager; settings scalars round-trip.
- **`TestSnapshotSanitization` (4)** — response carries **none** of 8 forbidden values planted in fixtures (bearer token, hash, cloudflare_token, audit `details` leak, audit `resource_id`, audit `user`, audit `ip_address`, `password_hash` literal). Audit entries are reduced to exactly the four allowed fields. Audit list capped at 5. Full-settings keys (users, api_keys, dns_providers, deploy_hooks, …) never appear at the top level of the response.
- **`TestSnapshotPartialFailure` (4)** — certificate count, audit log, and `shutil.disk_usage` each individually injected with failure; the relevant field becomes `null`, the `errors` map carries a documented reason, and the other fields still populate. Missing audit logger → empty list, no crash.

The sanitisation test flattens the entire response to a single string and asserts each forbidden token is absent. A future leak path that adds a new field carrying any of those tokens fails the test loudly.

README gains a **Reporting Bugs** subsection that explains the in-app flow, what's in the snapshot, and the fallback behaviour. The existing Support Checklist below it is preserved as the manual fallback; the curl example is updated from "cat settings.json" (which would leak credentials into a public issue) to "curl /api/diagnostics/snapshot".

## Test plan

Unit (in-process, no Docker, 1.14 s total):
- [x] `tests/test_diagnostics_snapshot.py` — 11 new tests pass
- [x] 125 pre-existing unit tests across `test_sprint1_*`, `test_apikeys`, `test_audit`, `test_settings_atomic_update`, `test_factory_logging`, `test_static_csp` still pass

Manual smoke (Docker on `localhost:8000`):
- [ ] As admin, trigger any of the 8 wired errors (e.g., POST /api/certificates/create with a malformed DNS provider). Toast shows the message + a "Report this issue" button. Click it.
- [ ] Clipboard contains the Markdown bug report; a new GitHub tab opens at `/issues/new?template=bug_report.md` with a pre-filled `[Bug] <status> <code> on <method> <endpoint>` title.
- [ ] Markdown body contains version, Python, OS, scheduler status, certificate count, DNS provider name, CA, challenge, storage, disk free, the 5 most recent sanitised audit entries, and the specific endpoint/status/code/message that failed.
- [ ] As a viewer (scoped API key with `role: viewer`), the same error toast does **not** render the Report button (`CM.role` check).
- [ ] In a browser that blocks `navigator.clipboard.writeText` (Firefox over HTTP), clicking the button opens the fallback modal instead, with the markdown in an editable textarea and a clickable GitHub link.

## Backward compatibility

- No existing API call shape changes. The new endpoint is purely additive.
- Every existing `CM.toast(msg, type, duration)` callsite continues to work — the `options` arg is optional.
- Every existing `showMessage(msg, type)` callsite continues to work — the `options` arg is optional.
- No new external dependency, no new build step, no new CSP origin required (the GitHub URL is `_blank` window.open, not a same-origin fetch).
- The remaining ~80 error toasts not wired in this PR simply don't surface the button; the user experience for those is unchanged.

## Non-goals (deferred)

- No telemetry. No automatic upload. No phone-home. The flow is fully manual end-to-end.
- No Sentry / Bugsnag integration.
- No screenshot capture (browsers block `html2canvas` under our strict CSP; structured fields are more useful anyway).
- No coverage of all 90 error sites — a wired site needs a server-derived status + endpoint to produce a useful report, and many of the 90 are client-side validation errors. The pattern is in place; future PRs (community or maintainer) can extend coverage where it adds value.

Closes #150