### PR TITLE
test: seed a valid api_bearer_token in the storage-migrate fixture

### DIFF
--- a/tests/test_storage_migrate_endpoint.py
+++ b/tests/test_storage_migrate_endpoint.py
@@ -39,7 +39,12 @@ def app_client(tmp_path, monkeypatch):
 
     settings_manager = container.managers['settings']
     settings = settings_manager.load_settings()
-    token = 'test-' + 'a' * 48
+    # Must satisfy validate_api_token (no weak patterns like 'test', >=12
+    # unique chars, no repeats) or save_settings strips it and the endpoint
+    # answers 401 instead of exercising the migrate logic. Use the project's
+    # own generator so the seed token is always valid.
+    from modules.core.utils import generate_secure_token
+    token = generate_secure_token()
     settings['api_bearer_token'] = token
     settings['certificate_storage'] = {
         'backend': 'local_filesystem',


### PR DESCRIPTION
## Summary

Three tests in `tests/test_storage_migrate_endpoint.py` failed on `main`: the fixture seeded `api_bearer_token = 'test-' + 'a'*48`, which `validate_api_token` now rejects (weak pattern `test`, too few unique characters). `save_settings` stripped the invalid token, so the requests reached the endpoint **unauthenticated** and returned `401` instead of the expected `200`/`400`.

Fix: seed the token with the project's own `generate_secure_token()`, which always produces a token that passes validation. Pure test-fixture change; no production code touched.

## Tests

`tests/test_storage_migrate_endpoint.py` — 3 passed. Full non-e2e suite now fully green: **981 passed, 0 failed**.

Generated with Claude Code.