### PR TITLE
Update Docker Compose configuration - allow enabling of proxy handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - CLOUDFLARE_TOKEN=${CLOUDFLARE_TOKEN}
       - API_BEARER_TOKEN=${API_BEARER_TOKEN:-}  # Auto-generated if empty; set a strong value for production
       #- API_BEARER_TOKEN_FILE=${API_BEARER_TOKEN_FILE:-}  # Alternative: path to a file containing the bearer token
+      - BEHIND_PROXY=${BEHIND_PROXY:-false}  # Set true when CertMate runs behind nginx or another trusted reverse proxy
       - PORT=${PORT:-8000}                      # Internal listen port; also update ports: mapping if changed
       - GUNICORN_TIMEOUT=${GUNICORN_TIMEOUT:-300}  # Worker timeout; increase for slow DNS providers
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL:-}    # Overrides the email set via the web UI when set


### PR DESCRIPTION
currently theres no way with the docker compose setup to handle setting of proxy headers (there is code but no way to enable it)
thus all user sessions get marked as from the same ip when coming from nginx

this causes rate limiting

```
certmate  | {"timestamp": "2026-05-12T15:48:49.161057Z", "level": "warning", "logger": "modules.core.rate_limit", "message": "Rate limit exceeded for 172.18.0.1 on certificate_list", "source": {"file": "rate_limit.py", "line": 122, "function": "is_allowed"}, "host": "d28e618fafef", "pid": 9}
```
