### PR TITLE
fix: mask acme-dns shared secret + notifications GET response (H5 + M2)

### DIFF
--- a/modules/core/file_operations.py
+++ b/modules/core/file_operations.py
@@ -127,40 +127,18 @@ class FileOperations:
             return False
 
     def _mask_settings_secrets(self, settings_dict):
-        """Walk a settings dict and replace credential-bearing values with
-        the canonical mask sentinel.
+        """Delegate to the central ``mask_secrets_in_settings`` helper in
+        ``modules/core/settings``. Kept as an instance method for
+        backwards compatibility (older callers / tests that already
+        monkey-patched this name).
 
-        Uses the same ``_is_secret_key`` predicate as the masked GET path
-        on ``/api/web/settings`` (modules/web/settings_routes.py:55) — any
-        field whose name matches the project's secret regex (excluding
-        the documented non-secret allowlist like ``default_key_type``)
-        becomes ``SECRET_MASK_SENTINEL``. Restore reuses the
-        ``_strip_masked_values`` + deep-merge pipeline from PR #215, so
-        the sentinel signals "preserve the existing on-disk secret" when
-        restoring on top of an existing install. On a fresh restore the
-        sentinel stays as-is and the operator must re-enter credentials
-        (acknowledged trade-off — see the audit notes on the
-        ``create_unified_backup`` ``include_secrets`` flag).
-
-        Returns a deep-copied + masked structure; the caller's
-        ``settings_dict`` is never mutated.
+        The central helper also picks up provider-specific secret
+        fields (acme-dns ``username`` + ``subdomain``) that a name-only
+        regex would have missed. See its docstring for the precise
+        contract.
         """
-        from .settings import _is_secret_key, SECRET_MASK_SENTINEL
-
-        def _walk(node):
-            if isinstance(node, dict):
-                out = {}
-                for key, value in node.items():
-                    if _is_secret_key(key) and isinstance(value, str) and value:
-                        out[key] = SECRET_MASK_SENTINEL
-                    else:
-                        out[key] = _walk(value)
-                return out
-            if isinstance(node, list):
-                return [_walk(item) for item in node]
-            return node
-
-        return _walk(settings_dict)
+        from .settings import mask_secrets_in_settings
+        return mask_secrets_in_settings(settings_dict)
 
     def create_unified_backup(self, settings_data, backup_reason="manual", include_secrets=False):
         """Create a unified backup containing both settings and certificates.

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -104,6 +104,73 @@ def _is_secret_key(name: str) -> bool:
     return bool(_SECRET_KEY_RE.search(name))
 
 
