### PR TITLE
Fix SSO save button rendering, Azure DNS alias mode, and NS1 wizard icon

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -388,16 +388,45 @@ class CertificateManager:
                     f"ACME-DNS domain_alias must match configured subdomain '{configured_alias}'"
                 )
 
+        resolved_zone = None
+        if dns_provider == 'azure':
+            from .dns_zone_discovery import (
+                has_zone_discovery, resolve_zones_for_domains,
+                resolve_zones_against_explicit_list,
+            )
+            if has_zone_discovery(dns_provider):
+                explicit_zones = dns_config.get('zone_domains') if isinstance(dns_config, dict) else None
+                try:
+                    if explicit_zones:
+                        zone_domains, _ = resolve_zones_against_explicit_list(
+                            dns_provider, explicit_zones, [domain_alias]
+                        )
+                    else:
+                        zone_domains, _ = resolve_zones_for_domains(
+                            dns_provider, dns_config, [domain_alias]
+                        )
+                    if zone_domains:
+                        resolved_zone = zone_domains[0]
+                except Exception as exc:
+                    logger.warning(
+                        "DNS alias zone resolution failed for provider '%s' and alias '%s': %s. "
+                        "Fallback resolver in hook will be used.",
+                        dns_provider, domain_alias, exc
+                    )
+
         fd, path = tempfile.mkstemp(prefix='certmate-dns-alias-', suffix='.json')
         config_path = Path(path)
+        payload = {
+            'provider': dns_provider,
+            'domain_alias': domain_alias.strip().rstrip('.'),
+            'propagation_seconds': int(propagation_seconds),
+            'config': dns_config,
+        }
+        if resolved_zone:
+            payload['resolved_zone'] = resolved_zone
         try:
             with os.fdopen(fd, 'w') as f:
-                json.dump({
-                    'provider': dns_provider,
-                    'domain_alias': domain_alias.strip().rstrip('.'),
-                    'propagation_seconds': int(propagation_seconds),
-                    'config': dns_config,
-                }, f)
+                json.dump(payload, f)
             config_path.chmod(0o600)
             return config_path
         except Exception:

--- a/modules/core/dns_alias_hook.py
+++ b/modules/core/dns_alias_hook.py
@@ -177,6 +177,26 @@ def _lexicon_config(provider, alias_domain, provider_config):
     return base
 
 
+def _find_azure_zone(provider_config, alias_domain):
+    try:
+        from lexicon.client import Client
+    except Exception as exc:
+        raise DNSAliasError("dns-lexicon is required for this DNS alias provider") from exc
+
+    for zone in _zone_guesses(alias_domain):
+        if zone == 'com' or '.' not in zone:
+            continue
+        try:
+            lexicon_config = _lexicon_config('azure', zone, provider_config)
+            with Client(lexicon_config) as operations:
+                # Call list_records to verify if the zone is valid/exists
+                operations.list_records(rtype='TXT')
+                return zone
+        except Exception:
+            continue
+    raise DNSAliasError(f"Unable to determine Azure DNS zone for alias '{alias_domain}'")
+
+
 def _lexicon_change(config, validation, action):
     provider = config['provider']
     provider_config = _provider_config(config)
@@ -188,7 +208,12 @@ def _lexicon_change(config, validation, action):
     except Exception as exc:
         raise DNSAliasError("dns-lexicon is required for this DNS alias provider") from exc
 
-    lexicon_config = _lexicon_config(provider, alias_domain, provider_config)
+    resolved_zone = config.get('resolved_zone')
+    if not resolved_zone and provider == 'azure':
+        resolved_zone = _find_azure_zone(provider_config, alias_domain)
+
+    lexicon_domain = resolved_zone if resolved_zone else alias_domain
+    lexicon_config = _lexicon_config(provider, lexicon_domain, provider_config)
     with Client(lexicon_config) as operations:
         if action == 'create':
             operations.create_record('TXT', record, validation)

--- a/templates/partials/settings_oidc.html
+++ b/templates/partials/settings_oidc.html
@@ -178,8 +178,7 @@
                     <div class="flex justify-end pt-2 border-t border-gray-200 dark:border-gray-700">
                         <button type="button" @click="save()" :disabled="saving"
                                 class="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold rounded-md disabled:opacity-50">
-                            <template x-if="saving"><i class="fas fa-spinner fa-spin mr-1"></i></template>
-                            <template x-if="!saving"><i class="fas fa-save mr-1"></i></template>
+                            <i class="fas mr-1" :class="saving ? 'fa-spinner fa-spin' : 'fa-save'"></i>
                             Save SSO settings
                         </button>
                     </div>

--- a/templates/partials/settings_storage.html
+++ b/templates/partials/settings_storage.html
@@ -259,7 +259,7 @@
                     </div><!-- /tab: storage -->
 
                     <!-- Form controls (visible on all form tabs) -->
