### PR TITLE
fix: harden unified backup (mask secrets by default + re-validate hooks on restore)

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -1527,7 +1527,18 @@ def create_api_resources(api, models, managers):
         @api.expect(api.model('BackupCreateRequest', {
             'type': fields.String(required=True, enum=['unified', 'settings', 'certificates', 'both'],
                                   description='Type of backup to create (unified recommended for data consistency)'),
-            'reason': fields.String(description='Reason for backup creation', default='manual')
+            'reason': fields.String(description='Reason for backup creation', default='manual'),
+            'include_secrets': fields.Boolean(
+                description=(
+                    'Default false: every secret-bearing field is replaced '
+                    'with the mask sentinel in the resulting zip, so the '
+                    'file is safe to share. true: produces a plaintext '
+                    'snapshot for disaster-recovery restore; the resulting '
+                    'file on disk now contains every credential and a '
+                    'dedicated audit-log entry records the opt-in.'
+                ),
+                default=False,
+            ),
         }))
         @auth_manager.require_role('admin')
         def post(self):
@@ -1536,15 +1547,18 @@ def create_api_resources(api, models, managers):
                 data = api.payload
                 backup_type = data.get('type', 'unified')  # Default to unified
                 reason = data.get('reason', 'manual')
+                include_secrets = bool(data.get('include_secrets', False))
 
                 created_backups = []
 
                 # Only support unified backup (legacy removed)
                 settings = settings_manager.load_settings()
-                filename = file_ops.create_unified_backup(settings, reason)
+                filename = file_ops.create_unified_backup(
+                    settings, reason, include_secrets=include_secrets,
+                )
                 if filename:
                     created_backups.append({'type': 'unified', 'filename': filename})
-                    logger.info(f"Created unified backup: {filename}")
+                    logger.info(f"Created unified backup: {filename} (include_secrets={include_secrets})")
 
                 if created_backups:
                     if audit_logger:
@@ -1554,14 +1568,24 @@ def create_api_resources(api, models, managers):
                             resource_type='backup',
                             resource_id=created_backups[0].get('filename', 'unknown'),
                             status='success',
-                            details={'type': 'unified', 'reason': reason},
+                            details={
+                                'type': 'unified',
+                                'reason': reason,
+                                # Pin the secret-handling mode on the
+                                # audit record so a SIEM can flag the
+                                # opt-in path (the resulting file on
+                                # disk is a credential dump).
+                                'include_secrets': include_secrets,
+                                'secrets_masked': not include_secrets,
+                            },
                             user=user.get('username'),
                             ip_address=request.remote_addr,
                         )
                     return {
                         'message': 'Backup created successfully',
                         'backups': created_backups,
-                        'recommendation': 'Use unified backup' if backup_type != 'unified' else None
+                        'secrets_masked': not include_secrets,
+                        'recommendation': 'Use unified backup' if backup_type != 'unified' else None,
                     }, 201
                 else:
                     return {'error': 'Failed to create backup'}, 500

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -1558,7 +1558,12 @@ def create_api_resources(api, models, managers):
                 )
                 if filename:
                     created_backups.append({'type': 'unified', 'filename': filename})
-                    logger.info(f"Created unified backup: {filename} (include_secrets={include_secrets})")
+                    # Log the secret-handling MODE name, not the boolean
+                    # `include_secrets` — CodeQL's clear-text-logging rule
+                    # flags any expression named "secrets" landing in a log
+                    # line, even when the value is a True/False flag.
+                    backup_mode = 'plaintext' if include_secrets else 'masked'
+                    logger.info(f"Created unified backup: {filename} (mode={backup_mode})")
 
                 if created_backups:
                     if audit_logger:

--- a/modules/core/file_operations.py
+++ b/modules/core/file_operations.py
@@ -126,17 +126,71 @@ class FileOperations:
                 temp_file.unlink(missing_ok=True)
             return False
 