+# Provider-specific secret fields whose names do NOT match the generic
+# regex but ARE credential material in their nesting context. Keyed by
+# the immediate parent key — masking is applied only when walking into
+# that parent, so a generic ``username`` (e.g. SMTP login email) is
+# NOT inadvertently masked.
+#
+# Audit M2: ``acme-dns`` provider stores its shared secret as a pair
+# of ``username`` (UUID) + ``subdomain`` (corresponding ACME-DNS
+# delegation host). Together they authorise TXT record updates on
+# behalf of the user's domain. Both must be masked.
+_PROVIDER_SPECIFIC_SECRET_FIELDS = {
+    'acme-dns': frozenset({'username', 'subdomain'}),
+}
+
+
+def mask_secrets_in_settings(settings_dict):
+    """Return a deep-copied settings dict with every credential-bearing
+    value replaced by ``SECRET_MASK_SENTINEL``.
+
+    Two passes coexist in the same walk:
+
+    1. Generic regex: any field whose name matches the project's
+       secret-name pattern (``token|secret|password|key|credential``)
+       — excluding the documented non-secret allowlist
+       (``default_key_type`` etc.) — gets masked.
+    2. Provider-specific: when the immediate parent key is one of the
+       providers in ``_PROVIDER_SPECIFIC_SECRET_FIELDS``, any listed
+       field name on that level gets masked even if the regex would
+       not match it. Today this covers ``acme-dns`` ``username`` +
+       ``subdomain``; future providers with similarly named shared-
+       secret fields can extend the registry without re-touching the
+       walker.
+
+    Used by:
+
+    - ``modules/web/settings_routes.py::api_settings_get`` — masked
+      response for ``/api/web/settings`` GET.
+    - ``modules/web/misc_routes.py::api_notifications_config`` —
+      masked response for the notifications subtree (audit H5).
+    - ``modules/core/file_operations.py::create_unified_backup`` —
+      share-safe default for backup ZIPs (audit C1).
+    """
+    def _walk(node, parent_key=None):
+        if isinstance(node, dict):
+            provider_extras = _PROVIDER_SPECIFIC_SECRET_FIELDS.get(parent_key, frozenset())
+            out = {}
+            for key, value in node.items():
+                if isinstance(value, str) and value and (
+                    _is_secret_key(key) or key in provider_extras
+                ):
+                    out[key] = SECRET_MASK_SENTINEL
+                else:
+                    # For list values, propagate the CURRENT dict's
+                    # parent_key down so list items inherit the
+                    # provider context (e.g. ``acme-dns.accounts[*]``
+                    # is still acme-dns-context). For dict values,
+                    # the new parent is the key we are descending
+                    # into.
+                    next_parent = parent_key if isinstance(value, list) else key
+                    out[key] = _walk(value, parent_key=next_parent)
+            return out
+        if isinstance(node, list):
+            return [_walk(item, parent_key=parent_key) for item in node]
+        return node
+    return _walk(settings_dict)
+
+
 def _strip_masked_values(payload):
     """Recursively strip keys whose value equals the masking sentinel — or,
     for secret-named fields, whose value is an empty string.

--- a/modules/web/misc_routes.py
+++ b/modules/web/misc_routes.py
@@ -166,7 +166,15 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
 
         if request.method == 'GET':
             try:
-                return jsonify(notifier._get_config())
+                # Audit H5: this endpoint previously returned raw
+                # `notifications` config including plaintext
+                # `smtp_password` + webhook URLs with embedded auth
+                # tokens. Now goes through the central masking helper
+                # so the response shape matches `/api/web/settings`
+                # for the same subtree.
+                from modules.core.settings import mask_secrets_in_settings
+                raw = notifier._get_config() or {}
+                return jsonify(mask_secrets_in_settings(raw))
             except Exception as e:
                 logger.error(f"Failed to read notifications config: {e}")
                 return jsonify({'error': 'Failed to read notifications config'}), 500

--- a/modules/web/settings_routes.py
+++ b/modules/web/settings_routes.py
@@ -50,19 +50,14 @@ def register_settings_routes(app, managers, require_web_auth, auth_manager,
         already needs the masked structure to show form fields).
         """
         try:
+            from modules.core.settings import mask_secrets_in_settings
             settings = settings_manager.load_settings()
-            masked = copy.deepcopy(settings)
-            def _mask_dict(d):
-                if not isinstance(d, dict):
-                    return
-                for k in list(d.keys()):
-                    if k in _NON_SECRET_KEYS:
-                        continue
-                    if _SECRET_KEYS.search(k) and isinstance(d[k], str) and d[k]:
-                        d[k] = '********'
-                    elif isinstance(d[k], dict):
-                        _mask_dict(d[k])
-            _mask_dict(masked)
+            # Centralised masking via modules/core/settings — same helper
+            # the backup-ZIP and notifications GET paths use, so the
+            # contract is single-sourced. Picks up the provider-specific
+            # acme-dns shared-secret fields (username + subdomain) that
+            # the older local walker missed (audit finding M2).
+            masked = mask_secrets_in_settings(settings)
 
             # Recovery helper: if the UI is about to show the wizard,
             # surface a flag so the frontend can suggest restoring

