### PR TITLE
feat: PKCS#1 private-key download via ?key_format=pkcs1 (#233)

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -1328,10 +1328,21 @@ def create_api_resources(api, models, managers):
                         return {'error': f'File {requested_file} not found for domain {domain}'}, 404
 
                     if requested_file == 'privkey.pem' and key_format == 'pkcs1':
+                        # Re-resolve with a constant filename and confirm the
+                        # path stays inside the (already validated) domain dir
+                        # before reading — defense in depth, and keeps the new
+                        # file read off any tainted path component.
+                        key_path = os.path.realpath(cert_dir / 'privkey.pem')
+                        if not key_path.startswith(os.path.realpath(cert_dir) + os.sep):
+                            return {'error': 'Invalid path'}, 400
                         try:
-                            pkcs1_pem = _privkey_to_pkcs1(file_path.read_bytes())
+                            with open(key_path, 'rb') as fh:
+                                pkcs1_pem = _privkey_to_pkcs1(fh.read())
                         except (ValueError, TypeError) as e:
-                            logger.error(f"Failed to convert key to PKCS#1 for {domain}: {e}")
+                            logger.error(
+                                "Failed to convert private key to PKCS#1: %s",
+                                type(e).__name__,
+                            )
                             return {
                                 'error': 'Could not convert the private key to PKCS#1 '
                                          '(the key type may not support it).'

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -68,6 +68,24 @@ def _certificate_fingerprint(cert_bytes):
     return cert.fingerprint(hashes.SHA256()).hex()
 
 
+def _privkey_to_pkcs1(pem_bytes):
+    """Re-serialize a PEM private key into the legacy PKCS#1/SEC1
+    ("TraditionalOpenSSL") form for stacks that don't accept the PKCS#8
+    that certbot writes (issue #233).
+
+    Raises ValueError/TypeError for key types that have no traditional
+    encoding (e.g. Ed25519); the caller maps that to a 422.
+    """
+    from cryptography.hazmat.primitives import serialization
+
+    key = serialization.load_pem_private_key(pem_bytes, password=None)
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
 def _tls_probe_timeout_seconds():
     """Read CERTMATE_TLS_PROBE_TIMEOUT_SECONDS, clamped to [1, 30]. Default 3s.
 
@@ -1199,6 +1217,10 @@ def create_api_resources(api, models, managers):
             (?include_private=0); anything that exposes the private key
             (privkey.pem, combined.pem, format=json, default ZIP)
             requires operator role.
+
+            ?file=privkey.pem&key_format=pkcs1 serves the key in legacy
+            PKCS#1/SEC1 form for stacks that reject certbot's PKCS#8
+            (issue #233); the default is the on-disk PKCS#8.
             """
             try:
                 scope_err = _check_domain_scope(domain, 'download')
@@ -1218,6 +1240,16 @@ def create_api_resources(api, models, managers):
 
                 if download_format and download_format not in ['json']:
                     return {'error': 'Invalid format requested.'}, 400
+
+                # Optional private-key serialization. Certbot stores PKCS#8
+                # ("BEGIN PRIVATE KEY"); some older stacks need the legacy
+                # PKCS#1 form ("BEGIN RSA PRIVATE KEY"). Convert on download
+                # rather than duplicating key material on disk (issue #233).
+                key_format = request.args.get('key_format')
+                if key_format is not None and key_format not in ('pkcs1', 'pkcs8'):
+                    return {'error': "Invalid key_format; use 'pkcs1' or 'pkcs8'."}, 400
+                if key_format and requested_file != 'privkey.pem':
+                    return {'error': 'key_format only applies to ?file=privkey.pem'}, 400
 
                 def _privkey_denied(file_label):
                     """Emit audit + return 403 for viewer trying to pull privkey."""
@@ -1294,6 +1326,22 @@ def create_api_resources(api, models, managers):
                     file_path = cert_dir / requested_file
                     if not file_path.exists():
                         return {'error': f'File {requested_file} not found for domain {domain}'}, 404
+
+                    if requested_file == 'privkey.pem' and key_format == 'pkcs1':
+                        try:
+                            pkcs1_pem = _privkey_to_pkcs1(file_path.read_bytes())
+                        except (ValueError, TypeError) as e:
+                            logger.error(f"Failed to convert key to PKCS#1 for {domain}: {e}")
+                            return {
+                                'error': 'Could not convert the private key to PKCS#1 '
+                                         '(the key type may not support it).'
+                            }, 422
+                        return send_file(
+                            io.BytesIO(pkcs1_pem),
+                            as_attachment=True,
+                            download_name=f'{domain}_privkey_pkcs1.pem',
+                            mimetype='application/x-pem-file',
+                        )
 
                     return send_file(
                         file_path,

--- a/tests/test_privkey_pkcs1_export.py
+++ b/tests/test_privkey_pkcs1_export.py
@@ -1,0 +1,42 @@
+"""Unit tests for PKCS#1 private-key export on download (issue #233).
+
+The download endpoint's ?key_format=pkcs1 converts certbot's PKCS#8 key
+("BEGIN PRIVATE KEY") into the legacy PKCS#1/SEC1 form on the fly. These
+pin the conversion helper without needing a running container.
+"""
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa, ec, ed25519
+
+from modules.api.resources import _privkey_to_pkcs1
+
+
+def _pkcs8_pem(key):
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+def test_rsa_pkcs8_converts_to_pkcs1_and_round_trips():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    out = _privkey_to_pkcs1(_pkcs8_pem(key))
+    # PKCS#1 uses the "RSA PRIVATE KEY" header (vs PKCS#8 "PRIVATE KEY").
+    assert b'BEGIN RSA PRIVATE KEY' in out
+    reloaded = serialization.load_pem_private_key(out, password=None)
+    assert reloaded.private_numbers() == key.private_numbers()
+
+
+def test_ecdsa_pkcs8_converts_to_sec1():
+    key = ec.generate_private_key(ec.SECP256R1())
+    out = _privkey_to_pkcs1(_pkcs8_pem(key))
+    # TraditionalOpenSSL for EC keys is SEC1 ("EC PRIVATE KEY").
+    assert b'BEGIN EC PRIVATE KEY' in out
+
+
+def test_unsupported_key_type_raises():
+    # Ed25519 has no traditional/SEC1 encoding; the route maps this to 422.
+    key = ed25519.Ed25519PrivateKey.generate()
+    with pytest.raises((ValueError, TypeError)):
+        _privkey_to_pkcs1(_pkcs8_pem(key))


### PR DESCRIPTION
## Summary

certbot writes the private key as PKCS#8 (`BEGIN PRIVATE KEY`). Some older stacks only accept the legacy PKCS#1/SEC1 form (`BEGIN RSA PRIVATE KEY` / `BEGIN EC PRIVATE KEY`). This adds an opt-in conversion on the existing download endpoint:

```
GET /api/certificates/<domain>/download?file=privkey.pem&key_format=pkcs1
```

- Converts the key **in-process** (`cryptography` TraditionalOpenSSL) — no second copy of private-key material is written to disk.
- `key_format` accepts `pkcs1` or `pkcs8` (default = the on-disk PKCS#8); anything else is `400`, and `key_format` with a non-privkey file is `400`.
- Operator role is still required for any private-key material (unchanged gating).
- An unsupported key type (e.g. Ed25519, which has no traditional encoding) returns `422`.

## Design note

#233 mentions "saving" the key in another format on disk. I went with **on-download conversion** instead: it's the more secure default (no duplicate key material at rest) and directly serves manual/API retrieval. If a deploy-script use case needs an on-disk PKCS#1 *file path*, that can be a follow-up — the `.pfx` work in #230 is the natural place for an on-disk artifact.

Renewals already preserve key type/size via certbot's renewal config, so no metadata changes were needed.

## Tests

`tests/test_privkey_pkcs1_export.py` (unit, no container): RSA PKCS#8 → PKCS#1 round-trips to the same key, ECDSA → SEC1, unsupported key type raises. Full non-e2e suite green (978 passed; the 3 `test_storage_migrate_endpoint.py` failures pre-exist on `main` and are unrelated).

Closes #233

Generated with Claude Code.