### PR TITLE
Added web file routes for /.well-known/acme-challenge/<file from certbot>

### DIFF
--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -341,6 +341,28 @@ def configure_app(container: AppContainer, app, test_config=None):
     app.secret_key = _secret_key_from_env_or_generate(container.data_dir)
     app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024
 
+    # 1. Define the base ACME storage path
+    app.config['ACME_CHALLENGES_DIR'] = os.environ.get(
+        'ACME_CHALLENGES_DIR', 
+        os.path.join(container.data_dir, 'acme-challenges')
+    )
+
+    # 2. Define the full physical path required for Let's Encrypt
+    # Result: /app/data/acme-challenges/.well-known/acme-challenge/
+    full_acme_path = os.path.join(
+        app.config['ACME_CHALLENGES_DIR'], 
+        '.well-known', 
+        'acme-challenge'
+    )
+
+    # 3. Create the directories if they don't exist
+    try:
+        os.makedirs(full_acme_path, exist_ok=True)
+    except Exception as e:
+        # It's good practice to log this if your logger is available, 
+        # otherwise Flask might fail later when trying to write to this path
+        print(f"Warning: Could not create ACME directory {full_acme_path}: {e}")
+
     if test_config:
         app.config.update(test_config)
 

--- a/modules/web/routes.py
+++ b/modules/web/routes.py
@@ -10,7 +10,7 @@ from functools import wraps
 from pathlib import Path
 from collections import defaultdict
 from time import time
-from flask import request, redirect, url_for
+from flask import request, redirect, url_for, send_from_directory
 
 logger = logging.getLogger(__name__)
 
@@ -199,3 +199,22 @@ def register_web_routes(app, managers):
                                  file_ops, settings_manager, cache_manager)
     register_oidc_routes(app, managers, auth_manager, managers['oidc'],
                          _check_login_rate_limit, _record_login_attempt)
+
+    @app.route('/.well-known/acme-challenge/<path:filename>')
+    def serve_acme_challenge(filename):
+        """
+        Serves ACME challenge files from the physical directory:
+        app/data/acme-challenges/.well-known/acme-challenge/
+        """
+        # Build the physical path: /app/data/acme-challenges/.well-known/acme-challenge/
+        acme_path = os.path.join(
+            app.config['ACME_CHALLENGES_DIR'], 
+            '.well-known', 
+            'acme-challenge'
+        )
+        
+        return send_from_directory(
+            directory=acme_path,
+            path=filename,
+            mimetype='text/plain'
+        )


### PR DESCRIPTION
I use certmate behind a reverse proxy server.  I have a backend that routes requests for /.well-known/acme-challenge/* to the certmate docker IP & port.

When using HTTP-01 verification:
  - Certmate's certbot command creates a challenge file in app/data/acme-challenges/.well-known/acme-challenge/
  - Letsencrypt requests /.well-known/acme-challenge/<file> but no route is available to serve the file
  - Letsencrypt gets a 404
  - Challenge doesn't pass, certificate issuance fails

After adding the web route, certmate now serves the static file, challenge/validation passes, & certificate is issued.