### PR TITLE
fix(dns-alias): resolve Azure sub-delegated zones via dnspython (#243)

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -389,31 +389,12 @@ class CertificateManager:
                     f"ACME-DNS domain_alias must match configured subdomain '{configured_alias}'"
                 )
 
-        resolved_zone = None
-        if dns_provider == 'azure':
-            from .dns_zone_discovery import (
-                has_zone_discovery, resolve_zones_for_domains,
-                resolve_zones_against_explicit_list,
-            )
-            if has_zone_discovery(dns_provider):
-                explicit_zones = dns_config.get('zone_domains') if isinstance(dns_config, dict) else None
-                try:
-                    if explicit_zones:
-                        zone_domains, _ = resolve_zones_against_explicit_list(
-                            dns_provider, explicit_zones, [domain_alias]
-                        )
-                    else:
-                        zone_domains, _ = resolve_zones_for_domains(
-                            dns_provider, dns_config, [domain_alias]
-                        )
-                    if zone_domains:
-                        resolved_zone = zone_domains[0]
-                except Exception as exc:
-                    logger.warning(
-                        "DNS alias zone resolution failed for provider '%s' and alias '%s': %s. "
-                        "Fallback resolver in hook will be used.",
-                        dns_provider, domain_alias, exc
-                    )
+        # Note: for Azure the DNS alias hook resolves the (possibly
+        # sub-delegated) hosted zone at runtime via Lexicon's
+        # resolve_zone_name (dnspython SOA lookup). We deliberately do NOT
+        # pre-resolve it here — tldextract-style pre-resolution collapsed
+        # sub-delegated zones to the registered domain and broke issuance
+        # (issue #243).
 
         fd, path = tempfile.mkstemp(prefix='certmate-dns-alias-', suffix='.json')
         config_path = Path(path)
@@ -423,8 +404,6 @@ class CertificateManager:
             'propagation_seconds': int(propagation_seconds),
             'config': dns_config,
         }
-        if resolved_zone:
-            payload['resolved_zone'] = resolved_zone
         try:
             with os.fdopen(fd, 'w') as f:
                 json.dump(payload, f)

--- a/modules/core/dns_alias_hook.py
+++ b/modules/core/dns_alias_hook.py
@@ -129,6 +129,12 @@ def _lexicon_config(provider, alias_domain, provider_config):
             'auth_tenant_id': provider_config['tenant_id'],
             'auth_client_id': provider_config['client_id'],
             'auth_client_secret': provider_config['client_secret'],
+            # Resolve the actual hosted zone with dnspython (a live SOA lookup)
+            # instead of Lexicon's default tldextract guess. tldextract always
+            # collapses to the registered domain, so a sub-delegated validation
+            # zone (e.g. acme-validation.example.com) is never matched and
+            # certbot fails with "does not contain the DNS zone". See issue #243.
+            'resolve_zone_name': True,
         })
     elif provider == 'google':
         _require(provider_config, 'project_id', 'service_account_key')
@@ -177,26 +183,6 @@ def _lexicon_config(provider, alias_domain, provider_config):
     return base
 
 
-def _find_azure_zone(provider_config, alias_domain):
-    try:
-        from lexicon.client import Client
-    except Exception as exc:
-        raise DNSAliasError("dns-lexicon is required for this DNS alias provider") from exc
-
-    for zone in _zone_guesses(alias_domain):
-        if zone == 'com' or '.' not in zone:
-            continue
-        try:
-            lexicon_config = _lexicon_config('azure', zone, provider_config)
-            with Client(lexicon_config) as operations:
-                # Call list_records to verify if the zone is valid/exists
-                operations.list_records(rtype='TXT')
-                return zone
-        except Exception:
-            continue
-    raise DNSAliasError(f"Unable to determine Azure DNS zone for alias '{alias_domain}'")
-
-
 def _lexicon_change(config, validation, action):
     provider = config['provider']
     provider_config = _provider_config(config)
@@ -208,12 +194,11 @@ def _lexicon_change(config, validation, action):
     except Exception as exc:
         raise DNSAliasError("dns-lexicon is required for this DNS alias provider") from exc
 
