### PR TITLE
fix: CA/DNS config panel visibility in settings (#226)

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1761,7 +1761,10 @@
         var caProviderToConfigId = {
             'letsencrypt': 'letsencrypt-config',
             'zerossl': 'zerossl-config',
-            'google': 'google-config',
+            // The DNS tab already owns id="google-config" for the Google DNS
+            // provider; the CA panel uses a distinct id so getElementById does
+            // not collide and leave the CA panel hidden (issue #226).
+            'google': 'google-ca-config',
             'buypass': 'buypass-config',
             'digicert': 'digicert-config',
             'sslcom': 'sslcom-config',
@@ -1769,7 +1772,7 @@
         };
 
         // Hide all CA configuration panels and disable their required fields
-        var caConfigs = ['letsencrypt-config', 'zerossl-config', 'google-config', 'buypass-config', 'digicert-config', 'sslcom-config', 'private-ca-config'];
+        var caConfigs = ['letsencrypt-config', 'zerossl-config', 'google-ca-config', 'buypass-config', 'digicert-config', 'sslcom-config', 'private-ca-config'];
         caConfigs.forEach(function (configId) {
             var element = document.getElementById(configId);
             if (element) {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -51,13 +51,14 @@
 
     function toggleChallengeType() {
         var selected = document.querySelector('input[name="challenge_type"]:checked');
-        var dnsSection = document.getElementById('dns-provider-section');
-        if (!dnsSection) return;
-        if (selected && selected.value === 'http-01') {
-            dnsSection.style.display = 'none';
-        } else {
-            dnsSection.style.display = '';
-        }
+        var isHttp = selected && selected.value === 'http-01';
+        // Hide both the provider picker and the per-provider config panels.
+        // The config panels are siblings of the picker, so hiding the picker
+        // alone left a stale DNS panel visible under HTTP-01 (issue #226).
+        ['dns-provider-section', 'dns-config-section'].forEach(function (id) {
+            var el = document.getElementById(id);
+            if (el) el.style.display = isHttp ? 'none' : '';
+        });
     }
 
     // =============================================

--- a/templates/partials/settings_ca.html
+++ b/templates/partials/settings_ca.html
@@ -95,7 +95,7 @@
                             </div>
 
                             <!-- Google Trust Services Configuration -->
-                            <div id="google-config" class="border border-blue-200 dark:border-blue-700 rounded-lg p-4 bg-blue-50/50 dark:bg-blue-900/10" style="display: none;">
+                            <div id="google-ca-config" class="border border-blue-200 dark:border-blue-700 rounded-lg p-4 bg-blue-50/50 dark:bg-blue-900/10" style="display: none;">
                                 <h4 class="text-sm font-semibold text-blue-700 dark:text-blue-300 mb-2 flex items-center">
                                     <i class="fab fa-google mr-2 text-blue-500"></i>
                                     Google Trust Services Configuration

--- a/templates/partials/settings_dns.html
+++ b/templates/partials/settings_dns.html
@@ -306,6 +306,11 @@
                     </div>
 
                     <!-- DNS Provider Configurations -->
+                    <!-- Wrapped so HTTP-01 can hide the whole block: these
+                         panels are siblings of #dns-provider-section, not
+                         children, so hiding the picker alone left them
+                         visible (issue #226). -->
+                    <div id="dns-config-section">
                     <!-- Cloudflare Configuration -->
                     <div id="cloudflare-config" class="dns-config hidden">
                         <div class="border border-orange-200 dark:border-orange-600 rounded-lg p-4 bg-orange-50 dark:bg-orange-900/20">
@@ -1083,6 +1088,7 @@
                             </div>
                         </div>
                     </div>
+                    </div><!-- /#dns-config-section -->
                     </div><!-- /tab: dns -->
 
                     

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -212,6 +212,31 @@ class TestSettingsUI:
         assert len(real_errors) == 0, f"JS errors: {real_errors}"
 
 
+class TestCAAndChallengeToggles:
+    """Regression tests for issue #226: CA provider config panels and the
+    HTTP-01 challenge toggle."""
+
+    def test_google_ca_panel_shows_when_selected(self, browser_page):
+        """Selecting Google Trust Services in the CA tab reveals the CA-side
+        config panel. Regression: it shared id="google-config" with the DNS-tab
+        Google panel, so getElementById matched the DNS one (rendered first)
+        and the CA panel stayed hidden (#226)."""
+        browser_page.goto(f"{BASE_URL}/settings")
+        browser_page.wait_for_load_state("networkidle")
+
+        # Switch to the CA tab — the label text is hidden on small viewports,
+        # so target the stable aria-label.
+        browser_page.locator('button[role="tab"][aria-label="CA"]').click(timeout=10000)
+        browser_page.wait_for_timeout(300)
+
+        browser_page.select_option('#default-ca', 'google')
+        browser_page.wait_for_timeout(300)
+
+        expect(browser_page.locator('#google-ca-config')).to_be_visible(timeout=5000)
+        # The DNS-tab Google panel is a distinct element and stays hidden.
+        expect(browser_page.locator('#google-config')).to_be_hidden()
+
+
 class TestSettingsCloudflareFlow:
     """Test adding a Cloudflare account via UI."""
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -236,6 +236,31 @@ class TestCAAndChallengeToggles:
         # The DNS-tab Google panel is a distinct element and stays hidden.
         expect(browser_page.locator('#google-config')).to_be_hidden()
 
+    def test_http01_hides_dns_config_panels(self, browser_page):
+        """Choosing HTTP-01 hides both the provider picker and the per-provider
+        config panels. Regression: the panels are siblings of the picker, so a
+        previously selected DNS config lingered under HTTP-01 (#226)."""
+        browser_page.goto(f"{BASE_URL}/settings")
+        browser_page.wait_for_load_state("networkidle")
+
+        # On the DNS tab (default). Select a provider so its config panel shows.
+        browser_page.click('label:has(input[name="dns_provider"][value="cloudflare"])')
+        browser_page.wait_for_timeout(300)
+        expect(browser_page.locator('#cloudflare-config')).to_be_visible(timeout=5000)
+
+        # Switch to HTTP-01 — picker and config panels must both disappear.
+        browser_page.click('label:has(input[name="challenge_type"][value="http-01"])')
+        browser_page.wait_for_timeout(300)
+        expect(browser_page.locator('#dns-provider-section')).to_be_hidden()
+        expect(browser_page.locator('#dns-config-section')).to_be_hidden()
+        expect(browser_page.locator('#cloudflare-config')).to_be_hidden()
+
+        # Switching back to DNS-01 restores them.
+        browser_page.click('label:has(input[name="challenge_type"][value="dns-01"])')
+        browser_page.wait_for_timeout(300)
+        expect(browser_page.locator('#dns-provider-section')).to_be_visible()
+        expect(browser_page.locator('#dns-config-section')).to_be_visible()
+
 
 class TestSettingsCloudflareFlow:
     """Test adding a Cloudflare account via UI."""


### PR DESCRIPTION
## Summary

Fixes both defects reported in #226, each with a distinct root cause.

### Bug 1 — Selecting Google Trust Services shows no CA options

The Certificate Authority tab and the DNS Providers tab both rendered a panel with `id="google-config"`. The DNS partial is included before the CA partial, so `getElementById()` in `toggleCAProviderConfig()` matched the DNS panel and the CA-side Google panel was never revealed.

Fix: rename the CA panel to `id="google-ca-config"` and update the two lookups in `settings.js` (the provider→config map and the hide-all list). This matches the approach in #227 (thanks @balkk1 for the diagnosis); the unrelated HTML-syntax changes described there do not apply to current `main` (the `<div>` is well-formed and there is no stray brace), so they are not included.

### Bug 2 — DNS configuration stays visible under HTTP-01

The per-provider DNS config panels are siblings of `#dns-provider-section`, not children, so `toggleChallengeType()` hiding the provider picker alone left a previously selected DNS configuration on screen when switching to HTTP-01.

Fix: wrap the config panels in `#dns-config-section` and hide both the picker and that wrapper for HTTP-01, restoring them for DNS-01.

## Note

HTTP-01 has no per-provider configuration of its own, so no extra panel is shown for it — the fix is to stop leaking the DNS panels, not to add an HTTP-01 form.

## Tests

Two Playwright regression tests in `tests/test_ui.py`:
- selecting Google in the CA tab reveals `#google-ca-config` while the DNS-tab `#google-config` stays hidden;
- choosing HTTP-01 hides `#dns-provider-section` and `#dns-config-section` (and the previously selected provider panel), and DNS-01 restores them.

Validated headless against a freshly built Docker image: the new tests plus the existing settings UI suite (including the no-console-errors check) pass.

Closes #226

Generated with Claude Code.