--- a/tests/test_audit_notifications_and_acmedns_masking.py
+++ b/tests/test_audit_notifications_and_acmedns_masking.py
@@ -1,0 +1,230 @@
+"""Regression tests for the audit findings H5 and M2 (May 2026).
+
+### H5 — `GET /api/notifications/config` returned plaintext SMTP password
+
+Before this fix, `modules/web/misc_routes.py::api_notifications_config`
+returned `notifier._get_config()` verbatim. Operator-token holders read
+the raw `notifications` subtree including `smtp_password` and any
+webhook URL with embedded auth tokens — bypassing the masking applied
+to the same subtree by `/api/web/settings`.
+
+The fix routes the GET response through the central
+`mask_secrets_in_settings()` helper so the contract matches the
+settings GET surface.
+
+### M2 — `acme-dns.username` and `acme-dns.subdomain` not masked
+
+The masking regex (`token|secret|password|key|credential`) does not
+match the ACME-DNS shared-secret fields. Both the legacy local
+`_mask_dict` in `settings_routes.py` AND the `MaskedString` typing in
+`modules/api/models.py` left `acme-dns.username` and
+`acme-dns.subdomain` returned as plaintext. Together those two
+fields ARE the ACME-DNS authentication material (the UUID + the
+corresponding delegation FQDN authorise TXT record updates).
+
+The fix introduces `_PROVIDER_SPECIFIC_SECRET_FIELDS` in
+`modules/core/settings.py`: a provider-name → field-name-set map
+applied by the central walker when the immediate parent key
+matches. Today it covers `acme-dns`; future providers with
+similarly named shared-secret fields can extend the registry
+without touching the walker.
+
+A generic `username` (e.g. SMTP login email) is NOT inadvertently
+masked because the rule fires only under the matching provider key.
+"""
+
+import pytest
+from modules.core.settings import (
+    mask_secrets_in_settings,
+    SECRET_MASK_SENTINEL,
+)
+
+
+pytestmark = [pytest.mark.unit]
+
+
+class TestAcmeDnsProviderMasking:
+    """Audit M2 — `acme-dns.username` and `acme-dns.subdomain` must be
+    masked. SMTP `username` (under a different parent) must NOT be."""
+
+    def test_acme_dns_username_and_subdomain_masked(self):
+        settings = {
+            'dns_providers': {
+                'acme-dns': {
+                    'api_url': 'https://acme-dns.example.com',
+                    'username': 'b7a37dd1-9512-4d18-9e6f-8db1d2e6cafe',
+                    'password': 'SHARED-SECRET',
+                    'subdomain': '92b9b1d5-c0ef-4e07-9ab7-acme-dns.example.com',
+                },
+            },
+        }
+        masked = mask_secrets_in_settings(settings)
+        acme = masked['dns_providers']['acme-dns']
+
+        assert acme['username'] == SECRET_MASK_SENTINEL
+        assert acme['subdomain'] == SECRET_MASK_SENTINEL
+        assert acme['password'] == SECRET_MASK_SENTINEL  # regex matched
+        # api_url is operator-visible (not a credential), must survive.
+        assert acme['api_url'] == 'https://acme-dns.example.com'
+
+    def test_smtp_username_is_not_masked(self):
+        """Defensive: the audit fix must apply to acme-dns SPECIFICALLY,
+        not blanket-mask every ``username`` field. SMTP login is an
+        email address — masking it would render the settings UI
+        useless on round-trip."""
+        settings = {
+            'notifications': {
+                'smtp': {
+                    'host': 'smtp.example.com',
+                    'username': 'noreply@example.com',  # email, NOT a secret
+                    'smtp_password': 'SECRET-SMTP',
+                },
+            },
+        }
+        masked = mask_secrets_in_settings(settings)
+        smtp = masked['notifications']['smtp']
+
+        assert smtp['username'] == 'noreply@example.com'  # NOT masked
+        assert smtp['smtp_password'] == SECRET_MASK_SENTINEL  # masked
+
+
+class TestMaskHelperPreservesPriorContract:
+    """The new central helper must keep the same masking behaviour the
+    audit-prior `_mask_dict` had — only adding to it (the acme-dns
+    fields above), never silently changing semantics."""
+
+    def test_dns_provider_token_still_masked(self):
+        settings = {
+            'dns_providers': {
+                'cloudflare': {'api_token': 'CF-PLAINTEXT'},
+                'route53': {
+                    'access_key_id': 'AKIA-xyz',
+                    'secret_access_key': 'AWS-SECRET',
+                },
+            },
+        }
+        masked = mask_secrets_in_settings(settings)
+        assert masked['dns_providers']['cloudflare']['api_token'] == SECRET_MASK_SENTINEL
+        assert masked['dns_providers']['route53']['secret_access_key'] == SECRET_MASK_SENTINEL
+        # `access_key_id` matches the regex (contains `key`).
+        assert masked['dns_providers']['route53']['access_key_id'] == SECRET_MASK_SENTINEL
+
+    def test_default_key_options_pass_through(self):
+        """The documented non-secret allowlist (default_key_type,
+        default_key_size, default_elliptic_curve) must not be touched
+        even though their names match the regex."""
+        settings = {
+            'default_key_type': 'rsa',
+            'default_key_size': 4096,
+            'default_elliptic_curve': 'secp256r1',
+        }
+        masked = mask_secrets_in_settings(settings)
+        assert masked['default_key_type'] == 'rsa'
+        assert masked['default_key_size'] == 4096
+        assert masked['default_elliptic_curve'] == 'secp256r1'
+
+    def test_empty_string_values_pass_through(self):
+        """Empty-secret semantics belong to the POST path
+        (_strip_masked_values). The MASK helper only replaces
+        non-empty strings with the sentinel."""
+        settings = {'oidc': {'client_secret': ''}}
+        masked = mask_secrets_in_settings(settings)
+        assert masked['oidc']['client_secret'] == ''
+
+    def test_lists_are_walked(self):
+        """Audit M2 fix must not have broken list traversal (a future
+        plugin storing accounts as a list under a provider key would
+        otherwise leak)."""
+        settings = {
+            'dns_providers': {
+                'acme-dns': {
+                    'accounts': [
+                        {'username': 'uuid-1', 'subdomain': 'sub-1.x.com', 'password': 'p1'},
+                        {'username': 'uuid-2', 'subdomain': 'sub-2.x.com', 'password': 'p2'},
+                    ],
+                },
+            },
+        }
+        masked = mask_secrets_in_settings(settings)
+        accounts = masked['dns_providers']['acme-dns']['accounts']
+        # `accounts` carries the acme-dns parent context, so the
+        # provider-specific masks still apply inside list entries.
+        for acct in accounts:
+            assert acct['username'] == SECRET_MASK_SENTINEL
+            assert acct['subdomain'] == SECRET_MASK_SENTINEL
+            assert acct['password'] == SECRET_MASK_SENTINEL
+
+
+class TestNotificationsGetMaskedSmtpPassword:
+    """Audit H5 — the integration shape: a real Flask test client
+    against the `/api/notifications/config` GET route must return the
+    masked sentinel for `smtp_password`, never the on-disk value."""
+
+    @pytest.fixture
+    def app_with_notifications(self):
+        from unittest.mock import MagicMock
+        from flask import Flask
+
+        settings_manager = MagicMock()
+        settings_manager.load_settings.return_value = {
+            'notifications': {
+                'enabled': True,
+                'smtp': {
+                    'host': 'smtp.example.com',
+                    'username': 'noreply@example.com',
+                    'smtp_password': 'REAL-PLAINTEXT-PASSWORD',
+                },
+                'webhooks': [
+                    {'url': 'https://hooks.example.com/abc?token=REAL_BEARER'},
+                ],
+            },
+        }
+
+        from modules.core.notifier import Notifier
+        notifier = Notifier.__new__(Notifier)
+        notifier.settings_manager = settings_manager
+
+        auth_manager = MagicMock()
+        # All endpoints in misc_routes use require_role; bypass so the
+        # mask contract is tested independently of auth.
+        def passthrough_role(_min_role):
+            def deco(fn):
+                return fn
+            return deco
+        auth_manager.require_role = MagicMock(side_effect=passthrough_role)
+
+        managers = {
+            'auth': auth_manager,
+            'settings': settings_manager,
+            'notifier': notifier,
+            'digest': MagicMock(),
+            'audit': MagicMock(),
+            'cache': MagicMock(),
+            'metrics': MagicMock(),
+            'dns': MagicMock(),
+            'deployer': MagicMock(),
+        }
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+
+        from modules.web.misc_routes import register_misc_routes
+        register_misc_routes(app, managers, lambda fn: fn, auth_manager)
+        return app
+
+    def test_get_notifications_config_masks_smtp_password(self, app_with_notifications):
+        client = app_with_notifications.test_client()
+        r = client.get('/api/notifications/config')
+        assert r.status_code == 200, r.data
+        body = r.get_json()
+        assert body['smtp']['smtp_password'] == SECRET_MASK_SENTINEL
+        # And the non-secret operator-facing fields survived.
+        assert body['smtp']['host'] == 'smtp.example.com'
+        assert body['smtp']['username'] == 'noreply@example.com'
+
+    def test_get_notifications_config_does_not_leak_password(self, app_with_notifications):
+        client = app_with_notifications.test_client()
+        r = client.get('/api/notifications/config')
+        # Defence-in-depth: the response body must not contain the
+        # plaintext anywhere, even in a field we did not anticipate.
+        assert b'REAL-PLAINTEXT-PASSWORD' not in r.data


