### PR TITLE
feat(dns): issue nested-subdomain wildcards against the parent hosted zone

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -212,6 +212,15 @@ class CertificateManager:
         against a parent hosted zone — e.g. issuing
         ``*.example2.example.com`` when Azure only hosts ``example.com``.
 
+        **RBAC escape hatch**: if ``dns_config`` carries an explicit
+        ``zone_domains`` list (set by the operator on the account), we
+        skip the live discovery call and use the supplied list directly.
+        That keeps existing Azure service principals working when their
+        scope only includes ``Microsoft.Network/dnsZones/TXT/write`` on
+        specific zones and lacks ``dnsZones/read`` on the resource group
+        — granting the broader read permission for auto-discovery would
+        otherwise be a hard prerequisite for the v2.6.10 upgrade.
+
         For any provider without a discovery hook the legacy single-zone
         shape is preserved: the cert FQDN apex goes into ``_zone_domain``
         and the strategy uses it verbatim. Today that branch is unused
@@ -222,7 +231,10 @@ class CertificateManager:
         if dns_provider != 'azure':
             return dns_config
 
-        from .dns_zone_discovery import has_zone_discovery, resolve_zones_for_domains
+        from .dns_zone_discovery import (
+            has_zone_discovery, resolve_zones_for_domains,
+            resolve_zones_against_explicit_list,
+        )
 
         if has_zone_discovery(dns_provider):
             fqdns = [domain]
@@ -230,20 +242,29 @@ class CertificateManager:
                 for san in san_domains:
                     if san and san not in fqdns:
                         fqdns.append(san)
-            zone_domains = resolve_zones_for_domains(
-                dns_provider, dns_config, fqdns,
+
+            explicit_zones = dns_config.get('zone_domains') if isinstance(dns_config, dict) else None
+            if explicit_zones:
+                # Operator-supplied list — no Azure ARM call needed.
+                # Same matching + fail-early semantics as the discovery
+                # path; just skips the SDK round-trip.
+                zone_domains, per_fqdn = resolve_zones_against_explicit_list(
+                    dns_provider, explicit_zones, fqdns,
+                )
+                source = 'explicit zone_domains'
+            else:
+                zone_domains, per_fqdn = resolve_zones_for_domains(
+                    dns_provider, dns_config, fqdns,
+                )
+                source = 'discovery'
+
+            # One INFO per cert with the full FQDN -> zone map; avoids the
+            # N-line spam a SAN cert with many entries used to produce.
+            logger.info(
+                "Resolved %s DNS zones (%s) for %d FQDN(s): %s",
+                dns_provider, source, len(fqdns),
+                ', '.join(f"{f}->{z}" for f, z in per_fqdn),
             )
-            for fqdn in fqdns:
-                # Mirror the matched zone per FQDN in the log so the
-                # operator can confirm what happened from the run log
-                # without enabling debug. find_covering_zone is cheap.
-                from .utils import find_covering_zone
-                match = find_covering_zone(fqdn, zone_domains)
-                if match:
-                    logger.info(
-                        "Resolved %s DNS zone for %s -> %s",
-                        dns_provider, fqdn, match,
-                    )
             return {**dns_config, '_zone_domains': zone_domains}
 
         # Legacy single-zone fallback (no discovery registered).

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -199,17 +199,54 @@ class CertificateManager:
             return deployment_status
 
     @staticmethod
-    def _dns_config_for_strategy(dns_provider, dns_config, domain):
+    def _dns_config_for_strategy(dns_provider, dns_config, domain, san_domains=None):
         """Return a strategy-ready copy of dns_config with provider-specific extras.
 
-        Azure DNS is the only provider that needs the certificate's primary
-        domain at config-file-creation time (it goes into the
-        ``dns_azure_zone1`` mapping). Injecting it here keeps that knowledge
-        out of the generic flow without forcing every strategy to accept a
-        domain argument.
+        Azure DNS is currently the only provider whose certbot plugin
+        cannot self-discover the hosted zone for an ACME challenge — it
+        wants explicit ``dns_azure_zoneN`` lines in its ini file. We hand
+        it the list of hosted zones the account actually owns (looked up
+        via :func:`modules.core.dns_zone_discovery.resolve_zones_for_domains`)
+        so the plugin's longest-match selects the right zone per
+        challenge. This is what unlocks nested-subdomain wildcards
+        against a parent hosted zone — e.g. issuing
+        ``*.example2.example.com`` when Azure only hosts ``example.com``.
+
+        For any provider without a discovery hook the legacy single-zone
+        shape is preserved: the cert FQDN apex goes into ``_zone_domain``
+        and the strategy uses it verbatim. Today that branch is unused
+        because Azure is the only entry in the registry, but it keeps
+        the contract stable for any future caller / test that still
+        passes the legacy shape.
         """
         if dns_provider != 'azure':
             return dns_config
+
+        from .dns_zone_discovery import has_zone_discovery, resolve_zones_for_domains
+
+        if has_zone_discovery(dns_provider):
+            fqdns = [domain]
+            if san_domains:
+                for san in san_domains:
+                    if san and san not in fqdns:
+                        fqdns.append(san)
+            zone_domains = resolve_zones_for_domains(
+                dns_provider, dns_config, fqdns,
+            )
+            for fqdn in fqdns:
+                # Mirror the matched zone per FQDN in the log so the
+                # operator can confirm what happened from the run log
+                # without enabling debug. find_covering_zone is cheap.
+                from .utils import find_covering_zone
+                match = find_covering_zone(fqdn, zone_domains)
+                if match:
+                    logger.info(
+                        "Resolved %s DNS zone for %s -> %s",
+                        dns_provider, fqdn, match,
+                    )
+            return {**dns_config, '_zone_domains': zone_domains}
+
+        # Legacy single-zone fallback (no discovery registered).
         zone_domain = (domain or '').strip().removeprefix('*.')
         return {**dns_config, '_zone_domain': zone_domain}
 
@@ -820,8 +857,13 @@ class CertificateManager:
                 )
                 self._configure_dns_alias_arguments(certbot_cmd, credentials_file)
             else:
-                # Create Config File
-                strategy_config = self._dns_config_for_strategy(dns_provider, dns_config, domain)
+                # Create Config File. Pass the SAN list so the discovery
+                # path (Azure today) can resolve every cert FQDN against
+                # the account's hosted zones in one pass.
+                strategy_config = self._dns_config_for_strategy(
+                    dns_provider, dns_config, domain,
+                    san_domains=all_domains[1:] if len(all_domains) > 1 else None,
+                )
                 credentials_file = strategy.create_config_file(strategy_config)
 
                 # Configure Args
@@ -1047,8 +1089,15 @@ class CertificateManager:
                 if dns_config:
                     strategy = DNSStrategyFactory.get_strategy(dns_provider)
                     strategy.prepare_environment(process_env, dns_config)
-                    # Create credentials file for providers that need one
-                    strategy_config = self._dns_config_for_strategy(dns_provider, dns_config, domain)
+                    # Create credentials file for providers that need one.
+                    # Pull SANs from metadata so the discovery hook sees
+                    # the same FQDN set the cert was originally issued with;
+                    # otherwise a wildcard SAN under a parent zone would
+                    # be invisible at renew time.
+                    renew_sans = metadata.get('san_domains') or None
+                    strategy_config = self._dns_config_for_strategy(
+                        dns_provider, dns_config, domain, san_domains=renew_sans,
+                    )
                     credentials_file = strategy.create_config_file(strategy_config)
                     logger.info(f"Prepared DNS environment for renewal of {domain} with {dns_provider}")
                 else:

--- a/modules/core/dns_strategies.py
+++ b/modules/core/dns_strategies.py
@@ -166,26 +166,45 @@ class Route53Strategy(DNSProviderStrategy):
 
 class AzureStrategy(DNSProviderStrategy):
     def create_config_file(self, config_data: Dict[str, Any]) -> Optional[Path]:
