### PR TITLE
feat: expose CERTMATE_CHAIN_PATH to deploy hooks (#232)

### DIFF
--- a/docs/deploy-hooks.md
+++ b/docs/deploy-hooks.md
@@ -107,6 +107,7 @@ Every invocation sets these in the hook's process environment:
 | `CERTMATE_CERT_PATH` | `/app/certificates/api.example.com/cert.pem` |
 | `CERTMATE_KEY_PATH` | `/app/certificates/api.example.com/privkey.pem` |
 | `CERTMATE_FULLCHAIN_PATH` | `/app/certificates/api.example.com/fullchain.pem` |
+| `CERTMATE_CHAIN_PATH` | `/app/certificates/api.example.com/chain.pem` (intermediates only, no leaf — for targets that want the chain as a separate file) |
 | `CERTMATE_EVENT` | `created` / `renewed` / `revoked` / `manual` |
 | `CERTMATE_DRY_RUN` | Set to `1` only during dry-run; absent otherwise. |
 

--- a/modules/core/deployer.py
+++ b/modules/core/deployer.py
@@ -151,6 +151,10 @@ class DeployManager:
         deploy_env['CERTMATE_CERT_PATH'] = str(self.cert_dir / domain / 'cert.pem')
         deploy_env['CERTMATE_KEY_PATH'] = str(self.cert_dir / domain / 'privkey.pem')
         deploy_env['CERTMATE_FULLCHAIN_PATH'] = str(self.cert_dir / domain / 'fullchain.pem')
+        # Intermediate chain on its own — some targets reject a chained cert
+        # (fullchain) and want the leaf and intermediates as separate files
+        # (issue #232).
+        deploy_env['CERTMATE_CHAIN_PATH'] = str(self.cert_dir / domain / 'chain.pem')
         deploy_env['CERTMATE_EVENT'] = event_type
         if dry_run:
             deploy_env['CERTMATE_DRY_RUN'] = '1'

--- a/modules/core/shell.py
+++ b/modules/core/shell.py
@@ -50,6 +50,7 @@ class MockShellExecutor(ShellExecutor):
     
     def __init__(self):
         self.commands_executed = []
+        self.envs_executed = []  # env dict passed alongside each command
         self.responses = {}  # Map cmd_substring -> (returncode, stdout, stderr)
         self.response_queue = []  # Queue of responses for sequential calls
         self.call_count = 0
@@ -70,6 +71,7 @@ class MockShellExecutor(ShellExecutor):
     def run(self, cmd: List[str], **kwargs) -> subprocess.CompletedProcess:
         cmd_str = " ".join(cmd)
         self.commands_executed.append(cmd_str)
+        self.envs_executed.append(kwargs.get('env'))
         self.call_count += 1
         logger.info(f"Mock Executing: {cmd_str}")
         

--- a/templates/partials/settings_deploy.html
+++ b/templates/partials/settings_deploy.html
@@ -34,6 +34,7 @@
                     <code class="text-xs text-blue-700 dark:text-blue-300">CERTMATE_CERT_PATH</code>,
                     <code class="text-xs text-blue-700 dark:text-blue-300">CERTMATE_KEY_PATH</code>,
                     <code class="text-xs text-blue-700 dark:text-blue-300">CERTMATE_FULLCHAIN_PATH</code>,
+                    <code class="text-xs text-blue-700 dark:text-blue-300">CERTMATE_CHAIN_PATH</code>,
                     <code class="text-xs text-blue-700 dark:text-blue-300">CERTMATE_EVENT</code>,
                     <code class="text-xs text-blue-700 dark:text-blue-300">CERTMATE_DRY_RUN</code>
                     <span class="text-xs text-blue-700 dark:text-blue-300">(only set during Test runs)</span>

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -126,6 +126,16 @@ class TestHookExecution:
         assert len(shell_executor.commands_executed) == 1
         assert 'sh -c env' in shell_executor.commands_executed[0]
 
+        env = shell_executor.envs_executed[0]
+        certs = tmp_path / 'certs' / 'mysite.com'
+        assert env['CERTMATE_DOMAIN'] == 'mysite.com'
+        assert env['CERTMATE_EVENT'] == 'renewed'
+        assert env['CERTMATE_CERT_PATH'] == str(certs / 'cert.pem')
+        assert env['CERTMATE_KEY_PATH'] == str(certs / 'privkey.pem')
+        assert env['CERTMATE_FULLCHAIN_PATH'] == str(certs / 'fullchain.pem')
+        # Intermediate-only chain for targets that reject fullchain (issue #232).
+        assert env['CERTMATE_CHAIN_PATH'] == str(certs / 'chain.pem')
+
     def test_dry_run_flag(self, deploy_manager, shell_executor):
         shell_executor.set_next_result(returncode=0)
         hook = {


### PR DESCRIPTION
## Summary

Deploy hooks already received the leaf certificate (`CERTMATE_CERT_PATH`) and the concatenated chain (`CERTMATE_FULLCHAIN_PATH`), but not the intermediate chain on its own. Some targets reject a chained cert and expect the leaf and intermediates as separate files.

`chain.pem` already exists on disk in the per-domain directory (`CERTIFICATE_FILES` in `constants.py`), so this simply exposes its path to hooks as `CERTMATE_CHAIN_PATH`, alongside the existing variables.

## Changes

- `modules/core/deployer.py`: set `CERTMATE_CHAIN_PATH` in the hook environment.
- `docs/deploy-hooks.md` and `templates/partials/settings_deploy.html`: document the new variable.
- `tests/test_deployer.py`: assert the full deploy environment (the mock shell executor now records the env passed to each command).

## Tests

`pytest tests/test_deployer.py` — 35 passed. Full non-e2e suite green (the 3 failures in `test_storage_migrate_endpoint.py` pre-exist on `main` and are unrelated). No Docker e2e: this is an environment-variable passthrough with no certificate issuance, fully covered by the unit assertion on the env dict.

Closes #232

Generated with Claude Code.