-    resolved_zone = config.get('resolved_zone')
-    if not resolved_zone and provider == 'azure':
-        resolved_zone = _find_azure_zone(provider_config, alias_domain)
-
-    lexicon_domain = resolved_zone if resolved_zone else alias_domain
-    lexicon_config = _lexicon_config(provider, lexicon_domain, provider_config)
+    # The full alias FQDN is handed to Lexicon as the domain; Lexicon resolves
+    # the owning zone (via tldextract by default, or dnspython when
+    # resolve_zone_name is set — see the azure branch of _lexicon_config) and
+    # writes the TXT record relative to it.
+    lexicon_config = _lexicon_config(provider, alias_domain, provider_config)
     with Client(lexicon_config) as operations:
         if action == 'create':
             operations.create_record('TXT', record, validation)

--- a/tests/test_domain_alias.py
+++ b/tests/test_domain_alias.py
@@ -479,32 +479,13 @@ def test_acme_dns_alias_rejects_non_matching_subdomain():
         )
 
 
-def test_create_dns_alias_hook_config_resolves_azure_zone(tmp_path):
-    mgr, shell = _manager(tmp_path, provider='azure')
-
-    # Mock dns_zone_discovery zone resolution
-    with patch('modules.core.dns_zone_discovery.resolve_zones_for_domains') as mock_resolve:
-        mock_resolve.return_value = (['validationdomain.com'], [('acme-validation.validationdomain.com', 'validationdomain.com')])
-
-        hook_config_path = mgr._create_dns_alias_hook_config(
-            'azure',
-            _provider_config('azure'),
-            'acme-validation.validationdomain.com',
-            60
-        )
-
-        assert hook_config_path.exists()
-        with open(hook_config_path, encoding='utf-8') as f:
-            payload = json.load(f)
-
-        assert payload['provider'] == 'azure'
-        assert payload['domain_alias'] == 'acme-validation.validationdomain.com'
-        assert payload['resolved_zone'] == 'validationdomain.com'
-
-        hook_config_path.unlink()
-
-
-def test_lexicon_alias_azure_uses_resolved_zone(monkeypatch):
+def test_lexicon_alias_azure_passes_full_fqdn_for_dnspython_zone_resolution(monkeypatch):
+    """Regression for #243: Azure alias mode must hand Lexicon the full alias
+    FQDN together with resolve_zone_name, so Lexicon resolves the real
+    (possibly sub-delegated) hosted zone via dnspython. The previous approach
+    pre-resolved/guessed a zone and passed that instead, which Lexicon's
+    tldextract then collapsed back to the registered domain — breaking
+    issuance against a delegated validation zone."""
     calls = []
 
     class FakeOperations:
@@ -516,7 +497,10 @@ def test_lexicon_alias_azure_uses_resolved_zone(monkeypatch):
 
     class FakeClient:
         def __init__(self, config):
-            calls.append(('config', config['provider_name'], config['domain']))
+            calls.append((
+                'config', config['provider_name'], config['domain'],
+                config.get('resolve_zone_name'),
+            ))
 
         def __enter__(self):
             return FakeOperations()
@@ -526,57 +510,37 @@ def test_lexicon_alias_azure_uses_resolved_zone(monkeypatch):
 
     monkeypatch.setitem(__import__('sys').modules, 'lexicon.client', MagicMock(Client=FakeClient))
 
+    alias = 'domain.com.acme-validation.validationdomain.com'
     hook_config = {
         'provider': 'azure',
-        'domain_alias': 'acme-validation.validationdomain.com',
-        'resolved_zone': 'validationdomain.com',
+        'domain_alias': alias,
         'config': _provider_config('azure'),
     }
 
     dns_alias_hook._lexicon_change(hook_config, 'val-token', 'create')
 