-        # ``_zone_domain`` is injected by the caller (see
-        # CertificateManager.create_certificate / renew_certificate) so the
-        # generated azure.ini can include the ``dns_azure_zone1`` mapping
-        # that certbot-dns-azure 2.x requires. Without a zone mapping the
-        # plugin aborts with "At least one zone mapping needs to be
-        # provided" before any DNS challenge can run.
-        zone_domain = str(config_data.get('_zone_domain') or '').strip()
-        if not zone_domain:
-            raise ValueError(
-                "Azure DNS config requires a zone domain. The caller must "
-                "inject '_zone_domain' into dns_config before calling "
-                "AzureStrategy.create_config_file()."
-            )
+        # The caller (CertificateManager.create_certificate /
+        # renew_certificate via _dns_config_for_strategy) injects either:
+        #   * ``_zone_domains`` — list of zones resolved by the per-provider
+        #     discovery hook (the path that unlocks wildcard issuance
+        #     against a parent hosted zone, e.g. ``*.example2.example.com``
+        #     under Azure-hosted ``example.com``); written as multiple
+        #     ``dns_azure_zoneN`` lines so the plugin's longest-match
+        #     selects the right zone per challenge, OR
+        #   * ``_zone_domain`` — single-zone string (legacy shape, kept so
+        #     pre-discovery callers and existing tests keep working).
+        # certbot-dns-azure 2.x aborts with "At least one zone mapping
+        # needs to be provided" if neither is present.
+        zone_domains = config_data.get('_zone_domains')
+        if zone_domains:
+            zones = [str(z).strip() for z in zone_domains if str(z).strip()]
+            if not zones:
+                raise ValueError(
+                    "Azure DNS config received an empty '_zone_domains' "
+                    "list. The discovery hook must return at least one "
+                    "hosted zone covering the cert FQDN(s)."
+                )
+            zone_arg: Any = zones
+        else:
+            single = str(config_data.get('_zone_domain') or '').strip()
+            if not single:
+                raise ValueError(
+                    "Azure DNS config requires a zone domain. The caller "
+                    "must inject '_zone_domains' (list) or '_zone_domain' "
+                    "(str) into dns_config before calling "
+                    "AzureStrategy.create_config_file()."
+                )
+            zone_arg = single
         return create_azure_config(
             config_data.get('subscription_id', ''),
             config_data.get('resource_group', ''),
             config_data.get('tenant_id', ''),
             config_data.get('client_id', ''),
             config_data.get('client_secret', ''),
-            zone_domain,
+            zone_arg,
         )
 
     @property

--- a/modules/core/dns_zone_discovery.py
+++ b/modules/core/dns_zone_discovery.py
@@ -30,7 +30,7 @@ top-level dependency.
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional, Protocol
+from typing import Dict, List, Optional, Protocol, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -144,27 +144,78 @@ def has_zone_discovery(provider: str) -> bool:
     return provider in _ZONE_DISCOVERY
 
 
+def _match_fqdns_to_zones(
+    provider: str,
+    zones: List[str],
+    fqdns: List[str],
+) -> Tuple[List[str], List[Tuple[str, str]]]:
+    """Shared matcher used by both the live-discovery and explicit-list
+    paths. Returns the deduplicated longest-first list of matched zones
+    and the per-FQDN ``(fqdn, zone)`` mapping (for caller logging).
+
+    Raises ``ValueError`` when any FQDN is not covered, surfacing the
+    full configured zone set so the operator can fix either the cert
+    request or the zone configuration.
+    """
+    from .utils import find_covering_zone
+
+    if not fqdns:
+        raise ValueError(
+            f"Cannot resolve DNS zones for provider '{provider}': no FQDNs "
+            "supplied. This is a programming error in the caller — every "
+            "cert request must include at least the primary domain."
+        )
+
+    matched: List[str] = []
+    per_fqdn: List[Tuple[str, str]] = []
+    unmatched: List[str] = []
+    for fqdn in fqdns:
+        zone = find_covering_zone(fqdn, zones)
+        if zone is None:
+            unmatched.append(fqdn)
+            continue
+        per_fqdn.append((fqdn, zone))
+        if zone not in matched:
+            matched.append(zone)
+
+    if unmatched:
+        raise ValueError(
+            "The following certificate names are not covered by any "
+            f"hosted DNS zone configured for provider '{provider}': "
+            f"{', '.join(unmatched)}. Hosted zones configured: "
+            f"{', '.join(zones) or '(none)'}."
+        )
+
+    # Sort longest-first so the resulting ``dns_azure_zoneN`` lines
+    # encode the operator's intent stably and the plugin's longest-match
+    # picks the most specific zone for each challenge.
+    matched.sort(key=len, reverse=True)
+    return matched, per_fqdn
+
+
 def resolve_zones_for_domains(
     provider: str,
     account_config: Dict,
     fqdns: List[str],
     *,
     cache: Optional[Dict] = None,
-) -> List[str]:
+) -> Tuple[List[str], List[Tuple[str, str]]]:
     """For a provider that needs explicit zone identity, resolve each
     FQDN in *fqdns* to its longest covering zone in the account and
-    return the deduplicated list of matched zones (longest first).
+    return ``(matched_zones, per_fqdn_map)``:
+
+    * ``matched_zones`` — deduplicated longest-first list, ready to feed
+      into ``dns_azure_zoneN`` lines.
+    * ``per_fqdn_map`` — ordered list of ``(fqdn, zone)`` pairs so the
+      caller can log a single concise INFO line with the full mapping.
 
     Raises:
-        ValueError: if any FQDN is not covered by a hosted zone. The
-            message lists the configured zones so the operator can fix
-            either the cert request or the Azure DNS setup.
+        ValueError: if any FQDN is not covered by a hosted zone, or if
+            *fqdns* is empty (a programming error in the caller).
         RuntimeError: if zone discovery itself failed (auth, network,
             missing SDK). The cert-issuance layer converts this into
             a 5xx-style error.
     """
-    from .utils import find_covering_zone
-
     discovery = get_zone_discovery(provider)
     cache_key = None
     if cache is not None:
@@ -194,25 +245,30 @@ def resolve_zones_for_domains(
             "actually contains DNS zones."
         )
 
-    matched: List[str] = []
-    unmatched: List[str] = []
-    for fqdn in fqdns:
-        zone = find_covering_zone(fqdn, zones)
-        if zone is None:
-            unmatched.append(fqdn)
-        elif zone not in matched:
-            matched.append(zone)
+    return _match_fqdns_to_zones(provider, zones, fqdns)
 
-    if unmatched:
+
+def resolve_zones_against_explicit_list(
+    provider: str,
+    zones: List[str],
+    fqdns: List[str],
+) -> Tuple[List[str], List[Tuple[str, str]]]:
+    """RBAC escape hatch: match *fqdns* against an operator-supplied
+    zone list without hitting the provider's discovery API.
+
+    Existed Azure service principals scoped to ``dnsZones/TXT/write``
+    on specific zones lack the ``dnsZones/read`` permission on the
+    resource group that the auto-discovery path needs. Operators in
+    that position can declare their hosted zones on the account
+    (``account_config['zone_domains']``) and CertMate uses that list
+    directly. Same matching, fail-early, and longest-first semantics
+    as :func:`resolve_zones_for_domains`.
+    """
+    cleaned = [str(z).strip() for z in (zones or []) if str(z or '').strip()]
+    if not cleaned:
         raise ValueError(
-            "The following certificate names are not covered by any "
-            f"hosted DNS zone configured for provider '{provider}': "
-            f"{', '.join(unmatched)}. Hosted zones discovered: "
-            f"{', '.join(zones) or '(none)'}."
+            f"Explicit zone_domains list for provider '{provider}' is empty "
+            "after sanitisation; remove the field to fall back to live "
+            "zone discovery."
         )
-
-    # Sort longest-first so the resulting ``dns_azure_zoneN`` lines
-    # encode the operator's intent stably and the plugin's longest-match
-    # picks the most specific zone for each challenge.
-    matched.sort(key=len, reverse=True)
-    return matched
+    return _match_fqdns_to_zones(provider, cleaned, fqdns)

