### PR TITLE
fix: close #212 (path-style /download/<file> URL returned 404)

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -1276,6 +1276,98 @@ def create_api_resources(api, models, managers):
                 logger.error(f"Error downloading certificate for {domain}: {e}")
                 return {'error': 'Failed to download certificate'}, 500
 
+    class DownloadCertificateFile(Resource):
+        # Path-style alias for the query-string form on DownloadCertificate.
+        # Documented in discussion #183 as the canonical scripting URL
+        # (curl ... /api/certificates/<domain>/download/fullchain). Without
+        # this route the documented URL returned 404 (issue #212).
+        #
+        # Short names map 1:1 to the on-disk filenames. The role gate and
+        # path-traversal guards mirror the ?file= branch in
+        # DownloadCertificate.get() — keep the two in sync.
+        _SHORT_NAME_TO_FILE = {
+            'cert': 'cert.pem',
+            'chain': 'chain.pem',
+            'fullchain': 'fullchain.pem',
+            'privkey': 'privkey.pem',
+            'combined': 'combined.pem',
+        }
+
+        @api.doc(security='Bearer')
+        @auth_manager.require_role('viewer')
+        def get(self, domain, file_type):
+            """Download a single certificate file by short name.
+
+            Path-style equivalent of ``?file=<name>.pem`` on the parent
+            ``/download`` route. ``file_type`` is one of ``cert``,
+            ``chain``, ``fullchain``, ``privkey``, ``combined``.
+
+            Role gating: viewers can pull public material (cert, chain,
+            fullchain); ``privkey`` and ``combined`` require operator+.
+            """
+            requested_file = self._SHORT_NAME_TO_FILE.get(file_type)
+            if requested_file is None:
+                return {
+                    'error': f'Invalid file type: {file_type}',
+                    'hint': f"Allowed: {sorted(self._SHORT_NAME_TO_FILE)}",
+                }, 400
+
+            try:
+                scope_err = _check_domain_scope(domain, 'download')
+                if scope_err:
+                    return scope_err
+                cert_dir, err = _validate_domain_path(domain, file_ops.cert_dir)
+                if err:
+                    return {'error': err}, 400
+                if not cert_dir.exists():
+                    return {'error': f'Certificate not found for domain: {domain}'}, 404
+
+                user = getattr(request, 'current_user', None) or {}
+
+                if requested_file in _PRIVATE_KEY_FILES and not _user_has_role(user, 'operator'):
+                    if audit_logger:
+                        audit_logger.log_authz_denied(
+                            operation='download',
+                            resource_type='certificate',
+                            resource_id=domain,
+                            reason=f'viewer cannot download private-key material ({requested_file})',
+                            user=user.get('username'),
+                            ip_address=request.remote_addr,
+                        )
+                    return {
+                        'error': 'operator role required to download private key material',
+                        'code': 'PRIVKEY_REQUIRES_OPERATOR',
+                        'hint': 'Use /download/fullchain to pull public material as a viewer.',
+                    }, 403
+
+                if requested_file == 'combined.pem':
+                    try:
+                        fullchain = (cert_dir / 'fullchain.pem').read_text(encoding='utf-8')
+                        privkey = (cert_dir / 'privkey.pem').read_text(encoding='utf-8')
+                        combined_data = io.BytesIO(f"{fullchain}{privkey}".encode())
+                        return send_file(
+                            combined_data,
+                            as_attachment=True,
+                            download_name=f'{domain}_combined.pem',
+                            mimetype='application/x-pem-file'
+                        )
+                    except FileNotFoundError:
+                        return {'error': f'Required cert files not found for domain {domain}'}, 404
+
+                file_path = cert_dir / requested_file
+                if not file_path.exists():
+                    return {'error': f'File {requested_file} not found for domain {domain}'}, 404
+
+                return send_file(
+                    file_path,
+                    as_attachment=True,
+                    download_name=f'{domain}_{requested_file}',
+                    mimetype='application/x-pem-file'
+                )
+            except Exception as e:
+                logger.error(f"Error downloading {file_type} for {domain}: {e}")
+                return {'error': 'Failed to download certificate file'}, 500
+
     class RenewCertificate(Resource):
         @api.doc(security='Bearer')
         @auth_manager.require_role('operator')
@@ -2295,6 +2387,7 @@ def create_api_resources(api, models, managers):
         'CertificateDeploymentStatus': CertificateDeploymentStatus,
         'CertificateDeploymentBrowserReports': CertificateDeploymentBrowserReports,
         'DownloadCertificate': DownloadCertificate,
+        'DownloadCertificateFile': DownloadCertificateFile,
         'RenewCertificate': RenewCertificate,
         'CertificateAutoRenew': CertificateAutoRenew,
         'CertificateRunDeploy': CertificateRunDeploy,

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -650,6 +650,7 @@ def setup_api(container: AppContainer, app):
     ns_certificates.add_resource(api_resources['CertificateDeploymentBrowserReports'], '/deployment-status/browser')
     ns_certificates.add_resource(api_resources['CertificateDNSAliasCheck'], '/<string:domain>/dns-alias-check')
     ns_certificates.add_resource(api_resources['DownloadCertificate'], '/<string:domain>/download')
