### PR TITLE
fix(storage): accept the Settings UI payload in POST /api/storage/migrate

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -352,10 +352,14 @@ def create_api_models(api):
     })
 
     storage_migration_config_model = api.model('StorageMigrationConfig', {
-        'source_backend': fields.String(description='Source storage backend type', required=True),
-        'target_backend': fields.String(description='Target storage backend type', required=True),
-        'source_config': fields.Raw(description='Source backend configuration', required=True),
-        'target_config': fields.Raw(description='Target backend configuration', required=True)
+        # All four fields are optional: source defaults to the active
+        # certificate_storage from settings and target_backend can be read
+        # from target_config['backend'] (the envelope shape the settings
+        # form emits via collectStorageBackendSettings()).
+        'source_backend': fields.String(description='Source storage backend type (defaults to current certificate_storage.backend)'),
+        'target_backend': fields.String(description='Target storage backend type (defaults to target_config.backend)'),
+        'source_config': fields.Raw(description='Source backend configuration (defaults to current certificate_storage)'),
+        'target_config': fields.Raw(description='Target backend configuration; accepts either the per-backend dict or the {backend, <backend>: {...}} envelope', required=True)
     })
 
     # CA Provider models

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -2196,71 +2196,119 @@ def create_api_resources(api, models, managers):
         @auth_manager.require_role('admin')
         @api.expect(models['storage_migration_config_model'])
         def post(self):
-            """Migrate certificates between storage backends"""
-            try:
-                data = api.payload
-                source_backend_type = data.get('source_backend')
-                target_backend_type = data.get('target_backend')
-                source_config = data.get('source_config', {})
-                target_config = data.get('target_config', {})
+            """Migrate certificates between storage backends.
 
-                # Import storage backends
-                from ..core.storage_backends import (
-                    LocalFileSystemBackend, AzureKeyVaultBackend,
-                    AWSSecretsManagerBackend, HashiCorpVaultBackend,
-                    InfisicalBackend
+            Payload is forgiving on purpose: the UI's "Start Migration"
+            button has no way to remember the previously-active backend
+            (the dropdown already shows the user's new target choice),
+            so we accept either the explicit four-field form
+            (``source_backend`` + ``source_config`` + ``target_backend`` +
+            ``target_config``) or a minimal payload where source defaults
+            to the currently-saved ``certificate_storage`` and the target
+            comes in as the structured ``{backend, <backend>: {...}}`` blob
+            the settings form already produces.
+            """
+            from ..core.storage_backends import (
+                LocalFileSystemBackend, AzureKeyVaultBackend,
+                AWSSecretsManagerBackend, HashiCorpVaultBackend,
+                InfisicalBackend
+            )
+
+            backend_classes = {
+                'local_filesystem': LocalFileSystemBackend,
+                'azure_keyvault': AzureKeyVaultBackend,
+                'aws_secrets_manager': AWSSecretsManagerBackend,
+                'hashicorp_vault': HashiCorpVaultBackend,
+                'infisical': InfisicalBackend,
+            }
+
+            def _resolve_config(backend_type, raw):
+                """Pull the per-backend sub-config out of either a flat dict
+                (already the right shape) or the structured envelope the
+                settings form emits (``{backend, <backend>: {...}}``)."""
+                if not isinstance(raw, dict):
+                    return {}
+                if backend_type in raw and isinstance(raw[backend_type], dict):
+                    return raw[backend_type]
+                # local_filesystem stores ``cert_dir`` at the top level both
+                # in settings and in the form payload, so the envelope and
+                # the flat form are indistinguishable — return as-is.
+                return {k: v for k, v in raw.items() if k != 'backend'}
+
+            def _build_backend(backend_type, config):
+                if backend_type == 'local_filesystem':
+                    return LocalFileSystemBackend(
+                        Path(config.get('cert_dir', 'certificates')))
+                return backend_classes[backend_type](config)
+
+            try:
+                data = api.payload or {}
+                target_raw = data.get('target_config') or {}
+                source_raw = data.get('source_config') or {}
+
+                # Source defaults to the currently-active backend if the
+                # caller didn't pass one — that's the dominant UI path.
+                source_backend_type = data.get('source_backend')
+                if not source_backend_type or not source_raw:
+                    current = settings_manager.load_settings() or {}
+                    current_storage = current.get('certificate_storage') or {}
+                    if not source_backend_type:
+                        source_backend_type = current_storage.get(
+                            'backend', 'local_filesystem')
+                    if not source_raw:
+                        source_raw = current_storage
+
+                # Target backend may be passed explicitly or inferred from
+                # the envelope produced by collectStorageBackendSettings().
+                target_backend_type = (
+                    data.get('target_backend')
+                    or (target_raw.get('backend') if isinstance(target_raw, dict) else None)
                 )
 
