### PR TITLE
fix(ui): preserve bearer token hash on settings save (issue #162)

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -212,13 +212,17 @@
                 throw new Error('DNS provider must be selected');
             }
 
-            // API Bearer Token is only required after initial setup
-            if (!settings.api_bearer_token && currentSettings.setup_completed) {
+            // API Bearer Token is only required after initial setup when the
+            // backend has no hashed token already. Post-2.4.8 settings.json
+            // stores only api_bearer_token_hash (the plaintext is intentionally
+            // absent from GET /api/web/settings), so an empty form field on
+            // save means "keep the existing hash", not "no token configured".
+            if (!settings.api_bearer_token && currentSettings.setup_completed && !currentSettings.api_bearer_token_hash) {
                 throw new Error('API Bearer Token is required');
             }
 
             // Auto-generate token for initial setup if not provided
-            if (!settings.api_bearer_token && !currentSettings.setup_completed) {
+            if (!settings.api_bearer_token && !currentSettings.setup_completed && !currentSettings.api_bearer_token_hash) {
                 settings.api_bearer_token = generateRandomToken();
                 var tokenField = document.getElementById('api_bearer_token');
                 if (tokenField) {
@@ -630,6 +634,12 @@
                 if (populateTokenField) {
                     populateTokenField.value = data.api_bearer_token;
                     addDebugLog('API bearer token field populated', 'info');
+                }
+            } else if (data.api_bearer_token_hash) {
+                var hashedTokenField = document.getElementById('api_bearer_token');
+                if (hashedTokenField) {
+                    hashedTokenField.placeholder = 'API token configured — leave empty to keep, or enter a new one to rotate';
+                    addDebugLog('API bearer token already configured (hash present)', 'info');
                 }
             }
 

--- a/tests/test_issue162_bearer_token_preservation.py
+++ b/tests/test_issue162_bearer_token_preservation.py
@@ -1,0 +1,67 @@
+"""
+Regression test for issue #162: saving settings without re-sending
+`api_bearer_token` must preserve the existing `api_bearer_token_hash`.
+
+The UI bug reported in #162 was a client-side throw ("API Bearer Token
+is required") that happened because post-2.4.8 settings.json only stores
+the hashed token. The fix landed in static/js/settings.js, but this test
+locks in the backend contract the UI fix relies on: a save that omits
+`api_bearer_token` must not clobber the existing hash.
+"""
+import json
+
+import pytest
+
+from modules.core.file_operations import FileOperations
+from modules.core.settings import SettingsManager
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def settings_manager(tmp_path):
+    cert_dir = tmp_path / "certificates"
+    data_dir = tmp_path / "data"
+    backup_dir = tmp_path / "backups"
+    logs_dir = tmp_path / "logs"
+    for d in (cert_dir, data_dir, backup_dir, logs_dir):
+        d.mkdir()
+    (backup_dir / "unified").mkdir()
+    file_ops = FileOperations(
+        cert_dir=cert_dir,
+        data_dir=data_dir,
+        backup_dir=backup_dir,
+        logs_dir=logs_dir,
+    )
+    return SettingsManager(file_ops=file_ops, settings_file=data_dir / "settings.json")
+
+
+def test_save_settings_without_bearer_field_preserves_hash(settings_manager):
+    settings_manager.settings_file.write_text(
+        json.dumps(
+            {
+                "email": "admin@example.com",
+                "domains": [],
+                "auto_renew": True,
+                "setup_completed": True,
+                "dns_provider": "cloudflare",
+                "challenge_type": "dns-01",
+                "api_bearer_token_hash": "hmac-sha256:abc123def456",
+            }
+        )
+    )
+
+    loaded = settings_manager.load_settings()
+    assert loaded.get("api_bearer_token_hash") == "hmac-sha256:abc123def456"
+    assert "api_bearer_token" not in loaded
+
+    loaded.pop("api_bearer_token", None)
+    loaded["default_ca"] = "letsencrypt"
+    settings_manager.save_settings(loaded)
+
+    on_disk = json.loads(settings_manager.settings_file.read_text())
+    assert on_disk["api_bearer_token_hash"] == "hmac-sha256:abc123def456", (
+        "Hash must be preserved across saves that omit the plaintext token field"
+    )
+    assert "api_bearer_token" not in on_disk
+    assert on_disk["default_ca"] == "letsencrypt"


### PR DESCRIPTION
## Summary

Closes #162.

After the 2.4.8 settings refactor moved `api_bearer_token` to `api_bearer_token_hash` (plaintext no longer persisted), the in-browser form became unsaveable for any installs that upgraded past that release. `GET /api/web/settings` returns no `api_bearer_token`, the input stays empty, and the client-side validator in [static/js/settings.js](static/js/settings.js) threw `Error('API Bearer Token is required')` on every save — including saves of unrelated sections like CA Providers, which is exactly the symptom reported in the issue.

The backend already preserves the existing hash when `api_bearer_token` is absent from the POST body, so the fix is purely on the frontend.

## Changes

### `static/js/settings.js`

1. Skip the required-field throw and the auto-generate branch when `currentSettings.api_bearer_token_hash` is present — treats an existing hash as "token already configured":
   ```diff
   - if (!settings.api_bearer_token && currentSettings.setup_completed) {
   + if (!settings.api_bearer_token && currentSettings.setup_completed && !currentSettings.api_bearer_token_hash) {
         throw new Error('API Bearer Token is required');
     }
   ```
2. When the GET response exposes only the hash, set a placeholder on the input so the user knows the field is optional:
   > "API token configured — leave empty to keep, or enter a new one to rotate"

### `tests/test_issue162_bearer_token_preservation.py`

One regression test that locks in the backend contract the UI fix relies on: a save that omits `api_bearer_token` must not clobber the existing `api_bearer_token_hash`.

## Verification

**pytest**
- New test: 1/1 PASS
- Full unit suite: 63/63 PASS

**Docker smoke (isolated volume)**
- Boot 2.4.17 image, complete wizard → settings.json holds `api_bearer_token_hash`, no plaintext.
- `GET /api/web/settings` returns `api_bearer_token: null`, `api_bearer_token_hash: '********'` (masked, but key present — what the JS fix checks for).
- `POST /api/web/settings` with a CA-save body (no `api_bearer_token` field) returns `{"message":"Settings updated"}`.
- Hash on disk identical before/after: `hmac-sha256:f758c55b…7e9a4`.
- Existing bearer token still authenticates against `/api/certificates`.

## Notes

- Independent from the just-merged #154 and #163.
- No backend change required: [modules/core/settings.py:530-557](modules/core/settings.py#L530-L557) already strips/preserves correctly when the field is missing.