### PR TITLE
fix: close domain validation gaps from internal security audit (C3 + H6)

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -606,6 +606,23 @@ def create_api_resources(api, models, managers):
                         'hint': 'Provide domain name only (e.g., example.com), not the full URL.'
                     }, 400
 
+                # Full structural validation of the primary domain. Until
+                # now only space/URL-prefix were rejected; an unvalidated
+                # ``domain`` flows into ``cert_dir / domain`` for
+                # ``mkdir(parents=True)`` and is persisted into
+                # ``settings.json`` for replay through ``check_renewals``.
+                # SAN entries already go through ``validate_domain`` at the
+                # core layer (modules/core/certificates.py:690); the primary
+                # domain must get the same gate, AT THE WRITE BOUNDARY, so
+                # a poisoned value cannot survive into background renewals.
+                from ..core.utils import validate_domain
+                primary_valid, primary_msg = validate_domain(domain)
+                if not primary_valid:
+                    return {
+                        'error': f'Invalid domain: {primary_msg}',
+                        'hint': 'Use only valid domain characters (letters, digits, hyphens, dots). For wildcards use *.example.com.'
+                    }, 400
+
                 # Validate SAN domains if provided
                 if san_domains:
                     if not isinstance(san_domains, list):
@@ -802,6 +819,9 @@ def create_api_resources(api, models, managers):
         @auth_manager.require_role('viewer')
         def get(self, domain):
             """Check DNS-01 alias CNAME records for an existing certificate."""
+            _, err = _validate_domain_path(domain, file_ops.cert_dir)
+            if err:
+                return {'error': err}, 400
             scope_err = _check_domain_scope(domain, 'dns_alias_check')
             if scope_err:
                 return scope_err
@@ -1376,6 +1396,9 @@ def create_api_resources(api, models, managers):
             try:
                 payload = request.get_json(silent=True) or {}
                 force = bool(payload.get('force', False))
+                _, err = _validate_domain_path(domain, file_ops.cert_dir)
+                if err:
+                    return {'error': err}, 400
                 scope_err = _check_domain_scope(domain, 'renew')
                 if scope_err:
                     return scope_err