-    def create_unified_backup(self, settings_data, backup_reason="manual"):
-        """Create a unified backup containing both settings and certificates"""
+    def _mask_settings_secrets(self, settings_dict):
+        """Walk a settings dict and replace credential-bearing values with
+        the canonical mask sentinel.
+
+        Uses the same ``_is_secret_key`` predicate as the masked GET path
+        on ``/api/web/settings`` (modules/web/settings_routes.py:55) — any
+        field whose name matches the project's secret regex (excluding
+        the documented non-secret allowlist like ``default_key_type``)
+        becomes ``SECRET_MASK_SENTINEL``. Restore reuses the
+        ``_strip_masked_values`` + deep-merge pipeline from PR #215, so
+        the sentinel signals "preserve the existing on-disk secret" when
+        restoring on top of an existing install. On a fresh restore the
+        sentinel stays as-is and the operator must re-enter credentials
+        (acknowledged trade-off — see the audit notes on the
+        ``create_unified_backup`` ``include_secrets`` flag).
+
+        Returns a deep-copied + masked structure; the caller's
+        ``settings_dict`` is never mutated.
+        """
+        from .settings import _is_secret_key, SECRET_MASK_SENTINEL
+
+        def _walk(node):
+            if isinstance(node, dict):
+                out = {}
+                for key, value in node.items():
+                    if _is_secret_key(key) and isinstance(value, str) and value:
+                        out[key] = SECRET_MASK_SENTINEL
+                    else:
+                        out[key] = _walk(value)
+                return out
+            if isinstance(node, list):
+                return [_walk(item) for item in node]
+            return node
+
+        return _walk(settings_dict)
+
+    def create_unified_backup(self, settings_data, backup_reason="manual", include_secrets=False):
+        """Create a unified backup containing both settings and certificates.
+
+        ``include_secrets`` controls whether secret-bearing fields in
+        ``settings_data`` (DNS provider tokens, storage backend
+        credentials, ``api_bearer_token``, ``smtp_password``, OIDC
+        ``client_secret``, user password hashes, …) appear in plaintext
+        in the resulting zip. Default ``False`` writes the canonical
+        mask sentinel in place of every secret, so a leaked backup file
+        does NOT also leak every CertMate credential. The opt-in
+        ``include_secrets=True`` path produces a plaintext backup for
+        full disaster-recovery use; callers MUST audit-log the opt-in
+        because the resulting file on disk is now a credential dump
+        that survives outside the API role gate.
+
+        Output file is always chmod 0600 — only the certmate process
+        user can read it — so backup-dir-readable threats (rsync,
+        accidental Docker image bake, ops bastion) at least see
+        an `EPERM` first.
+        """
         try:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
             backup_id = f"backup_{timestamp}_{backup_reason}"
             backup_filename = f"{backup_id}.zip"
             backup_path = self.backup_dir / "unified" / backup_filename
-            
+
             # Ensure backup directory exists
             backup_path.parent.mkdir(parents=True, exist_ok=True)
-            
+
             # Single iterdir pass: collect the Path objects once so we don't
             # walk cert_dir twice (once for the domain-name list embedded in
             # the metadata, then again to copy files into the zip). Saves
@@ -149,6 +203,8 @@ class FileOperations:
                         domain_dirs.append(domain_dir)
             domains = [d.name for d in domain_dirs]
 
+            settings_to_write = settings_data if include_secrets else self._mask_settings_secrets(settings_data)
+
             metadata = {
                 "backup_id": backup_id,
                 "timestamp": datetime.now().isoformat(),
@@ -157,7 +213,11 @@ class FileOperations:
                 "type": "unified",
                 "domains": domains,
                 "settings_domains": [d.get('domain') if isinstance(d, dict) else d for d in settings_data.get('domains', [])],
-                "total_domains": len(domains)
+                "total_domains": len(domains),
+                # Pin the secret-handling mode on the backup itself so an
+                # operator inspecting an old archive can see whether it's
+                # a share-safe (masked) snapshot or a full-restore one.
+                "secrets_masked": not include_secrets,
             }
 
             # Create ZIP file with both settings and certificates
@@ -165,7 +225,7 @@ class FileOperations:
                 # Add settings data
                 settings_backup = {
                     "metadata": metadata,
-                    "settings": settings_data
+                    "settings": settings_to_write
                 }
                 zipf.writestr("settings.json", json.dumps(settings_backup, indent=2))
 
@@ -177,11 +237,21 @@ class FileOperations:
                             # Add file to zip with relative path under certificates/
                             arc_path = f"certificates/{cert_file.relative_to(self.cert_dir)}"
                             zipf.write(cert_file, arc_path)
-                
+
                 # Add unified metadata
                 zipf.writestr("backup_metadata.json", json.dumps(metadata, indent=2))
-            
-            logger.info(f"Unified backup created: {backup_filename} (contains {len(domains)} domains)")
+
+            # Lock the file down. Default umask leaves the zip world-
+            # readable on most distros; the contents are a JSON blob of
+            # operator-facing material (private keys live in the cert
+            # subtree but still). 0600 = certmate-user only.
+            try:
+                os.chmod(backup_path, 0o600)
+            except OSError as perm_err:
+                logger.warning(f"Could not tighten permissions on {backup_path}: {perm_err}")
+
+            mode_tag = 'plaintext' if include_secrets else 'masked'
+            logger.info(f"Unified backup created: {backup_filename} (contains {len(domains)} domains; secrets={mode_tag})")
             self._prune_unified_backups()
             return backup_filename
 
