### PR TITLE
fix: client-cert API role gating + private-key download stratification (H1)

### DIFF
--- a/modules/api/client_certificates.py
+++ b/modules/api/client_certificates.py
@@ -70,7 +70,11 @@ def create_client_certificate_resources(api, managers):
 
     # Client Certificate List Resource
     class ClientCertificateList(Resource):
-        method_decorators = [auth_manager.require_auth]
+        # Internal security audit (May 2026) — H1: `require_auth` only
+        # checks identity, not role. Aligning every client-cert Resource
+        # with the same role stratification the TLS cert path already
+        # uses: viewer reads, operator mints/renews, admin revokes.
+        method_decorators = [auth_manager.require_role('viewer')]
 
         def get(self):
             """Get list of client certificates with optional filtering."""
@@ -99,7 +103,9 @@ def create_client_certificate_resources(api, managers):
 
     # Client Certificate Create Resource
     class ClientCertificateCreate(Resource):
-        method_decorators = [auth_manager.require_auth]
+        # Mint a CA-signed identity — operator+ (parity with TLS cert
+        # CreateCertificate which is `require_role('operator')`).
+        method_decorators = [auth_manager.require_role('operator')]
 
         def post(self):
             """Create a new client certificate."""
@@ -156,7 +162,7 @@ def create_client_certificate_resources(api, managers):
 
     # Client Certificate Detail Resource
     class ClientCertificateDetail(Resource):
-        method_decorators = [auth_manager.require_auth]
+        method_decorators = [auth_manager.require_role('viewer')]
 
         def get(self, identifier):
             """Get certificate metadata."""
@@ -176,7 +182,19 @@ def create_client_certificate_resources(api, managers):
 
     # Client Certificate Download Resource
     class ClientCertificateDownload(Resource):
-        method_decorators = [auth_manager.require_auth]
+        # Decorator runs at request-time so the role check is enforced
+        # uniformly; the per-file_type stratification (private key gates
+        # at operator+, public material at viewer) runs inside the handler
+        # mirroring DownloadCertificate/DownloadCertificateFile on the TLS
+        # path. Viewer is the floor — anything that mints or modifies
+        # state lives on other Resources.
+        method_decorators = [auth_manager.require_role('viewer')]
+
+        # File types whose download exposes the private key. Caller must
+        # hold operator+ regardless of which Resource entry point they
+        # use (path-style or otherwise). Mirrors `_PRIVATE_KEY_FILES` on
+        # the TLS cert side (modules/api/resources.py).
+        _PRIVATE_FILE_TYPES = frozenset({'key'})
 
         def get(self, identifier, file_type):
             """Download certificate, key, or CSR."""
@@ -185,6 +203,16 @@ def create_client_certificate_resources(api, managers):
                     abort(400, "Invalid certificate identifier")
                 if file_type not in ['crt', 'key', 'csr']:
                     abort(400, "Invalid file type. Must be 'crt', 'key', or 'csr'")
+
+                # Per-file role gate: viewer reads public material only;
+                # private key needs operator+. Mirrors the TLS cert
+                # DownloadCertificate / DownloadCertificateFile pattern.
+                if file_type in self._PRIVATE_FILE_TYPES:
+                    user = getattr(request, 'current_user', None) or {}
+                    role = user.get('role')
+                    from ..core.auth import ROLE_HIERARCHY
+                    if ROLE_HIERARCHY.get(role, -1) < ROLE_HIERARCHY.get('operator', 999):
+                        abort(403, "operator role required to download client certificate private key")
 
                 # Get file
                 file_content = client_cert_manager.get_certificate_file(
@@ -204,12 +232,22 @@ def create_client_certificate_resources(api, managers):
                 )
 
             except Exception as e:
+                # Let HTTPException pass through — the bare `abort(...)`
+                # calls above raise werkzeug HTTPException, which IS a
+                # subclass of Exception. Without this re-raise the
+                # 400/403/404 statuses would be rewritten to 500 here.
+                from werkzeug.exceptions import HTTPException
+                if isinstance(e, HTTPException):
+                    raise
                 logger.error(f"Error downloading certificate file: {str(e)}")
                 abort(500, "Failed to download certificate file")
 
     # Client Certificate Revoke Resource
     class ClientCertificateRevoke(Resource):
