### PR TITLE
docs(readme): add Ecosystem + Enterprise section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@
 
 ---
 
+## Ecosystem
+
+CertMate is the open-source core of a small, focused toolset:
+
+- **[certmate-tools](https://github.com/fabriziosalmi/certmate-tools)** — free, privacy-first, client-side TLS / certificate / ACME diagnostics (runs entirely in your browser).
+- **[certmate-agent](https://github.com/fabriziosalmi/certmate-agent)** — conversational assistant: a local LLM mapped 1:1 to CertMate's REST API, with RAG over the docs.
+- **[nis2-public](https://github.com/fabriziosalmi/nis2-public)** — NIS2 continuous posture management & remediation.
+
+**Enterprise / high-scale** — multi-tenant, mTLS, white-label and NIS2-aligned deployments are available through *CertMate-ng* (source-available, BSL 1.1, EU-built). For access or a deployment discussion, email **fabrizio.salmi@gmail.com**.
+
+---
+
 ## Why CertMate?
 
 CertMate solves the complexity of SSL certificate management in modern distributed architectures. Whether you're running a single application or managing certificates across multiple datacenters, CertMate provides:


### PR DESCRIPTION
Adds an above-the-fold **Ecosystem** block cross-linking the public companions (certmate-tools, certmate-agent, nis2-public) and an honest **Enterprise** note for CertMate-ng — source-available (BSL 1.1), EU-built — reachable by email (fabrizio.salmi@gmail.com). No link (the repo is private) and no unverified performance numbers.

Generated with Claude Code.