### PR TITLE
fix(storage): reload backend when certificate_storage settings change

### DIFF
--- a/modules/core/storage_backends.py
+++ b/modules/core/storage_backends.py
@@ -10,6 +10,7 @@ import logging
 import re
 import shutil
 import tempfile
+import threading
 import time
 import zipfile
 from abc import ABC, abstractmethod
@@ -1439,20 +1440,65 @@ class InfisicalBackend(CertificateStorageBackend):
 
 class StorageManager:
     """Manager class for certificate storage backends"""
-    
+
     def __init__(self, settings_manager):
         self.settings_manager = settings_manager
         self._backend = None
         self._initialized = False
-    
+        # Snapshot of the certificate_storage subtree that was used to build
+        # the currently-cached backend. We compare the live settings against
+        # this on every get_backend() so a settings update that changes the
+        # backend (or its config) is picked up without a process restart.
+        self._config_signature = None
+        self._lock = threading.RLock()
+
+    def reload(self):
+        """Force the next get_backend() to re-read settings and rebuild the
+        backend. Call this after persisting a settings change that mutates
+        ``certificate_storage`` so the running process picks up the new
+        backend without a restart."""
+        with self._lock:
+            self._backend = None
+            self._initialized = False
+            self._config_signature = None
+
+    @staticmethod
+    def _signature_for(storage_config):
+        """Stable signature of the storage config subtree. Used to detect
+        out-of-band changes so the backend can be rebuilt lazily."""
+        try:
+            return json.dumps(storage_config or {}, sort_keys=True, default=str)
+        except (TypeError, ValueError):
+            # Last-resort fallback: repr is stable enough for change-detection.
+            return repr(storage_config)
+
     def _initialize_backend(self):
-        """Initialize storage backend based on settings"""
-        if self._initialized:
-            return
-        
+        """Initialize storage backend based on settings.
+
+        Lazy + change-aware: rebuilds the backend when the certificate_storage
+        subtree differs from the snapshot used last time. This is what makes a
+        backend swap from the UI take effect immediately instead of waiting
+        for an app restart."""
         try:
             settings = self.settings_manager.load_settings()
-            storage_config = settings.get('certificate_storage', {})
+        except Exception as e:
+            # If we can't read settings, keep whatever backend we have so
+            # in-flight operations don't crash. The original error already
+            # logged by load_settings carries the context.
+            logger.error("StorageManager could not read settings: %s", e)
+            if self._initialized:
+                return
+            self._backend = LocalFileSystemBackend(Path('certificates'))
+            self._initialized = True
+            self._config_signature = None
+            return
+
+        storage_config = settings.get('certificate_storage', {}) or {}
+        signature = self._signature_for(storage_config)
+        if self._initialized and signature == self._config_signature:
+            return
+
+        try:
             backend_type = storage_config.get('backend', 'local_filesystem')
             
             if backend_type == 'local_filesystem':
@@ -1482,8 +1528,9 @@ class StorageManager:
                 self._backend = LocalFileSystemBackend(cert_dir)
             
             self._initialized = True
+            self._config_signature = signature
             logger.info(f"Storage backend initialized: {self._backend.get_backend_name()}")
-            
+
         except Exception as e:
             logger.error(
                 "Failed to initialize storage backend '%s': %s. "
@@ -1493,11 +1540,15 @@ class StorageManager:
             )
             self._backend = LocalFileSystemBackend(Path('certificates'))
             self._initialized = True
-    
+            # Cache the signature even on the fallback path so a subsequent
+            # call doesn't keep retrying the broken backend on every get.
+            self._config_signature = signature
+
     def get_backend(self) -> CertificateStorageBackend:
         """Get the current storage backend"""
-        self._initialize_backend()
-        return self._backend
+        with self._lock:
+            self._initialize_backend()
+            return self._backend
     
     def store_certificate(self, domain: str, cert_files: Dict[str, bytes], metadata: Dict[str, Any]) -> bool:
         """Store certificate using the configured backend"""

