### PR TITLE
fix: sanitize certbot stderr before surfacing in API error responses (H3)

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -921,8 +921,16 @@ class CertificateManager:
             )
 
             if result.returncode != 0:
+                # Log the FULL stderr internally for operator debugging.
+                # certbot-dns-azure and a few other plugins echo the
+                # offending credentials .ini line on parse failure, so
+                # the raw stderr carries secret material. Sanitise
+                # before bubbling up into the exception that becomes
+                # the API response body. Internal audit finding H3.
                 logger.error(f"Certbot failed for {domain}: {result.stderr}")
-                raise RuntimeError(f"Certificate creation failed: {result.stderr}")
+                from .utils import sanitize_certbot_stderr
+                safe_stderr = sanitize_certbot_stderr(result.stderr)
+                raise RuntimeError(f"Certificate creation failed: {safe_stderr}")
             
             # Move certificates to standard location
             live_dir = cert_output_dir / 'live' / domain
@@ -1156,9 +1164,14 @@ class CertificateManager:
                     'message': "Certificate renewed successfully"
                 }
             else:
+                # Mirror the create-path sanitisation: log raw stderr,
+                # surface a redacted copy. See sanitize_certbot_stderr
+                # docstring for the precise stripping rules.
                 error_msg = result.stderr or "Certificate not found"
                 logger.error(f"Certificate renewal failed for {domain}: {error_msg}")
-                raise RuntimeError(f"Renewal failed: {error_msg}")
+                from .utils import sanitize_certbot_stderr
+                safe_error = sanitize_certbot_stderr(error_msg) if result.stderr else error_msg
+                raise RuntimeError(f"Renewal failed: {safe_error}")
         except Exception as e:
             error_msg = str(e)
             logger.error(f"Exception during certificate renewal for {domain}: {error_msg}")