-                # Create backend instances
-                backend_classes = {
-                    'local_filesystem': LocalFileSystemBackend,
-                    'azure_keyvault': AzureKeyVaultBackend,
-                    'aws_secrets_manager': AWSSecretsManagerBackend,
-                    'hashicorp_vault': HashiCorpVaultBackend,
-                    'infisical': InfisicalBackend
-                }
+                if source_backend_type not in backend_classes:
+                    return {'error': 'Invalid source backend type'}, 400
+                if target_backend_type not in backend_classes:
+                    return {'error': 'Invalid target backend type'}, 400
 
-                if source_backend_type not in backend_classes or target_backend_type not in backend_classes:
-                    return {'error': 'Invalid backend type'}, 400
+                source_config = _resolve_config(source_backend_type, source_raw)
+                target_config = _resolve_config(target_backend_type, target_raw)
 
                 try:
-                    # Initialize backends
-                    if source_backend_type == 'local_filesystem':
-                        source_backend = LocalFileSystemBackend(Path(source_config.get('cert_dir', 'certificates')))
-                    else:
-                        source_backend = backend_classes[source_backend_type](source_config)
+                    source_backend = _build_backend(source_backend_type, source_config)
+                    target_backend = _build_backend(target_backend_type, target_config)
 
-                    if target_backend_type == 'local_filesystem':
-                        target_backend = LocalFileSystemBackend(Path(target_config.get('cert_dir', 'certificates')))
-                    else:
-                        target_backend = backend_classes[target_backend_type](target_config)
-
-                    # Perform migration using storage manager
                     storage_manager = managers.get('storage')
                     if not storage_manager:
                         return {'error': 'Storage manager not available'}, 500
 
-                    migration_results = storage_manager.migrate_certificates(source_backend, target_backend)
+                    migration_results = storage_manager.migrate_certificates(
+                        source_backend, target_backend)
 
-                    successful = sum(1 for success in migration_results.values() if success)
+                    successful = sum(1 for ok in migration_results.values() if ok)
                     total = len(migration_results)
