### PR TITLE
fix: redirect dead /certificates and /audit routes (were 500)

### DIFF
--- a/modules/web/ui_routes.py
+++ b/modules/web/ui_routes.py
@@ -23,10 +23,14 @@ def register_ui_routes(app, managers, require_web_auth, auth_manager):
         return render_template('index.html')
 
     @app.route('/certificates')
-    @auth_manager.require_role('viewer')
     def certificates_page():
-        """Certificates list page"""
-        return render_template('certificates.html')
+        """Certificates list (alias) — unified into the dashboard at `/`.
+
+        `certificates.html` never existed, so this route used to 500. The
+        certificate list lives on the dashboard now; redirect there (the
+        index route enforces auth), mirroring the client-certificates alias.
+        """
+        return redirect(url_for('index'))
 
     @app.route('/settings')
     @auth_manager.require_role('admin')
@@ -35,10 +39,13 @@ def register_ui_routes(app, managers, require_web_auth, auth_manager):
         return render_template('settings.html')
 
     @app.route('/audit')
-    @auth_manager.require_role('admin')
     def audit_page():
-        """Audit logs page"""
-        return render_template('audit.html')
+        """Audit log (alias) — unified into the activity page.
+
+        `audit.html` never existed (route used to 500). The audit/activity
+        log lives at `/activity`; redirect there (which enforces auth).
+        """
+        return redirect(url_for('activity_page'))
 
     @app.route('/help')
     @auth_manager.require_role('viewer')

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -29,6 +29,20 @@ class TestPageLoading:
         assert r.status_code == 302
         assert "/#client" in r.headers.get("Location", "")
 
+    def test_certificates_alias_redirects_to_dashboard(self, api):
+        """/certificates (template never existed → used to 500) now 302s to /."""
+        r = api.get("/certificates", allow_redirects=False)
+        assert r.status_code == 302, f"/certificates → {r.status_code}"
+        # And following it lands on a real page, not a 500.
+        assert api.get("/certificates", allow_redirects=True).status_code == 200
+
+    def test_audit_alias_redirects_to_activity(self, api):
+        """/audit (template never existed → used to 500) now 302s to /activity."""
+        r = api.get("/audit", allow_redirects=False)
+        assert r.status_code == 302, f"/audit → {r.status_code}"
+        assert "/activity" in r.headers.get("Location", "")
+        assert api.get("/audit", allow_redirects=True).status_code == 200
+
 
 class TestWelcomeBanner:
     """Dashboard page should load dashboard JS module and key UI elements."""


### PR DESCRIPTION
`/certificates` and `/audit` rendered templates that never existed in the repo (`certificates.html`, `audit.html`), so every request 500'd. Both routes are unlinked from the UI and superseded by the unified views:

- `/certificates` -> redirect to `/` (the dashboard is the certificate list)
- `/audit` -> redirect to `/activity` (the audit/activity log)

This mirrors the existing `/client-certificates` alias pattern and drops the now-redundant `require_role` decorators (the redirect targets enforce auth themselves). Flagged originally in docs/THEME_MIGRATION.md as an out-of-scope finding.

## Verification
Two redirect tests added (302 + follow to 200, proving no 500 and no loop). Full E2E gate green: Docker smoke + CSP/auth/settings/pages/backup + real Let's Encrypt issuance and renewal over Cloudflare DNS-01 (90/90).

Generated with [Claude Code](https://claude.com/claude-code)