--- a/tests/test_storage_backends_coverage.py
+++ b/tests/test_storage_backends_coverage.py
@@ -406,17 +406,56 @@ class TestStorageManagerDispatch:
 
     def test_initialization_is_lazy_and_idempotent(self, tmp_path):
         """get_backend must not hit the disk / cloud on construction —
-        only on first call. And subsequent calls must return the same
-        instance (no re-init)."""
+        only on first call. Subsequent calls must return the same
+        instance as long as the certificate_storage config is unchanged
+        (no needless re-init). When the config changes, get_backend must
+        pick that up without an app restart — see
+        test_get_backend_rebuilds_on_config_change for that contract."""
         sm = self._settings_mgr({'backend': 'local_filesystem',
                                   'cert_dir': str(tmp_path / 'certs')})
         mgr = StorageManager(sm)
         sm.load_settings.assert_not_called()  # not called in __init__
         first = mgr.get_backend()
-        sm.load_settings.assert_called_once()  # only on first get_backend
         second = mgr.get_backend()
-        assert first is second  # same instance
-        sm.load_settings.assert_called_once()  # still only once
+        assert first is second  # same instance when config unchanged
+
+    def test_get_backend_rebuilds_on_config_change(self, tmp_path):
+        """A live settings change to certificate_storage must take effect
+        without a process restart. The user-reported bug was that swapping
+        backends only applied after restarting the app — guarded here."""
+        sm = MagicMock()
+        sm.load_settings.return_value = {
+            'certificate_storage': {
+                'backend': 'local_filesystem',
+                'cert_dir': str(tmp_path / 'certs-a'),
+            }
+        }
+        mgr = StorageManager(sm)
+        first = mgr.get_backend()
+        assert isinstance(first, LocalFileSystemBackend)
+
+        sm.load_settings.return_value = {
+            'certificate_storage': {
+                'backend': 'local_filesystem',
+                'cert_dir': str(tmp_path / 'certs-b'),
+            }
+        }
+        second = mgr.get_backend()
+        assert second is not first  # rebuilt because cert_dir changed
+
+    def test_reload_forces_rebuild_on_next_get(self, tmp_path):
+        """reload() is the explicit hook callers use after persisting a
+        settings update; the next get_backend() must rebuild even if the
+        config dict happens to compare equal (e.g. credential rotation
+        where the storage subtree byte-identical doesn't tell the whole
+        story)."""
+        sm = self._settings_mgr({'backend': 'local_filesystem',
+                                  'cert_dir': str(tmp_path / 'certs')})
+        mgr = StorageManager(sm)
+        first = mgr.get_backend()
+        mgr.reload()
+        second = mgr.get_backend()
+        assert second is not first
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary

Swapping the certificate storage backend from the Settings UI used to require restarting the app before the running process actually used the new backend. `StorageManager` built its backend on first use and cached it behind an `_initialized` flag that was never reset, so any subsequent settings change was invisible until the next process start.

This PR makes the backend hot-reload itself when `certificate_storage` changes, without touching any of the per-backend implementations or their tests beyond the manager-level contract.

## What changed

- `modules/core/storage_backends.py`
  - `StorageManager` now snapshots the `certificate_storage` subtree (stable JSON signature) at init time. On every `get_backend()` it compares the live settings against the snapshot and rebuilds lazily when the signature differs.
  - Added an explicit `StorageManager.reload()` for callers that want to force a rebuild on the next `get_backend()` (e.g. credential rotation where the dict happens to compare equal byte-for-byte).
  - Added an `_lock` so a concurrent settings change cannot interleave with an in-flight rebuild.
  - On the fallback-to-local path the signature is still cached, so a misconfigured backend doesn't retry the broken init on every call.
- `tests/test_storage_backends_coverage.py`
  - Updated `test_initialization_is_lazy_and_idempotent` to reflect the new contract: lazy + stable while config is unchanged, but no longer asserts `load_settings` is called exactly once (it now also runs the cheap signature check on each `get_backend`).
  - Added `test_get_backend_rebuilds_on_config_change` — the user-reported regression guard.
  - Added `test_reload_forces_rebuild_on_next_get` — covers the explicit-invalidation API.

## Why this approach

I considered two alternatives before settling on signature-compare-in-`get_backend`:

1. **Wire an observer from `SettingsManager` save paths into `StorageManager.reload()`.** Rejected because it relies on every future settings-mutation path remembering to call `reload()`; missing one would silently reintroduce the bug.
2. **Always re-read settings and rebuild on every `get_backend`.** Rejected because it loses the "same instance returned when config is unchanged" property that callers rely on (and that the existing test explicitly documents).

Signature-compare keeps the lazy/idempotent guarantee for the no-change case (which is the hot path) and recovers automatically for *any* path that mutates settings — the request-scoped settings cache means the extra `load_settings` call inside a Flask request is free.

## Test plan

- [x] `pytest tests/test_storage_backends_coverage.py` — 58 passed locally
- [x] Manual: switch backend in the Settings UI, save, observe `get_backend()` picks up the new backend on the next renewal tick without restart