--- a/modules/core/utils.py
+++ b/modules/core/utils.py
@@ -339,6 +339,76 @@ def validate_key_options(
 
 
 # =============================================
+# CERTBOT STDERR SANITIZER
+# =============================================
+
+# Matches a single line of the form `key = value` where `key` carries a
+# credential-bearing name fragment. certbot-dns-azure and a few other
+# plugins echo the credentials file line-by-line on parse error, so the
+# offending value would otherwise round-trip into a 422 JSON response.
+# Anchored on word-start so substrings like "monkeysecret" don't fire
+# but `dns_azure_sp_client_secret = ...` does.
+_CERTBOT_STDERR_CREDENTIAL_LINE_RE = re.compile(
+    # NB: digits in the character class — provider names like
+    # ``route53`` carry digits, and stripping them from the alphabet
+    # would skip ``dns_route53_access_key_id`` entirely.
+    r'(?im)^\s*([A-Za-z0-9_]*(?:secret|token|password|key|credential|hmac|api_bearer)[A-Za-z0-9_]*)\s*=\s*.+$'
+)
+
+# Matches absolute paths to per-provider credential .ini files
+# (letsencrypt/config/<provider>.ini and friends). The path itself is
+# not a credential, but operator-side troubleshooting hints already
+# point operators at the path via the log, and stripping it from the
+# client-facing error message is consistent with the general policy of
+# not echoing internal paths.
+_CERTBOT_CONFIG_PATH_RE = re.compile(
+    r'(?i)(?:[\w\-./]+/)?letsencrypt/config/[A-Za-z0-9_\-.]+\.ini'
+)
+
+# Hard cap on the sanitized stderr we surface to API clients. Certbot's
+# verbose mode can emit several KB; the client doesn't need the full
+# trace (which is in the application log), and a huge payload is its
+# own DoS shape.
+_CERTBOT_STDERR_MAX_BYTES = 4096
+
+
+def sanitize_certbot_stderr(stderr_text: str) -> str:
+    """Strip credential material from a certbot stderr blob before it
+    is sent to an API client.
+
+    What gets stripped:
+
+    * Lines of the form ``<name>_secret = ...``, ``<name>_token = ...``,
+      ``<name>_password = ...``, ``<name>_key = ...``, ``<name>_credential = ...``,
+      ``<name>_hmac = ...`` and ``api_bearer = ...``. Some certbot plugins
+      (notably ``certbot-dns-azure``) echo the offending config line
+      verbatim when they fail to parse, which round-tripped the secret
+      value into the API response.
+    * Credential file paths (``letsencrypt/config/<provider>.ini``) are
+      replaced with ``<credential file>``. Not secret per se but
+      consistent with not echoing internal paths to API consumers.
+
+    What is preserved:
+
+    * ACME server errors, plugin error narration, DNS verification
+      failures, hint URLs, exit codes — everything an operator needs
+      to figure out why a renewal failed.
+
+    The full unredacted stderr is still written to the application log
+    (``logger.error``) at the call site; this helper only sanitises the
+    copy that flows into the API response.
+    """
+    if not stderr_text:
+        return ''
+    text = str(stderr_text)
+    text = _CERTBOT_STDERR_CREDENTIAL_LINE_RE.sub(lambda m: f'{m.group(1)} = [REDACTED]', text)
+    text = _CERTBOT_CONFIG_PATH_RE.sub('<credential file>', text)
+    if len(text) > _CERTBOT_STDERR_MAX_BYTES:
+        text = text[:_CERTBOT_STDERR_MAX_BYTES] + '\n[…truncated — see application log for full output]'
+    return text
+
+
+# =============================================
 # SECURITY & TOKEN FUNCTIONS
 # =============================================
 

--- a/tests/test_audit_certbot_stderr_sanitizer.py
+++ b/tests/test_audit_certbot_stderr_sanitizer.py
@@ -1,0 +1,132 @@
+"""Regression tests for the certbot stderr sanitiser (internal security
+audit, May 2026, finding H3).
+
+Before this fix, when ``certbot`` failed at credential parsing time the
+plugin echoed the offending ``.ini`` line verbatim into stderr. The
+``CertificateManager.create_certificate`` / ``renew_certificate`` flows
+wrapped that stderr into a ``RuntimeError`` whose ``str(e)`` flowed back
+into the API response body (``modules/web/cert_routes.py:145, 202``).
+Net result: a misconfigured ``dns_azure_sp_client_secret = <REAL>`` line
+landed in the JSON 422 the operator saw.
+
+The fix splits the two consumers:
+
+* The application log keeps the raw stderr — operators reading
+  ``data/logs/`` still see every detail and can debug the failure.
+* The exception that flows into the API response is sanitised:
+  credential-bearing lines redact their value, paths to the
+  credentials ``.ini`` are replaced with a generic marker, and the
+  whole message is capped so a verbose certbot trace cannot bloat the
+  response.
+
+Helper lives in ``modules/core/utils.py::sanitize_certbot_stderr`` and
+the contract pinned below is what the API depends on. Future regressions
+that re-route credential text into the response will fail one of these
+test cases.
+"""
+
+import pytest
+
+from modules.core.utils import sanitize_certbot_stderr
+
+
+pytestmark = [pytest.mark.unit]
+
+
+class TestSanitizeCertbotStderr:
+    """The core contract: secret values out, ACME / plugin narration in."""
+
+    def test_redacts_azure_sp_client_secret_line(self):
+        raw = (
+            "Saving debug log to /app/certificates/example.com/logs/letsencrypt.log\n"
+            "letsencrypt/config/azure.ini: parse error\n"
+            "dns_azure_sp_client_secret = SUPER-SECRET-VALUE-do-not-leak\n"
+            "Ask for help at https://community.letsencrypt.org.\n"
+        )
+        out = sanitize_certbot_stderr(raw)
+        assert 'SUPER-SECRET-VALUE-do-not-leak' not in out
+        assert 'dns_azure_sp_client_secret = [REDACTED]' in out
+        # ACME help URL and the general narration must survive.
+        assert 'community.letsencrypt.org' in out
+
+    def test_redacts_route53_aws_keys(self):
+        raw = (
+            "dns_route53_access_key_id = AKIAIDISCLOSURE1234\n"
+            "dns_route53_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n"
+            "Error 403 from Route53\n"
+        )
+        out = sanitize_certbot_stderr(raw)
+        assert 'AKIAIDISCLOSURE1234' not in out
+        assert 'wJalrXUtnFEMI' not in out
+        # And the operational error survives so the operator knows
+        # *why* the plugin failed.
+        assert 'Error 403' in out
+
+    def test_redacts_cloudflare_api_token(self):
+        raw = "dns_cloudflare_api_token = aZmRyZHNmbmFkc2tqaG\n"
+        out = sanitize_certbot_stderr(raw)
+        assert 'aZmRyZHNmbmFkc2tqaG' not in out
+        assert '[REDACTED]' in out
+
+    def test_redacts_generic_password_and_credential_lines(self):
+        raw = (
+            "dns_powerdns_api_key = AAAAAAAA\n"
+            "smtp_password = HelloPass\n"
+            "vault_token = hvs.SUPER-VAULT-TOKEN\n"
+            "api_bearer_token = certmate_BEARER_xyz\n"
+        )
+        out = sanitize_certbot_stderr(raw)
+        for needle in ('AAAAAAAA', 'HelloPass', 'hvs.SUPER-VAULT-TOKEN', 'certmate_BEARER_xyz'):
+            assert needle not in out, f'{needle!r} leaked through'
+
+    def test_redacts_credential_config_paths(self):
+        raw = (
+            "letsencrypt/config/azure.ini: parse error\n"
+            "more output\n"
+            "see /opt/certmate/letsencrypt/config/cloudflare.ini\n"
+        )
+        out = sanitize_certbot_stderr(raw)
+        # Both the bare relative path and the rooted absolute path are
+        # normalised to the same generic marker.
+        assert 'letsencrypt/config/azure.ini' not in out
+        assert 'letsencrypt/config/cloudflare.ini' not in out
+        assert '<credential file>' in out
+
+    def test_preserves_non_secret_narration(self):
+        """Anything that does NOT name a credential field must survive
+        unredacted so operators can still read the error narrative."""
+        raw = (
+            "Saving debug log to /app/log/letsencrypt.log\n"
+            "An unexpected error occurred:\n"
+            "Error finalizing order :: rate limit exceeded\n"
+            "Ask for help or search for solutions at https://community.letsencrypt.org.\n"
+        )
+        out = sanitize_certbot_stderr(raw)
+        # No credentials were present; the narration must round-trip.
+        assert 'rate limit exceeded' in out
+        assert 'community.letsencrypt.org' in out
+        assert '[REDACTED]' not in out
+
+    def test_caps_output_size(self):
+        raw = 'A' * 10_000
+        out = sanitize_certbot_stderr(raw)
+        # Hard cap from the implementation is 4096; the truncation
+        # marker is appended after.
+        assert len(out) <= 4096 + len('\n[…truncated — see application log for full output]')
+        assert '[…truncated' in out
+
+    def test_empty_input_returns_empty_string(self):
+        assert sanitize_certbot_stderr('') == ''
+        assert sanitize_certbot_stderr(None) == ''
+
+    def test_partial_word_does_not_trigger(self):
+        """The pattern is anchored on whole credential-name fragments so
+        a non-secret line containing the substring ``secret`` (e.g.
+        somebody's domain name) is not corrupted by the regex."""
+        raw = (
+            "Validating https://mysecretrecipe.com — DNS challenge passed\n"
+            "Order finalised successfully\n"
+        )
+        out = sanitize_certbot_stderr(raw)
+        assert 'mysecretrecipe.com' in out
+        assert 'Order finalised successfully' in out


### PR DESCRIPTION
## Summary

Internal security audit (May 2026), finding **H3**: certbot DNS plugins echo the offending `.ini` line verbatim into `stderr` on parse failure. `CertificateManager.create_certificate` and `renew_certificate` wrapped that `stderr` into `RuntimeError(...)`, and the web routes returned `jsonify({'error': str(e)}), 422` — operators reproducing a config bug saw their own credentials echoed in the response body, and any HTTP-traffic logger / SaaS error tracker between them and the API captured the plaintext secret along the way.

## Fix

- New `sanitize_certbot_stderr(stderr_text)` in `modules/core/utils.py`:
  - Regex strips credential-bearing `<name> = <value>` lines and replaces the value with `[REDACTED]`. The name regex anchors on any of `secret|token|password|key|credential|hmac|api_bearer` as a substring of the field name, with **digit-tolerant** surroundings (provider names like `route53` carry digits, so a digit-free character class would have silently skipped `dns_route53_access_key_id` — pinned by a regression test).
  - Credential `.ini` paths replaced with `<credential file>`.
  - Output capped at 4 KB with a truncation marker.
- `CertificateManager.create_certificate` and `renew_certificate` now `logger.error` the raw stderr (operator-visible in application logs) and raise `RuntimeError` with the sanitized copy. Two-leak points, two call sites, same shape.

## Tests

`tests/test_audit_certbot_stderr_sanitizer.py` (new, 9 cases):

- Azure SP `client_secret` line redacted; ACME help URL preserved
- Route53 AWS access key + secret access key both redacted; plugin error narration ("Error 403 from Route53") preserved
- Cloudflare `api_token` redacted
- Generic `smtp_password`, `vault_token`, `api_bearer_token`, `dns_powerdns_api_key` all redacted
- Credential `.ini` paths (relative + absolute) replaced with generic marker
- Non-secret narration (rate limit, ACME URL) survives unredacted
- 10 KB input capped at 4 KB + truncation marker
- `None` / `''` inputs return `''`
- Substring `secret` in non-credential context (e.g. `mysecretrecipe.com` domain) NOT corrupted — pattern requires column-1 `name = value` shape

## Test plan

- [x] `pytest tests/test_audit_certbot_stderr_sanitizer.py` — 9/9
- [x] Full local unit suite: 884 passed, 2 skipped, 115 deselected
- [ ] CI green
- [ ] Manual smoke: misconfigure `dns_azure_sp_client_secret`, trigger create, verify the API 422 body contains `[REDACTED]` not the secret value