### PR TITLE
fix(api): always return JSON on /api/* errors (issue #164)

### DIFF
--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Optional
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
-from flask import Flask, request
+from flask import Flask, jsonify, request
 from flask_cors import CORS
 from flask_restx import Api, Namespace
 
@@ -696,6 +696,44 @@ def setup_csrf_protection(app):
         return None
 
 
+def setup_error_handlers(app):
+    """Force JSON responses for unhandled errors on /api/* paths.
+
+    Without these handlers, Werkzeug serves its HTML default page when a
+    request fails to match a registered route (e.g. a trailing slash that
+    no rule covers) or when an unhandled exception escapes a view function.
+    Frontends that pipe the response through `r.json()` then surface
+    "Unexpected token '<'" / NETWORK_ERROR — the symptom reported in #164.
+    Non-API paths keep Flask's default behaviour.
+    """
+    from werkzeug.exceptions import HTTPException
+
+    @app.errorhandler(HTTPException)
+    def _api_http_exception(e):
+        if request.path.startswith('/api/'):
+            return jsonify({
+                'error': e.name,
+                'message': e.description,
+                'code': e.code,
+            }), e.code
+        return e
+
+    @app.errorhandler(Exception)
+    def _api_unhandled_exception(e):
+        if not request.path.startswith('/api/'):
+            raise e
+        logger.exception(
+            "Unhandled exception in API request",
+            path=request.path,
+            method=request.method,
+        )
+        return jsonify({
+            'error': 'Internal Server Error',
+            'message': 'An unexpected error occurred. Check the server logs for details.',
+            'code': 500,
+        }), 500
+
+
 def setup_security_headers(app):
     @app.after_request
     def add_security_headers(response):
@@ -812,6 +850,7 @@ def create_app(test_config=None):
     setup_api(container, app)
     register_web_routes(app, container.managers)
     setup_csrf_protection(app)
+    setup_error_handlers(app)
     setup_security_headers(app)
     setup_rate_limiting(app, container)
     setup_slow_request_logging(app, container)

--- a/tests/test_issue164_api_json_error_handlers.py
+++ b/tests/test_issue164_api_json_error_handlers.py
@@ -1,0 +1,76 @@
+"""
+Regression test for issue #164: API endpoints must never serve HTML error
+pages. The reporter saw `NETWORK_ERROR` / "Unexpected token '<'" because
+Werkzeug's default HTML 404 page reached the browser; the in-app fetch
+wrapper then failed to parse the body as JSON and surfaced it as a
+client-side network error.
+
+The fix registers two global error handlers (`HTTPException` and
+`Exception`) that force JSON for any request whose path starts with
+`/api/`, while leaving Flask's default rendering intact for the rest
+of the application.
+"""
+import pytest
+
+from modules.core import factory
+
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv('DATA_DIR', str(tmp_path))
+    factory._flask_app = None
+    flask_app, _container = factory.create_app(test_config={'TESTING': True})
+    return flask_app
+
+
+def _assert_json_error(resp, expected_status):
+    assert resp.status_code == expected_status
+    assert resp.content_type.startswith('application/json'), (
+        f"expected JSON content-type, got {resp.content_type!r}: {resp.data[:120]!r}"
+    )
+    body = resp.get_json()
+    assert body is not None
+    assert 'error' in body
+    assert body.get('code') == expected_status
+
+
+def test_api_404_on_unknown_path_returns_json(app):
+    """Path that no route matches (typo) → JSON 404, not HTML."""
+    client = app.test_client()
+    resp = client.post('/api/certificates/example.com/renw')
+    _assert_json_error(resp, 404)
+
+
+def test_api_404_on_anomalous_trailing_slash_returns_json(app):
+    """Trailing slash that isn't registered → JSON 404, not HTML.
+
+    This is the most plausible production trigger for #164: a proxy
+    (Kubernetes Ingress, NGINX) or a client redirect normalises the
+    path with a trailing slash that the strict Werkzeug routing
+    doesn't recognise.
+    """
+    client = app.test_client()
+    resp = client.post('/api/certificates/example.com/renew/')
+    _assert_json_error(resp, 404)
+
+
+def test_non_api_404_keeps_html(app):
+    """Non-API paths must keep Flask's default HTML 404 page."""
+    client = app.test_client()
+    resp = client.get('/some-random-non-api-page-xyz')
+    assert resp.status_code == 404
+    assert 'text/html' in resp.content_type, (
+        f"non-API 404 should remain HTML, got {resp.content_type!r}"
+    )
+
+
+def test_api_405_method_not_allowed_returns_json(app):
+    """RESTX already returns JSON for 405; this locks that contract in."""
+    client = app.test_client()
+    # /api/health is GET-only; POST should yield 405
+    resp = client.post('/api/health')
+    assert resp.status_code in (404, 405)
+    assert resp.content_type.startswith('application/json')


### PR DESCRIPTION
## Summary

Closes #164.

Without a global error handler, Werkzeug serves its default HTML 404/500 pages when a request fails to match a registered route or when an unhandled exception escapes a view function. The dashboard's `fetch(...).then(r => r.json())` then chokes on `<!DOCTYPE html>...` and surfaces the failure as `NETWORK_ERROR` / `Unexpected token '<'` — exactly what the reporter saw.

The `Status: 0` in the original report is a JS-side artefact of the in-app fetch wrapper labelling a JSON-parse failure as a network error; the underlying HTTP status was a normal 404/500 with an HTML body.

## Changes

### `modules/core/factory.py` — new `setup_error_handlers(app)`

Two Flask handlers wired in `create_app()` between `setup_csrf_protection` and `setup_security_headers`:

- `@app.errorhandler(HTTPException)` — when `request.path` starts with `/api/`, returns `{error, message, code}` JSON with the original status code; otherwise lets Flask render the default HTML.
- `@app.errorhandler(Exception)` — catches anything else, logs via the structured logger with `path` + `method`, returns a sanitized JSON 500 to API callers; re-raised for non-API paths so static-page rendering is unaffected.

### `tests/test_issue164_api_json_error_handlers.py` — 4 regression tests

- `test_api_404_on_unknown_path_returns_json` — typo URL produces JSON 404
- `test_api_404_on_anomalous_trailing_slash_returns_json` — the most plausible production trigger (Ingress/NGINX normalising paths)
- `test_non_api_404_keeps_html` — non-API 404 must remain HTML (no regression for browser navigation)
- `test_api_405_method_not_allowed_returns_json` — locks in the JSON contract for 405

## Verification

**pytest**
- New tests: 4/4 PASS
- Full unit suite (`-m unit`): 67/67 PASS, no regressions

**Docker smoke (isolated volumes, before/after)**

Reproduced four production-shaped triggers that returned `text/html; charset=utf-8` on `main` HEAD:

```
POST /api/certificates/<dom>/renew/        404 text/html
POST /api/certificates/<dom>/renw          404 text/html
POST /api/foo/bar                          404 text/html
POST /api/.../..%2F..%2Fetc%2Fpasswd/...   404 text/html
```

After the fix, all four return `application/json` with structured body:

```json
{"code": 404, "error": "Not Found", "message": "The requested URL was not found on the server..."}
```

Non-API path stays HTML, confirming no regression:

```
GET /some-random-non-api-page              404 text/html; charset=utf-8
```

## Notes for reviewers

- The PR does not change the response shape of routes that already return JSON errors via RESTX (e.g. 500 from `renew` is still `{"error": "Certificate renewal failed"}`). RESTX handles its own routes first; the new handlers only catch what falls through to Werkzeug.
- The 500 catch-all sanitizes the message to "An unexpected error occurred. Check the server logs for details." — no stack trace leaks to the client. Server-side logging is structured via the existing `factory` logger.
- The reporter's specific `dns-tools.project-t48.com` request didn't reproduce in isolation, but the fix removes the entire class of "HTML response on /api/*" failures, so any future unhandled path is covered. If the reporter can supply the failing URL verbatim, we can confirm it's the same root cause; otherwise the global handler is the right systemic fix regardless.