--- a/modules/web/cert_routes.py
+++ b/modules/web/cert_routes.py
@@ -79,6 +79,17 @@ def register_cert_routes(app, managers, require_web_auth, auth_manager,
             if not domain:
                 return jsonify({'error': 'Domain is required'}), 400
 
+            # Full structural validation at the write boundary. Without
+            # this gate a poisoned ``domain`` ("../poisoned") flows into
+            # ``cert_dir / domain`` for ``mkdir(parents=True)`` and gets
+            # persisted into ``settings.json`` for replay through
+            # ``check_renewals``. Same fix shape applied to the API
+            # variant in modules/api/resources.py::CreateCertificate.post.
+            from ..core.utils import validate_domain
+            primary_valid, primary_msg = validate_domain(domain)
+            if not primary_valid:
+                return jsonify({'error': f'Invalid domain: {primary_msg}'}), 400
+
             # Scope check: primary domain + every SAN must be in scope.
             denial = _scope_denied(domain, 'create')
             if denial:
@@ -171,10 +182,22 @@ def register_cert_routes(app, managers, require_web_auth, auth_manager,
             user = getattr(request, 'current_user', None) or {}
             scope = user.get('allowed_domains')
 
+            from ..core.utils import validate_domain
             results = []
             for domain in domains:
                 domain = (domain if isinstance(domain, str) else '').strip()
                 if not domain:
+                    continue
+                # Structural validation BEFORE scope check so a poisoned
+                # entry (e.g. "../escape") never even reaches the cert
+                # manager or settings.json. Same gate the single-cert path
+                # now applies.
+                d_valid, d_msg = validate_domain(domain)
+                if not d_valid:
+                    results.append({
+                        'domain': domain, 'success': False,
+                        'message': f'Invalid domain: {d_msg}',
+                    })
                     continue
                 if not auth_manager.domain_matches_scope(domain, scope):
                     if audit_logger:

--- a/tests/test_audit_domain_validation_gaps.py
+++ b/tests/test_audit_domain_validation_gaps.py
@@ -1,0 +1,230 @@
+"""Regression tests for the domain validation gaps surfaced by the
+internal security audit (May 2026).
+
+Before this fix:
+
+* ``POST /api/certificates/create`` and the web equivalents
+  (``/api/web/certificates/create``, ``/api/web/certificates/batch``)
+  validated only whitespace and the ``http://`` URL prefix on the
+  primary ``domain`` body field. ``validate_domain()`` ran on every
+  SAN entry but NOT on the primary, so a payload like
+  ``{"domain": "../poisoned", ...}`` reached
+  ``CertificateManager.create_certificate`` and the call
+  ``cert_output_dir = cert_dir / domain ; mkdir(parents=True, ...)``
+  created a directory above the cert root. Worse: the malicious
+  ``domain`` was then persisted into ``settings.json`` via
+  ``settings_manager.update`` and replayed by ``check_renewals``
+  on every renewal tick.
+
+* ``POST /api/certificates/<domain>/renew`` and
+  ``GET /api/certificates/<domain>/dns-alias-check`` did not call
+  ``_validate_domain_path`` (other ``<domain>``-bearing resources do).
+  Flask's URL routing today scrubs ``/`` from a ``<string:domain>``
+  slot, but the only line of defence was the routing layer — once a
+  poisoned domain was persisted via the gap above, the
+  ``check_renewals`` background loop would replay it through
+  ``renew_certificate`` unchecked.
+
+The fix tightens the WRITE boundary: ``validate_domain()`` runs on
+the primary in every create path, and ``_validate_domain_path()``
+runs on every ``<domain>`` handler. Defence in depth: the validator
+on the read side did not change.
+"""
+
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from flask import Flask, request
+from flask_restx import Api, Namespace
+
+from modules.api.models import create_api_models
+from modules.api.resources import create_api_resources
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def _passthrough_decorator(_min_role):
+    def deco(fn):
+        return fn
+    return deco
+
+
+@pytest.fixture
+def cert_dir(tmp_path):
+    """An on-disk cert root with one existing domain."""
+    d = tmp_path / 'example.com'
+    d.mkdir()
+    (d / 'fullchain.pem').write_text('FAKE-fullchain')
+    return tmp_path
+
+
+def _make_app(cert_dir):
+    """Flask test client wiring DownloadCertificate-style resources
+    so we can exercise CreateCertificate / RenewCertificate /
+    CertificateDNSAliasCheck handlers with their decorators bypassed."""
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_decorator)
+    auth_manager.user_can_access_domain.return_value = True
+    auth_manager.domain_matches_scope.return_value = True
+
+    file_ops = MagicMock(cert_dir=Path(cert_dir))
+    settings_manager = MagicMock()
+    settings_manager.load_settings.return_value = {
+        'email': 'ops@example.com',
+        'dns_provider': 'cloudflare',
+        'default_ca': 'letsencrypt',
+        'challenge_type': 'dns-01',
+    }
+    certificate_manager = MagicMock(cert_dir=Path(cert_dir))
+    certificate_manager.create_certificate.return_value = {'status': 'ok'}
+    certificate_manager.renew_certificate.return_value = {'dns_provider': 'cloudflare', 'duration': 1.0}
+    audit_logger = MagicMock()
+
+    managers = {
+        'auth': auth_manager,
+        'settings': settings_manager,
+        'certificates': certificate_manager,
+        'file_ops': file_ops,
+        'cache': MagicMock(),
+        'dns': MagicMock(),
+        'audit': audit_logger,
+    }
+
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    api = Api(app, prefix='/api')
+    models = create_api_models(api)
+    resources = create_api_resources(api, models, managers)
+
+    ns = Namespace('certificates', description='certs')
+    api.add_namespace(ns)
+    ns.add_resource(resources['CreateCertificate'], '/create')
+    ns.add_resource(resources['RenewCertificate'], '/<string:domain>/renew')
+    ns.add_resource(resources['CertificateDNSAliasCheck'], '/<string:domain>/dns-alias-check')
+
+    @app.before_request
+    def _attach_user():
+        request.current_user = {
+            'username': 'fake_operator',
+            'role': 'operator',
+            'allowed_domains': None,
+        }
+
+    return app, managers
+
+
+class TestCreateCertificateRejectsPathTraversalDomain:
+    """The primary ``domain`` field on the create endpoint must pass
+    ``validate_domain()`` before any side effect — directory creation,
+    settings persistence or certbot invocation. ``../poisoned`` is the
+    canonical exploit shape; verify it is rejected at the API boundary,
+    not just one layer down."""
+
+    @pytest.mark.parametrize('bad_domain', [
+        '../poisoned',
+        '../../etc/passwd',
+        '..',
+        'foo/bar',
+        'foo\\bar',
+        'foo;bar',
+        'with space.example.com',  # spaces always rejected, but pin it
+        '\x00null.example.com',
+    ])
+    def test_create_rejects_invalid_domain(self, cert_dir, bad_domain):
+        app, managers = _make_app(cert_dir)
+        client = app.test_client()
+        r = client.post('/api/certificates/create', json={
+            'domain': bad_domain,
+            'dns_provider': 'cloudflare',
+            'account_id': 'e2e',
+        })
+        assert r.status_code == 400, r.data
+        body = r.get_json()
+        assert 'Invalid domain' in body['error'] or 'Invalid domain format' in body['error']
+        # Critical: the create path must never have reached the cert
+        # manager — that's the layer that would have built the unsafe
+        # Path and persisted into settings.json.
+        managers['certificates'].create_certificate.assert_not_called()
+
+    def test_create_accepts_valid_apex(self, cert_dir):
+        app, managers = _make_app(cert_dir)
+        client = app.test_client()
+        r = client.post('/api/certificates/create', json={
+            'domain': 'shiny-new.example.com',
+            'dns_provider': 'cloudflare',
+            'account_id': 'e2e',
+        })
+        assert r.status_code in (200, 201), r.data
+        managers['certificates'].create_certificate.assert_called_once()
+
+    def test_create_accepts_wildcard(self, cert_dir):
+        app, managers = _make_app(cert_dir)
+        client = app.test_client()
+        r = client.post('/api/certificates/create', json={
+            'domain': '*.example.com',
+            'dns_provider': 'cloudflare',
+            'account_id': 'e2e',
+        })
+        assert r.status_code in (200, 201), r.data
+        managers['certificates'].create_certificate.assert_called_once()
+
+
+class TestRenewCertificateValidatesDomain:
+    """``RenewCertificate`` handler must call ``_validate_domain_path``
+    on its ``<domain>`` path param, mirroring the other
+    ``<domain>``-bearing resources. Defence against a poisoned domain
+    surviving in ``settings.json`` from an older permissive create
+    path and being replayed by ``check_renewals``."""
+
+    def test_renew_rejects_traversal_domain(self, cert_dir):
+        app, managers = _make_app(cert_dir)
+        client = app.test_client()
+        # werkzeug URL normalisation already strips '..' from the
+        # path segment, so we go in through .test_client() with an
+        # already-decoded path that bypasses normalisation. The point
+        # is to lock the handler contract independently of the
+        # routing layer.
+        r = client.open('/api/certificates/..poisoned/renew', method='POST')
+        assert r.status_code == 400
+        managers['certificates'].renew_certificate.assert_not_called()
+
+    def test_renew_accepts_valid_domain(self, cert_dir):
+        app, managers = _make_app(cert_dir)
+        client = app.test_client()
+        r = client.post('/api/certificates/example.com/renew')
+        assert r.status_code == 200
+        managers['certificates'].renew_certificate.assert_called_once_with(
+            'example.com', force=False,
+        )
+
+
+class TestDNSAliasCheckValidatesDomain:
+    """Same contract for ``CertificateDNSAliasCheck.get``."""
+
+    def test_dns_alias_check_rejects_traversal_domain(self, cert_dir):
+        app, managers = _make_app(cert_dir)
+        client = app.test_client()
+        r = client.get('/api/certificates/..poisoned/dns-alias-check')
+        assert r.status_code == 400
+        managers['certificates'].get_certificate_info.assert_not_called()
+
+
+class TestCreateCertificatePoisonedDomainDoesNotPersist:
+    """The most important property of the fix: a rejected create must
+    NOT touch ``settings_manager.update``. Otherwise the malicious
+    domain would survive into background renewals (via
+    ``check_renewals``), which is the actual exploit chain the audit
+    surfaced. Pin it."""
+
+    def test_invalid_domain_does_not_call_settings_update(self, cert_dir):
+        app, managers = _make_app(cert_dir)
+        client = app.test_client()
+        r = client.post('/api/certificates/create', json={
+            'domain': '../escape',
+            'dns_provider': 'cloudflare',
+            'account_id': 'e2e',
+        })
+        assert r.status_code == 400
+        managers['settings'].update.assert_not_called()


### PR DESCRIPTION
## Summary

Internal security audit (May 2026) surfaced **2 finding-classes** of the same root cause: domain validators applied at READ boundaries but skipped at WRITE boundaries on several routes. This PR closes the gaps.

## Findings addressed

### C3 (CRITICAL) — primary `domain` on the create path

`POST /api/certificates/create`, `POST /api/web/certificates/create`, `POST /api/web/certificates/batch` validated whitespace + `http://` prefix but NOT the full structural format. SAN entries already went through `validate_domain()` at the core layer (`modules/core/certificates.py:690`); the primary did not.

A payload `{"domain": "../poisoned", ...}` flowed into `cert_output_dir = cert_dir / domain` + `mkdir(parents=True, exist_ok=True)`, and certbot was invoked with `--config-dir`/`--work-dir`/`--logs-dir` pointing into the attacker-chosen directory. The malicious `domain` was then **persisted into `settings.json`** via `settings_manager.update`, so background `check_renewals()` would replay it on every tick.

### H6 (HIGH) — `<domain>` path param on renew + dns-alias-check

`POST /api/certificates/<domain>/renew` and `GET /api/certificates/<domain>/dns-alias-check` did not call `_validate_domain_path` (the other `<domain>`-bearing resources do). Flask URL routing today scrubs `/` so traversal cannot reach the handler via URL, but the only defence was the routing layer. Once a poisoned domain landed in `settings.json` via C3, `check_renewals` would replay it through `renew_certificate(domain)` unchecked.

## Changes

- `modules/api/resources.py`
  - `CreateCertificate.post`: `validate_domain()` runs immediately after the whitespace/URL checks, before any side effect.
  - `RenewCertificate.post`: `_validate_domain_path()` at the top of the handler.
  - `CertificateDNSAliasCheck.get`: same.
- `modules/web/cert_routes.py`
  - `create_certificate_web`: same `validate_domain()` gate.
  - `batch_create_web`: per-entry `validate_domain()` before scope + cert manager call; invalid entries get `success: false` instead of mutating state.

## Tests

`tests/test_audit_domain_validation_gaps.py` (new, 14 cases):

- Parametrised: 8 invalid domain shapes (`../poisoned`, `../../etc/passwd`, `..`, `foo/bar`, `foo\bar`, `foo;bar`, space-bearing, NUL-bearing) → 400 + `create_certificate` never called.
- Valid apex + wildcard accepted (200/201).
- Renew rejects traversal path → `renew_certificate` never called.
- Renew accepts valid domain → called once with `force=False`.
- DNS-alias-check rejects traversal → `get_certificate_info` never called.
- **The critical chain pin**: invalid create payload MUST NOT reach `settings_manager.update` — otherwise the malicious domain survives into background renewals.

## Test plan

- [x] `pytest tests/test_audit_domain_validation_gaps.py` — 14/14
- [x] Full local unit suite: **800 passed, 2 skipped, 115 deselected** (e2e/slow markers)
- [ ] CI green on this PR
- [ ] Manual smoke: try `curl -X POST .../api/certificates/create -d '{"domain":"../escape","dns_provider":"cloudflare"}' -H "Authorization: Bearer $TOKEN"` → 400

## Audit context

This is **PR-A** in a multi-PR fix sequence for findings from the internal security audit. Remaining items in the queue (separate PRs):

- PR-B: settings-mutating routes that bypass `settings_manager.update(mutator)` — same root cause as #215 but in storage / notifications / CA routes (CRITICAL secret-destruction via `'********'` literal write).
- PR-C: backup ZIP plaintext credentials (CRITICAL).
- PR-D: client cert API role + scope (HIGH).
- PR-E: certbot stderr sanitization on error responses (HIGH).
- PR-F: notifications GET masking + acme-dns username/subdomain regex (HIGH+MEDIUM).
- PR-G: backup restore re-validates `deploy_hooks` (MEDIUM).
- PR-H: settings GET filters `domains[]` by scope + check_dns_alias body scope (MEDIUM).