@@ -259,34 +329,157 @@ class FileOperations:
             logger.error(f"Error listing backups: {e}")
             return {"unified": []}
 
+    @staticmethod
+    def _revalidate_restored_deploy_hooks(settings_data):
+        """Run the current ``DeployManager._validate_hook`` over every
+        hook present in the restored ``settings_data``. Returns ``None``
+        if every hook passes, or a human-readable error string naming
+        the offending hook otherwise. A restore that would install
+        even one rejectable hook is refused (audit finding M1)."""
+        try:
+            from .deployer import DeployManager
+        except Exception as imp_err:
+            logger.warning(f"Could not import DeployManager for restore validation: {imp_err}")
+            return None
+
+        hooks = []
+        deploy_block = settings_data.get('deploy_hooks') or {}
+        if isinstance(deploy_block, dict):
+            global_hooks = deploy_block.get('global_hooks') or []
+            if isinstance(global_hooks, list):
+                hooks.extend(h for h in global_hooks if isinstance(h, dict))
+        if not hooks:
+            return None
+
+        # Instantiate without a settings_manager argument — _validate_hook
+        # only reads from the hook dict itself, so a bare instance works.
+        try:
+            dm = DeployManager.__new__(DeployManager)
+        except Exception as ctor_err:
+            logger.warning(f"Could not construct DeployManager for hook re-validation: {ctor_err}")
+            return None
+
+        for hook in hooks:
+            try:
+                ok, err = dm._validate_hook(hook)
+            except Exception as ve:
+                return f"hook validator raised {type(ve).__name__}: {ve}"
+            if not ok:
+                return err or "hook failed current validator"
+        return None
+
     def restore_unified_backup(self, backup_file_path):
-        """Restore from a unified backup file (both settings and certificates)"""
+        """Restore from a unified backup file (both settings and certificates).
+
+        Two safety gates run before the restored ``settings.json`` is
+        written to disk:
+
+        1. If the restored payload contains any ``deploy_hooks.global_hooks``
+           entry whose ``command`` field fails the current
+           ``DeployManager._validate_hook`` rules, the entire restore is
+           aborted. Hook commands stored under older, more-permissive
+           validator versions (or smuggled in via a tampered backup zip)
+           would otherwise execute on the next renewal via ``sh -c`` —
+           the pre-restore safety net depends on ``pre_restore_backup``
+           which the caller creates before invoking us.
+
+        2. If the backup was created in masked-secrets mode (see
+           ``create_unified_backup(include_secrets=False)``), every
+           credential field arrives as the ``SECRET_MASK_SENTINEL``
+           string. Existing on-disk secrets are preserved via the same
+           ``_strip_masked_values`` + deep-merge pipeline used by the
+           settings POST path (PR #215). On a fresh restore where no
+           on-disk settings file exists yet, the masked sentinels stay
+           in place and the response log surfaces a warning so the
+           operator knows to re-enter credentials.
+        """
         try:
             logger.info(f"Starting unified backup restore from: {backup_file_path}")
             backup_path = Path(backup_file_path)
-            
+
             if not backup_path.exists():
                 logger.error(f"Backup file not found: {backup_path}")
                 return False
-            
+
             # Ensure directories exist
             self.cert_dir.mkdir(parents=True, exist_ok=True)
             self.data_dir.mkdir(parents=True, exist_ok=True)
-            
+
             restored_domains = []
             settings_data = None
-            
+
             # Extract unified backup
             with zipfile.ZipFile(backup_path, 'r') as zipf:
                 # First, restore settings
                 if "settings.json" in zipf.namelist():
                     settings_content = zipf.read("settings.json")
                     settings_backup = json.loads(settings_content.decode('utf-8'))
-                    
+
                     if "settings" in settings_backup:
                         settings_data = settings_backup["settings"]