+    ns_certificates.add_resource(api_resources['DownloadCertificateFile'], '/<string:domain>/download/<string:file_type>')
     ns_certificates.add_resource(api_resources['RenewCertificate'], '/<string:domain>/renew')
     ns_certificates.add_resource(api_resources['CertificateAutoRenew'], '/<string:domain>/auto-renew')
     ns_certificates.add_resource(api_resources['CertificateRunDeploy'], '/<string:domain>/deploy')

--- a/tests/test_issue212_download_path_style.py
+++ b/tests/test_issue212_download_path_style.py
@@ -1,0 +1,201 @@
+"""Regression test for issue #212.
+
+The discussion at https://github.com/fabriziosalmi/certmate/discussions/183
+documents the canonical scripting URL for fetching a single PEM file as::
+
+    GET /api/certificates/<domain>/download/<cert|chain|fullchain|privkey>
+
+But the route registered in factory.py only carried the query-string form
+``/<domain>/download`` (consumed by ``?file=<name>.pem``). Path-style URLs
+returned 404 — reported by SpeeDFireCZE as issue #212, "BUG: download
+specific cert file thru API". The user reproduced it with the exact curl
+example from discussion #183.
+
+This test pins the new ``DownloadCertificateFile`` route so the documented
+path-style URL works for every short name and applies the same role and
+scope checks the query-string form already had (Sprint 1.5 audit
+follow-up: viewer cannot pull private-key material).
+
+No Docker; runs in-process.
+"""
+
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from flask import Flask, request
+from flask_restx import Api, Namespace
+
+from modules.api.models import create_api_models
+from modules.api.resources import create_api_resources
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def _passthrough_decorator(_min_role):
+    def deco(fn):
+        return fn
+    return deco
+
+
+@pytest.fixture
+def cert_dir(tmp_path):
+    d = tmp_path / 'example.com'
+    d.mkdir()
+    (d / 'cert.pem').write_text('PUBLIC-cert')
+    (d / 'chain.pem').write_text('PUBLIC-chain')
+    (d / 'fullchain.pem').write_text('PUBLIC-fullchain')
+    (d / 'privkey.pem').write_text('PRIVATE-key')
+    return tmp_path
+
+
+@pytest.fixture
+def app_with_path_download(cert_dir):
+    """Flask test client with the path-style download route wired up.
+
+    Bypasses ``require_role`` so per-file role gating is tested via the
+    handler's own checks against ``request.current_user`` (set by
+    ``_attach_user`` per test)."""
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_decorator)
+    auth_manager.user_can_access_domain.return_value = True
+    auth_manager.domain_matches_scope.return_value = True
+
+    file_ops = MagicMock(cert_dir=Path(cert_dir))
+    settings_manager = MagicMock()
+    settings_manager.load_settings.return_value = {}
+    certificate_manager = MagicMock(cert_dir=Path(cert_dir))
+    audit_logger = MagicMock()
+
+    managers = {
+        'auth': auth_manager,
+        'settings': settings_manager,
+        'certificates': certificate_manager,
+        'file_ops': file_ops,
+        'cache': MagicMock(),
+        'dns': MagicMock(),
+        'audit': audit_logger,
+    }
+
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    api = Api(app, prefix='/api')
+    models = create_api_models(api)
+    resources = create_api_resources(api, models, managers)
+
+    ns = Namespace('certificates', description='certs')
+    api.add_namespace(ns)
+    ns.add_resource(
+        resources['DownloadCertificateFile'],
+        '/<string:domain>/download/<string:file_type>',
+    )
+
+    return app, managers
+
+
+def _attach_user(app, role):
+    @app.before_request
+    def _set_user():
+        from flask import request as _r
+        _r.current_user = {
+            'username': f'fake_{role}',
+            'role': role,
+            'allowed_domains': None,
+        }
+
+
+class TestPathStyleDownload:
+    """The documented ``/download/<short>`` URLs must work for the four
+    short names and apply identical role gating to the query-string form."""
+
+    @pytest.mark.parametrize('short,expected_body', [
+        ('cert', b'PUBLIC-cert'),
+        ('chain', b'PUBLIC-chain'),
+        ('fullchain', b'PUBLIC-fullchain'),
+    ])
+    def test_viewer_can_pull_public_short_names(
+        self, app_with_path_download, short, expected_body,
+    ):
+        app, _ = app_with_path_download
+        _attach_user(app, 'viewer')
+        client = app.test_client()
+        r = client.get(f'/api/certificates/example.com/download/{short}')
+        assert r.status_code == 200, r.data
+        assert expected_body in r.data
+        assert r.headers['Content-Type'] == 'application/x-pem-file'
+
+    def test_viewer_cannot_pull_privkey_short_name(self, app_with_path_download):
+        app, managers = app_with_path_download
+        _attach_user(app, 'viewer')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download/privkey')
+        assert r.status_code == 403
+        body = r.get_json()
+        assert body['code'] == 'PRIVKEY_REQUIRES_OPERATOR'
+        managers['audit'].log_authz_denied.assert_called()
+
+    def test_viewer_cannot_pull_combined_short_name(self, app_with_path_download):
+        app, managers = app_with_path_download
+        _attach_user(app, 'viewer')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download/combined')
+        assert r.status_code == 403
+        body = r.get_json()
+        assert body['code'] == 'PRIVKEY_REQUIRES_OPERATOR'
+        managers['audit'].log_authz_denied.assert_called()
+
+    def test_operator_can_pull_privkey_short_name(self, app_with_path_download):
+        app, _ = app_with_path_download
+        _attach_user(app, 'operator')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download/privkey')
+        assert r.status_code == 200
+        assert b'PRIVATE-key' in r.data
+
+    def test_operator_can_pull_combined_short_name(self, app_with_path_download):
+        app, _ = app_with_path_download
+        _attach_user(app, 'operator')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download/combined')
+        assert r.status_code == 200
+        # Combined = fullchain + privkey concatenated.
+        assert b'PUBLIC-fullchain' in r.data
+        assert b'PRIVATE-key' in r.data
+
+    def test_unknown_short_name_returns_400(self, app_with_path_download):
+        app, _ = app_with_path_download
+        _attach_user(app, 'operator')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download/bogus')
+        assert r.status_code == 400
+        body = r.get_json()
+        assert 'Invalid file type' in body['error']
+
+    def test_path_short_name_does_not_accept_pem_suffix(self, app_with_path_download):
+        """The documented contract is bare short names. ``fullchain.pem``
+        as a path segment is NOT the documented form and must 400 so
+        callers don't get a misleading "file not found" for what is a
+        URL-shape error."""
+        app, _ = app_with_path_download
+        _attach_user(app, 'operator')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download/fullchain.pem')
+        assert r.status_code == 400
+
+    def test_missing_domain_returns_404(self, app_with_path_download):
+        app, _ = app_with_path_download
+        _attach_user(app, 'viewer')
+        client = app.test_client()
+        r = client.get('/api/certificates/nope.example.com/download/fullchain')
+        assert r.status_code == 404
+
+    def test_missing_file_on_disk_returns_404(self, app_with_path_download, cert_dir):
+        # Delete chain.pem and ensure we 404 with a useful message rather
+        # than crashing or 500ing.
+        (Path(cert_dir) / 'example.com' / 'chain.pem').unlink()
+        app, _ = app_with_path_download
+        _attach_user(app, 'viewer')
+        client = app.test_client()
+        r = client.get('/api/certificates/example.com/download/chain')
+        assert r.status_code == 404