-                    <div id="formControls" x-show="['dns','ca','general','storage'].includes(tab)"
+                    <div id="formControls" x-show="['dns','ca','general','storage'].includes(tab)">
                         <!-- DNS Provider Test Connection -->
                         <div id="testConnectionResult" class="mt-4 hidden">
                             <div class="p-4 rounded-md text-sm" id="testConnectionMessage">

--- a/tests/test_domain_alias.py
+++ b/tests/test_domain_alias.py
@@ -477,3 +477,106 @@ def test_acme_dns_alias_rejects_non_matching_subdomain():
             'validation-token',
             'create',
         )
+
+
+def test_create_dns_alias_hook_config_resolves_azure_zone(tmp_path):
+    mgr, shell = _manager(tmp_path, provider='azure')
+
+    # Mock dns_zone_discovery zone resolution
+    with patch('modules.core.dns_zone_discovery.resolve_zones_for_domains') as mock_resolve:
+        mock_resolve.return_value = (['validationdomain.com'], [('acme-validation.validationdomain.com', 'validationdomain.com')])
+
+        hook_config_path = mgr._create_dns_alias_hook_config(
+            'azure',
+            _provider_config('azure'),
+            'acme-validation.validationdomain.com',
+            60
+        )
+
+        assert hook_config_path.exists()
+        with open(hook_config_path, encoding='utf-8') as f:
+            payload = json.load(f)
+
+        assert payload['provider'] == 'azure'
+        assert payload['domain_alias'] == 'acme-validation.validationdomain.com'
+        assert payload['resolved_zone'] == 'validationdomain.com'
+
+        hook_config_path.unlink()
+
+
+def test_lexicon_alias_azure_uses_resolved_zone(monkeypatch):
+    calls = []
+
+    class FakeOperations:
+        def create_record(self, rtype, name, content):
+            calls.append(('create', rtype, name, content))
+
+        def delete_record(self, identifier=None, rtype=None, name=None, content=None):
+            calls.append(('delete', rtype, name, content))
+
+    class FakeClient:
+        def __init__(self, config):
+            calls.append(('config', config['provider_name'], config['domain']))
+
+        def __enter__(self):
+            return FakeOperations()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setitem(__import__('sys').modules, 'lexicon.client', MagicMock(Client=FakeClient))
+
+    hook_config = {
+        'provider': 'azure',
+        'domain_alias': 'acme-validation.validationdomain.com',
+        'resolved_zone': 'validationdomain.com',
+        'config': _provider_config('azure'),
+    }
+
+    dns_alias_hook._lexicon_change(hook_config, 'val-token', 'create')
+
+    # Verify client initialized with the resolved zone, not the full alias domain
+    assert ('config', 'azure', 'validationdomain.com') in calls
+    assert ('create', 'TXT', '_acme-challenge.acme-validation.validationdomain.com', 'val-token') in calls
+
+
+def test_lexicon_alias_azure_fallback_guessing_zone(monkeypatch):
+    calls = []
+
+    class FakeOperations:
+        def list_records(self, rtype=None):
+            # Simulate success when domain is validationdomain.com
+            # Raise exception for other domain guesses
+            pass
+
+        def create_record(self, rtype, name, content):
+            calls.append(('create', rtype, name, content))
+
+    class FakeClient:
+        def __init__(self, config):
+            self.domain = config['domain']
+            calls.append(('config', config['provider_name'], config['domain']))
+            if self.domain != 'validationdomain.com':
+                raise ValueError("Zone not found in Azure")
+
+        def __enter__(self):
+            return FakeOperations()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setitem(__import__('sys').modules, 'lexicon.client', MagicMock(Client=FakeClient))
+
+    hook_config = {
+        'provider': 'azure',
+        'domain_alias': 'acme-validation.validationdomain.com',
+        # resolved_zone is missing
+        'config': _provider_config('azure'),
+    }
+
+    dns_alias_hook._lexicon_change(hook_config, 'val-token', 'create')
+
+    # Verify it tried multiple guesses and eventually called create with 'validationdomain.com'
+    assert ('config', 'azure', 'acme-validation.validationdomain.com') in calls
+    assert ('config', 'azure', 'validationdomain.com') in calls
+    assert ('create', 'TXT', '_acme-challenge.acme-validation.validationdomain.com', 'val-token') in calls


### PR DESCRIPTION
This PR addresses multiple issues:
- **SSO Save Button (Issue #244)**: Fixes a missing closing bracket in the storage settings template and refactors the OIDC save button to use class-binding toggles instead of nested templates.
- **Azure DNS Alias Mode (Issue #243)**: Automatically resolves zone names for domain aliases under Azure DNS, and implements a parent label traversing fallback using Lexicon inside the manual DNS hook.
- **NS1 Wizard Icon (PR #241)**: Changes the NS1 provider icon in the setup wizard to network-wired.

Includes unit test coverage for the Azure DNS alias zone resolution and fallback guessing logic.