### PR TITLE
feat: encrypted Windows .pfx (PKCS#12) export (#230)

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -1070,7 +1070,7 @@ def create_api_resources(api, models, managers):
     # therefore also operator-gated. (2026-05-12 API auth audit
     # follow-up: viewer-can-pull-privkey was an information-disclosure
     # surface that the original endpoint exposed.)
-    _PRIVATE_KEY_FILES = frozenset({'privkey.pem', 'combined.pem'})
+    _PRIVATE_KEY_FILES = frozenset({'privkey.pem', 'combined.pem', 'cert.pfx'})
     _PUBLIC_DOWNLOAD_FILES = frozenset({'cert.pem', 'chain.pem', 'fullchain.pem'})
 
     def _user_has_role(user, min_role):
@@ -1221,6 +1221,10 @@ def create_api_resources(api, models, managers):
             ?file=privkey.pem&key_format=pkcs1 serves the key in legacy
             PKCS#1/SEC1 form for stacks that reject certbot's PKCS#8
             (issue #233); the default is the on-disk PKCS#8.
+
+            ?file=cert.pfx serves the encrypted PKCS#12 bundle when a PFX
+            export password is configured (issue #230); 404 otherwise. It
+            contains the private key, so it requires operator role.
             """
             try:
                 scope_err = _check_domain_scope(domain, 'download')
@@ -1354,11 +1358,15 @@ def create_api_resources(api, models, managers):
                             mimetype='application/x-pem-file',
                         )
 
+                    file_mimetype = (
+                        'application/x-pkcs12' if requested_file.endswith('.pfx')
+                        else 'application/x-pem-file'
+                    )
                     return send_file(
                         file_path,
                         as_attachment=True,
                         download_name=f'{domain}_{requested_file}',
-                        mimetype='application/x-pem-file'
+                        mimetype=file_mimetype
                     )
 
                 # Fallback ZIP. Two flavors:

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -192,6 +192,59 @@ class CertificateManager:
             logger.warning(f"Failed to save metadata for {domain}: {e}")
             return False
 
+    def _write_pfx(self, domain: str) -> None:
+        """(Re)generate <domain>/cert.pfx from the on-disk PEMs when a PFX
+        export password is configured, else remove any stale bundle.
+
+        Called after each successful issuance/renewal so the .pfx fingerprint
+        tracks the live certificate — Windows automation can poll it to detect
+        a fresh cert (issue #230). Best-effort: it never fails the surrounding
+        certificate operation.
+        """
+        domain_dir = self.cert_dir / domain
+        pfx_path = domain_dir / 'cert.pfx'
+        try:
+            settings = self.settings_manager.load_settings()
+        except Exception:
+            settings = {}
+        password = ''
+        if isinstance(settings, dict):
+            password = (settings.get('pfx_password') or '').strip()
+
+        if not password:
+            # Export disabled: don't leave a bundle encrypted with an old
+            # password lying around.
+            try:
+                pfx_path.unlink()
+            except FileNotFoundError:
+                pass
+            except Exception as e:
+                logger.warning(f"Could not remove stale PFX for {domain}: {e}")
+            return
+
+        cert_file = domain_dir / 'cert.pem'
+        key_file = domain_dir / 'privkey.pem'
+        chain_file = domain_dir / 'chain.pem'
+        if not cert_file.exists() or not key_file.exists():
+            logger.warning(f"Cannot build PFX for {domain}: cert.pem/privkey.pem missing")
+            return
+
+        try:
+            from .storage_backends import _build_pfx
+            chain_bytes = chain_file.read_bytes() if chain_file.exists() else None
+            pfx_bytes = _build_pfx(
+                cert_file.read_bytes(), chain_bytes, key_file.read_bytes(),
+                password=password.encode('utf-8'),
+            )
+            tmp = pfx_path.with_name('cert.pfx.tmp')
+            with open(tmp, 'wb') as f:
+                f.write(pfx_bytes)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, pfx_path)
+            logger.info(f"Wrote encrypted PKCS#12 bundle for {domain}")
+        except Exception as e:
+            logger.warning(f"Failed to build PFX for {domain}: {e}")
+
     def get_deployment_status_record(self, domain: str) -> dict:
         metadata = self._load_metadata(domain)
         status = metadata.get('deployment_status')
@@ -1010,7 +1063,8 @@ class CertificateManager:
             duration = time.time() - start_time
             logger.info(f"Certificate created successfully for {domain} in {duration:.2f} seconds")
             self._invalidate_certificate_info_cache(domain)
-            
+            self._write_pfx(domain)
+
             return {
                 'success': True,
                 'domain': domain,
@@ -1189,6 +1243,7 @@ class CertificateManager:
                 
                 logger.info(f"Certificate renewed successfully for {domain}")
                 self._invalidate_certificate_info_cache(domain)
+                self._write_pfx(domain)
                 return {
                     'success': True,
                     'domain': domain,

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -54,6 +54,10 @@ PUBLIC_SETTINGS_WRITABLE_KEYS = frozenset({
     'default_key_type',
     'default_key_size',
     'default_elliptic_curve',
+    # Password used to encrypt the on-disk Windows .pfx export (issue #230).
+    # Empty/unset disables the export. Masked on GET and preserved on POST by
+    # the generic secret machinery (name matches the secret regex).
+    'pfx_password',
 })
 
 # Keys whose mutation via the bulk settings endpoint would create a privilege
@@ -549,6 +553,7 @@ class SettingsManager:
                 'default_key_type': 'rsa',
                 'default_key_size': 2048,
                 'default_elliptic_curve': 'secp256r1',
+                'pfx_password': '',  # Encrypts the on-disk .pfx export; empty = disabled (#230)
                 'dns_providers': {},  # Start with empty DNS providers - only add what's actually configured
                 'certificate_storage': {  # New storage backend configuration
                     'backend': 'local_filesystem',  # Default to local filesystem for backward compatibility
@@ -616,6 +621,7 @@ class SettingsManager:
                 'default_key_type': 'rsa',
                 'default_key_size': 2048,
                 'default_elliptic_curve': 'secp256r1',
+                'pfx_password': '',  # Encrypts the on-disk .pfx export; empty = disabled (#230)
                 'dns_providers': {
                     'cloudflare': {'api_token': ''},
                     'route53': {'access_key_id': '', 'secret_access_key': '', 'region': 'us-east-1'},

--- a/modules/core/storage_backends.py
+++ b/modules/core/storage_backends.py
@@ -105,17 +105,21 @@ AZURE_KV_VALID_MODES = frozenset({AZURE_KV_MODE_SECRETS, AZURE_KV_MODE_CERTIFICA
 _AZURE_TAG_VALUE_MAX = 256
 
 
-def _build_pfx(cert_pem: bytes, chain_pem: Optional[bytes], privkey_pem: bytes) -> bytes:
+def _build_pfx(cert_pem: bytes, chain_pem: Optional[bytes], privkey_pem: bytes,
+               password: Optional[bytes] = None) -> bytes:
     """Bundle cert + chain + private key into a PKCS12 blob.
 
-    The PFX is unencrypted — Key Vault re-encrypts it at rest on import. If
-    the leaf or key bytes are missing or malformed, ``cryptography`` raises
-    ``ValueError`` directly; we let that propagate so the caller sees a
-    descriptive message.
+    With ``password=None`` the PFX is unencrypted (Key Vault re-encrypts it
+    at rest on import). Pass a non-empty ``password`` (bytes) to encrypt the
+    bundle with ``BestAvailableEncryption`` — required for the on-disk
+    Windows ``.pfx`` export (issue #230). If the leaf or key bytes are
+    missing or malformed, ``cryptography`` raises ``ValueError`` directly; we
+    let that propagate so the caller sees a descriptive message.
     """
     from cryptography.hazmat.primitives.serialization import (
         pkcs12,
         load_pem_private_key,
+        BestAvailableEncryption,
         NoEncryption,
     )
     from cryptography.x509 import load_pem_x509_certificates
@@ -123,12 +127,13 @@ def _build_pfx(cert_pem: bytes, chain_pem: Optional[bytes], privkey_pem: bytes) 
     leaf = load_pem_x509_certificates(cert_pem)[0]
     chain = load_pem_x509_certificates(chain_pem) if chain_pem else []
     key = load_pem_private_key(privkey_pem, password=None)
+    encryption = BestAvailableEncryption(password) if password else NoEncryption()
     return pkcs12.serialize_key_and_certificates(
         name=None,
         key=key,
         cert=leaf,
         cas=chain or None,
-        encryption_algorithm=NoEncryption(),
+        encryption_algorithm=encryption,
     )
 
 

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -214,6 +214,16 @@
                 default_elliptic_curve: defaultEllipticCurve
             };
 
+            // PFX export password (#230). Secret field: only send when the
+            // user typed a value — a blank field means "keep existing", which
+            // the backend honours for secret-named keys. Sending the password
+            // empty would be treated the same way, but omitting it keeps the
+            // payload clean.
+            var pfxPasswordField = document.getElementById('pfx_password');
+            if (pfxPasswordField && pfxPasswordField.value) {
+                settings.pfx_password = pfxPasswordField.value;
+            }
+
             // Validate required fields - email comes from the selected CA provider
             if (!settings.email) {
                 var caDisplayName = defaultCA === 'letsencrypt' ? "Let's Encrypt" :

--- a/templates/partials/settings_general.html
+++ b/templates/partials/settings_general.html
@@ -46,6 +46,20 @@
                                 </p>
                             </div>
 
+                            <!-- PFX / PKCS#12 export (issue #230) -->
+                            <div>
+                                <label for="pfx_password" class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">
+                                    Windows .pfx Export Password
+                                </label>
+                                <input type="password" id="pfx_password" name="pfx_password"
+                                       autocomplete="new-password"
+                                       placeholder="Leave blank to disable / keep current"
+                                       class="w-72 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary dark:bg-gray-700 dark:text-white text-sm">
+                                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                    When set, each certificate is also written as an encrypted <code class="text-xs">cert.pfx</code> (PKCS#12) using this password, downloadable for Windows hosts. Leave blank to disable. Stored like other secrets and never shown again after saving.
+                                </p>
+                            </div>
+
                             <!-- Default Certificate Key Shape -->
                             <div class="border-t border-gray-200 dark:border-gray-600 pt-4">
                                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">

--- a/tests/test_pfx_export.py
+++ b/tests/test_pfx_export.py
@@ -1,0 +1,96 @@
+"""Unit tests for the Windows .pfx (PKCS#12) export (issue #230)."""
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import pkcs12
+
+from modules.core.certificates import CertificateManager
+from modules.core.storage_backends import _build_pfx
+
+pytestmark = [pytest.mark.unit]
+
+
+def _self_signed():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "example.com")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name).issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=90))
+        .sign(key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    return cert_pem, key_pem
+
+
+def test_build_pfx_with_password_is_loadable_and_rejects_wrong_password():
+    cert_pem, key_pem = _self_signed()
+    blob = _build_pfx(cert_pem, None, key_pem, password=b's3cr3t-pw')
+    key, cert, _chain = pkcs12.load_key_and_certificates(blob, b's3cr3t-pw')
+    assert key is not None and cert is not None
+    with pytest.raises(ValueError):
+        pkcs12.load_key_and_certificates(blob, b'wrong-pw')
+
+
+def test_build_pfx_without_password_is_unencrypted():
+    cert_pem, key_pem = _self_signed()
+    blob = _build_pfx(cert_pem, None, key_pem)  # default: NoEncryption (Azure path)
+    key, cert, _chain = pkcs12.load_key_and_certificates(blob, None)
+    assert key is not None and cert is not None
+
+
+def _manager(tmp_path, password):
+    sm = MagicMock()
+    sm.load_settings.return_value = {'pfx_password': password}
+    return CertificateManager(
+        cert_dir=tmp_path, settings_manager=sm,
+        dns_manager=MagicMock(), storage_manager=None, ca_manager=None,
+    )
+
+
+def _seed_domain(tmp_path, domain='example.com'):
+    cert_pem, key_pem = _self_signed()
+    d = tmp_path / domain
+    d.mkdir()
+    (d / 'cert.pem').write_bytes(cert_pem)
+    (d / 'privkey.pem').write_bytes(key_pem)
+    return d
+
+
+def test_write_pfx_creates_encrypted_bundle_when_password_set(tmp_path):
+    d = _seed_domain(tmp_path)
+    _manager(tmp_path, 'win-pw-123')._write_pfx('example.com')
+
+    pfx = d / 'cert.pfx'
+    assert pfx.exists()
+    # Private-key material must be owner-only.
+    assert (pfx.stat().st_mode & 0o777) == 0o600
+    key, cert, _chain = pkcs12.load_key_and_certificates(pfx.read_bytes(), b'win-pw-123')
+    assert key is not None and cert is not None
+
+
+def test_write_pfx_removes_stale_bundle_when_password_unset(tmp_path):
+    d = _seed_domain(tmp_path)
+    (d / 'cert.pfx').write_bytes(b'stale')
+    _manager(tmp_path, '')._write_pfx('example.com')
+    assert not (d / 'cert.pfx').exists()
+
+
+def test_write_pfx_noop_when_pems_missing(tmp_path):
+    (tmp_path / 'example.com').mkdir()
+    # No cert.pem/privkey.pem present; must not raise or create a bundle.
+    _manager(tmp_path, 'win-pw-123')._write_pfx('example.com')
+    assert not (tmp_path / 'example.com' / 'cert.pfx').exists()


### PR DESCRIPTION
## Summary

Adds an optional encrypted PKCS#12 (`.pfx`) export for Windows hosts. When a PFX export password is configured, each certificate is also written to disk as `cert.pfx` on **issuance and renewal**, so its fingerprint tracks the live certificate and Windows-side automation can poll it to detect a fresh cert (the use case in #230). The bundle is downloadable and included in backups.

## Design choices

- **On-disk, on issue/renew** (not on-the-fly download): the issue wants a stable fingerprint that changes only when the cert changes. `_write_pfx` regenerates `cert.pfx` after each successful create/renew (both re-copy the live PEMs first), so the fingerprint is stable between renewals.
- **Password stored as a settings secret** (`pfx_password`): a PKCS#12 for Windows needs a password, and an on-disk bundle must be encrypted at write time. It's stored like the app's other secrets — masked on GET, preserved on blank/masked POST — via the existing name-based secret machinery (no new registration). Empty password disables the export and removes any stale bundle.

## Changes

- `_build_pfx`: optional `password` → `BestAvailableEncryption`; the Azure import path (no password) keeps `NoEncryption`, unchanged.
- `CertificateManager._write_pfx`: best-effort (never fails the cert op) generation of `cert.pfx` (`0600`) from the on-disk PEMs; removes a stale bundle when disabled.
- Download: `?file=cert.pfx` serves the bundle (operator role, `application/x-pkcs12`), `404` when not generated. It's not added to `CERTIFICATE_FILES`, so the default ZIP is unaffected.
- Settings: `pfx_password` added to defaults and `PUBLIC_SETTINGS_WRITABLE_KEYS`; password field + help text in the **General** tab; `settings.js` sends it only when typed.

## Tests

`tests/test_pfx_export.py` (unit, no container): `_build_pfx` with password is loadable and rejects the wrong password; without a password it's unencrypted (Azure path); `_write_pfx` writes a `0600` encrypted bundle when configured, removes a stale one when disabled, and is a no-op when PEMs are missing. Full non-e2e suite green (983 passed; the 3 `test_storage_migrate_endpoint.py` failures pre-exist on `main` and are unrelated).

Closes #230

Generated with Claude Code.