### PR DESCRIPTION
## Summary

Closes #212.

Discussion #183 documents the canonical scripting URL for fetching a single PEM file as:

```
GET /api/certificates/<domain>/download/<cert|chain|fullchain|privkey>
```

The only route registered in `factory.py` was the query-string form `/<domain>/download` (consumed by `?file=<name>.pem`). The documented path-style URLs returned 404 — reported by SpeeDFireCZE with the exact curl example from #183.

## Changes

- **`modules/api/resources.py`** — new `DownloadCertificateFile` resource. Maps short names (`cert`, `chain`, `fullchain`, `privkey`, `combined`) to the on-disk filenames and reuses the existing scope / role / path-traversal guards from the `?file=` branch. Viewer can pull public material; `privkey` + `combined` require operator+, with the audit-log denial path preserved.
- **`modules/core/factory.py`** — register `/<string:domain>/download/<string:file_type>` alongside the existing `/<string:domain>/download`. The query-string form is untouched — zero breaking change to callers using `?file=`.

## Tests

- **`tests/test_issue212_download_path_style.py`** (new, 11 cases): three public short names parametrised, `privkey` / `combined` denied for viewer, both allowed for operator, unknown short name → 400, `.pem` suffix on the path → 400 (URL-shape error, not a misleading 404), missing domain → 404, missing file on disk → 404.
- The 23 existing role-split tests in `tests/test_sprint1_5_audit_followup.py` remain green — the `?file=` form is intact.

Full local suite: **887 passed, 14 skipped, 2 xfailed, 0 failed** in 102s.

## Test plan

- [x] `pytest tests/test_issue212_download_path_style.py tests/test_sprint1_5_audit_followup.py -v` — 34/34 green
- [x] Full local suite — 887 passed
- [ ] CI green on the PR
- [ ] Manual smoke: `curl -fsSL -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/certificates/<domain>/download/fullchain -o /tmp/fullchain.pem` against a Docker stack with an issued cert