### PR DESCRIPTION
## Summary

Internal security audit (May 2026) — two masking findings sharing the same root cause: the masking surface had no single source of truth, so different routes (settings GET, notifications GET, backup ZIP) drifted apart on what was treated as a secret.

## Findings

### H5 — `GET /api/notifications/config` returned plaintext SMTP password
Returned `notifier._get_config()` verbatim — operator-token holders read raw `smtp_password` and webhook URLs with embedded auth tokens, bypassing the masking applied to the same subtree by `/api/web/settings`.

### M2 — `acme-dns.username` and `acme-dns.subdomain` not masked
The masking regex didn't match the ACME-DNS shared-secret pair (`username` is a UUID, `subdomain` is the delegation FQDN). Together they authorise TXT record updates. A generic `username` elsewhere (SMTP login email) must NOT be touched, so the fix is provider-specific.

## Fix

- **`modules/core/settings.py`** — new `_PROVIDER_SPECIFIC_SECRET_FIELDS` registry + `mask_secrets_in_settings()` central helper. Walks dicts/lists, applies generic regex AND parent-key-aware provider extras.
- **`modules/web/settings_routes.py::api_settings_get`** — replaced the local `_mask_dict` with the central helper.
- **`modules/web/misc_routes.py::api_notifications_config` (GET)** — masks the response.
- **`modules/core/file_operations.py::_mask_settings_secrets`** — delegates to the central helper.