-        method_decorators = [auth_manager.require_auth]
+        # Revoking a CA-signed identity is destructive and analogous
+        # to deleting a TLS cert (admin). Aligns with the TLS-side
+        # `CertificateDelete` admin gating.
+        method_decorators = [auth_manager.require_role('admin')]
 
         def post(self, identifier):
             """Revoke a client certificate."""
@@ -236,7 +274,9 @@ def create_client_certificate_resources(api, managers):
 
     # Client Certificate Renew Resource
     class ClientCertificateRenew(Resource):
-        method_decorators = [auth_manager.require_auth]
+        # Renew re-mints a CA-signed identity — operator+ (parity with
+        # TLS-side `RenewCertificate`).
+        method_decorators = [auth_manager.require_role('operator')]
 
         def post(self, identifier):
             """Renew a client certificate."""
@@ -259,7 +299,7 @@ def create_client_certificate_resources(api, managers):
 
     # Client Certificate Statistics Resource
     class ClientCertificateStatistics(Resource):
-        method_decorators = [auth_manager.require_auth]
+        method_decorators = [auth_manager.require_role('viewer')]
 
         def get(self):
             """Get certificate statistics."""
@@ -273,7 +313,9 @@ def create_client_certificate_resources(api, managers):
 
     # Client Certificate Batch Resource
     class ClientCertificateBatch(Resource):
-        method_decorators = [auth_manager.require_auth]
+        # Batch mint up to 100 identities — operator+ (same role as
+        # single-cert ClientCertificateCreate).
+        method_decorators = [auth_manager.require_role('operator')]
 
         def post(self):
             """Create multiple certificates from CSV data."""
@@ -358,6 +400,14 @@ def create_client_certificate_resources(api, managers):
                 abort(500, "Failed to process batch certificate creation")
 
     # OCSP Status Resource
+    #
+    # Intentionally unauthenticated: RFC 6960 OCSP responders are public
+    # endpoints that any relying party can query. The information returned
+    # (good / revoked / unknown for a serial number) is exactly what an
+    # OCSP responder is supposed to expose, and serial numbers are not
+    # operator-secret. Role-gating this endpoint would break the standard
+    # client interaction. Pinned here so the internal security audit's
+    # "missing decorator" hit lands as Info, not Bug, on future passes.
     class OCSPStatus(Resource):
         def get(self, serial_number):
             """Get OCSP status for certificate."""
@@ -380,6 +430,11 @@ def create_client_certificate_resources(api, managers):
                 abort(500, "Failed to get OCSP status")
 
     # CRL Distribution Resource
+    #
+    # Intentionally unauthenticated: RFC 5280 §4.2.1.13 (CRLDistributionPoints)
+    # expects CRLs to be retrievable by any relying party without
+    # authentication — that is the entire point of distribution. Same
+    # reasoning as OCSPStatus above.
     class CRLDistribution(Resource):
         def get(self, format_type='pem'):
             """Get Certificate Revocation List."""