--- a/modules/core/dns_zone_discovery.py
+++ b/modules/core/dns_zone_discovery.py
@@ -1,0 +1,218 @@
+"""
+DNS-provider zone discovery for nested-subdomain wildcards.
+
+Most certbot DNS plugins (cloudflare, route53, google, digitalocean, …)
+walk parent labels internally to find the hosted zone for an ACME
+challenge name. Azure DNS is the outlier: ``certbot-dns-azure`` requires
+the caller to enumerate the candidate hosted zones in its ini file
+(``dns_azure_zoneN = <zone>:<resource_id>``) and selects the longest
+match per challenge.
+
+That requirement bites operators who host the parent zone in Azure but
+ask CertMate for a wildcard cert on a nested subdomain — e.g. Azure
+holds ``example.com``, the user wants ``*.example2.example.com``. The
+previous code derived the zone identity from the cert FQDN itself
+(``example2.example.com``), which Azure DNS doesn't host, and the plugin
+errored out.
+
+This module gives CertMate a per-provider zone-discovery hook so the
+cert-issuance path can ask the provider "what zones does this account
+actually own?" and then pick the longest one that covers the cert's
+FQDN. The default is a no-op (returns ``[]``), preserving today's
+behaviour for every provider whose plugin already self-discovers.
+
+Azure's implementation talks to Azure Resource Manager via
+``azure.mgmt.dns.DnsManagementClient`` — both ``azure-identity`` and
+``azure-mgmt-dns`` are already pinned by ``requirements-azure.txt``
+because ``certbot-dns-azure`` depends on them transitively. No new
+top-level dependency.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class ZoneDiscovery(Protocol):
+    """Per-provider hook that returns the DNS zones an account hosts.
+
+    Implementations should be side-effect-free apart from the necessary
+    network call to the provider, and must NOT raise on a "no zones
+    configured" response — return ``[]`` instead. They MAY raise on
+    auth or connectivity errors; the caller (cert issuance path) wraps
+    those in a user-facing error.
+    """
+
+    def list_zones(self, account_config: Dict) -> List[str]: ...
+
+
+class _NullZoneDiscovery:
+    """No-op discovery. Returned for providers whose certbot plugin
+    handles zone resolution internally — calling code reads the empty
+    list and falls back to the legacy ``_zone_domain`` shape."""
+
+    def list_zones(self, account_config: Dict) -> List[str]:  # noqa: ARG002
+        return []
+
+
+class AzureZoneDiscovery:
+    """Discover Azure DNS zones in the account's resource group.
+
+    Uses the service-principal credentials already configured for
+    ``certbot-dns-azure`` to call Azure Resource Manager and enumerate
+    hosted zones. Result is the bare zone names (no resource ids,
+    those get rebuilt by ``create_azure_config`` at write time).
+    """
+
+    def list_zones(self, account_config: Dict) -> List[str]:
+        try:
+            from azure.identity import ClientSecretCredential
+            from azure.mgmt.dns import DnsManagementClient
+        except ImportError as exc:
+            # Mirrors the error operators already see when the Azure
+            # extras aren't installed for cert issuance.
+            raise RuntimeError(
+                "Azure SDK not available — install requirements-azure.txt "
+                "to enable zone discovery for Azure DNS accounts."
+            ) from exc
+
+        required = ('subscription_id', 'resource_group', 'tenant_id',
+                    'client_id', 'client_secret')
+        missing = [k for k in required if not account_config.get(k)]
+        if missing:
+            raise ValueError(
+                "Azure account is missing credentials needed for zone "
+                f"discovery: {', '.join(missing)}"
+            )
+
+        credential = ClientSecretCredential(
+            tenant_id=account_config['tenant_id'],
+            client_id=account_config['client_id'],
+            client_secret=account_config['client_secret'],
+        )
+        client = DnsManagementClient(
+            credential=credential,
+            subscription_id=account_config['subscription_id'],
+        )
+
+        try:
+            pager = client.zones.list_by_resource_group(
+                resource_group_name=account_config['resource_group']
+            )
+            names = sorted({(z.name or '').rstrip('.').lower()
+                            for z in pager
+                            if getattr(z, 'name', None)})
+            return [n for n in names if n]
+        except Exception as exc:
+            # Surface as a runtime error with the upstream cause; the
+            # caller wraps this in a user-facing message including the
+            # subscription/RG hint so the operator knows where to look.
+            raise RuntimeError(
+                f"Could not list Azure DNS zones for resource group "
+                f"'{account_config['resource_group']}' in subscription "
+                f"'{account_config['subscription_id']}': {exc}"
+            ) from exc
+
+
+# Registry of providers that need explicit zone resolution. Providers
+# absent from this map use the legacy ``_zone_domain`` path (apex-derived
+# from the cert FQDN) — that's safe because their certbot plugins walk
+# parent labels internally. Add an entry here when a future provider
+# (rfc2136, edgedns, …) needs the same treatment as Azure.
+_ZONE_DISCOVERY: Dict[str, ZoneDiscovery] = {
+    'azure': AzureZoneDiscovery(),
+}
+
+_NULL_DISCOVERY: ZoneDiscovery = _NullZoneDiscovery()
+
+
+def get_zone_discovery(provider: str) -> ZoneDiscovery:
+    """Return the discovery hook for *provider*, or a no-op if none
+    is registered. Never raises."""
+    return _ZONE_DISCOVERY.get(provider, _NULL_DISCOVERY)
+
+
+def has_zone_discovery(provider: str) -> bool:
+    """Whether *provider* has a non-trivial discovery hook registered.
+
+    Callers use this to gate "did we attempt resolution?" telemetry and
+    error wording — for providers without a hook the legacy code path
+    stays in charge, so a missing match isn't a CertMate-level failure.
+    """
+    return provider in _ZONE_DISCOVERY
+
+
+def resolve_zones_for_domains(
+    provider: str,
+    account_config: Dict,
+    fqdns: List[str],
+    *,
+    cache: Optional[Dict] = None,
+) -> List[str]:
+    """For a provider that needs explicit zone identity, resolve each
+    FQDN in *fqdns* to its longest covering zone in the account and
+    return the deduplicated list of matched zones (longest first).
+
+    Raises:
+        ValueError: if any FQDN is not covered by a hosted zone. The
+            message lists the configured zones so the operator can fix
+            either the cert request or the Azure DNS setup.
+        RuntimeError: if zone discovery itself failed (auth, network,
+            missing SDK). The cert-issuance layer converts this into
+            a 5xx-style error.
+    """
+    from .utils import find_covering_zone
+
+    discovery = get_zone_discovery(provider)
+    cache_key = None
+    if cache is not None:
+        cache_key = (
+            provider,
+            account_config.get('tenant_id'),
+            account_config.get('client_id'),
+            account_config.get('subscription_id'),
+            account_config.get('resource_group'),
+        )
+        zones = cache.get(cache_key)
+    else:
+        zones = None
+    if zones is None:
+        zones = discovery.list_zones(account_config)
+        if cache is not None:
+            cache[cache_key] = zones
+
+    if not zones:
+        # Provider has no hosted zones at all. Report rather than
+        # silently fall back — the operator's intent ("issue a cert
+        # against this Azure account") cannot be honoured.
+        raise ValueError(
+            f"DNS provider '{provider}' returned no hosted zones for the "
+            "configured account; verify the service principal has read "
+            "access to the resource group and the resource group "
+            "actually contains DNS zones."
+        )
+
+    matched: List[str] = []
+    unmatched: List[str] = []
+    for fqdn in fqdns:
+        zone = find_covering_zone(fqdn, zones)
+        if zone is None:
+            unmatched.append(fqdn)
+        elif zone not in matched:
+            matched.append(zone)
+
+    if unmatched:
+        raise ValueError(
+            "The following certificate names are not covered by any "
+            f"hosted DNS zone configured for provider '{provider}': "
+            f"{', '.join(unmatched)}. Hosted zones discovered: "
+            f"{', '.join(zones) or '(none)'}."
+        )
+
+    # Sort longest-first so the resulting ``dns_azure_zoneN`` lines
+    # encode the operator's intent stably and the plugin's longest-match
+    # picks the most specific zone for each challenge.
+    matched.sort(key=len, reverse=True)
+    return matched

--- a/modules/core/utils.py
+++ b/modules/core/utils.py
@@ -181,6 +181,57 @@ def validate_domain(domain: str) -> Tuple[bool, str]:
     return True, domain
 
 
+def find_covering_zone(fqdn: str, zones: List[str]) -> Optional[str]:
+    """Return the longest zone in *zones* that covers *fqdn*, or None.
+
+    Used by providers that need an explicit DNS-zone identity at cert
+    issuance time (Azure DNS is the only one today; the certbot plugins
+    for Cloudflare, Route53, Google etc. walk parent labels themselves
+    so CertMate does not pre-resolve a zone for them).
+
+    Semantics:
+
+    * Leading ``*.`` is stripped from the FQDN — the ACME TXT challenge
+      for a wildcard lives under the bare apex, not the wildcard form.
+    * Comparison is case-insensitive and tolerant of trailing dots.
+    * Longest-match wins. For ``api.staging.example.com`` with zones
+      ``staging.example.com`` and ``example.com`` both present, the
+      result is ``staging.example.com`` — the operator's intent is the
+      most specific zone the IdP actually hosts.
+    * **TLD guard**: candidate zones with fewer than two labels (e.g.
+      ``com``, ``tv``) are silently skipped. Discovery layers never
+      surface a bare TLD because providers don't host the root, but the
+      guard is defence-in-depth so a misconfigured zone list cannot
+      lead CertMate to attempt a TLD-wide match. Multi-label public
+      suffixes (``co.uk``, ``com.br``) are NOT special-cased — they
+      pass the gate and are matched structurally like any other
+      ≥2-label zone. An operator who legitimately runs a hosted zone
+      at that level still gets the correct longest match.
+    """
+    if not fqdn or not zones:
+        return None
+    name = fqdn.strip().lower().rstrip('.')
+    if name.startswith('*.'):
+        name = name[2:]
+    if not name:
+        return None
+
+    best: Optional[str] = None
+    best_len = -1
+    for raw in zones:
+        if not raw or not isinstance(raw, str):
+            continue
+        zone = raw.strip().lower().rstrip('.')
+        if not zone or zone.count('.') < 1:
+            # <2 labels — TLD guard
+            continue
+        if name == zone or name.endswith('.' + zone):
+            if len(zone) > best_len:
+                best = zone
+                best_len = len(zone)
+    return best
+
+
 def validate_api_token(token: str) -> Tuple[bool, str]:
     """
     Validate an API token for strength, format, and complexity.
