### PR TITLE
fix(settings): drop redundant top-level storage_backend from save payload

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -197,7 +197,6 @@
                 challenge_type: formData.get('challenge_type') || 'dns-01',
                 api_bearer_token: tokenValue,
                 cache_ttl: parseInt(formData.get('cache_ttl')) || 300,
-                storage_backend: formData.get('storage_backend'),
                 certificate_storage: collectStorageBackendSettings(),
                 default_ca: defaultCA,
                 ca_providers: caProviders

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -42,6 +42,38 @@ class TestSettingsSave:
         data = r.json()
         assert data.get("email") == email
 
+    def test_save_full_ui_payload_shape(self, api):
+        r = api.post_json("/api/web/settings", {
+            "email": "ui-shape@example.com",
+            "domains": [],
+            "auto_renew": True,
+            "renewal_threshold_days": 30,
+            "dns_provider": "cloudflare",
+            "challenge_type": "dns-01",
+            "cache_ttl": 300,
+            "certificate_storage": {
+                "backend": "local_filesystem",
+                "cert_dir": "/data/certs",
+            },
+            "default_ca": "letsencrypt",
+            "ca_providers": {
+                "letsencrypt": {"email": "ui-shape@example.com"},
+            },
+        })
+        assert r.status_code == 200, r.text
+        assert r.json() == {"message": "Settings updated"}
+
+    def test_save_rejects_unknown_top_level_field(self, api):
+        r = api.post_json("/api/web/settings", {
+            "email": "unknown-field@example.com",
+            "dns_provider": "cloudflare",
+            "totally_made_up_field": "nope",
+        })
+        assert r.status_code == 400
+        data = r.json()
+        assert data["error"] == "Unknown fields in payload"
+        assert data["unknown"] == ["totally_made_up_field"]
+
 
 class TestDNSProviderAccounts:
     """DNS provider account CRUD."""


### PR DESCRIPTION
Saving anything from the Settings page returns HTTP 400:

```json
{"error":"Unknown fields in payload","hint":"Only documented settings keys are accepted.","unknown":["storage_backend"]}
```

`static/js/settings.js` builds the save payload with a top-level `storage_backend`
field, but the server's whitelist (`PUBLIC_SETTINGS_WRITABLE_KEYS` in
`modules/core/settings.py`) doesn't accept it. The same value is already sent
inside `certificate_storage.backend` via `collectStorageBackendSettings()`, so
the top-level copy is redundant.

Fix is a one-line deletion in `settings.js`. Two regression tests added to
`tests/test_settings.py::TestSettingsSave`, one POSTs the relevant Settings UI payload shape without the stray `storage_backend` field and asserts 200, the other asserts a stray field still returns the
documented 400 body so the whitelist can't be silently widened later.