-    # Verify client initialized with the resolved zone, not the full alias domain
-    assert ('config', 'azure', 'validationdomain.com') in calls
-    assert ('create', 'TXT', '_acme-challenge.acme-validation.validationdomain.com', 'val-token') in calls
+    # Full FQDN handed to Lexicon, with dnspython zone resolution enabled.
+    assert ('config', 'azure', alias, True) in calls
+    assert ('create', 'TXT', f'_acme-challenge.{alias}', 'val-token') in calls
 
 
-def test_lexicon_alias_azure_fallback_guessing_zone(monkeypatch):
-    calls = []
-
-    class FakeOperations:
-        def list_records(self, rtype=None):
-            # Simulate success when domain is validationdomain.com
-            # Raise exception for other domain guesses
-            pass
-
-        def create_record(self, rtype, name, content):
-            calls.append(('create', rtype, name, content))
-
-    class FakeClient:
-        def __init__(self, config):
-            self.domain = config['domain']
-            calls.append(('config', config['provider_name'], config['domain']))
-            if self.domain != 'validationdomain.com':
-                raise ValueError("Zone not found in Azure")
-
-        def __enter__(self):
-            return FakeOperations()
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-    monkeypatch.setitem(__import__('sys').modules, 'lexicon.client', MagicMock(Client=FakeClient))
-
-    hook_config = {
-        'provider': 'azure',
-        'domain_alias': 'acme-validation.validationdomain.com',
-        # resolved_zone is missing
-        'config': _provider_config('azure'),
-    }
-
-    dns_alias_hook._lexicon_change(hook_config, 'val-token', 'create')
-
-    # Verify it tried multiple guesses and eventually called create with 'validationdomain.com'
-    assert ('config', 'azure', 'acme-validation.validationdomain.com') in calls
-    assert ('config', 'azure', 'validationdomain.com') in calls
-    assert ('create', 'TXT', '_acme-challenge.acme-validation.validationdomain.com', 'val-token') in calls
+def test_azure_alias_lexicon_config_uses_dnspython_zone_resolution():
+    """Regression for #243: Azure DNS-01 alias mode against a sub-delegated
+    validation zone (e.g. acme-validation.example.net delegated under
+    example.net) must resolve the real hosted zone via dnspython, not
+    Lexicon's default tldextract — which collapses to the registered domain
+    (example.net) that does not exist in the resource group."""
+    cfg = dns_alias_hook._lexicon_config(
+        'azure',
+        'domain.com.acme-validation.example.net',
+        {
+            'subscription_id': 'sub', 'resource_group': 'rg', 'tenant_id': 't',
+            'client_id': 'c', 'client_secret': 'secret',
+        },
+    )
+    # dnspython SOA lookup instead of tldextract guess.
+    assert cfg['resolve_zone_name'] is True
+    # The full alias FQDN is passed; Lexicon resolves the owning zone from it.
+    assert cfg['domain'] == 'domain.com.acme-validation.example.net'
+    assert cfg['provider_name'] == 'azure'
+    assert cfg['auth_subscription_id'] == 'sub'


### PR DESCRIPTION
## P0 — the shipped fix for #243 does not work

Azure DNS-01 **alias mode** against a sub-delegated validation zone (e.g. `acme-validation.example.com`, delegated via NS under `example.com`) still fails on v2.8.1 / v2.8.2 with:

> Resource group … does not contain the DNS zone `example.com`

## Root cause

Lexicon resolves the owning zone with **tldextract by default** (`lexicon/client.py`), which always collapses to the *registered* domain (`example.com`). The delegated zone (`acme-validation.example.com`) is never matched.

The previous fix (#246) tried to pre-resolve / guess the zone and pass it to Lexicon — but that **can't work**: Lexicon's tldextract collapses *whatever* domain it receives back to the registered domain unless `resolve_zone_name` is set. So both `_find_azure_zone` and the `resolved_zone` pre-resolution were ineffective.

## Fix

Set Lexicon's **`resolve_zone_name`** for Azure, so it resolves the real hosted zone with a **dnspython SOA lookup** from the full alias FQDN (the approach the reporter validated). This handles both top-level and sub-delegated validation zones.

- `dns_alias_hook.py`: `resolve_zone_name: True` in the Azure Lexicon config; hand Lexicon the full alias FQDN; remove the ineffective `_find_azure_zone` fallback.
- `certificates.py`: remove the now-redundant Azure zone pre-resolution in `_create_dns_alias_hook_config` (it did a pointless Azure API call at issuance and its result was collapsed by tldextract anyway).

## Tests
Replaced the 3 tests that asserted the old (broken) behavior with one that pins the correct contract: Azure alias hands Lexicon the full FQDN with `resolve_zone_name=True`. Full non-e2e suite: **1020 passed, 0 failed**.

Thanks to @jensaops for the precise diagnosis and POC.

Closes #243