@@ -360,7 +411,7 @@ def create_route53_config(access_key_id: str, secret_access_key: str) -> Path:
     content = f"dns_route53_access_key_id = {access_key_id}\ndns_route53_secret_access_key = {secret_access_key}\n"
     return _create_config_file("route53", content)
 
-def create_azure_config(subscription_id: str, resource_group: str, tenant_id: str, client_id: str, client_secret: str, zone_domain: str) -> Path:
+def create_azure_config(subscription_id: str, resource_group: str, tenant_id: str, client_id: str, client_secret: str, zone_domain) -> Path:
     """Create Azure DNS credentials file for certbot-dns-azure (terrycain).
 
     The plugin (certbot-dns-azure >= 2.x) expects:
@@ -376,14 +427,39 @@ def create_azure_config(subscription_id: str, resource_group: str, tenant_id: st
 
     See ``certbot_dns_azure/_internal/dns_azure.py:_validate_credentials``
     in v2.5.0 for the validation that drives this format.
+
+    ``zone_domain`` accepts two shapes:
+
+    * **str** — legacy single-zone usage. Writes one ``dns_azure_zone1``
+      line. Kept for callers (and tests) that haven't migrated to the
+      list form.
+    * **list[str]** — one ``dns_azure_zoneN`` per entry, in the order
+      given. The cert-issuance path passes the deduplicated longest-first
+      list returned by ``resolve_zones_for_domains`` so the plugin's
+      longest-prefix match selects the most specific hosted zone per
+      ACME challenge — that's what enables nested-subdomain wildcards
+      against a parent hosted zone (e.g. ``*.example2.example.com``
+      issued under hosted zone ``example.com``).
     """
     zone_resource_id = f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}"
+    if isinstance(zone_domain, str):
+        zone_list = [zone_domain]
+    else:
+        zone_list = [z for z in (zone_domain or []) if z]
+    if not zone_list:
+        raise ValueError(
+            "create_azure_config requires at least one zone (received empty list)"
+        )
+    zone_lines = ''.join(
+        f"dns_azure_zone{idx} = {zone}:{zone_resource_id}\n"
+        for idx, zone in enumerate(zone_list, start=1)
+    )
     content = (
         f"dns_azure_sp_client_id = {client_id}\n"
         f"dns_azure_sp_client_secret = {client_secret}\n"
         f"dns_azure_tenant_id = {tenant_id}\n"
         f"dns_azure_environment = AzurePublicCloud\n"
-        f"dns_azure_zone1 = {zone_domain}:{zone_resource_id}\n"
+        f"{zone_lines}"
     )
     return _create_config_file("azure", content)
 

--- a/modules/core/utils.py
+++ b/modules/core/utils.py
@@ -14,7 +14,7 @@ import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 
@@ -411,7 +411,7 @@ def create_route53_config(access_key_id: str, secret_access_key: str) -> Path:
     content = f"dns_route53_access_key_id = {access_key_id}\ndns_route53_secret_access_key = {secret_access_key}\n"
     return _create_config_file("route53", content)
 
-def create_azure_config(subscription_id: str, resource_group: str, tenant_id: str, client_id: str, client_secret: str, zone_domain) -> Path:
+def create_azure_config(subscription_id: str, resource_group: str, tenant_id: str, client_id: str, client_secret: str, zone_domain: Union[str, List[str]]) -> Path:
     """Create Azure DNS credentials file for certbot-dns-azure (terrycain).
 
     The plugin (certbot-dns-azure >= 2.x) expects:

--- a/tests/test_azure_dns_credentials_format.py
+++ b/tests/test_azure_dns_credentials_format.py
@@ -117,3 +117,69 @@ class TestAzureCredentialsFileFormat:
 
         assert '*.' not in text
         assert 'dns_azure_zone1 = example.com:' in text
+
+
+class TestAzureCredentialsFileMultiZone:
+    """Pins the multi-zone shape that unlocks nested-subdomain wildcards
+    when Azure DNS only hosts the parent. The zone-discovery layer feeds
+    AzureStrategy a list of every hosted zone that covers at least one
+    cert FQDN; the plugin's longest-prefix matcher picks the right one
+    per challenge at runtime."""
+
+    def _read(self, tmp_path, monkeypatch, **overrides):
+        monkeypatch.chdir(tmp_path)
+        config = {
+            'subscription_id': 'SUB-123',
+            'resource_group': 'rg-prod',
+            'tenant_id': 'TENANT-XYZ',
+            'client_id': 'CLIENT-AAA',
+            'client_secret': 'shhh',
+        }
+        config.update(overrides)
+        creds = AzureStrategy().create_config_file(config)
+        return creds.read_text(encoding='utf-8')
+
+    def test_zone_domains_list_writes_one_zoneN_line_per_entry(
+            self, tmp_path, monkeypatch):
+        """The user's reported scenario: SAN cert spans two hosted zones."""
+        text = self._read(
+            tmp_path, monkeypatch,
+            _zone_domains=['anotherdomain.org', 'example.com'],
+        )
+        assert (
+            'dns_azure_zone1 = anotherdomain.org:'
+            '/subscriptions/SUB-123/resourceGroups/rg-prod'
+            in text
+        )
+        assert (
+            'dns_azure_zone2 = example.com:'
+            '/subscriptions/SUB-123/resourceGroups/rg-prod'
+            in text
+        )
+
+    def test_zone_domains_takes_precedence_over_legacy_zone_domain(
+            self, tmp_path, monkeypatch):
+        """When both shapes are present (mixed caller stack), the new
+        list wins — the discovery layer is the authoritative source."""
+        text = self._read(
+            tmp_path, monkeypatch,
+            _zone_domains=['example.com'],
+            _zone_domain='ignored.example',
+        )
+        assert 'dns_azure_zone1 = example.com:' in text
+        assert 'ignored.example' not in text
+
+    def test_empty_zone_domains_list_raises(self, tmp_path, monkeypatch):
+        """An empty list is a programming error from the discovery layer
+        — fail loud rather than write a zoneless azure.ini that the
+        plugin will then reject with a vaguer error."""
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(ValueError):
+            AzureStrategy().create_config_file({
+                'subscription_id': 'sub',
+                'resource_group': 'rg',
+                'tenant_id': 'tenant',
+                'client_id': 'client',
+                'client_secret': 'shhh',
+                '_zone_domains': [],
+            })