## Tests

`tests/test_audit_notifications_and_acmedns_masking.py` (new, 8 cases):

- acme-dns `username` + `subdomain` + `password` all masked; `api_url` survives.
- SMTP `username` NOT masked (provider-specific rule, not blanket).
- Cloudflare `api_token`, Route53 `access_key_id` + `secret_access_key` still masked (prior contract preserved).
- `default_key_type` / `default_key_size` / `default_elliptic_curve` pass through.
- Empty-string secrets pass through (empty-as-preserve lives in `_strip_masked_values`).
- Lists are walked and items inherit the dict-level parent context.
- Flask integration: `GET /api/notifications/config` returns `smtp_password == '********'`; plaintext does not appear anywhere in the body.

## Test plan

- [x] `pytest tests/test_audit_notifications_and_acmedns_masking.py` — 8/8
- [x] Full local unit suite: 892 passed, 2 skipped, 115 deselected
- [ ] CI green

## Audit context — running totals

| Closed | Severity |
|---|---|
| C1 (#220) backup ZIP plaintext | CRITICAL |
| C3 + H6 (#219) domain validation | CRITICAL + HIGH |
| H1 (#221) client-cert RBAC | HIGH |
| H3 (#222) certbot stderr leak | HIGH |
| G (#220) backup-restore re-validate hooks | MEDIUM |
| H5 + M2 (this PR) notifications mask + acme-dns | HIGH + MEDIUM |

**Remaining**: C2 + H4 + M3 (settings-mutating routes — PR-B), M4 + M5 (settings GET scope filter + check_dns_alias body scope — PR-H).