+                    failed = total - successful
 
                     return {
                         'success': True,
                         'message': f'Migration completed: {successful}/{total} certificates migrated',
+                        # migrated_count is the field the UI reads — keep it
+                        # alongside migration_results for older API callers.
+                        'migrated_count': successful,
+                        'failed_count': failed,
+                        'total': total,
                         'migration_results': migration_results,
                         'source_backend': source_backend_type,
-                        'target_backend': target_backend_type
+                        'target_backend': target_backend_type,
                     }
 
                 except Exception as migration_error:
                     logger.error(f"Storage migration failed: {migration_error}")
                     return {
                         'success': False,
-                        'message': 'Migration failed',
+                        'message': f'Migration failed: {migration_error}',
                         'source_backend': source_backend_type,
-                        'target_backend': target_backend_type
-                    }
+                        'target_backend': target_backend_type,
+                    }, 500
 
             except Exception as e:
                 logger.error(f"Error during storage migration: {e}")

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -2462,11 +2462,16 @@
     }
 
     function performStorageMigration() {
-        var currentBackend = document.getElementById('storage-backend').value;
         var newConfig = collectStorageBackendSettings();
+        // Pull the per-backend sub-config out of the envelope produced by
+        // collectStorageBackendSettings (which nests under the backend key,
+        // e.g. { backend: 'azure_keyvault', azure_keyvault: {...} }). The
+        // server validator runs against the sub-config, not the envelope.
+        var targetSubConfig = (newConfig.backend === 'local_filesystem')
+            ? { cert_dir: newConfig.cert_dir }
+            : (newConfig[newConfig.backend] || {});
 
-        // Validate new configuration first
-        if (!validateStorageConfig(newConfig.backend, newConfig)) {
+        if (!validateStorageConfig(newConfig.backend, targetSubConfig)) {
             showMessage('Please configure and test the new storage backend before migrating.', 'error');
             return;
         }
@@ -2474,20 +2479,36 @@
         showMessage('Starting certificate migration...', 'info');
         closeStorageMigrationModal();
 
+        // Send target_backend explicitly + the envelope as target_config. The
+        // server defaults source_backend/source_config from the currently
+        // saved certificate_storage, so the UI doesn't have to track the
+        // pre-edit backend identity itself.
         fetch('/api/storage/migrate', {
             method: 'POST',
             headers: API_HEADERS,
             body: JSON.stringify({
-                source_backend: currentBackend,
+                target_backend: newConfig.backend,
                 target_config: newConfig
             })
         })
-            .then(function (response) { return response.json(); })
-            .then(function (data) {
-                if (data.success) {
-                    showMessage('Migration completed successfully. ' + (data.migrated_count || 0) + ' certificates migrated.', 'success');
+            .then(function (response) {
+                return response.json().then(function (body) {
+                    return { ok: response.ok, body: body };
+                });
+            })
+            .then(function (result) {
+                var data = result.body || {};
+                if (result.ok && data.success) {
+                    var migrated = (data.migrated_count != null) ? data.migrated_count : 0;
+                    var failed = (data.failed_count != null) ? data.failed_count : 0;
+                    var msg = 'Migration completed. ' + migrated + ' certificates migrated';
+                    if (failed > 0) {
+                        msg += ', ' + failed + ' failed (see server logs)';
+                    }
+                    msg += '.';
+                    showMessage(msg, failed > 0 ? 'warning' : 'success');
                 } else {
-                    showMessage('Migration failed: ' + (data.message || 'Unknown error'), 'error');
+                    showMessage('Migration failed: ' + (data.message || data.error || 'Unknown error'), 'error');
                 }
             })
             .catch(function (error) {

--- a/tests/test_storage_migrate_endpoint.py
+++ b/tests/test_storage_migrate_endpoint.py
@@ -1,0 +1,102 @@
+"""
+Regression tests: POST /api/storage/migrate must accept the minimal
+payload the Settings UI actually sends.
+
+The Settings UI's "Start Migration" button has no way to remember the
+previously-active backend identity (the dropdown already shows the
+user's new target choice), so the JS only sends target_backend +
+target_config. The previous endpoint required four fields and rejected
+the UI payload with 400.
+
+The endpoint is now lenient:
+
+* source_backend / source_config default to the currently-saved
+  certificate_storage when absent.
+* target_backend may be inferred from target_config['backend'] when the
+  UI passes the structured ``{backend, <backend>: {...}}`` envelope
+  produced by collectStorageBackendSettings().
+"""
+
+import pytest
+
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def app_client(tmp_path, monkeypatch):
+    """Stand up the real Flask app against tmp_path so we can hit the
+    migrate endpoint end-to-end. Both source and target are
+    local_filesystem so the test needs no cloud SDKs."""
+    monkeypatch.setenv('CERTMATE_DATA_DIR', str(tmp_path / 'data'))
+    monkeypatch.setenv('CERTMATE_CERT_DIR', str(tmp_path / 'certs'))
+    monkeypatch.setenv('CERTMATE_BACKUP_DIR', str(tmp_path / 'backups'))
+    monkeypatch.setenv('CERTMATE_LOGS_DIR', str(tmp_path / 'logs'))
+
+    from modules.core.factory import create_app
+    app, container = create_app()
+    app.config['TESTING'] = True
+
+    settings_manager = container.managers['settings']
+    settings = settings_manager.load_settings()
+    token = 'test-' + 'a' * 48
+    settings['api_bearer_token'] = token
+    settings['certificate_storage'] = {
+        'backend': 'local_filesystem',
+        'cert_dir': str(tmp_path / 'certs'),
+    }
+    settings_manager.save_settings(settings, 'test_seed')
+
+    return app.test_client(), token, tmp_path
+
+
+def _post(client, body, token):
+    return client.post(
+        '/api/storage/migrate',
+        json=body,
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+
+def test_minimal_payload_with_envelope_target_config(app_client):
+    """The exact payload the fixed performStorageMigration sends."""
+    client, token, tmp_path = app_client
+    target_dir = tmp_path / 'migrated'
+
+    resp = _post(client, {
+        'target_backend': 'local_filesystem',
+        'target_config': {
+            'backend': 'local_filesystem',
+            'cert_dir': str(target_dir),
+        },
+    }, token)
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json()
+    assert body['success'] is True
+    assert body['source_backend'] == 'local_filesystem'
+    assert body['target_backend'] == 'local_filesystem'
+    # migrated_count is the field the UI reads back to format its toast.
+    assert 'migrated_count' in body
+
+
+def test_target_backend_inferred_from_envelope_when_omitted(app_client):
+    """If the caller forgets target_backend but includes the envelope
+    target_config with a ``backend`` field, the endpoint accepts it."""
+    client, token, tmp_path = app_client
+    resp = _post(client, {
+        'target_config': {
+            'backend': 'local_filesystem',
+            'cert_dir': str(tmp_path / 'inferred'),
+        },
+    }, token)
+    assert resp.status_code == 200, resp.get_json()
+    assert resp.get_json()['target_backend'] == 'local_filesystem'
+
+
+def test_invalid_target_backend_returns_400(app_client):
+    client, token, _ = app_client
+    resp = _post(client, {
+        'target_backend': 'mongodb_or_something_weird',
+        'target_config': {},
+    }, token)
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary

The "Start Migration" button in the Settings UI never worked. Clicking it always returned `400 Invalid backend type`, so users could not migrate certificates between storage backends through the UI.

Root cause was a shape mismatch on both ends:

- **Frontend:** `performStorageMigration` sent only `{ source_backend, target_config }`, where `target_config` was the structured envelope produced by `collectStorageBackendSettings` (`{ backend, <backend>: {...} }`). It also validated the wrong shape (passing the envelope to `validateStorageConfig`, which expects the flat sub-config), and read `data.migrated_count` from a response field the server never returned.
- **Backend:** `StorageBackendMigrate` required four fields — `source_backend`, `source_config`, `target_backend`, `target_config` — and treated `target_config` as the per-backend constructor input. With the UI omitting `target_backend` entirely, the endpoint rejected every request.

## What changed

- `modules/api/resources.py`
  - `StorageBackendMigrate` is now lenient about its payload. `source_backend` / `source_config` default to the currently-saved `certificate_storage` (the dominant UI path — the dropdown already reflects the user's new target choice, not the source). `target_backend` can be inferred from `target_config['backend']` when callers pass the structured envelope.
  - Per-backend sub-config is resolved from either the flat dict or the envelope shape, so the same payload that goes into `POST /api/settings` works here too.
  - Response now includes `migrated_count`, `failed_count`, and `total` alongside `migration_results` — both the new UI message and any older API caller get what they need.
  - Migration failures return `500` with the underlying error message instead of a silent `200 {success: false}` envelope.
- `modules/api/models.py`
  - `storage_migration_config_model`: `source_backend`, `source_config`, `target_backend` relaxed from `required=True` to optional, with descriptions documenting the defaults. `target_config` remains the only required field.
- `static/js/settings.js`
  - `performStorageMigration` now extracts the per-backend sub-config for validation, sends `target_backend` explicitly alongside the envelope `target_config`, and reads `migrated_count` / `failed_count` from the response. The success/warning split surfaces partial failures instead of pretending everything succeeded.
- `tests/test_storage_migrate_endpoint.py` (new)
  - Posts the exact payload the fixed JS sends and asserts `200` with the expected response shape — the user-reported regression guard.
  - Covers the `target_backend` inference path when the caller only provides the envelope.
  - Covers the invalid-backend rejection so the leniency doesn't widen into silent acceptance of typos.

## Test plan

- [x] `pytest tests/test_storage_migrate_endpoint.py` — 3 passed locally
- [x] `pytest tests/` — 881 passed, 10 skipped, 0 failed
- [x] Manual: switched backend in Settings, clicked "Start Migration", confirmed migration runs and the UI toast reports the count