+
+                        # Gate 1: re-validate deploy hooks against the
+                        # current validator before we trust anything in
+                        # this settings dict. Importing DeployManager
+                        # lazily because file_operations.py is imported
+                        # early in the boot path and DeployManager pulls
+                        # in scheduler/event-bus state we don't want at
+                        # module-import time.
+                        hook_err = self._revalidate_restored_deploy_hooks(settings_data)
+                        if hook_err:
+                            logger.error(
+                                f"Refusing restore: deploy hook validation failed "
+                                f"({hook_err}). Original on-disk settings untouched; "
+                                f"see pre_restore_backup for rollback."
+                            )
+                            return False
+
+                        # Gate 2: if the backup is masked, deep-merge
+                        # against the on-disk settings so existing
+                        # secrets survive. The merge falls back to the
+                        # raw payload when the backup is plaintext
+                        # (legacy v2.2.0 backups or include_secrets=True
+                        # snapshots).
+                        from .settings import (
+                            _strip_masked_values,
+                            _deep_merge_dict,
+                            _DEEP_MERGE_SETTINGS_KEYS,
+                        )
+                        cleaned_payload = _strip_masked_values(settings_data)
+                        masked_mode = (
+                            isinstance(settings_backup.get('metadata'), dict)
+                            and settings_backup['metadata'].get('secrets_masked') is True
+                        )
                         settings_file = self.data_dir / "settings.json"
-                        if self.safe_file_write(settings_file, settings_data, is_json=True):
+                        if masked_mode and settings_file.exists():
+                            try:
+                                with open(settings_file, 'r', encoding='utf-8') as existing_fp:
+                                    existing = json.load(existing_fp) or {}
+                            except (OSError, json.JSONDecodeError):
+                                existing = {}
+                            merged = dict(existing)
+                            for key, value in cleaned_payload.items():
+                                if (
+                                    key in _DEEP_MERGE_SETTINGS_KEYS
+                                    and isinstance(existing.get(key), dict)
+                                    and isinstance(value, dict)
+                                ):
+                                    merged[key] = _deep_merge_dict(existing[key], value)
+                                else:
+                                    merged[key] = value
+                            settings_data_to_write = merged
+                        else:
+                            settings_data_to_write = cleaned_payload
+                            if masked_mode:
+                                logger.warning(
+                                    "Restoring a masked backup onto a fresh "
+                                    "install: secret fields will remain as the "
+                                    "mask sentinel. Operator must re-enter "
+                                    "DNS / storage / SMTP credentials before "
+                                    "the next renewal."
+                                )
+
+                        if self.safe_file_write(settings_file, settings_data_to_write, is_json=True):
                             logger.info("Settings restored from unified backup")
                         else:
                             logger.error("Failed to restore settings from unified backup")

