### PR TITLE
feat(ui): copy buttons on DNS-01 alias source/expected rows (issue #159)

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1373,8 +1373,10 @@
             }
             return '<div class="mt-2 text-xs ' + rowClass + '">' +
                 '<div><i class="fas ' + (check.ok ? 'fa-check' : 'fa-times') + ' mr-1"></i>' +
-                '<code class="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">' + escapeHtml(check.source) + '</code></div>' +
-                '<div class="mt-1 ml-5">Expected: <code class="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">' + escapeHtml(check.expected_target) + '</code></div>' +
+                '<code class="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">' + escapeHtml(check.source) + '</code>' +
+                aliasCopyButtonHtml(check.source) + '</div>' +
+                '<div class="mt-1 ml-5">Expected: <code class="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">' + escapeHtml(check.expected_target) + '</code>' +
+                aliasCopyButtonHtml(check.expected_target) + '</div>' +
                 '<div class="mt-1 ml-5">Found: <code class="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">' + escapeHtml(found) + '</code></div>' +
                 '</div>';
         }).join('');
@@ -1838,6 +1840,58 @@
         document.body.removeChild(textArea);
     }
 
+    function aliasCopyButtonHtml(value) {
+        if (!value) return '';
+        return ' <button type="button" class="ml-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors align-middle"' +
+            ' data-copy="' + escapeHtml(value) + '"' +
+            ' onclick="copyAliasValueToClipboard(this)"' +
+            ' title="Copy to clipboard" aria-label="Copy to clipboard">' +
+            '<i class="fas fa-clipboard text-xs"></i></button>';
+    }
+
+    function copyAliasValueToClipboard(button) {
+        // The raw value is stored in data-copy and trimmed at copy time so the
+        // user can't end up pasting the leading/trailing whitespace that the
+        // browser tends to grab when a CNAME string is selected by hand
+        // (issue #159).
+        var text = String(button.dataset.copy || '').trim();
+        if (!text) return;
+        var icon = button.querySelector('i');
+        var originalIconClass = icon ? icon.className : 'fas fa-clipboard text-xs';
+        function flashSuccess() {
+            if (icon) icon.className = 'fas fa-check text-xs';
+            button.classList.add('text-green-600', 'dark:text-green-400');
+            setTimeout(function () {
+                if (icon) icon.className = originalIconClass;
+                button.classList.remove('text-green-600', 'dark:text-green-400');
+            }, 1500);
+        }
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(flashSuccess).catch(function () {
+                aliasFallbackCopy(text, flashSuccess);
+            });
+        } else {
+            aliasFallbackCopy(text, flashSuccess);
+        }
+    }
+
+    function aliasFallbackCopy(text, onSuccess) {
+        var textArea = document.createElement('textarea');
+        textArea.value = text;
+        textArea.style.top = '0';
+        textArea.style.left = '0';
+        textArea.style.position = 'fixed';
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        try {
+            if (document.execCommand('copy')) onSuccess();
+        } catch (err) {
+            /* swallow: feedback simply won't flash */
+        }
+        document.body.removeChild(textArea);
+    }
+
     // Initialize on page load
     document.addEventListener('DOMContentLoaded', function () {
         // Resolve the caller's role first so the initial cert list can
@@ -1923,4 +1977,5 @@
     window.updateCAProviderInfo = updateCAProviderInfo;
     window.updateDnsAliasHelp = updateDnsAliasHelp;
     window.checkDnsAliasForCertificate = checkDnsAliasForCertificate;
+    window.copyAliasValueToClipboard = copyAliasValueToClipboard;
 })();


### PR DESCRIPTION
## Summary

Closes #159.

The reporter's pain point: hand-selecting `_acme-challenge.<domain>` and the expected CNAME target out of the DNS-01 alias check result tends to grab leading/trailing whitespace along with the FQDN. Pasting that into a DNS provider that's strict about value parsing either fails to save or quietly creates a record that doesn't match.

This PR adds a small clipboard icon next to `<code>` for **Source** and **Expected** in the DNS-01 alias check result panel. The icon flashes green for 1.5s on success.

## Changes

### `static/js/dashboard.js`

- `aliasCopyButtonHtml(value)` — renders the button with the value in `data-copy` (HTML-escaped to avoid attribute breakout).
- `copyAliasValueToClipboard(button)` — uses `navigator.clipboard.writeText` with the existing `document.execCommand('copy')` textarea fallback; swaps the icon to `fa-check` + green for 1.5s so users see a positive ack without a full toast (the alias panel already takes the toast region next to it). Value is `.trim()`-ed at copy time — the whole point of the issue.
- `renderDnsAliasCheckResult` now appends the copy button after `<code>{source}</code>` and `<code>{expected_target}</code>`. The `Found` row deliberately omits the button: it can hold a free-form error string and a copy there would be misleading.
- Window export so the inline `onclick` resolves.

## Visual

Before each `<code>` line in the alias result panel:

```
[X] _acme-challenge.example.com               [📋]
    Expected: _acme-challenge.validation.example.org [📋]
    Found: No CNAME found
```

The icon is `fa-clipboard` in the row's standard text color, hover-darkens, swaps to `fa-check` green on success.

## Verification

- `node --check static/js/dashboard.js` → syntax clean.
- Docker smoke (isolated volume): `/static/js/dashboard.js` served by the running container contains the new helpers and the `window.copyAliasValueToClipboard` export. `/login` and `/health` still render normally.
- Manual: open the create-cert form, fill a domain with DNS-01 alias, click "Check DNS-01 Alias" — the result rows now show clipboard icons that copy the trimmed FQDN.

## Notes for reviewers

- No backend change, no test infra change, no new dependencies.
- The fallback path (`aliasFallbackCopy`) silently no-ops if the browser blocks `execCommand('copy')`. There's no toast on failure: the user notices no green flash, which is enough signal that something didn't work, without spamming an error message. Same pattern as the existing curl-copy modal.