### PR TITLE
fix(deployer): surface deploy-history write failures (issue #165)

### DIFF
--- a/modules/core/deployer.py
+++ b/modules/core/deployer.py
@@ -236,7 +236,17 @@ class DeployManager:
                 f.write(json.dumps(result) + '\n')
             self._truncate_history()
         except OSError as e:
-            logger.debug(f"Failed to write deploy history: {e}")
+            # Surface write failures at warning level so the "history is
+            # empty even after a manual trigger" symptom (#165) is
+            # diagnosable from production logs. The typical cause on
+            # Kubernetes is a PersistentVolume mounted with an owner
+            # uid that doesn't match the certmate user (uid 1000) in
+            # the container image.
+            logger.warning(
+                "Failed to write deploy history to %s: %s. "
+                "Check that the data volume is writable by uid 1000.",
+                self._history_path, e,
+            )
 
     def _truncate_history(self):
         """Keep only the last MAX_HISTORY_ENTRIES entries (atomic)."""
@@ -291,15 +301,28 @@ class DeployManager:
                 raw = raw.strip()
                 if not raw:
                     continue
-                entry = json.loads(raw)
+                try:
+                    entry = json.loads(raw)
+                except json.JSONDecodeError:
+                    # A single corrupted line should not blank the whole
+                    # history pane. Skip it and carry on with the rest.
+                    logger.debug(
+                        "Skipping corrupted deploy history line in %s",
+                        self._history_path,
+                    )
+                    continue
                 if domain and entry.get('domain') != domain:
                     continue
                 entries.append(entry)
                 if len(entries) >= limit:
                     break
             return entries
-        except (OSError, json.JSONDecodeError) as e:
-            logger.debug(f"Failed to read deploy history: {e}")
+        except OSError as e:
+            logger.warning(
+                "Failed to read deploy history from %s: %s. "
+                "Check filesystem permissions on the data volume.",
+                self._history_path, e,
+            )
             return []
 
     # ------------------------------------------------------------------

--- a/tests/test_issue165_deploy_history_silent_fail.py
+++ b/tests/test_issue165_deploy_history_silent_fail.py
@@ -1,0 +1,96 @@
+"""
+Regression test for issue #165: deploy history "stays empty even after a
+manual trigger" with status 200 and a clear Kubernetes log.
+
+The reporter's situation matches a PersistentVolume mounted with an
+owner uid that doesn't match the certmate user (uid 1000) in the
+container. `_log_history` then raises `PermissionError` on every write
+and the old `logger.debug(...)` call swallowed it at production log
+level (INFO/WARNING). The endpoint kept returning 200 with an empty
+list, leaving the operator without a single diagnostic breadcrumb.
+
+This test pins the write-failure path to WARNING-level so a future
+maintainer can't quietly demote it again, and locks in the path in
+the log message — the path is the actionable bit for the operator
+("oh, the volume must be writable by uid 1000").
+
+A second test guards the read-side: a corrupted line in the JSONL
+file must skip the line, not blank the whole pane.
+"""
+import json
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modules.core.deployer import DeployManager
+from modules.core.shell import MockShellExecutor
+
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def deploy_manager(tmp_path):
+    settings = MagicMock()
+    settings.load_settings.return_value = {'deploy_hooks': {'enabled': True}}
+    return DeployManager(
+        settings_manager=settings,
+        shell_executor=MockShellExecutor(),
+        audit_logger=MagicMock(),
+        event_bus=MagicMock(),
+        cert_dir=tmp_path / 'certs',
+        data_dir=str(tmp_path / 'data'),
+    )
+
+
+def test_log_history_permission_error_logs_at_warning(deploy_manager, caplog):
+    """A write failure caused by a PermissionError on the data volume
+    must surface as a WARNING with the path, not a debug whisper."""
+    result = {
+        'hook_id': 'h1', 'hook_name': 'Test', 'domain': 'example.com',
+        'event': 'manual', 'success': True, 'duration_ms': 0,
+    }
+
+    with patch('builtins.open', side_effect=PermissionError(13, "Permission denied")):
+        with caplog.at_level(logging.WARNING, logger='modules.core.deployer'):
+            deploy_manager._log_history(result)
+
+    records = [r for r in caplog.records if r.name == 'modules.core.deployer']
+    assert records, "expected a WARNING from the deployer logger"
+    assert any(r.levelno == logging.WARNING for r in records), (
+        "write failure must be WARNING, not debug — that's the whole point of #165"
+    )
+    assert any('deploy_history.jsonl' in r.getMessage() for r in records), (
+        "log message must cite the path so the operator knows where to look"
+    )
+    assert any('uid 1000' in r.getMessage() for r in records), (
+        "log message must hint at the typical Kubernetes root cause"
+    )
+
+
+def test_get_history_skips_corrupted_line_instead_of_blanking_whole_pane(
+    deploy_manager, tmp_path
+):
+    """A single corrupted JSONL line must not return [] for the whole
+    history. The healthy lines around it must still come through."""
+    history_path = deploy_manager._history_path
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    good = json.dumps({
+        'hook_id': 'h1', 'hook_name': 'Good', 'domain': 'a.com',
+        'event': 'manual', 'success': True, 'duration_ms': 5,
+    })
+    good2 = json.dumps({
+        'hook_id': 'h2', 'hook_name': 'Good2', 'domain': 'b.com',
+        'event': 'manual', 'success': True, 'duration_ms': 5,
+    })
+    history_path.write_text(good + '\n' + 'this-is-not-json\n' + good2 + '\n')
+
+    entries = deploy_manager.get_history()
+
+    assert len(entries) == 2, (
+        f"expected the 2 healthy entries to survive a corrupted middle line, "
+        f"got {len(entries)}"
+    )
+    names = {e['hook_name'] for e in entries}
+    assert names == {'Good', 'Good2'}


### PR DESCRIPTION
## Summary

Closes #165.

The reporter saw the "Recent Executions" pane stay empty even after manually triggering hooks, with `GET /api/deploy/history` happily returning 200 and a clear Kubernetes log. The shape of the symptom matches a PersistentVolume mounted with an owner uid that doesn't match the `certmate` user (uid 1000) in the container image: every `_log_history` call hits `PermissionError`, but [modules/core/deployer.py:238-239](modules/core/deployer.py#L238-L239) caught the OSError at `logger.debug` level. At the default production log level (INFO/WARNING) the operator had no breadcrumb at all.

## Changes

### `modules/core/deployer.py`

1. `_log_history` now logs OSError at **WARNING** with the path and an actionable hint:
   ```
   Failed to write deploy history to /app/data/deploy_history.jsonl: [Errno 13] Permission denied: '/app/data/deploy_history.jsonl'.
   Check that the data volume is writable by uid 1000.
   ```
2. `get_history` splits the catch: OSError → WARNING (same hint), `json.JSONDecodeError` stays a `debug` per-line skip — and the parsing now happens **inside the loop** so a single corrupted record can no longer blank the whole pane.

### `tests/test_issue165_deploy_history_silent_fail.py` (new, 2 tests)

- `test_log_history_permission_error_logs_at_warning` pins the WARNING level, the path in the message, and the `uid 1000` hint, so a future cleanup can't quietly demote it back to debug.
- `test_get_history_skips_corrupted_line_instead_of_blanking_whole_pane` exercises the new per-line parser with one bad JSON line sandwiched between two good ones; the two healthy entries must still come through.

## Verification

**pytest**
- New tests: 2/2 PASS
- `tests/test_deployer.py`: 39/39 PASS, no regressions on existing TestHistory cases
- Full unit suite (`-m unit`): 69/69 PASS

**Docker smoke (isolated volumes)**

Happy path is unaffected — configured an `echo` hook, hit `POST /api/deploy/test/h1`, `GET /api/deploy/history` returned the single entry as expected.

## Notes for reviewers

- The fix is **diagnostic**, not corrective: the operator still needs to fix their volume permissions to make hooks actually log. The point is that the symptom now has a log line pointing at the root cause instead of a silent return.
- The reporter mentioned Kubernetes specifically; the same pattern applies to docker volumes mounted with a host-side uid that doesn't match the image user, or to any read-only filesystem under `/app/data`.
- Independent from the just-merged #154 / #163 / #166 / #167.