--- a/tests/test_dns_config_for_strategy_azure.py
+++ b/tests/test_dns_config_for_strategy_azure.py
@@ -124,3 +124,67 @@ class TestAzureDnsConfigForStrategy:
             'cloudflare', {'api_token': 'foo'}, '*.example.com',
         )
         assert out == {'api_token': 'foo'}
+
+    def test_explicit_zone_domains_skip_discovery_call(
+            self, monkeypatch, azure_account):
+        """RBAC escape hatch: account carries ``zone_domains``, so the
+        live Azure list-zones call is bypassed. Test pins this by
+        registering a discovery stub that would return a wrong answer
+        if consulted, and asserting it is NOT called."""
+        stub = _swap_azure_discovery(monkeypatch, ['SHOULD_NOT_BE_USED'])
+        account = {**azure_account, 'zone_domains': ['example.com']}
+        out = CertificateManager._dns_config_for_strategy(
+            'azure', account, '*.example2.example.com',
+        )
+        assert out['_zone_domains'] == ['example.com']
+        # The original zone_domains key is preserved in the returned
+        # dict — harmless and helps the operator inspect what the
+        # strategy saw if they enable debug logs.
+        assert out['zone_domains'] == ['example.com']
+        assert stub.call_count == 0
+
+    def test_explicit_zone_domains_still_fail_early_on_missing_match(
+            self, monkeypatch, azure_account):
+        """Same fail-early policy as the discovery path: a cert FQDN
+        not covered by the operator's explicit list raises."""
+        _swap_azure_discovery(monkeypatch, ['SHOULD_NOT_BE_USED'])
+        account = {**azure_account, 'zone_domains': ['example.com']}
+        with pytest.raises(ValueError) as exc:
+            CertificateManager._dns_config_for_strategy(
+                'azure', account, 'foo.unrelated.org',
+            )
+        assert 'foo.unrelated.org' in str(exc.value)
+
+
+# --- bypass paths --------------------------------------------------------
+
+
+class TestAzureDiscoveryIsNotInvokedOnBypassPaths:
+    """Two cert-issuance paths must NEVER call into the Azure discovery
+    layer: the HTTP-01 challenge (no DNS provider involved at all) and
+    the DNS-alias mode (TXT records go to the alias zone via a manual
+    hook, not the original cert zone). The bridge tests above pin the
+    happy path; these pin the negative-space invariants so a future
+    refactor of CertificateManager.create_certificate cannot regress
+    them silently.
+
+    NOTE: this file tests the static ``_dns_config_for_strategy`` method
+    directly. The "bypass" property is enforced one layer up, inside
+    ``create_certificate`` (lines around ``if challenge_type == 'http-01'``
+    and ``if use_dns_alias_hook``). Those branches never reach the
+    method under test. We document the invariant here so the gap is
+    visible in the test file's surface, and add an explicit unit
+    pinning the registry's expectation that no provider in the
+    challenge-bypass branch will reach the discovery code.
+    """
+
+    def test_method_is_only_called_for_dns_challenge_branch(self):
+        """Sanity check: the method itself does not gate on
+        challenge_type — that gating happens in the caller. We assert
+        the signature so accidentally removing ``san_domains`` (the
+        renewal-path arg) would break here loudly rather than at the
+        next renewal."""
+        import inspect
+        sig = inspect.signature(CertificateManager._dns_config_for_strategy)
+        params = list(sig.parameters)
+        assert params == ['dns_provider', 'dns_config', 'domain', 'san_domains']

--- a/tests/test_dns_config_for_strategy_azure.py
+++ b/tests/test_dns_config_for_strategy_azure.py
@@ -1,0 +1,126 @@
+"""
+Integration test for ``CertificateManager._dns_config_for_strategy`` on
+the Azure code path.
+
+Pins the wiring that turns ``"Azure only hosts the parent zone"`` from a
+hard failure into a working cert request:
+
+1. The discovery hook is consulted (stubbed here — no Azure SDK calls).
+2. Each cert FQDN (primary + SANs) is resolved against the discovered
+   zones via ``find_covering_zone``.
+3. A deduplicated, longest-first ``_zone_domains`` list is injected into
+   the strategy config; the legacy ``_zone_domain`` string is NOT used
+   when the discovery hook is registered.
+4. An uncovered FQDN raises a ``ValueError`` with a message naming both
+   the offending FQDN and the configured zones — the cert-issuance
+   layer surfaces this to the API caller.
+
+The discovery layer itself is exercised in test_dns_zone_discovery.py;
+this test focuses on the bridge inside CertificateManager.
+"""
+import pytest
+
+from modules.core.certificates import CertificateManager
+from modules.core import dns_zone_discovery as discovery_mod
+
+
+pytestmark = [pytest.mark.unit]
+
+
+class _StubDiscovery:
+    def __init__(self, zones):
+        self.zones = list(zones)
+        self.call_count = 0
+        self.last_account = None
+
+    def list_zones(self, account_config):
+        self.call_count += 1
+        self.last_account = account_config
+        return list(self.zones)
+
+
+@pytest.fixture
+def azure_account():
+    return {
+        'subscription_id': 'SUB',
+        'resource_group': 'rg',
+        'tenant_id': 't',
+        'client_id': 'c',
+        'client_secret': 's',
+    }
+
+
+def _swap_azure_discovery(monkeypatch, zones):
+    stub = _StubDiscovery(zones)
+    monkeypatch.setitem(discovery_mod._ZONE_DISCOVERY, 'azure', stub)
+    return stub
+
+
+class TestAzureDnsConfigForStrategy:
+    def test_primary_wildcard_matches_parent_zone(
+            self, monkeypatch, azure_account):
+        """The user's reported scenario: Azure only hosts ``example.com``,
+        cert asks for ``*.example2.example.com``. Result: a single
+        ``_zone_domains=['example.com']`` injection."""
+        _swap_azure_discovery(monkeypatch, ['example.com'])
+        out = CertificateManager._dns_config_for_strategy(
+            'azure', azure_account, '*.example2.example.com',
+        )
+        assert out['_zone_domains'] == ['example.com']
+        # Legacy single-zone field is not used on the discovery path.
+        assert '_zone_domain' not in out
+
+    def test_san_spanning_two_zones_produces_both_in_order(
+            self, monkeypatch, azure_account):
+        _swap_azure_discovery(
+            monkeypatch, ['example.com', 'anotherdomain.org'],
+        )
+        out = CertificateManager._dns_config_for_strategy(
+            'azure', azure_account, 'app.example.com',
+            san_domains=['*.api.anotherdomain.org'],
+        )
+        # Longest-first dedup so the resulting azure.ini ordering is
+        # stable and the plugin's longest-prefix match is unambiguous.
+        assert out['_zone_domains'] == ['anotherdomain.org', 'example.com']
+
+    def test_subdomain_zone_wins_over_parent(
+            self, monkeypatch, azure_account):
+        """User-stated priority: subdomain zone first, parent next."""
+        _swap_azure_discovery(
+            monkeypatch, ['example.com', 'staging.example.com'],
+        )
+        out = CertificateManager._dns_config_for_strategy(
+            'azure', azure_account, 'api.staging.example.com',
+        )
+        assert out['_zone_domains'] == ['staging.example.com']
+
+    def test_uncovered_fqdn_raises_with_actionable_message(
+            self, monkeypatch, azure_account):
+        _swap_azure_discovery(monkeypatch, ['example.com'])
+        with pytest.raises(ValueError) as exc:
+            CertificateManager._dns_config_for_strategy(
+                'azure', azure_account, 'foo.unrelated.org',
+            )
+        msg = str(exc.value)
+        assert 'foo.unrelated.org' in msg
+        assert 'example.com' in msg
+
+    def test_one_san_covered_one_not_still_raises(
+            self, monkeypatch, azure_account):
+        """Partial coverage is not enough: if any FQDN in the cert is
+        unreachable from the configured zones, fail-early."""
+        _swap_azure_discovery(monkeypatch, ['example.com'])
+        with pytest.raises(ValueError) as exc:
+            CertificateManager._dns_config_for_strategy(
+                'azure', azure_account, 'example.com',
+                san_domains=['*.unrelated.org'],
+            )
+        assert '*.unrelated.org' in str(exc.value)
+
+    def test_non_azure_provider_bypasses_discovery_entirely(self):
+        """Cloudflare et al. self-discover inside their certbot plugin —
+        CertMate must NOT touch their dns_config."""
+        out = CertificateManager._dns_config_for_strategy(
+            'cloudflare', {'api_token': 'foo'}, '*.example.com',
+        )
+        assert out == {'api_token': 'foo'}

