### PR TITLE
Fix certificate listing performance and backup pressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,36 +343,48 @@ For container orchestration and high availability deployments.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
- name: certmate
+  name: certmate
 spec:
- replicas: 2
- selector:
- matchLabels:
- app: certmate
- template:
- metadata:
- labels:
- app: certmate
- spec:
- containers:
- - name: certmate
- image: certmate:latest
- ports:
- - containerPort: 8000
- env:
- - name: API_BEARER_TOKEN
- valueFrom:
- secretKeyRef:
- name: certmate-secrets
- key: api-token
- volumeMounts:
- - name: certificates
- mountPath: /app/certificates
- volumes:
- - name: certificates
- persistentVolumeClaim:
- claimName: certmate-certificates
+  replicas: 1
+  selector:
+    matchLabels:
+      app: certmate
+  template:
+    metadata:
+      labels:
+        app: certmate
+    spec:
+      containers:
+        - name: certmate
+          image: certmate:latest
+          ports:
+            - containerPort: 8000
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1536Mi
+          env:
+            - name: API_BEARER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: certmate-secrets
+                  key: api-token
+            - name: CERTMATE_CERT_INFO_CACHE_TTL
+              value: "60"
+          volumeMounts:
+            - name: certificates
+              mountPath: /app/certificates
+      volumes:
+        - name: certificates
+          persistentVolumeClaim:
+            claimName: certmate-certificates
 ```
+
+For production sizing, OOM troubleshooting, and a `kubectl patch` example, see
+[Kubernetes Production Notes](docs/kubernetes.md).
 
 ### System Package Installation
 For system-wide installation on Linux distributions.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Welcome to the CertMate documentation. This folder contains comprehensive guides
 ### Getting Started
 - **[Installation Guide](./installation.md)** — Setup, dependencies, production deployment
 - **[Docker Guide](./docker.md)** — Docker builds, multi-platform, Docker Compose
+- **[Kubernetes Notes](./kubernetes.md)** — Production resources, OOM sizing, runtime patching
 
 ### Core Features
 - **[DNS Providers](./dns-providers.md)** — supported providers, multi-account, domain alias
@@ -39,8 +40,9 @@ Welcome to the CertMate documentation. This folder contains comprehensive guides
 ### For Administrators
 
 1. **[Docker Deployment](./docker.md)** — Production Docker setup
-2. **[CA Providers](./ca-providers.md)** — Configure certificate authorities
-3. **[DNS Providers](./dns-providers.md#multi-account-support)** — Enterprise multi-account setup
+2. **[Kubernetes Notes](./kubernetes.md)** — Production pod sizing and operational patching
+3. **[CA Providers](./ca-providers.md)** — Configure certificate authorities
+4. **[DNS Providers](./dns-providers.md#multi-account-support)** — Enterprise multi-account setup
 
 ---
 
@@ -139,6 +141,7 @@ docs/
   README.md            ← You are here
   index.md             ← Client certificates landing page
   installation.md      ← Installation & setup
+  kubernetes.md        ← Kubernetes production notes
   dns-providers.md     ← DNS providers & multi-account
   ca-providers.md      ← Certificate Authority providers
   docker.md            ← Docker build & deployment

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,6 +118,7 @@ curl http://localhost:8000/api/client-certs/USER_ID/download/key \
 ### Main Documentation
 
 - **[Installation Guide](./installation.md)** — Setup, dependencies, deployment
+- **[Kubernetes Notes](./kubernetes.md)** — Production pod sizing and OOM troubleshooting
 - **[DNS Providers](./dns-providers.md)** — supported providers, multi-account, domain alias
 - **[CA Providers](./ca-providers.md)** — Let's Encrypt, DigiCert, Private CA
 - **[Docker Guide](./docker.md)** — Docker builds, multi-platform, Compose

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,0 +1,75 @@
+# Kubernetes Production Notes
+
+This guide captures the production sizing baseline for CertMate when it runs
+behind a Kubernetes Ingress/HTTPRoute and uses a remote certificate backend
+such as Azure Key Vault.
+
+## Recommended Resources
+
+CertMate runs gunicorn plus certbot subprocesses in the same container. During
+certificate creation or renewal, certbot and DNS plugins can temporarily add a
+large memory spike. With Azure Key Vault in `both` mode, listing certificates
+also performs remote calls, so very small limits can turn routine operations
+into OOM restarts.
+
+Use this baseline for production pods that manage dozens of certificates:
+
+```yaml
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1536Mi
+env:
+  - name: CERTMATE_CERT_INFO_CACHE_TTL
+    value: "60"
+  - name: GUNICORN_TIMEOUT
+    value: "300"
+```
+
+For the specific failure mode where a pod with `memory: 512Mi` restarts while
+creating a certificate, raise the memory limit first. The code path now avoids
+the previous list-view `openssl` subprocesses, uses lightweight Azure Key Vault
+certificate-info reads, and excludes certbot scratch/history directories from
+routine backups, but certbot still needs headroom while issuing certificates.
+
+## Deployment Patch Example
+
+```bash
+kubectl -n certificate-management patch deployment certmate --type='strategic' -p '
+spec:
+  template:
+    spec:
+      containers:
+        - name: certmate
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1536Mi
+          env:
+            - name: CERTMATE_CERT_INFO_CACHE_TTL
+              value: "60"
+            - name: GUNICORN_TIMEOUT
+              value: "300"
+'
+```
+
+Verify the next restart reason after applying:
+
+```bash
+kubectl -n certificate-management describe pod -l app=certmate | grep -A6 "Last State"
+kubectl -n certificate-management top pod -l app=certmate
+```
+
+## Replica Count
+
+Run `replicas: 1` unless all mutable paths (`/app/data`, `/app/certificates`,
+`/app/backups`, `/app/logs`) are backed by storage that is safe for concurrent
+writers and you have validated scheduler/renewal behavior for multiple pods.
+Azure Key Vault can store certificates remotely, but CertMate still keeps local
+settings, metadata, backups, and runtime state.

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -955,7 +955,8 @@ def create_api_resources(api, models, managers):
                 if new_alias_dns_provider:
                     metadata['alias_dns_provider'] = new_alias_dns_provider
 
-                certificate_manager._atomic_json_write(metadata_file, metadata)
+                if not certificate_manager._save_metadata(domain, metadata):
+                    return {'error': f'Failed to update metadata for domain: {domain}'}, 500
                 logger.info(
                     f"Updated DNS provider for {domain}: "
                     f"{old_provider} → {new_dns_provider or old_provider}"

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -1319,12 +1319,11 @@ class CertificateManager:
                 'inferred': True  # Mark as inferred for debugging
             }
             
-            try:
-                self._save_metadata(domain, metadata)
+            if self._save_metadata(domain, metadata):
                 logger.info(f"Created metadata for {domain} with inferred DNS provider: {dns_provider}")
                 created_count += 1
-            except Exception as e:
-                logger.error(f"Failed to create metadata for {domain}: {e}")
+            else:
+                logger.error(f"Failed to create metadata for {domain}")
         
         logger.info(f"Created metadata files for {created_count} certificates")
         return created_count

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -4,6 +4,7 @@ Handles certificate creation, renewal, and information retrieval
 """
 
 import os
+import copy
 import json
 import shlex
 import subprocess
@@ -18,10 +19,11 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 from datetime import datetime, timedelta
+from cryptography import x509
 from .shell import ShellExecutor
 from .dns_strategies import DNSStrategyFactory, HTTP01Strategy, check_certbot_plugin_installed
 from .constants import CERTIFICATE_FILES, get_domain_name
-from .utils import validate_domain, utc_now, utc_now_iso, validate_key_options
+from .utils import DeploymentStatusCache, validate_domain, utc_now, utc_now_iso, validate_key_options
 
 logger = logging.getLogger(__name__)
 
@@ -72,9 +74,47 @@ class CertificateManager:
         self.storage_manager = storage_manager
         self.ca_manager = ca_manager
         self.shell_executor = shell_executor or ShellExecutor()
+        self._certificate_info_cache = DeploymentStatusCache(default_ttl=self._certificate_info_cache_ttl())
         # Per-domain locks to prevent concurrent create/renew on the same domain
         self._domain_locks: dict[str, threading.Lock] = {}
         self._domain_locks_mutex = threading.Lock()
+
+    @staticmethod
+    def _certificate_info_cache_ttl() -> int:
+        try:
+            return max(0, min(3600, int(os.environ.get('CERTMATE_CERT_INFO_CACHE_TTL', '60'))))
+        except (TypeError, ValueError):
+            return 60
+
+    @staticmethod
+    def _certificate_info_cache_key(domain: str, settings: dict | None) -> str:
+        threshold = 30
+        if isinstance(settings, dict):
+            try:
+                threshold = int(settings.get('renewal_threshold_days', 30))
+            except (TypeError, ValueError):
+                threshold = 30
+        return f"{domain}|renewal_threshold_days={threshold}|date={utc_now().date().isoformat()}"
+
+    def _get_cached_certificate_info(self, domain: str, settings: dict | None = None):
+        cached = self._certificate_info_cache.get(self._certificate_info_cache_key(domain, settings))
+        return copy.deepcopy(cached) if cached is not None else None
+
+    def _set_cached_certificate_info(self, domain: str, info: dict, settings: dict | None = None) -> None:
+        ttl = self._certificate_info_cache_ttl()
+        if ttl > 0:
+            self._certificate_info_cache.set(
+                self._certificate_info_cache_key(domain, settings),
+                copy.deepcopy(info),
+                ttl=ttl,
+            )
+
+    def _invalidate_certificate_info_cache(self, domain: str) -> None:
+        # Cache keys include settings-derived renewal thresholds and current
+        # UTC date, so a domain can have multiple active entries. Metadata
+        # mutations are infrequent; clearing the small certificate-info cache
+        # avoids leaving any domain variants behind.
+        self._certificate_info_cache.clear()
 
     @staticmethod
     def _atomic_binary_copy(src: Path, dest: Path) -> None:
@@ -146,6 +186,7 @@ class CertificateManager:
         metadata_file = self._metadata_path(domain)
         try:
             self._atomic_json_write(metadata_file, metadata)
+            self._invalidate_certificate_info_cache(domain)
             return True
         except Exception as e:
             logger.warning(f"Failed to save metadata for {domain}: {e}")
@@ -447,12 +488,42 @@ class CertificateManager:
         
         # First try to get certificate from storage backend if available
         if self.storage_manager:
+            cache_enabled = settings is None
+            cache_settings = settings
+            if cache_settings is None:
+                try:
+                    cache_settings = self.settings_manager.load_settings()
+                except Exception:
+                    cache_settings = {}
+            if cache_enabled:
+                cached = self._get_cached_certificate_info(domain, cache_settings)
+                if cached is not None:
+                    return cached
             try:
-                storage_result = self.storage_manager.retrieve_certificate(domain)
+                retrieve_info = getattr(self.storage_manager, 'retrieve_certificate_info', None)
+                storage_result = None
+                if callable(retrieve_info):
+                    candidate = retrieve_info(domain)
+                    if candidate is None:
+                        storage_result = None
+                    elif isinstance(candidate, tuple) and len(candidate) == 2:
+                        storage_result = candidate
+                    else:
+                        logger.debug(
+                            "Storage backend returned invalid certificate-info "
+                            "shape for %s; falling back to full retrieve.",
+                            domain,
+                        )
+                        storage_result = self.storage_manager.retrieve_certificate(domain)
+                else:
+                    storage_result = self.storage_manager.retrieve_certificate(domain)
                 if storage_result:
                     cert_files, metadata = storage_result
                     if 'cert.pem' in cert_files:
-                        return self._parse_certificate_info(domain, cert_files['cert.pem'], metadata)
+                        info = self._parse_certificate_info(domain, cert_files['cert.pem'], metadata, settings=cache_settings)
+                        if cache_enabled:
+                            self._set_cached_certificate_info(domain, info, cache_settings)
+                        return info
             except Exception as e:
                 logger.warning(f"Failed to retrieve certificate from storage backend for {domain}: {e}")
         
@@ -494,21 +565,6 @@ class CertificateManager:
             logger.error(f"Failed to read certificate file for {domain}: {e}")
             return self._create_empty_cert_info(domain)
     
-    @staticmethod
-    def _parse_openssl_date(date_str):
-        """Parse openssl date string, trying multiple formats for cross-platform compatibility."""
-        formats = [
-            '%b %d %H:%M:%S %Y %Z',   # Most common: "Jan  1 00:00:00 2026 GMT"
-            '%b  %d %H:%M:%S %Y %Z',  # Double-space variant for single-digit days
-            '%b %d %H:%M:%S %Y',       # Without timezone
-        ]
-        for fmt in formats:
-            try:
-                return datetime.strptime(date_str.strip(), fmt)
-            except ValueError:
-                continue
-        raise ValueError(f"Unable to parse certificate date: {date_str!r}")
-
     def _parse_certificate_info(self, domain, cert_content, metadata=None, settings=None):
         """Parse certificate information from certificate content.
 
@@ -533,57 +589,34 @@ class CertificateManager:
         renewal_threshold_days = settings.get('renewal_threshold_days', 30)
 
         try:
-            # Write cert content to temporary file for openssl processing
-            with tempfile.NamedTemporaryFile(mode='wb', suffix='.pem', delete=False) as temp_cert:
-                temp_cert.write(cert_content)
-                temp_cert_path = temp_cert.name
+            # Parse the certificate in-process with `cryptography` (already a
+            # dependency, used elsewhere in this codebase). The previous
+            # implementation wrote each cert to a temp file and spawned an
+            # `openssl x509 -enddate` subprocess; with many certificates that
+            # meant one process spawn + one temp file per row on every table
+            # load, which dominated listing latency on a CPU-throttled
+            # container.
+            cert = x509.load_pem_x509_certificate(cert_content)
+            # not_valid_after_utc is timezone-aware UTC; drop the tzinfo so the
+            # arithmetic matches utc_now(), which is naive UTC by design.
+            expiry_date = cert.not_valid_after_utc.replace(tzinfo=None)
+            now_utc = utc_now()
+            days_left = (expiry_date - now_utc).days
 
-            try:
-                # Get certificate expiry using openssl — prefer -enddate for simpler parsing
-                result = self.shell_executor.run([
-                    'openssl', 'x509', '-in', temp_cert_path, '-noout', '-enddate'
-                ], capture_output=True, text=True)
-
-                not_after = None
-                if result.returncode == 0:
-                    output = result.stdout.strip()
-                    # Output format: "notAfter=Jan  1 00:00:00 2026 GMT"
-                    if '=' in output:
-                        not_after = output.split('=', 1)[1]
-
-                if not_after:
-                    try:
-                        expiry_date = self._parse_openssl_date(not_after)
-                        now_utc = utc_now()
-                        days_left = (expiry_date - now_utc).days
-
-                        return {
-                            'domain': domain,
-                            'exists': True,
-                            'expiry_date': expiry_date.strftime('%Y-%m-%d %H:%M:%S'),
-                            'days_left': days_left,
-                            'days_until_expiry': days_left,
-                            'needs_renewal': days_left < renewal_threshold_days,
-                            'dns_provider': dns_provider,
-                            'domain_alias': domain_alias,
-                            'alias_dns_provider': alias_dns_provider,
-                            'san_domains': san_domains
-                        }
-                    except ValueError as e:
-                        logger.error(f"Error parsing certificate date for {domain}: {e}")
-                else:
-                    logger.error(f"openssl returned no expiry for {domain}: rc={result.returncode} stderr={result.stderr}")
-            finally:
-                # Clean up temporary file
-                try:
-                    os.unlink(temp_cert_path)
-                except FileNotFoundError:
-                    pass
-                except Exception as cleanup_err:
-                    logger.warning(f"Failed to clean up temp cert file {temp_cert_path}: {cleanup_err}")
-
+            return {
+                'domain': domain,
+                'exists': True,
+                'expiry_date': expiry_date.strftime('%Y-%m-%d %H:%M:%S'),
+                'days_left': days_left,
+                'days_until_expiry': days_left,
+                'needs_renewal': days_left < renewal_threshold_days,
+                'dns_provider': dns_provider,
+                'domain_alias': domain_alias,
+                'alias_dns_provider': alias_dns_provider,
+                'san_domains': san_domains
+            }
         except Exception as e:
-            logger.error(f"Error getting certificate info for {domain}: {e}")
+            logger.error(f"Error parsing certificate for {domain}: {e}")
 
         # Certificate file exists but we couldn't parse the expiry — still mark exists=True
         return {
@@ -971,15 +1004,12 @@ class CertificateManager:
                 except Exception as e:
                     logger.error(f"Error storing certificate in storage backend for {domain}: {e}")
             
-            metadata_file = cert_output_dir / 'metadata.json'
-            try:
-                self._atomic_json_write(metadata_file, metadata)
-                logger.info(f"Saved certificate metadata to {metadata_file}")
-            except Exception as e:
-                logger.warning(f"Failed to save metadata for {domain}: {e}")
+            if self._save_metadata(domain, metadata):
+                logger.info(f"Saved certificate metadata to {self._metadata_path(domain)}")
             
             duration = time.time() - start_time
             logger.info(f"Certificate created successfully for {domain} in {duration:.2f} seconds")
+            self._invalidate_certificate_info_cache(domain)
             
             return {
                 'success': True,
@@ -1152,12 +1182,13 @@ class CertificateManager:
                 if metadata_file.exists():
                     try:
                         metadata['renewed_at'] = datetime.now().isoformat()
-                        self._atomic_json_write(metadata_file, metadata)
+                        self._save_metadata(domain, metadata)
                         logger.info(f"Updated renewal timestamp in metadata for {domain}")
                     except Exception as e:
                         logger.warning(f"Failed to update metadata for {domain}: {e}")
                 
                 logger.info(f"Certificate renewed successfully for {domain}")
+                self._invalidate_certificate_info_cache(domain)
                 return {
                     'success': True,
                     'domain': domain,
@@ -1289,7 +1320,7 @@ class CertificateManager:
             }
             
             try:
-                self._atomic_json_write(metadata_file, metadata)
+                self._save_metadata(domain, metadata)
                 logger.info(f"Created metadata for {domain} with inferred DNS provider: {dns_provider}")
                 created_count += 1
             except Exception as e:
@@ -1338,6 +1369,7 @@ class CertificateManager:
             if domain_dir.exists():
                 shutil.rmtree(domain_dir)
                 logger.info(f"Certificate deleted for {domain}")
+                self._invalidate_certificate_info_cache(domain)
                 return True
             return False
         finally:

--- a/modules/core/file_operations.py
+++ b/modules/core/file_operations.py
@@ -19,6 +19,12 @@ logger = logging.getLogger(__name__)
 BACKUP_RETENTION_DAYS = 30  # Keep backups for 30 days
 MAX_BACKUPS_PER_TYPE = 50   # Maximum number of backups to keep per type
 
+# Top-level subdirectories under certificates/<domain>/ that certbot fills
+# with ephemeral scratch and verbose logs. certbot's accounts/ and archive/
+# directories are intentionally retained because renew_certificate() reuses
+# the domain config dir for future renewals after a restore.
+_BACKUP_EXCLUDE_DIRS = frozenset({'logs', 'work'})
+
 
 class FileOperations:
     """Class to handle file operations and backup management"""
@@ -211,10 +217,20 @@ class FileOperations:
                 # second iterdir + is_dir() on the same cert_dir.
                 for domain_dir in domain_dirs:
                     for cert_file in domain_dir.rglob("*"):
-                        if cert_file.is_file():
-                            # Add file to zip with relative path under certificates/
-                            arc_path = f"certificates/{cert_file.relative_to(self.cert_dir)}"
-                            zipf.write(cert_file, arc_path)
+                        if not cert_file.is_file():
+                            continue
+                        # certbot runs with --config-dir/--work-dir/--logs-dir
+                        # all under certificates/<domain>/, so each domain dir
+                        # accumulates logs/ and work/. Those have no restore
+                        # value and can dominate routine backups. Keep
+                        # accounts/ and archive/: certbot renew needs lineage
+                        # state after a backup restore.
+                        rel_parts = cert_file.relative_to(domain_dir).parts
+                        if rel_parts and rel_parts[0] in _BACKUP_EXCLUDE_DIRS:
+                            continue
+                        # Add file to zip with relative path under certificates/
+                        arc_path = f"certificates/{cert_file.relative_to(self.cert_dir)}"
+                        zipf.write(cert_file, arc_path)
 
                 # Add unified metadata
                 zipf.writestr("backup_metadata.json", json.dumps(metadata, indent=2))

--- a/modules/core/storage_backends.py
+++ b/modules/core/storage_backends.py
@@ -144,6 +144,22 @@ class CertificateStorageBackend(ABC):
     def retrieve_certificate(self, domain: str) -> Optional[Tuple[Dict[str, bytes], Dict[str, Any]]]:
         """Retrieve certificate files and metadata for a domain"""
         pass
+
+    def retrieve_certificate_info(self, domain: str) -> Optional[Tuple[Dict[str, bytes], Dict[str, Any]]]:
+        """Retrieve only the certificate material needed by list/info views.
+
+        Backends can override this to avoid fetching private keys or full
+        bundles. The default preserves compatibility by falling back to the
+        full retrieve path.
+        """
+        result = self.retrieve_certificate(domain)
+        if not result:
+            return None
+        cert_files, metadata = result
+        cert_pem = cert_files.get('cert.pem')
+        if not cert_pem:
+            return None
+        return {'cert.pem': cert_pem}, metadata
     
     @abstractmethod
     def list_certificates(self) -> List[str]:
@@ -383,6 +399,32 @@ class _AzureKeyVaultCertificateImporter:
             logger.debug("Could not read tags for Certificate %s: %s", cert_name, e)
             return {}
         return self._tags_to_metadata(dict(getattr(cert.properties, 'tags', None) or {}))
+
+    def get_certificate_summary(self, domain: str) -> Optional[Tuple[Dict[str, bytes], Dict[str, Any], Optional['datetime']]]:
+        """Read public cert + metadata from the Certificate API without PFX export."""
+        from cryptography import x509
+        from cryptography.hazmat.primitives.serialization import Encoding
+
+        cert_name = self._certificate_name(domain)
+        try:
+            cert = self._get_cert_client().get_certificate(cert_name)
+        except Exception as e:
+            logger.debug("Could not read Certificate summary %s: %s", cert_name, e)
+            return None
+
+        cert_bytes = getattr(cert, 'cer', None)
+        if not cert_bytes:
+            return None
+        try:
+            cert_pem = x509.load_der_x509_certificate(cert_bytes).public_bytes(Encoding.PEM)
+        except Exception as e:
+            logger.debug("Could not parse Certificate API public cert for %s: %s", domain, e)
+            return None
+
+        props = getattr(cert, 'properties', None)
+        metadata = self._tags_to_metadata(dict(getattr(props, 'tags', None) or {}))
+        updated_on = getattr(props, 'updated_on', None)
+        return {'cert.pem': cert_pem}, metadata, updated_on
 
     def import_certificate(self, domain: str, cert_files: Dict[str, bytes], metadata: Dict[str, Any]) -> bool:
         """Import the cert+chain+key bundle as a Key Vault Certificate object."""
@@ -702,6 +744,85 @@ class AzureKeyVaultBackend(CertificateStorageBackend):
             logger.debug(f"Metadata not found in Azure Key Vault for {domain}: {e}")
 
         return cert_files, metadata, latest_update
+
+    def _retrieve_info_from_secrets(self, domain: str) -> Optional[Tuple[Dict[str, bytes], Dict[str, Any], 'Optional[datetime]']]:
+        """Read only cert.pem plus metadata from the Secrets surface."""
+        client = self._get_client()
+        secret_name = self._sanitize_secret_name(f"cert-{domain}-cert-pem")
+        try:
+            secret = client.get_secret(secret_name)
+        except Exception as e:
+            logger.debug(f"cert.pem secret not found for {domain}: {e}")
+            return None
+
+        cert_pem = secret.value.encode('utf-8')
+        cert_pem_update = getattr(secret.properties, 'updated_on', None)
+
+        metadata: Dict[str, Any] = {}
+        try:
+            metadata_name = self._sanitize_secret_name(f"cert-{domain}-metadata")
+            metadata_secret = client.get_secret(metadata_name)
+            metadata = json.loads(metadata_secret.value)
+        except Exception as e:
+            logger.debug(f"Metadata not found in Azure Key Vault for {domain}: {e}")
+
+        return {'cert.pem': cert_pem}, metadata, cert_pem_update
+
+    @_with_retry()
+    def retrieve_certificate_info(self, domain: str) -> Optional[Tuple[Dict[str, bytes], Dict[str, Any]]]:
+        """Retrieve only cert.pem and metadata for dashboard/listing paths."""
+        try:
+            if self.storage_mode == AZURE_KV_MODE_SECRETS:
+                result = self._retrieve_info_from_secrets(domain)
+                if result is None:
+                    return None
+                cert_files, metadata, _ = result
+                return cert_files, metadata
+
+            if self.storage_mode == AZURE_KV_MODE_CERTIFICATE:
+                summary = self._get_cert_importer().get_certificate_summary(domain)
+                if summary is None:
+                    return None
+                cert_files, metadata, _ = summary
+                return cert_files, metadata
+
+            secrets_result = self._retrieve_info_from_secrets(domain)
+            cert_update = self._get_cert_importer().get_certificate_update_time(domain)
+
+            if secrets_result is not None and cert_update is None:
+                cert_files, metadata, _ = secrets_result
+                if not metadata:
+                    metadata = self._get_cert_importer().get_metadata_tags(domain)
+                return cert_files, metadata
+
+            if secrets_result is None and cert_update is not None:
+                summary = self._get_cert_importer().get_certificate_summary(domain)
+                if summary is None:
+                    return None
+                cert_files, metadata, _ = summary
+                return cert_files, metadata
+
+            if secrets_result is not None and cert_update is not None:
+                cert_files, metadata, secrets_update = secrets_result
+                if secrets_update is not None and cert_update > secrets_update:
+                    summary = self._get_cert_importer().get_certificate_summary(domain)
+                    if summary is not None:
+                        summary_files, summary_metadata, _ = summary
+                        return summary_files, summary_metadata
+                    logger.warning(
+                        "Azure KV both-mode: Certificate API claims a fresher "
+                        "public cert for %s but summary read failed; falling "
+                        "back to Secrets cert.pem snapshot.",
+                        domain,
+                    )
+                if not metadata:
+                    metadata = self._get_cert_importer().get_metadata_tags(domain)
+                return cert_files, metadata
+
+            return None
+        except Exception as e:
+            logger.error(f"Failed to retrieve certificate info from Azure Key Vault for {domain}: {e}")
+            return None
 
     @_with_retry()
     def retrieve_certificate(self, domain: str) -> Optional[Tuple[Dict[str, bytes], Dict[str, Any]]]:
@@ -1559,6 +1680,11 @@ class StorageManager:
         """Retrieve certificate using the configured backend"""
         backend = self.get_backend()
         return backend.retrieve_certificate(domain)
+
+    def retrieve_certificate_info(self, domain: str) -> Optional[Tuple[Dict[str, bytes], Dict[str, Any]]]:
+        """Retrieve lightweight certificate info using the configured backend."""
+        backend = self.get_backend()
+        return backend.retrieve_certificate_info(domain)
     
     def list_certificates(self) -> List[str]:
         """List certificates using the configured backend"""

--- a/tests/test_azure_keyvault_certificate_storage.py
+++ b/tests/test_azure_keyvault_certificate_storage.py
@@ -687,6 +687,98 @@ class TestTagsMetadataRoundTrip:
 
 
 class TestRetrieveBothMode:
+    def test_retrieve_certificate_info_reads_only_cert_pem_and_metadata(self, vault_config):
+        """Table/list views only need cert.pem + metadata.
+
+        In Azure Key Vault ``both`` mode, the full retrieve path reads every
+        PEM secret and may export the Certificate object. The lightweight info
+        path must avoid private-key/fullchain/chain reads and avoid PFX export.
+        """
+        from modules.core.storage_backends import AzureKeyVaultBackend
+        backend = AzureKeyVaultBackend({**vault_config, "storage_mode": "both"})
+
+        secret_client = MagicMock()
+        _now = datetime.datetime(2026, 5, 1, 12, 0, 0)
+
+        def fake_get_secret(secret_name):
+            if "cert-pem" in secret_name:
+                secret = MagicMock()
+                secret.properties.updated_on = _now
+                secret.value = "CERT-PEM"
+                return secret
+            if "metadata" in secret_name:
+                secret = MagicMock()
+                secret.properties.updated_on = _now
+                secret.value = json.dumps({"domain": "test.example.com", "dns_provider": "azure"})
+                return secret
+            raise AssertionError(f"unexpected heavy secret read: {secret_name}")
+
+        secret_client.get_secret.side_effect = fake_get_secret
+        backend._client = secret_client
+
+        importer = MagicMock()
+        importer.get_certificate_update_time.return_value = None
+        backend._cert_importer = importer
+
+        result = backend.retrieve_certificate_info("test.example.com")
+
+        assert result == (
+            {"cert.pem": b"CERT-PEM"},
+            {"domain": "test.example.com", "dns_provider": "azure"},
+        )
+        requested_names = [call.args[0] for call in secret_client.get_secret.call_args_list]
+        assert len(requested_names) == 2
+        assert any("cert-pem" in name for name in requested_names)
+        assert any("metadata" in name for name in requested_names)
+        importer.export_certificate.assert_not_called()
+
+    def test_retrieve_certificate_info_uses_cert_pem_freshness_not_metadata_freshness(self, vault_config):
+        """A metadata rewrite must not make stale Secrets cert.pem look newer.
+
+        In both mode, certificate freshness is about the certificate bytes. A
+        later metadata secret update must not stop the info path from selecting
+        a newer Certificate API public cert.
+        """
+        from modules.core.storage_backends import AzureKeyVaultBackend
+        backend = AzureKeyVaultBackend({**vault_config, "storage_mode": "both"})
+
+        secret_client = MagicMock()
+        cert_pem_ts = datetime.datetime(2026, 1, 1, 0, 0, 0)
+        metadata_ts = datetime.datetime(2026, 7, 1, 0, 0, 0)
+
+        def fake_get_secret(secret_name):
+            secret = MagicMock()
+            if "cert-pem" in secret_name:
+                secret.properties.updated_on = cert_pem_ts
+                secret.value = "OLD-CERT-PEM"
+                return secret
+            if "metadata" in secret_name:
+                secret.properties.updated_on = metadata_ts
+                secret.value = json.dumps({"domain": "skew.example.com", "version": "metadata-new"})
+                return secret
+            raise AssertionError(f"unexpected heavy secret read: {secret_name}")
+
+        secret_client.get_secret.side_effect = fake_get_secret
+        backend._client = secret_client
+
+        cert_ts = datetime.datetime(2026, 6, 1, 0, 0, 0)
+        importer = MagicMock()
+        importer.get_certificate_update_time.return_value = cert_ts
+        importer.get_certificate_summary.return_value = (
+            {"cert.pem": b"NEW-CERT-PEM"},
+            {"domain": "skew.example.com", "version": "cert-new"},
+            cert_ts,
+        )
+        backend._cert_importer = importer
+
+        result = backend.retrieve_certificate_info("skew.example.com")
+
+        assert result == (
+            {"cert.pem": b"NEW-CERT-PEM"},
+            {"domain": "skew.example.com", "version": "cert-new"},
+        )
+        importer.get_certificate_summary.assert_called_once_with("skew.example.com")
+
     def test_secrets_present_certificate_api_not_touched(self, vault_config, cert_files):
         """When Secrets path returns a populated bundle and no Certificate
         object exists yet, the backend returns the Secrets data without

--- a/tests/test_backup_excludes_certbot_scratch.py
+++ b/tests/test_backup_excludes_certbot_scratch.py
@@ -1,0 +1,75 @@
+"""The unified backup must not archive certbot's ephemeral scratch/log dirs.
+
+certbot is invoked with ``--config-dir``/``--work-dir``/``--logs-dir`` all
+pointing at ``certificates/<domain>/`` (see CertificateManager.create_certificate),
+so each domain directory accumulates ``logs/`` (verbose certbot logs) and
+``work/`` (scratch). ``create_unified_backup`` used to ``rglob("*")`` the whole
+tree into the ZIP on every settings save — including those bloat dirs — which,
+right after a certbot run, piled IO/CPU/disk onto an already memory-tight
+container. ``accounts/`` and ``archive/`` are intentionally retained because
+certbot needs that lineage/account state to renew a restored certificate.
+"""
+
+import zipfile
+
+import pytest
+
+from modules.core.file_operations import FileOperations
+
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def file_ops(tmp_path):
+    cert_dir = tmp_path / "certificates"
+    data_dir = tmp_path / "data"
+    backup_dir = tmp_path / "backups"
+    logs_dir = tmp_path / "logs"
+    for d in (cert_dir, data_dir, backup_dir, logs_dir):
+        d.mkdir()
+    return FileOperations(cert_dir, data_dir, backup_dir, logs_dir)
+
+
+def _seed_domain_tree(cert_dir, domain):
+    """Lay out a realistic certbot config-dir for one domain."""
+    dom = cert_dir / domain
+    (dom).mkdir()
+    # Canonical served files + CertMate metadata — MUST be backed up.
+    (dom / "cert.pem").write_text("CERT")
+    (dom / "chain.pem").write_text("CHAIN")
+    (dom / "fullchain.pem").write_text("FULLCHAIN")
+    (dom / "privkey.pem").write_text("KEY")
+    (dom / "metadata.json").write_text('{"dns_provider": "cloudflare"}')
+    # certbot scratch/log dirs — MUST be excluded.
+    (dom / "logs").mkdir()
+    (dom / "logs" / "letsencrypt.log").write_text("x" * 5000)
+    (dom / "work").mkdir()
+    (dom / "work" / "scratch.tmp").write_text("y" * 5000)
+    # certbot lineage/account state — MUST be retained for restored renewal.
+    (dom / "archive").mkdir()
+    (dom / "archive" / "cert1.pem").write_text("z" * 5000)
+    (dom / "accounts").mkdir()
+    (dom / "accounts" / "regr.json").write_text("a" * 5000)
+
+
+def test_backup_keeps_cert_files_excludes_logs_and_work(file_ops):
+    _seed_domain_tree(file_ops.cert_dir, "example.com")
+
+    filename = file_ops.create_unified_backup({"domains": []}, "test")
+    assert filename, "create_unified_backup returned None"
+
+    with zipfile.ZipFile(file_ops.backup_dir / "unified" / filename) as zf:
+        names = zf.namelist()
+
+    assert "certificates/example.com/cert.pem" in names
+    assert "certificates/example.com/privkey.pem" in names
+    assert "certificates/example.com/metadata.json" in names
+    assert "certificates/example.com/archive/cert1.pem" in names
+    assert "certificates/example.com/accounts/regr.json" in names
+
+    leaked = [
+        n for n in names
+        if any(part in n for part in ("/logs/", "/work/"))
+    ]
+    assert not leaked, f"certbot scratch/log dirs leaked into backup: {leaked}"

--- a/tests/test_cert_info_cache_and_storage_summary.py
+++ b/tests/test_cert_info_cache_and_storage_summary.py
@@ -1,0 +1,125 @@
+"""Certificate list lookups should use lightweight cached storage metadata."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from modules.core.certificates import CertificateManager
+from modules.core.file_operations import FileOperations
+from modules.core.settings import SettingsManager
+from modules.core.storage_backends import LocalFileSystemBackend
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def _make_cert_pem(not_after: datetime) -> bytes:
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "example.com")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(not_after)
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+@pytest.fixture
+def cert_manager(tmp_path):
+    cert_dir = tmp_path / "certificates"
+    data_dir = tmp_path / "data"
+    backup_dir = tmp_path / "backups"
+    logs_dir = tmp_path / "logs"
+    for directory in (cert_dir, data_dir, backup_dir, logs_dir):
+        directory.mkdir()
+
+    file_ops = FileOperations(cert_dir, data_dir, backup_dir, logs_dir)
+    settings_manager = SettingsManager(file_ops, data_dir / "settings.json")
+    storage = MagicMock()
+    storage.retrieve_certificate_info.return_value = (
+        {"cert.pem": _make_cert_pem(datetime.now(timezone.utc) + timedelta(days=60))},
+        {"domain": "example.com", "dns_provider": "azure"},
+    )
+
+    return CertificateManager(
+        cert_dir=cert_dir,
+        settings_manager=settings_manager,
+        dns_manager=MagicMock(),
+        storage_manager=storage,
+        shell_executor=MagicMock(),
+    )
+
+
+def test_storage_certificate_info_uses_lightweight_backend_method(cert_manager):
+    info = cert_manager.get_certificate_info("example.com")
+
+    assert info["exists"] is True
+    assert info["dns_provider"] == "azure"
+    cert_manager.storage_manager.retrieve_certificate_info.assert_called_once_with("example.com")
+    cert_manager.storage_manager.retrieve_certificate.assert_not_called()
+
+
+def test_storage_certificate_info_is_cached_per_domain(cert_manager):
+    first = cert_manager.get_certificate_info("example.com")
+    second = cert_manager.get_certificate_info("example.com")
+
+    assert first == second
+    cert_manager.storage_manager.retrieve_certificate_info.assert_called_once_with("example.com")
+    cert_manager.storage_manager.retrieve_certificate.assert_not_called()
+
+
+def test_storage_certificate_info_cache_varies_by_renewal_threshold(cert_manager):
+    low_threshold = {"renewal_threshold_days": 30}
+    high_threshold = {"renewal_threshold_days": 90}
+
+    first = cert_manager.get_certificate_info("example.com", settings=low_threshold)
+    second = cert_manager.get_certificate_info("example.com", settings=high_threshold)
+
+    assert first["needs_renewal"] is False
+    assert second["needs_renewal"] is True
+    assert cert_manager.storage_manager.retrieve_certificate_info.call_count == 2
+    cert_manager.storage_manager.retrieve_certificate.assert_not_called()
+
+
+def test_save_metadata_invalidates_cached_certificate_info(tmp_path):
+    cert_dir = tmp_path / "certificates"
+    data_dir = tmp_path / "data"
+    backup_dir = tmp_path / "backups"
+    logs_dir = tmp_path / "logs"
+    for directory in (cert_dir, data_dir, backup_dir, logs_dir):
+        directory.mkdir()
+
+    file_ops = FileOperations(cert_dir, data_dir, backup_dir, logs_dir)
+    settings_manager = SettingsManager(file_ops, data_dir / "settings.json")
+    domain_dir = cert_dir / "example.com"
+    domain_dir.mkdir()
+    (domain_dir / "cert.pem").write_bytes(
+        _make_cert_pem(datetime.now(timezone.utc) + timedelta(days=60))
+    )
+    (domain_dir / "metadata.json").write_text('{"dns_provider": "cloudflare"}')
+
+    manager = CertificateManager(
+        cert_dir=cert_dir,
+        settings_manager=settings_manager,
+        dns_manager=MagicMock(),
+        storage_manager=LocalFileSystemBackend(cert_dir),
+        shell_executor=MagicMock(),
+    )
+
+    first = manager.get_certificate_info("example.com")
+    assert first["dns_provider"] == "cloudflare"
+
+    assert manager._save_metadata("example.com", {"dns_provider": "route53"}) is True
+    second = manager.get_certificate_info("example.com")
+
+    assert second["dns_provider"] == "route53"

--- a/tests/test_cert_info_inproc_parse.py
+++ b/tests/test_cert_info_inproc_parse.py
@@ -1,0 +1,120 @@
+"""Certificate expiry parsing must happen in-process via ``cryptography``.
+
+Before this change, ``_parse_certificate_info`` wrote each certificate to a
+temp file and spawned an ``openssl x509 -enddate`` subprocess. With ~30
+certificates that is 30 process spawns + 30 temp files on every table load,
+which under a CPU-throttled container makes the listing crawl. These tests
+pin the behaviour: expiry is parsed in-process and NO ``openssl`` subprocess
+is spawned.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from modules.core.certificates import CertificateManager
+from modules.core.file_operations import FileOperations
+from modules.core.settings import SettingsManager
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def _make_cert_pem(not_after: datetime) -> bytes:
+    """Build a throwaway self-signed cert with a known notAfter."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "example.com")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(not_after)
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+@pytest.fixture
+def cert_manager(tmp_path):
+    cert_dir = tmp_path / "certificates"
+    data_dir = tmp_path / "data"
+    backup_dir = tmp_path / "backups"
+    logs_dir = tmp_path / "logs"
+    for d in (cert_dir, data_dir, backup_dir, logs_dir):
+        d.mkdir()
+
+    file_ops = FileOperations(
+        cert_dir=cert_dir, data_dir=data_dir, backup_dir=backup_dir, logs_dir=logs_dir
+    )
+    settings_manager = SettingsManager(
+        file_ops=file_ops, settings_file=data_dir / "settings.json"
+    )
+
+    # A shell executor that explodes if anyone tries to spawn openssl: the
+    # parse path must be fully in-process now.
+    shell = MagicMock()
+
+    def _no_subprocess(cmd, *args, **kwargs):
+        raise AssertionError(f"unexpected subprocess spawn during parse: {cmd!r}")
+
+    shell.run.side_effect = _no_subprocess
+
+    return CertificateManager(
+        cert_dir=cert_dir,
+        settings_manager=settings_manager,
+        dns_manager=MagicMock(),
+        shell_executor=shell,
+    )
+
+
+def _write_cert(cert_manager, domain, pem):
+    cert_path = cert_manager.cert_dir / domain
+    cert_path.mkdir(parents=True, exist_ok=True)
+    (cert_path / "cert.pem").write_bytes(pem)
+
+
+def test_expiry_parsed_in_process_without_openssl(cert_manager):
+    not_after = datetime.now(timezone.utc) + timedelta(days=42)
+    _write_cert(cert_manager, "example.com", _make_cert_pem(not_after))
+
+    info = cert_manager.get_certificate_info("example.com")
+
+    assert info["exists"] is True
+    assert info["expiry_date"] is not None
+    # Allow off-by-one on day boundary rounding.
+    assert info["days_left"] in (41, 42)
+    assert info["needs_renewal"] is False
+    # The shell executor must never have been touched.
+    cert_manager.shell_executor.run.assert_not_called()
+
+
+def test_near_expiry_flags_needs_renewal(cert_manager):
+    not_after = datetime.now(timezone.utc) + timedelta(days=5)
+    _write_cert(cert_manager, "soon.example.com", _make_cert_pem(not_after))
+
+    info = cert_manager.get_certificate_info("soon.example.com")
+
+    assert info["exists"] is True
+    assert info["days_left"] in (4, 5)
+    assert info["needs_renewal"] is True
+    cert_manager.shell_executor.run.assert_not_called()
+
+
+def test_unparseable_cert_marks_exists_without_crashing(cert_manager):
+    _write_cert(cert_manager, "garbage.example.com", b"not a real certificate")
+
+    info = cert_manager.get_certificate_info("garbage.example.com")
+
+    assert info["exists"] is True
+    assert info["expiry_date"] is None
+    assert info["needs_renewal"] is True
+    cert_manager.shell_executor.run.assert_not_called()

--- a/tests/test_certificates_concurrency_and_alias.py
+++ b/tests/test_certificates_concurrency_and_alias.py
@@ -110,6 +110,14 @@ class TestConcurrentIssuanceLock:
         fail later for any reason (DNS provider not configured, etc.) —
         we only assert the lock barrier behaviour."""
         mgr = _make_manager(tmp_path)
+        first_thread_in_downstream = threading.Event()
+
+        def slow_dns_config(*_args, **_kwargs):
+            first_thread_in_downstream.set()
+            time.sleep(0.1)
+            raise ValueError("simulated downstream failure")
+
+        mgr._get_dns_config = slow_dns_config
 
         outcomes: list[str] = []
         outcomes_lock = threading.Lock()
@@ -136,6 +144,7 @@ class TestConcurrentIssuanceLock:
         t1 = threading.Thread(target=attempt)
         t2 = threading.Thread(target=attempt)
         t1.start(); t2.start()
+        assert first_thread_in_downstream.wait(timeout=5), "one thread should enter downstream path"
         t1.join(timeout=10); t2.join(timeout=10)
 
         # Exactly one thread saw the lock barrier. The other made it past

--- a/tests/test_metadata_corruption_handling.py
+++ b/tests/test_metadata_corruption_handling.py
@@ -133,5 +133,25 @@ def test_os_error_on_read_does_not_quarantine(tmp_path):
     )
 
 
+def test_create_missing_metadata_does_not_count_failed_save(tmp_path):
+    mgr = _make_manager(tmp_path)
+    mgr.settings_manager.load_settings.return_value = {
+        "email": "admin@example.com",
+        "domains": [],
+    }
+
+    domain = "example.com"
+    domain_dir = tmp_path / domain
+    domain_dir.mkdir()
+    (domain_dir / "cert.pem").write_text("placeholder cert")
+
+    with patch.object(mgr, "_save_metadata", return_value=False) as save_metadata:
+        created_count = mgr.create_missing_metadata()
+
+    assert created_count == 0
+    save_metadata.assert_called_once()
+    assert not (domain_dir / "metadata.json").exists()
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])

--- a/tests/test_storage_backends_coverage.py
+++ b/tests/test_storage_backends_coverage.py
@@ -457,6 +457,27 @@ class TestStorageManagerDispatch:
         second = mgr.get_backend()
         assert second is not first
 
+    def test_retrieve_certificate_info_delegates_to_active_backend(self):
+        """CertificateManager receives StorageManager in production.
+
+        The lightweight list/detail path must therefore be exposed by the
+        wrapper; otherwise the Azure backend's optimized cert.pem-only read is
+        unreachable and callers fall back to retrieve_certificate().
+        """
+        mgr = StorageManager(self._settings_mgr({'backend': 'local_filesystem'}))
+        backend = MagicMock()
+        backend.retrieve_certificate_info.return_value = (
+            {'cert.pem': b'CERT'},
+            {'domain': 'example.com'},
+        )
+        mgr.get_backend = MagicMock(return_value=backend)
+
+        result = mgr.retrieve_certificate_info('example.com')
+
+        assert result == ({'cert.pem': b'CERT'}, {'domain': 'example.com'})
+        backend.retrieve_certificate_info.assert_called_once_with('example.com')
+        backend.retrieve_certificate.assert_not_called()
+
 
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- replace per-certificate openssl subprocess parsing with in-process cryptography parsing
- add lightweight cached certificate info retrieval for storage backends, including Azure Key Vault both mode
- reduce routine backup pressure by excluding certbot scratch logs/work while retaining renewal lineage
- document Kubernetes resource guidance for production CertMate deployments

## Tests
- pytest -q
- pytest -q tests/test_metadata_corruption_handling.py tests/test_cert_info_cache_and_storage_summary.py tests/test_azure_keyvault_certificate_storage.py