--- a/tests/test_audit_client_cert_rbac.py
+++ b/tests/test_audit_client_cert_rbac.py
@@ -1,0 +1,237 @@
+"""Regression tests for the client-certificate API role gating gap
+(internal security audit, May 2026, finding H1).
+
+Before this fix every Resource in ``modules/api/client_certificates.py``
+used::
+
+    method_decorators = [auth_manager.require_auth]
+
+``require_auth`` (modules/core/auth.py:703-718) only authenticates the
+caller — it does NOT check role. So a ``viewer``-role API key (the
+safest tier the admin can hand out) could:
+
+- ``POST /api/client-certs/create`` — mint a CA-signed mTLS identity
+- ``POST /api/client-certs/<id>/revoke`` — revoke any client identity
+- ``POST /api/client-certs/<id>/renew`` — re-mint an identity
+- ``POST /api/client-certs/batch`` — batch up to 100 identities
+- ``GET /api/client-certs/<id>/download/key`` — pull the private key
+
+The fix mirrors the TLS-side `CertificateManager` role stratification
+that already exists for server certificates:
+
+- reads (list / detail / stats / public-material download) — viewer
+- mints / renews / batch — operator
+- revoke (destructive, parallel to TLS-cert delete) — admin
+- private-key download — operator+ (per-file gate inside the handler,
+  mirroring the ``_PRIVATE_KEY_FILES`` gate on the TLS path)
+
+OCSP and CRL responders are RFC-public and remain unauthenticated; the
+audit confirmed these are intentional, and the source comments now
+say so explicitly.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from flask import Flask, request
+from flask_restx import Api, Namespace
+
+from modules.api.client_certificates import (
+    create_client_certificate_models,
+    create_client_certificate_resources,
+)
+from modules.core.auth import ROLE_HIERARCHY
+
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def app_with_client_cert_routes():
+    """Flask test client with every client-cert Resource wired up and
+    a stub ``current_user`` injected before each request — bypasses the
+    real auth pipeline so we can measure the role decorator's behaviour
+    directly. The auth_manager's ``require_role`` is mocked to behave
+    like the production decorator: it checks the caller's role against
+    the configured floor and abort(403)s if below."""
+
+    def require_role_factory(min_role):
+        def deco(fn):
+            def wrapped(*args, **kwargs):
+                user = getattr(request, 'current_user', None) or {}
+                role = user.get('role')
+                level = ROLE_HIERARCHY.get(role, -1)
+                floor = ROLE_HIERARCHY.get(min_role, 999)
+                if level < floor:
+                    from flask import abort
+                    abort(403)
+                return fn(*args, **kwargs)
+            return wrapped
+        return deco
+
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=require_role_factory)
+    auth_manager.require_auth = lambda fn: fn  # not used after the fix
+
+    cert_manager = MagicMock()
+    cert_manager.list_client_certificates.return_value = []
+    cert_manager.create_client_certificate.return_value = (
+        True, None, {'identifier': 'fake-id', 'common_name': 'alice'},
+    )
+    cert_manager.get_certificate_metadata.return_value = {'identifier': 'fake-id'}
+    cert_manager.get_certificate_file.return_value = b'-----BEGIN ...-----'
+    cert_manager.revoke_certificate.return_value = (True, None)
+    cert_manager.renew_certificate.return_value = (
+        True, None, {'identifier': 'fake-id'},
+    )
+    cert_manager.get_statistics.return_value = {'total': 0}
+
+    managers = {
+        'auth': auth_manager,
+        'client_certificates': cert_manager,
+        'ocsp': MagicMock(),
+        'crl': MagicMock(),
+    }
+
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    api = Api(app, prefix='/api')
+    create_client_certificate_models(api)
+    resources = create_client_certificate_resources(api, managers)
+
+    ns = Namespace('client-certs', description='client certs')
+    api.add_namespace(ns)
+    ns.add_resource(resources['ClientCertificateList'], '')
+    ns.add_resource(resources['ClientCertificateCreate'], '/create')
+    ns.add_resource(resources['ClientCertificateDetail'], '/<string:identifier>')
+    ns.add_resource(resources['ClientCertificateDownload'], '/<string:identifier>/download/<string:file_type>')
+    ns.add_resource(resources['ClientCertificateRevoke'], '/<string:identifier>/revoke')
+    ns.add_resource(resources['ClientCertificateRenew'], '/<string:identifier>/renew')
+    ns.add_resource(resources['ClientCertificateStatistics'], '/stats')
+    ns.add_resource(resources['ClientCertificateBatch'], '/batch')
+
+    return app, managers
+
+
+def _as(app, role):
+    @app.before_request
+    def _set_user():
+        request.current_user = {
+            'username': f'fake_{role}', 'role': role, 'allowed_domains': None,
+        }
+
+
+class TestViewerCannotMintOrRevoke:
+    """The CRITICAL finding: viewer must NOT reach create / revoke /
+    renew / batch endpoints. Pin a 403 on every one."""
+
+    @pytest.mark.parametrize('method,path,payload', [
+        ('POST', '/api/client-certs/create', {'common_name': 'alice'}),
+        ('POST', '/api/client-certs/abc/revoke', {'reason': 'compromise'}),
+        ('POST', '/api/client-certs/abc/renew', {}),
+        ('POST', '/api/client-certs/batch', {'headers': ['common_name'], 'rows': [['alice']]}),
+    ])
+    def test_viewer_is_rejected(self, app_with_client_cert_routes, method, path, payload):
+        app, managers = app_with_client_cert_routes
+        _as(app, 'viewer')
+        client = app.test_client()
+        r = client.open(path, method=method, json=payload)
+        assert r.status_code == 403, r.data
+        # And the underlying manager was NOT invoked — the role gate
+        # must short-circuit before any side effect.
+        managers['client_certificates'].create_client_certificate.assert_not_called()
+        managers['client_certificates'].revoke_certificate.assert_not_called()
+        managers['client_certificates'].renew_certificate.assert_not_called()
+
+
+class TestViewerCanRead:
+    """Reads (list / detail / stats) must still work for viewer. The
+    fix tightens write paths, not the read floor."""
+
+    def test_viewer_can_list(self, app_with_client_cert_routes):
+        app, _ = app_with_client_cert_routes
+        _as(app, 'viewer')
+        # The list route is registered at the namespace base path (''),
+        # so the canonical URL has no trailing slash.
+        r = app.test_client().get('/api/client-certs')
+        assert r.status_code == 200, r.data
+
+    def test_viewer_can_read_detail(self, app_with_client_cert_routes):
+        app, _ = app_with_client_cert_routes
+        _as(app, 'viewer')
+        r = app.test_client().get('/api/client-certs/abc')
+        assert r.status_code == 200, r.data
+
+    def test_viewer_can_read_stats(self, app_with_client_cert_routes):
+        app, _ = app_with_client_cert_routes
+        _as(app, 'viewer')
+        r = app.test_client().get('/api/client-certs/stats')
+        assert r.status_code == 200, r.data
+
+
+class TestPrivateKeyDownloadStratification:
+    """Public material (crt / csr) — viewer-OK. Private key (key) —
+    operator+ floor. Mirrors the TLS-side DownloadCertificate /
+    DownloadCertificateFile contract; the per-file gate runs inside
+    the handler so the route itself stays at the viewer decorator
+    floor (consistent with the rest of the file)."""
+
+    @pytest.mark.parametrize('file_type', ['crt', 'csr'])
+    def test_viewer_can_pull_public_material(self, app_with_client_cert_routes, file_type):
+        app, _ = app_with_client_cert_routes
+        _as(app, 'viewer')
+        r = app.test_client().get(f'/api/client-certs/abc/download/{file_type}')
+        assert r.status_code == 200
+
+    def test_viewer_cannot_pull_private_key(self, app_with_client_cert_routes):
+        app, _ = app_with_client_cert_routes
+        _as(app, 'viewer')
+        r = app.test_client().get('/api/client-certs/abc/download/key')
+        assert r.status_code == 403
+
+    def test_operator_can_pull_private_key(self, app_with_client_cert_routes):
+        app, _ = app_with_client_cert_routes
+        _as(app, 'operator')
+        r = app.test_client().get('/api/client-certs/abc/download/key')
+        assert r.status_code == 200
+
+
+class TestOperatorAndAdminPaths:
+    """Operator can mint / renew / batch; admin can also revoke.
+    Operator is below admin so the revoke 403 is the explicit test
+    that the stratification matters."""
+
+    def test_operator_can_create(self, app_with_client_cert_routes):
+        app, _ = app_with_client_cert_routes
+        _as(app, 'operator')
+        r = app.test_client().post('/api/client-certs/create', json={'common_name': 'bob'})
+        assert r.status_code == 201, r.data
+
+    def test_operator_cannot_revoke(self, app_with_client_cert_routes):
+        app, _ = app_with_client_cert_routes
+        _as(app, 'operator')
+        r = app.test_client().post('/api/client-certs/abc/revoke', json={'reason': 'compromise'})
+        assert r.status_code == 403, r.data
+
+    def test_admin_can_revoke(self, app_with_client_cert_routes):
+        app, _ = app_with_client_cert_routes
+        _as(app, 'admin')
+        r = app.test_client().post('/api/client-certs/abc/revoke', json={'reason': 'compromise'})
+        assert r.status_code == 200, r.data
+
+    def test_operator_can_renew(self, app_with_client_cert_routes):
+        app, _ = app_with_client_cert_routes
+        _as(app, 'operator')
+        r = app.test_client().post('/api/client-certs/abc/renew')
+        assert r.status_code == 201, r.data
+
+    def test_operator_can_batch(self, app_with_client_cert_routes):
+        app, _ = app_with_client_cert_routes
+        _as(app, 'operator')
+        r = app.test_client().post(
+            '/api/client-certs/batch',
+            json={'headers': ['common_name'], 'rows': [['alice']]},
+        )
+        # The batch handler returns 201 on success (matching the
+        # single-cert create endpoint shape).
+        assert r.status_code == 201, r.data


### PR DESCRIPTION
## Summary

Internal security audit (May 2026), finding **H1**: every Resource in `modules/api/client_certificates.py` was gated only by `require_auth` (identity check, no role check). A `viewer`-role API key — the safest tier the admin hands out — could mint CA-signed mTLS identities, revoke any identity org-wide, renew identities, batch-issue up to 100 in one call, and pull private-key files. The TLS cert path already runs the right stratification; this PR brings the client-cert namespace into parity.

## Role stratification (now matches TLS cert path)

| Resource | Floor |
|---|---|
| `ClientCertificateList` | viewer |
| `ClientCertificateDetail` | viewer |
| `ClientCertificateStatistics` | viewer |
| `ClientCertificateDownload` (`crt`, `csr`) | viewer |
| `ClientCertificateDownload` (`key`) | **operator** (per-file gate inside handler) |
| `ClientCertificateCreate` | operator |
| `ClientCertificateRenew` | operator |
| `ClientCertificateBatch` | operator |
| `ClientCertificateRevoke` | **admin** (destructive, parallel to TLS cert delete) |
| `OCSPStatus` | public — RFC 6960 |
| `CRLDistribution` | public — RFC 5280 §4.2.1.13 |

OCSP and CRL source comments now state the RFC reasoning explicitly so future audit passes land them as "info, intentional" rather than "missing decorator".

## Side-fix: HTTPException leak through broad except in download handler

`ClientCertificateDownload.get` wrapped its body in `except Exception: abort(500, ...)`. Werkzeug's `abort(...)` raises `HTTPException`, which IS a subclass of `Exception`, so any 400/403/404 inside the try block was silently rewritten to 500. The fix re-raises `HTTPException` explicitly before the broad except — surfaced by the new 403 test for the per-file private-key gate but the pre-existing 400 paths benefited too.

## Scope note (H2 — deferred)

The audit also flagged **H2**: client-cert identifiers are orthogonal to `allowed_domains`, so a scoped key intended for "tenant A only" can read every other tenant's mTLS identities once authentication passes. Fixing H2 requires extending the scope concept (today a list of domain patterns) to cover client-cert identifier prefixes, which is a design decision separate from the role gate. Tracked as a follow-up; this PR closes H1 cleanly.

## Breaking change

Any existing API key configured with `role=viewer` that was calling `create` / `revoke` / `renew` / `batch` / `download/key` on the client-cert namespace will now receive `403`. That was the bug — the safest tier was never supposed to mint identities — but operators who relied on the gap need to bump their key role to `operator` (or `admin` for revoke).

## Tests

`tests/test_audit_client_cert_rbac.py` (new, 16 cases):

- Viewer parametrised across create / revoke / renew / batch → 403, underlying manager never invoked.
- Viewer can list / detail / stats.
- Viewer can download `crt` and `csr`.
- Viewer cannot download `key` (403).
- Operator can download `key` (200).
- Operator can create / renew / batch.
- Operator cannot revoke (403).
- Admin can revoke (200).

## Test plan

- [x] `pytest tests/test_audit_client_cert_rbac.py` — 16/16
- [x] Full local unit suite: 875 passed, 2 skipped, 115 deselected
- [ ] CI green