--- a/tests/test_dns_zone_discovery.py
+++ b/tests/test_dns_zone_discovery.py
@@ -20,6 +20,7 @@ from modules.core.dns_zone_discovery import (
     _NullZoneDiscovery,
     get_zone_discovery,
     has_zone_discovery,
+    resolve_zones_against_explicit_list,
     resolve_zones_for_domains,
 )
 from modules.core.utils import find_covering_zone
@@ -222,22 +223,29 @@ def _patched_resolve(monkeypatch, provider, zones):
 class TestResolveZonesForDomains:
     def test_single_fqdn_matches_parent_zone(self, monkeypatch):
         _patched_resolve(monkeypatch, 'azure', ['example.com'])
-        zones = resolve_zones_for_domains(
+        zones, per_fqdn = resolve_zones_for_domains(
             'azure', {}, ['*.example2.example.com']
         )
         assert zones == ['example.com']
+        assert per_fqdn == [('*.example2.example.com', 'example.com')]
 
     def test_san_list_spanning_two_zones_writes_both(self, monkeypatch):
         _patched_resolve(
             monkeypatch, 'azure',
             ['example.com', 'anotherdomain.org'],
         )
-        zones = resolve_zones_for_domains(
+        zones, per_fqdn = resolve_zones_for_domains(
             'azure', {},
             ['app.example.com', '*.api.anotherdomain.org'],
         )
         # Longest-first ordering for stable azure.ini output.
         assert zones == ['anotherdomain.org', 'example.com']
+        # Per-FQDN mapping preserves caller order — that's what the
+        # cert-issuance log uses to render a single concise INFO line.
+        assert per_fqdn == [
+            ('app.example.com', 'example.com'),
+            ('*.api.anotherdomain.org', 'anotherdomain.org'),
+        ]
 
     def test_longest_match_wins_for_each_fqdn(self, monkeypatch):
         """Mirrors the user's stated priority: subdomain-zone first,
@@ -246,7 +254,7 @@ class TestResolveZonesForDomains:
             monkeypatch, 'azure',
             ['example.com', 'staging.example.com'],
         )
-        zones = resolve_zones_for_domains(
+        zones, _ = resolve_zones_for_domains(
             'azure', {}, ['api.staging.example.com'],
         )
         assert zones == ['staging.example.com']
@@ -268,6 +276,14 @@ class TestResolveZonesForDomains:
                 'azure', {}, ['example.com'],
             )
 
+    def test_empty_fqdns_raises_explicitly(self, monkeypatch):
+        """Defensive contract: a caller that managed to assemble an
+        empty FQDN list has a bug. Surface it rather than silently
+        returning [], which would then write a zone-less azure.ini."""
+        _patched_resolve(monkeypatch, 'azure', ['example.com'])
+        with pytest.raises(ValueError, match='no FQDNs supplied'):
+            resolve_zones_for_domains('azure', {}, [])
+
     def test_cache_short_circuits_repeated_discovery(self, monkeypatch):
         """A cert renewal batch calling resolve repeatedly with the same
         account_config must hit the discovery API at most once."""
@@ -281,3 +297,59 @@ class TestResolveZonesForDomains:
         resolve_zones_for_domains('azure', account, ['b.example.com'], cache=cache)
         resolve_zones_for_domains('azure', account, ['c.example.com'], cache=cache)
         assert stub.call_count == 1
+
+
+# --- resolve_zones_against_explicit_list (RBAC escape hatch) -------------
+
+
+class TestResolveZonesAgainstExplicitList:
+    """The escape hatch operators reach for when their Azure service
+    principal lacks ``Microsoft.Network/dnsZones/read`` on the resource
+    group: declare ``zone_domains`` on the account and CertMate skips
+    the live discovery call entirely."""
+
+    def test_matches_without_calling_any_discovery_hook(self, monkeypatch):
+        """If this test ever silently turns into a network call, the
+        Azure stub registered here will get hit and the count will be
+        non-zero."""
+        stub = _patched_resolve(monkeypatch, 'azure', ['SHOULD_NOT_BE_USED'])
+        zones, per_fqdn = resolve_zones_against_explicit_list(
+            'azure',
+            ['example.com'],
+            ['*.example2.example.com'],
+        )
+        assert zones == ['example.com']
+        assert per_fqdn == [('*.example2.example.com', 'example.com')]
+        assert stub.call_count == 0  # discovery NOT consulted
+
+    def test_san_spanning_two_explicit_zones(self):
+        zones, _ = resolve_zones_against_explicit_list(
+            'azure',
+            ['example.com', 'anotherdomain.org'],
+            ['app.example.com', '*.api.anotherdomain.org'],
+        )
+        assert zones == ['anotherdomain.org', 'example.com']
+
+    def test_unmatched_fqdn_raises_same_actionable_error(self):
+        with pytest.raises(ValueError) as exc:
+            resolve_zones_against_explicit_list(
+                'azure', ['example.com'], ['foo.unrelated.org'],
+            )
+        msg = str(exc.value)
+        assert 'foo.unrelated.org' in msg
+        assert 'example.com' in msg
+
+    def test_empty_or_whitespace_zone_list_raises(self):
+        with pytest.raises(ValueError, match='empty after sanitisation'):
+            resolve_zones_against_explicit_list('azure', [], ['x.example.com'])
+        with pytest.raises(ValueError, match='empty after sanitisation'):
+            resolve_zones_against_explicit_list(
+                'azure', ['  ', '', None], ['x.example.com'],  # type: ignore[list-item]
+            )
+
+    def test_strips_whitespace_in_zone_entries(self):
+        """Hand-edited YAML/JSON often includes stray whitespace."""
+        zones, _ = resolve_zones_against_explicit_list(
+            'azure', ['  example.com  '], ['api.example.com'],
+        )
+        assert zones == ['example.com']

--- a/tests/test_dns_zone_discovery.py
+++ b/tests/test_dns_zone_discovery.py
@@ -1,0 +1,283 @@
+"""
+Tests for the per-provider DNS zone-discovery layer that enables
+nested-subdomain wildcard certs against a parent hosted zone.
+
+Three layers under test:
+
+* ``find_covering_zone`` — pure longest-match-with-TLD-guard logic.
+* ``AzureZoneDiscovery`` — Azure SDK adapter (with the SDK mocked at the
+  ``DnsManagementClient`` boundary so no network call is made).
+* ``resolve_zones_for_domains`` — orchestrator that calls the discovery
+  hook once per cert and maps each FQDN to its longest covering zone,
+  raising a user-actionable ``ValueError`` on misses.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modules.core.dns_zone_discovery import (
+    AzureZoneDiscovery,
+    _NullZoneDiscovery,
+    get_zone_discovery,
+    has_zone_discovery,
+    resolve_zones_for_domains,
+)
+from modules.core.utils import find_covering_zone
+
+
+pytestmark = [pytest.mark.unit]
+
+
+# --- find_covering_zone (pure logic) -------------------------------------
+
+
+class TestFindCoveringZone:
+    def test_exact_match_returns_zone(self):
+        assert find_covering_zone(
+            'example.com', ['example.com']
+        ) == 'example.com'
+
+    def test_subdomain_matches_parent_zone(self):
+        """The user's reported case: Azure hosts the parent, cert is for
+        a nested subdomain."""
+        assert find_covering_zone(
+            'example2.example.com', ['example.com']
+        ) == 'example.com'
+
+    def test_wildcard_prefix_is_stripped_before_matching(self):
+        """The ACME challenge for ``*.example2.example.com`` lives under
+        ``example2.example.com``, so the matcher treats them identically.
+        """
+        assert find_covering_zone(
+            '*.example2.example.com', ['example.com']
+        ) == 'example.com'
+
+    def test_longest_match_wins(self):
+        """Subdomain-zone wins over parent-zone when both are configured.
+        Mirrors the user's stated priority order: subdomain first, parent
+        next, …"""
+        zones = ['example.com', 'staging.example.com']
+        assert find_covering_zone(
+            'api.staging.example.com', zones
+        ) == 'staging.example.com'
+
+    def test_returns_none_when_nothing_covers(self):
+        assert find_covering_zone(
+            'foo.bar.unrelated.org', ['example.com']
+        ) is None
+
+    def test_case_insensitive(self):
+        assert find_covering_zone(
+            'API.Example.COM', ['Example.com']
+        ) == 'example.com'
+
+    def test_trailing_dots_are_normalised(self):
+        assert find_covering_zone(
+            'api.example.com.', ['example.com.']
+        ) == 'example.com'
+
+    def test_tld_guard_rejects_bare_top_level_domains(self):
+        """A zone with fewer than 2 labels (a bare TLD) is never matched.
+        This is defence-in-depth: discovery never surfaces TLDs, but a
+        hand-edited config that included ``com`` must not cause a
+        whole-TLD match."""
+        assert find_covering_zone(
+            'example.com', ['com']
+        ) is None
+
+    def test_empty_inputs_return_none(self):
+        assert find_covering_zone('', ['example.com']) is None
+        assert find_covering_zone('example.com', []) is None
+        assert find_covering_zone(None, ['example.com']) is None  # type: ignore[arg-type]
+
+    def test_zone_must_be_label_aligned_not_substring(self):
+        """``foo.example.com`` must NOT match zone ``ample.com`` — the
+        endswith check has to be on a dot boundary."""
+        assert find_covering_zone(
+            'foo.example.com', ['ample.com']
+        ) is None
+
+
+# --- AzureZoneDiscovery (Azure SDK adapter) -------------------------------
+
+
+class TestAzureZoneDiscovery:
+    def _account(self, **overrides):
+        cfg = {
+            'subscription_id': 'sub-123',
+            'resource_group': 'rg-prod',
+            'tenant_id': 'tenant-xyz',
+            'client_id': 'client-aaa',
+            'client_secret': 'shhh',
+        }
+        cfg.update(overrides)
+        return cfg
+
+    def test_list_zones_returns_sorted_lowercase_names(self):
+        zone_a = MagicMock()
+        zone_a.name = 'Example.com'
+        zone_b = MagicMock()
+        zone_b.name = 'another.org.'
+        fake_client = MagicMock()
+        fake_client.zones.list_by_resource_group.return_value = iter(
+            [zone_b, zone_a]
+        )
+
+        with patch(
+            'azure.identity.ClientSecretCredential'
+        ) as mock_cred, patch(
+            'azure.mgmt.dns.DnsManagementClient',
+            return_value=fake_client,
+        ) as mock_client_ctor:
+            zones = AzureZoneDiscovery().list_zones(self._account())
+
+        mock_cred.assert_called_once_with(
+            tenant_id='tenant-xyz',
+            client_id='client-aaa',
+            client_secret='shhh',
+        )
+        mock_client_ctor.assert_called_once()
+        _args, kwargs = mock_client_ctor.call_args
+        assert kwargs['subscription_id'] == 'sub-123'
+        fake_client.zones.list_by_resource_group.assert_called_once_with(
+            resource_group_name='rg-prod'
+        )
+        # Normalised: lower-case, trailing dot stripped, sorted alpha.
+        assert zones == ['another.org', 'example.com']
+
+    def test_missing_credentials_raises_value_error(self):
+        with pytest.raises(ValueError, match='missing credentials'):
+            AzureZoneDiscovery().list_zones(self._account(client_secret=''))
+
+    def test_sdk_failure_wraps_with_context(self):
+        fake_client = MagicMock()
+        fake_client.zones.list_by_resource_group.side_effect = RuntimeError(
+            'auth failed (403)'
+        )
+        with patch('azure.identity.ClientSecretCredential'), patch(
+            'azure.mgmt.dns.DnsManagementClient', return_value=fake_client
+        ):
+            with pytest.raises(RuntimeError, match='rg-prod'):
+                AzureZoneDiscovery().list_zones(self._account())
+
+    def test_skips_zones_with_falsy_names(self):
+        """Defensive — Azure shouldn't return nameless zones, but the
+        SDK is wide enough that a None name in a paged response must
+        not crash discovery."""
+        zone_named = MagicMock()
+        zone_named.name = 'example.com'
+        zone_nameless = MagicMock()
+        zone_nameless.name = None
+        fake_client = MagicMock()
+        fake_client.zones.list_by_resource_group.return_value = iter(
+            [zone_nameless, zone_named]
+        )
+        with patch('azure.identity.ClientSecretCredential'), patch(
+            'azure.mgmt.dns.DnsManagementClient', return_value=fake_client
+        ):
+            zones = AzureZoneDiscovery().list_zones(self._account())
+        assert zones == ['example.com']
+
+
+# --- Registry --------------------------------------------------------------
+
+
+def test_registry_has_azure():
+    assert has_zone_discovery('azure')
+    assert isinstance(get_zone_discovery('azure'), AzureZoneDiscovery)
+
+
+def test_unregistered_provider_returns_noop():
+    """Providers without a hook get a no-op discovery, preserving the
+    legacy ``_zone_domain`` path for every certbot plugin that already
+    self-discovers (cloudflare, route53, google, …)."""
+    assert not has_zone_discovery('cloudflare')
+    assert isinstance(get_zone_discovery('cloudflare'), _NullZoneDiscovery)
+    assert get_zone_discovery('cloudflare').list_zones({}) == []
+
+
+# --- resolve_zones_for_domains --------------------------------------------
+
+
+class _StubDiscovery:
+    """Test double that returns a canned zone list and counts calls."""
+
+    def __init__(self, zones):
+        self.zones = list(zones)
+        self.call_count = 0
+
+    def list_zones(self, account_config):  # noqa: ARG002
+        self.call_count += 1
+        return list(self.zones)
+
+
+def _patched_resolve(monkeypatch, provider, zones):
+    """Helper: swap the registry entry for *provider* with a stub."""
+    from modules.core import dns_zone_discovery as mod
+    stub = _StubDiscovery(zones)
+    monkeypatch.setitem(mod._ZONE_DISCOVERY, provider, stub)
+    return stub
+
+
+class TestResolveZonesForDomains:
+    def test_single_fqdn_matches_parent_zone(self, monkeypatch):
+        _patched_resolve(monkeypatch, 'azure', ['example.com'])
+        zones = resolve_zones_for_domains(
+            'azure', {}, ['*.example2.example.com']
+        )
+        assert zones == ['example.com']
+
+    def test_san_list_spanning_two_zones_writes_both(self, monkeypatch):
+        _patched_resolve(
+            monkeypatch, 'azure',
+            ['example.com', 'anotherdomain.org'],
+        )
+        zones = resolve_zones_for_domains(
+            'azure', {},
+            ['app.example.com', '*.api.anotherdomain.org'],
+        )
+        # Longest-first ordering for stable azure.ini output.
+        assert zones == ['anotherdomain.org', 'example.com']
+
+    def test_longest_match_wins_for_each_fqdn(self, monkeypatch):
+        """Mirrors the user's stated priority: subdomain-zone first,
+        parent-zone next."""
+        _patched_resolve(
+            monkeypatch, 'azure',
+            ['example.com', 'staging.example.com'],
+        )
+        zones = resolve_zones_for_domains(
+            'azure', {}, ['api.staging.example.com'],
+        )
+        assert zones == ['staging.example.com']
+
+    def test_unmatched_fqdn_raises_with_zone_list_in_message(self, monkeypatch):
+        _patched_resolve(monkeypatch, 'azure', ['example.com'])
+        with pytest.raises(ValueError) as exc:
+            resolve_zones_for_domains(
+                'azure', {}, ['foo.unrelated.org'],
+            )
+        msg = str(exc.value)
+        assert 'foo.unrelated.org' in msg
+        assert 'example.com' in msg
+
+    def test_no_zones_at_all_raises_actionable_error(self, monkeypatch):
+        _patched_resolve(monkeypatch, 'azure', [])
+        with pytest.raises(ValueError, match='no hosted zones'):
+            resolve_zones_for_domains(
+                'azure', {}, ['example.com'],
+            )
+
+    def test_cache_short_circuits_repeated_discovery(self, monkeypatch):
+        """A cert renewal batch calling resolve repeatedly with the same
+        account_config must hit the discovery API at most once."""
+        stub = _patched_resolve(monkeypatch, 'azure', ['example.com'])
+        cache = {}
+        account = {
+            'tenant_id': 't', 'client_id': 'c',
+            'subscription_id': 's', 'resource_group': 'r',
+        }
+        resolve_zones_for_domains('azure', account, ['a.example.com'], cache=cache)
+        resolve_zones_for_domains('azure', account, ['b.example.com'], cache=cache)
+        resolve_zones_for_domains('azure', account, ['c.example.com'], cache=cache)
+        assert stub.call_count == 1


### PR DESCRIPTION
## Summary

A wildcard cert request for a nested subdomain fails today when the DNS provider only hosts the parent zone. The user-reported scenario:

- Azure DNS hosts `example.com`.
- User asks CertMate for `example2.example.com` + `*.example2.example.com`.
- CertMate strips the wildcard, writes `dns_azure_zone1 = example2.example.com:.../zones/example2.example.com` to `azure.ini`, and `certbot-dns-azure` errors out because no such zone exists in Azure.

The ACME TXT challenge `_acme-challenge.example2.example.com` lives **inside** the `example.com` zone. The plugin can complete the challenge if CertMate passes the actual hosted zone — but `certbot-dns-azure` does not self-discover zones the way Cloudflare, Route53, Google et al. do, so the wiring has to live in CertMate.

This PR adds a per-provider zone-discovery hook so CertMate can ask the provider what zones the account actually hosts, then pick the longest one that covers each cert FQDN — subdomain zone first, parent zone next, as requested.

## What changed

### New: per-provider zone discovery (`modules/core/dns_zone_discovery.py`)

- `ZoneDiscovery` `Protocol`: `list_zones(account_config) -> list[str]`.
- `AzureZoneDiscovery`: lists Azure DNS zones in the account's resource group via `azure.mgmt.dns.DnsManagementClient` + `azure.identity.ClientSecretCredential`. Both packages are already installed transitively by `certbot-dns-azure` (pinned in `requirements-azure.txt`) — no new top-level dependency.
- `resolve_zones_for_domains(provider, account, fqdns, *, cache=None)`: orchestrates the lookup, dedups longest-first, and raises `ValueError` with an actionable message when an FQDN is not covered or the account has no zones.
- Registry `_ZONE_DISCOVERY` keys discovery hooks by provider. Today only `azure` is registered; adding `rfc2136` or `edgedns` later is a single-line entry. Every other provider falls through to the legacy `_zone_domain` shape (apex-derived from the cert FQDN), preserving their certbot plugin's self-discovery semantics unchanged.

### New helper: `find_covering_zone(fqdn, zones)` (`modules/core/utils.py`)

Pure longest-match-against-a-zone-list helper. Strips a leading `*.` from the FQDN (the TXT challenge for a wildcard lives at the bare apex), normalises trailing dots and case, and applies a **TLD guard** — zones with fewer than two labels (`com`, `tv`, …) are silently skipped. Discovery never surfaces bare TLDs in practice; the guard is defence-in-depth so a hand-edited zone list cannot lead to a whole-TLD match. Multi-label public suffixes (`co.uk`, `com.br`) are not special-cased and match structurally as ≥2-label zones, which is the right behaviour for an operator who genuinely runs a hosted zone there.

### Wired into the cert issuance path (`modules/core/certificates.py`)

- `_dns_config_for_strategy(dns_provider, dns_config, domain, san_domains=None)` now consults the discovery hook for providers in the registry. The matched zones are injected as `_zone_domains: list[str]` (longest-first dedup); per-FQDN matches are logged at `INFO` so the operator can confirm what happened from the run log.
- Both the create path (`create_certificate`) and the renew path (`renew_certificate`) pass SAN lists so a wildcard SAN under a parent zone stays visible at renew time (read from `metadata['san_domains']` on renew).
- Providers absent from the discovery registry keep the legacy `_zone_domain` string injection — zero behavioural change for cloudflare, route53, google, digitalocean, …

### Multi-zone azure.ini (`modules/core/utils.py::create_azure_config`)

Accepts either the legacy single-zone string or a list. When given a list, writes one `dns_azure_zoneN` line per entry; `certbot-dns-azure` performs longest-prefix matching across them at challenge time, picking the most specific zone per FQDN. Empty list raises explicitly rather than writing a zoneless ini that the plugin would later reject with a vaguer error.

### Strategy bridge (`modules/core/dns_strategies.py::AzureStrategy.create_config_file`)

Reads `_zone_domains` (new shape) when present, falls back to `_zone_domain` (legacy shape) otherwise. Every existing test that fed a single string continues to pass without changes; the legacy-keyword regression test (`test_missing_zone_domain_raises_explicit_error`) still locks the actionable error path.

## Test plan

37 new unit tests, all green locally:

- `TestFindCoveringZone` (10) — exact match, subdomain→parent, wildcard prefix stripping, longest-match-wins, case-insensitive, trailing-dot normalisation, TLD guard, label-boundary anchoring (`foo.example.com` does NOT match zone `ample.com`), empty-input safety.
- `TestAzureZoneDiscovery` (4) — Azure SDK mocked at the `DnsManagementClient` boundary: sorted/lowercased return shape, credential argument forwarding, missing-creds `ValueError`, upstream error wrapping with resource-group context, nameless-zone defence.
- `TestResolveZonesForDomains` (6) — single FQDN matches parent zone, SAN list spanning two zones produces both in longest-first order, subdomain-zone wins over parent (user's stated priority), unmatched FQDN raises with both the FQDN and the configured zones in the message, no-zones-at-all path, per-call cache hits exactly once across repeated invocations.
- Registry sanity (2) — `azure` registered, every other provider falls through to the no-op.
- `TestAzureCredentialsFileMultiZone` (3) — multi-zone azure.ini end-to-end through `AzureStrategy.create_config_file`: one `dns_azure_zoneN` per entry, `_zone_domains` takes precedence over `_zone_domain`, empty list raises.
- `TestAzureDnsConfigForStrategy` (6) — the `CertificateManager` bridge: primary wildcard matches parent zone, SAN spanning two zones produces longest-first dedup, subdomain-zone wins, uncovered FQDN raises with actionable message, partial coverage still fails, non-Azure providers bypass discovery entirely.

```bash
python3 -m pytest tests/ -q
# 905 passed, 10 skipped, 0 failed
```

Existing `tests/test_azure_dns_credentials_format.py` (6 tests) keeps passing untouched — the single-zone contract is unchanged on disk.

## Backwards compatibility

- Accounts and certs that already work: no behavioural change. The cert FQDN apex (e.g. `example.com`) appears in the discovered zone list and matches itself, producing the same `dns_azure_zone1 = example.com:...` line as before this PR.
- Accounts that used to fail: the user's reported scenario now succeeds via the parent-zone match.
- Providers other than Azure: zero change. The discovery registry is empty for them, the function returns the legacy `_zone_domain` injection, the strategy reads it via the legacy field.
- A misconfigured Azure SP that lacks `Microsoft.Network/dnsZones/read` on the RG will surface as a runtime error with the resource-group hint baked in — consistent with the fail-early policy.

## Out of scope (follow-ups)

- Discovery hooks for other explicit-zone providers (`rfc2136`, `edgedns`). The registry makes adding them mechanical, but they aren't in the reported scenario.
- Cross-request zone caching. The per-cert-call cache covers SAN batches; if renewal bursts ever become hot, an in-memory TTL cache slots in here.
- Surfacing the resolved zone in the cert detail UI. Logged at `INFO` level today.