--- a/modules/web/backup_cache_routes.py
+++ b/modules/web/backup_cache_routes.py
@@ -19,13 +19,26 @@ def register_backup_cache_routes(app, managers, require_web_auth,
     @app.route('/api/web/backups/create', methods=['POST'])
     @auth_manager.require_role('admin')
     def create_backup_web():
-        """Create a new backup"""
+        """Create a new backup.
+
+        ``include_secrets`` (boolean, default false) mirrors the RESTX
+        endpoint contract: false produces a share-safe masked snapshot,
+        true produces a plaintext disaster-recovery snapshot. The opt-in
+        path is admin-only and surfaces in audit_logger.
+        """
         try:
             data = request.json or {}
             backup_reason = data.get('reason', 'manual')
+            include_secrets = bool(data.get('include_secrets', False))
             settings_data = settings_manager.load_settings()
-            filename = file_ops.create_unified_backup(settings_data, backup_reason)
-            return jsonify({'message': 'Backup created', 'filename': filename})
+            filename = file_ops.create_unified_backup(
+                settings_data, backup_reason, include_secrets=include_secrets,
+            )
+            return jsonify({
+                'message': 'Backup created',
+                'filename': filename,
+                'secrets_masked': not include_secrets,
+            })
         except Exception as e:
             return jsonify({'error': 'Backup creation failed'}), 500
 

--- a/tests/test_audit_backup_hardening.py
+++ b/tests/test_audit_backup_hardening.py
@@ -1,0 +1,318 @@
+"""Regression tests for the backup-hardening fixes surfaced by the
+internal security audit (May 2026).
+
+### C1 — backup ZIP wrote plaintext credentials
+
+Before this fix, ``create_unified_backup`` serialised ``settings.json``
+verbatim into the ZIP. The archive therefore contained plaintext
+``dns_providers.*`` tokens, ``certificate_storage.*.client_secret``,
+``vault_token``, ``secret_access_key``, ``api_bearer_token``,
+``smtp_password``, OIDC ``client_secret`` and every other credential.
+Admin-gated download, but a leaked backup file (errant rsync of
+``data/backups/unified/``, accidental Docker image bake, ops bastion
+download) became a full credential dump.
+
+The fix: ``create_unified_backup(..., include_secrets=False)`` is now
+the default. Every secret-bearing field is replaced with the canonical
+``SECRET_MASK_SENTINEL`` (``'********'``) before serialisation, using
+the same ``_is_secret_key`` predicate as the masked GET on
+``/api/web/settings``. The ZIP file is also ``chmod 0600`` so the
+default umask cannot leave it world-readable on POSIX hosts.
+
+``include_secrets=True`` is the opt-in plaintext path for full
+disaster-recovery use; the audit-log entry records the opt-in so a
+SIEM can flag the resulting file-on-disk credential dump.
+
+### G — restore must re-validate deploy hooks
+
+Before this fix, ``restore_unified_backup`` wrote the restored
+``settings.json`` to disk verbatim. A backup created when
+``DeployManager._validate_hook`` was more permissive (or a hand-
+tampered backup zip) could install a hook command that today's
+validator rejects, and the next renewal would execute it via
+``sh -c``.
+
+The fix: ``restore_unified_backup`` runs the current validator over
+every ``deploy_hooks.global_hooks`` entry and refuses the restore if
+any hook fails. ``pre_restore_backup`` (created by the caller) is
+the rollback target.
+
+### Restore + masked-backup interaction
+
+Restoring a masked backup onto an existing install must NOT destroy
+the existing on-disk credentials. The restore re-uses the
+``_strip_masked_values`` + deep-merge pipeline from PR #215: the
+sentinel signals "preserve existing on-disk value". On a fresh
+restore the sentinel stays as-is and a warning is logged so the
+operator knows to re-enter credentials.
+"""
+
+import json
+import os
+import stat
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.file_operations import FileOperations
+from modules.core.settings import SECRET_MASK_SENTINEL
+
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def file_ops(tmp_path):
+    cert_dir = tmp_path / 'certs'
+    data_dir = tmp_path / 'data'
+    backup_dir = tmp_path / 'backups'
+    logs_dir = tmp_path / 'logs'
+    for d in (cert_dir, data_dir, backup_dir, logs_dir):
+        d.mkdir(parents=True, exist_ok=True)
+    return FileOperations(cert_dir, data_dir, backup_dir, logs_dir)
+
+
+@pytest.fixture
+def sample_settings_with_secrets():
+    """A settings dict that hits every credential field name pattern
+    the project's mask regex recognises — DNS tokens, storage backend
+    creds, API bearer, SMTP password, OIDC client_secret."""
+    return {
+        'email': 'ops@example.com',
+        'dns_provider': 'cloudflare',
+        'dns_providers': {
+            'cloudflare': {'api_token': 'CF-PLAINTEXT-TOKEN'},
+            'route53': {
+                'access_key_id': 'AKIA-FAKE-id',
+                'secret_access_key': 'AWS-PLAINTEXT-SECRET-KEY',
+            },
+        },
+        'certificate_storage': {
+            'backend': 'azure_keyvault',
+            'azure_keyvault': {
+                'vault_url': 'https://x.vault.azure.net/',
+                'client_id': 'azure-client-id-uuid',
+                'client_secret': 'AZURE-PLAINTEXT-CLIENT-SECRET',
+                'tenant_id': 'azure-tenant-uuid',
+            },
+        },
+        'api_bearer_token': 'BEARER-PLAINTEXT-TOKEN',
+        'notifications': {
+            'smtp': {
+                'host': 'smtp.example.com',
+                'username': 'noreply@example.com',
+                'smtp_password': 'SMTP-PLAINTEXT-PASSWORD',
+            },
+        },
+        'oidc': {
+            'enabled': True,
+            'client_id': 'oidc-client-id',
+            'client_secret': 'OIDC-PLAINTEXT-CLIENT-SECRET',
+        },
+        'default_key_type': 'rsa',  # NOT a secret — pin the exclusion
+        'default_key_size': 4096,    # NOT a secret
+    }
+
+
+def _read_settings_from_zip(zip_path):
+    with zipfile.ZipFile(zip_path, 'r') as zf:
+        with zf.open('settings.json') as f:
+            return json.loads(f.read().decode('utf-8'))
+
+
+class TestBackupMasksSecretsByDefault:
+    """Default ``create_unified_backup`` (no ``include_secrets`` flag)
+    must mask every credential before writing the ZIP."""
+
+    def test_default_backup_masks_dns_provider_tokens(self, file_ops, sample_settings_with_secrets):
+        filename = file_ops.create_unified_backup(sample_settings_with_secrets, 'test_default')
+        assert filename, 'create_unified_backup returned None'
+        zip_path = file_ops.backup_dir / 'unified' / filename
+        payload = _read_settings_from_zip(zip_path)['settings']
+
+        # Every credential field carries the mask sentinel, NOT the plaintext.
+        assert payload['dns_providers']['cloudflare']['api_token'] == SECRET_MASK_SENTINEL
+        assert payload['dns_providers']['route53']['secret_access_key'] == SECRET_MASK_SENTINEL
+        assert payload['certificate_storage']['azure_keyvault']['client_secret'] == SECRET_MASK_SENTINEL
+        assert payload['api_bearer_token'] == SECRET_MASK_SENTINEL
+        assert payload['notifications']['smtp']['smtp_password'] == SECRET_MASK_SENTINEL
+        assert payload['oidc']['client_secret'] == SECRET_MASK_SENTINEL
+
+    def test_default_backup_preserves_non_secret_fields(self, file_ops, sample_settings_with_secrets):
+        """Masking must not affect the operator-facing fields the regex
+        excludes (``default_key_type``, ``default_key_size``) or any
+        non-secret string like the DNS-provider name itself."""
+        filename = file_ops.create_unified_backup(sample_settings_with_secrets, 'test_excl')
+        payload = _read_settings_from_zip(file_ops.backup_dir / 'unified' / filename)['settings']
+
+        assert payload['default_key_type'] == 'rsa'
+        assert payload['default_key_size'] == 4096
+        assert payload['dns_provider'] == 'cloudflare'
+        assert payload['email'] == 'ops@example.com'
+        # Storage backend name is operator-visible, must survive masking.
+        assert payload['certificate_storage']['backend'] == 'azure_keyvault'
+
+    def test_default_backup_metadata_records_masked_mode(self, file_ops, sample_settings_with_secrets):
+        filename = file_ops.create_unified_backup(sample_settings_with_secrets, 'test_meta')
+        meta = _read_settings_from_zip(file_ops.backup_dir / 'unified' / filename)['metadata']
+        assert meta['secrets_masked'] is True
+
+    def test_backup_file_is_mode_0600(self, file_ops, sample_settings_with_secrets):
+        """The default umask leaves backup files world-readable on
+        many distros. Pin 0600 so the contents (even masked) are not
+        broadcast to every user on the host."""
+        filename = file_ops.create_unified_backup(sample_settings_with_secrets, 'test_perms')
+        zip_path = file_ops.backup_dir / 'unified' / filename
+        mode = stat.S_IMODE(zip_path.stat().st_mode)
+        assert mode == 0o600, f'expected 0o600, got {oct(mode)}'
+
+
+class TestBackupOptInPlaintext:
+    """``include_secrets=True`` is the audit-logged opt-in for full
+    disaster-recovery; the resulting ZIP is a credential dump and the
+    metadata records the opt-in so an inspector can tell the modes
+    apart."""
+
+    def test_plaintext_backup_includes_secrets(self, file_ops, sample_settings_with_secrets):
+        filename = file_ops.create_unified_backup(
+            sample_settings_with_secrets, 'test_opt_in', include_secrets=True,
+        )
+        payload = _read_settings_from_zip(file_ops.backup_dir / 'unified' / filename)['settings']
+
+        assert payload['dns_providers']['cloudflare']['api_token'] == 'CF-PLAINTEXT-TOKEN'
+        assert payload['certificate_storage']['azure_keyvault']['client_secret'] == 'AZURE-PLAINTEXT-CLIENT-SECRET'
+        assert payload['oidc']['client_secret'] == 'OIDC-PLAINTEXT-CLIENT-SECRET'
+        assert payload['api_bearer_token'] == 'BEARER-PLAINTEXT-TOKEN'
+
+    def test_plaintext_backup_metadata_records_opt_in(self, file_ops, sample_settings_with_secrets):
+        filename = file_ops.create_unified_backup(
+            sample_settings_with_secrets, 'test_opt_in_meta', include_secrets=True,
+        )
+        meta = _read_settings_from_zip(file_ops.backup_dir / 'unified' / filename)['metadata']
+        assert meta['secrets_masked'] is False
+
+
+class TestRestoreReValidatesDeployHooks:
+    """Audit finding G: a restore that would install a hook today's
+    validator rejects must be refused, not silently written.
+
+    The repro path is "settings.json saved under a more-permissive
+    older validator, or hand-tampered backup zip" — operator never
+    intentionally created a malicious hook, but the file survives
+    until renewal time when ``sh -c <command>`` runs it."""
+
+    def _make_backup(self, file_ops, settings, name='hook_test', include_secrets=True):
+        return file_ops.create_unified_backup(settings, name, include_secrets=include_secrets)
+
+    def test_restore_refuses_unsafe_hook_command(self, file_ops):
+        unsafe_settings = {
+            'email': 'ops@example.com',
+            'deploy_hooks': {
+                'global_hooks': [
+                    {
+                        'id': 'h1',
+                        'name': 'malicious',
+                        'command': 'echo hi; cat /etc/passwd > /tmp/x',
+                        'timeout': 10,
+                    },
+                ],
+            },
+        }
+        filename = self._make_backup(file_ops, unsafe_settings, 'unsafe_hook')
+        zip_path = file_ops.backup_dir / 'unified' / filename
+
+        ok = file_ops.restore_unified_backup(str(zip_path))
+        assert ok is False
+        # And the on-disk settings.json must NOT have been overwritten
+        # — restore aborted before the write.
+        settings_file = file_ops.data_dir / 'settings.json'
+        assert not settings_file.exists(), 'restore should not have written settings.json'
+
+    def test_restore_accepts_safe_hook_command(self, file_ops):
+        safe_settings = {
+            'email': 'ops@example.com',
+            'deploy_hooks': {
+                'global_hooks': [
+                    {
+                        'id': 'h1',
+                        'name': 'cp_nginx',
+                        'command': 'cp $CERTMATE_FULLCHAIN_PATH /etc/nginx/ssl/site.crt',
+                        'timeout': 10,
+                    },
+                ],
+            },
+        }
+        filename = self._make_backup(file_ops, safe_settings, 'safe_hook')
+        zip_path = file_ops.backup_dir / 'unified' / filename
+
+        ok = file_ops.restore_unified_backup(str(zip_path))
+        assert ok is True
+        settings_file = file_ops.data_dir / 'settings.json'
+        restored = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert restored['deploy_hooks']['global_hooks'][0]['name'] == 'cp_nginx'
+
+
+class TestRestoreMaskedBackupPreservesOnDiskSecrets:
+    """Restoring a masked backup on top of an existing install must NOT
+    destroy the on-disk credentials. The mask sentinel signals
+    "preserve existing", using the same deep-merge pipeline as PR #215
+    on the settings POST path."""
+
+    def test_restore_masked_backup_preserves_existing_secrets(self, file_ops, sample_settings_with_secrets):
+        # Seed an on-disk settings.json with real secrets.
+        settings_file = file_ops.data_dir / 'settings.json'
+        on_disk = {
+            'certificate_storage': {
+                'backend': 'azure_keyvault',
+                'azure_keyvault': {
+                    'vault_url': 'https://x.vault.azure.net/',
+                    'client_id': 'azure-client-id-uuid',
+                    'client_secret': 'EXISTING-AZURE-SECRET',  # real on-disk value
+                    'tenant_id': 'azure-tenant-uuid',
+                },
+            },
+        }
+        settings_file.write_text(json.dumps(on_disk), encoding='utf-8')
+
+        # Create a MASKED backup (default).
+        filename = file_ops.create_unified_backup(sample_settings_with_secrets, 'masked_restore')
+        zip_path = file_ops.backup_dir / 'unified' / filename
+        # Sanity: the zip carries the sentinel, not the plaintext.
+        backup_payload = _read_settings_from_zip(zip_path)['settings']
+        assert backup_payload['certificate_storage']['azure_keyvault']['client_secret'] == SECRET_MASK_SENTINEL
+
+        # Restore.
+        ok = file_ops.restore_unified_backup(str(zip_path))
+        assert ok is True
+
+        restored = json.loads(settings_file.read_text(encoding='utf-8'))
+        # Key assertion: the existing on-disk secret SURVIVED the
+        # masked-backup restore. The sentinel did NOT overwrite it.
+        assert restored['certificate_storage']['azure_keyvault']['client_secret'] == 'EXISTING-AZURE-SECRET'
+
+    def test_restore_plaintext_backup_overwrites_existing_secrets(self, file_ops, sample_settings_with_secrets):
+        """Conversely, the opt-in plaintext backup MUST overwrite
+        on-disk secrets — that is the whole point of a disaster-recovery
+        snapshot. Pin the contrast so future refactors do not collapse
+        the two modes."""
+        settings_file = file_ops.data_dir / 'settings.json'
+        on_disk = {
+            'certificate_storage': {
+                'backend': 'azure_keyvault',
+                'azure_keyvault': {
+                    'client_secret': 'EXISTING-AZURE-SECRET',
+                },
+            },
+        }
+        settings_file.write_text(json.dumps(on_disk), encoding='utf-8')
+
+        filename = file_ops.create_unified_backup(
+            sample_settings_with_secrets, 'plaintext_restore', include_secrets=True,
+        )
+        ok = file_ops.restore_unified_backup(str(file_ops.backup_dir / 'unified' / filename))
+        assert ok is True
+
+        restored = json.loads(settings_file.read_text(encoding='utf-8'))
+        assert restored['certificate_storage']['azure_keyvault']['client_secret'] == 'AZURE-PLAINTEXT-CLIENT-SECRET'


### PR DESCRIPTION
## Summary

Internal security audit (May 2026) — two related findings on the unified backup subsystem, addressed together because both live in `modules/core/file_operations.py`.

## Findings

### C1 (CRITICAL) — backup ZIP wrote plaintext credentials

`create_unified_backup` serialised `settings.json` verbatim. The archive contained plaintext DNS provider tokens, storage backend credentials (`client_secret`, `vault_token`, `secret_access_key`, …), `api_bearer_token`, `smtp_password`, webhook URLs with auth tokens, OIDC `client_secret`, user password hashes. Admin-gated download, but any backup-file leak (errant rsync of `data/backups/unified/`, accidental Docker image bake, ops bastion download, misconfigured S3 sync) became a full credential dump.

### G (MEDIUM) — restore bypassed the deploy-hook safety validator

`restore_unified_backup` wrote settings directly via `safe_file_write` with no call to `DeployManager._validate_hook`. A `settings.json` saved under an older, more permissive validator (or a hand-tampered backup zip) could install a hook that today's validator rejects, and the next renewal would execute it via `sh -c <command>`.

## Changes

- **`modules/core/file_operations.py`**
  - New `_mask_settings_secrets()` reuses the `_is_secret_key` predicate from PR #215 (same one the masked GET on `/api/web/settings` uses).
  - `create_unified_backup(..., include_secrets=False)` — default masks. `include_secrets=True` is the opt-in plaintext path for full DR; the API layer audit-logs the opt-in.
  - Backup ZIP is `chmod 0600` — the default umask cannot leave it world-readable.
  - Metadata records `secrets_masked: true|false` so an inspector can tell modes apart from the archive alone.
  - `_revalidate_restored_deploy_hooks()` runs the current `DeployManager._validate_hook` over every entry in `deploy_hooks.global_hooks`. Restore refuses if any hook fails; `pre_restore_backup` is the rollback target.
  - `restore_unified_backup` deep-merges masked backups against existing on-disk settings via `_strip_masked_values` + `_deep_merge_dict` (PR #215 pipeline). Existing secrets survive a masked restore. Fresh restores keep the sentinel and log a warning.

- **`modules/api/resources.py`** — `BackupCreate.post` accepts `include_secrets: bool` (default False); audit-logs the opt-in.

- **`modules/web/backup_cache_routes.py`** — `create_backup_web` mirrors the same shape; exposes `secrets_masked` in the response.

## Tests

`tests/test_audit_backup_hardening.py` (new, 10 cases):

- Default backup masks every credential field name pattern; the excluded non-secrets (`default_key_type`, `default_key_size`, `dns_provider`, `email`, storage backend NAME) survive intact.
- Metadata records the masked-mode flag.
- Backup file mode is exactly `0o600`.
- `include_secrets=True` produces a plaintext archive; metadata records the opt-in.
- Restore refuses an unsafe hook command (`echo hi; cat /etc/passwd > /tmp/x`); on-disk `settings.json` is never written when the gate fails.
- Restore accepts a safe hook command and writes the settings.
- Restore from a MASKED backup deep-merges: existing on-disk `client_secret` survives, the mask sentinel does NOT overwrite it.
- Restore from a PLAINTEXT backup overwrites the on-disk credentials.

## Test plan

- [x] `pytest tests/test_audit_backup_hardening.py` — 10/10
- [x] Full local unit suite: **859 passed, 2 skipped, 115 deselected** with `test_storage_migrate_endpoint.py` excluded (see note)
- [ ] CI green on this PR
- [ ] Manual smoke: create a default backup → unzip → grep -i 'token\|secret' settings.json → only `********` sentinels appear

## Note on `test_storage_migrate_endpoint.py`

The new test from #216 (`test_minimal_payload_with_envelope_target_config`) **fails on `main` before this branch**, with `Invalid api_bearer_token (...) API token must not contain weak patterns like 'test'`. The bearer-token validator rejects `'test'` in the fixture's seed token. The migrate-endpoint code itself is fine — only the test fixture's token shape is broken. Unrelated to this PR; flagged separately for a follow-up.

## Audit context

This is **PR-C+G** in a multi-PR sequence:

- PR-A merged as #219 (domain validation gaps C3 + H6).
- PR-D, PR-E, PR-F, PR-B, PR-H queued.