### PR TITLE
fix(routes): remove dead/broken list_certificates_web route

### DIFF
--- a/modules/web/cert_routes.py
+++ b/modules/web/cert_routes.py
@@ -40,27 +40,6 @@ def register_cert_routes(app, managers, require_web_auth, auth_manager,
             'code': 'DOMAIN_OUT_OF_SCOPE',
         }), 403
 
-    @app.route('/api/certificates', methods=['GET'])
-    @app.route('/api/web/certificates', methods=['GET'])
-    @auth_manager.require_role('viewer')
-    def list_certificates_web():
-        """List all certificates via web — filtered by API-key scope."""
-        try:
-            user = getattr(request, 'current_user', None) or {}
-            scope = user.get('allowed_domains')
-            certs = certificate_manager.list_certificates()
-            if scope is not None and isinstance(certs, list):
-                certs = [
-                    c for c in certs
-                    if isinstance(c, dict) and auth_manager.domain_matches_scope(
-                        c.get('domain', ''), scope
-                    )
-                ]
-            return jsonify(certs)
-        except Exception as e:
-            logger.error(f"Failed to list certificates: {e}")
-            return jsonify({'error': 'Failed to list certificates'}), 500
-
     @app.route('/api/certificates/create', methods=['POST'])
     @app.route('/api/web/certificates/create', methods=['POST'])
     @auth_manager.require_role('operator')

--- a/tests/test_certificates_route_dedup.py
+++ b/tests/test_certificates_route_dedup.py
@@ -1,0 +1,84 @@
+"""Pin the /api/certificates routing contract after removing the dead
+``list_certificates_web`` web route.
+
+Background: ``modules/web/cert_routes.py`` used to define
+``list_certificates_web`` decorated with BOTH ``/api/certificates`` and
+``/api/web/certificates`` (GET). On ``/api/certificates`` it was shadowed by
+the Flask-RESTX ``CertificateList`` resource (endpoint
+``certificates_certificate_list``); on the bare ``/api/web/certificates`` it
+was the live handler but always 500'd because it called the non-existent
+``CertificateManager.list_certificates()``. The route was removed; this test
+locks in that:
+
+  * the function/endpoint is gone,
+  * ``GET /api/certificates`` is still served by the RESTX resource, and
+  * the bare ``GET /api/web/certificates`` is no longer routable, while the
+    sibling ``POST /api/web/certificates/create`` group route survives.
+"""
+from pathlib import Path
+
+import pytest
+import werkzeug.exceptions
+
+from modules.core.factory import create_app
+
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    """Boot the real app with all of its data/cert/log/backup directories
+    anchored under ``tmp_path`` so ``create_app()`` never writes into the repo.
+
+    Uses the same path-anchor trick as ``tests/test_factory_directories.py``:
+    point ``modules.core.factory.__file__`` at a fake ``factory.py`` inside a
+    temp project tree, so ``setup_directories`` resolves all dirs relative to
+    that tree instead of the real checkout.
+    """
+    project_root = tmp_path / "certmate"
+    module_dir = project_root / "modules" / "core"
+    module_dir.mkdir(parents=True)
+    fake_factory_file = module_dir / "factory.py"
+    fake_factory_file.write_text("# test path anchor\n")
+    monkeypatch.setattr("modules.core.factory.__file__", str(fake_factory_file))
+
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.setenv("TESTING", "true")
+
+    application, container = create_app()
+
+    # Sanity: directories really landed under tmp_path, not the repo.
+    # setup_directories resolves dirs from the monkeypatched factory.__file__.
+    assert Path(container.cert_dir).resolve().is_relative_to(tmp_path)
+
+    return application
+
+
+def test_list_certificates_web_view_function_removed(app):
+    """The dead web handler must not be registered as a view function."""
+    assert 'list_certificates_web' not in app.view_functions
+
+
+def test_api_certificates_served_by_restx(app):
+    """GET /api/certificates resolves to the RESTX CertificateList resource."""
+    adapter = app.url_map.bind('localhost')
+    endpoint, _ = adapter.match('/api/certificates', method='GET')
+    assert endpoint == 'certificates_certificate_list'
+
+
+def test_bare_web_certificates_no_longer_routable(app):
+    """The bare GET /api/web/certificates route was removed -> not routable."""
+    adapter = app.url_map.bind('localhost')
+    with pytest.raises(
+        (werkzeug.exceptions.NotFound, werkzeug.exceptions.MethodNotAllowed)
+    ):
+        adapter.match('/api/web/certificates', method='GET')
+
+
+def test_sibling_create_route_still_resolves(app):
+    """Removing the list route must not disturb the /api/web/certificates/*
+    group: POST /api/web/certificates/create still maps to its handler."""
+    adapter = app.url_map.bind('localhost')
+    endpoint, _ = adapter.match('/api/web/certificates/create', method='POST')
+    assert endpoint == 'create_certificate_web'


### PR DESCRIPTION
## Summary

Removes `list_certificates_web` from `modules/web/cert_routes.py`. It was
registered on two GET routes, and was dead on one and broken on the other:

- **`GET /api/certificates`** — shadowed by the Flask-RESTX `CertificateList`
  resource (endpoint `certificates_certificate_list`). Werkzeug matches this
  path to the RESTX handler, so `list_certificates_web` was never reached here.
- **`GET /api/web/certificates`** (bare) — this *was* the live handler, but it
  calls `certificate_manager.list_certificates()`, a method that does not exist
  on `CertificateManager`. So every request raised `AttributeError`, was caught,
  and returned `HTTP 500`. Nothing in the repo (frontend, tests, docs) consumes
  this endpoint.

Deleting the function leaves `GET /api/certificates` served by the RESTX
resource (unchanged) and turns the unused, already-broken bare
`/api/web/certificates` into a 404. The sibling `/api/web/certificates/*`
routes (`create`, `batch`, `download/batch`, `dns-providers`, `test-provider`,
`<domain>/renew`) are untouched.

## Verification

Routing was confirmed empirically by booting the app and inspecting
`app.url_map` (both rules existed for `GET /api/certificates`; Werkzeug matched
the RESTX endpoint).

## Test plan

`tests/test_certificates_route_dedup.py` (unit) boots the real app via
`create_app()` (data dirs anchored under a `tmp_path`) and pins the routing
contract:

- [x] `list_certificates_web` is no longer a registered view function
- [x] `GET /api/certificates` resolves to `certificates_certificate_list` (RESTX)
- [x] the bare `GET /api/web/certificates` is no longer routable (NotFound/405)
- [x] the sibling `POST /api/web/certificates/create` still resolves (group intact)
- [x] `pytest`: 4 passed
- [x] flake8 (`E9,F63,F7,F82`) clean; bandit `--severity-level medium` no findings

## Note (out of scope)

`modules/api/resources.py` (diagnostics snapshot) also calls the non-existent
`certificate_manager.list_certificates()`, but it is wrapped in try/except and
degrades to `certificate_count = None`. That latent bug is left for a separate
PR to keep this change focused on removing the dead route.