### PR TITLE
fix(certs): wait briefly for the per-domain lock and return 409 when busy

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -20,6 +20,7 @@ from ..core.metrics import get_metrics_summary, is_prometheus_available
 from ..core.constants import CERTIFICATE_FILES, iter_cert_domain_dirs
 from ..core.auth import ROLE_HIERARCHY
 from ..core.utils import utc_now_iso
+from ..core.certificates import DomainOperationInProgress
 
 _DOMAIN_RE = re.compile(r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$')
 
@@ -992,6 +993,8 @@ def create_api_resources(api, models, managers):
                     'error': error_msg,
                     'hint': hint
                 }, 400
+            except DomainOperationInProgress as e:
+                return {'error': str(e), 'code': 'DOMAIN_OPERATION_IN_PROGRESS'}, 409
             except RuntimeError as e:
                 # Certbot execution errors
                 error_msg = str(e)
@@ -1755,6 +1758,9 @@ def create_api_resources(api, models, managers):
                     'duration': result.get('duration')
                 }, 200
 
+            except DomainOperationInProgress as e:
+                # Domain busy is not a failure; do not publish a failure event.
+                return {'error': str(e), 'code': 'DOMAIN_OPERATION_IN_PROGRESS'}, 409
             except Exception as e:
                 logger.error(f"Certificate renewal failed for {domain}: {str(e)}")
                 event_bus = current_app.config.get('EVENT_BUS')

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -64,6 +64,14 @@ DNS_ALIAS_REQUIRED_FIELDS = {
 }
 
 
+class DomainOperationInProgress(RuntimeError):
+    """Raised when a create/renew can't acquire the per-domain lock within the
+    timeout because another operation for the same domain is in progress."""
+    def __init__(self, domain):
+        self.domain = domain
+        super().__init__(f"A certificate operation for {domain} is already in progress")
+
+
 class CertificateManager:
     """Class to handle certificate operations"""
     
@@ -85,6 +93,15 @@ class CertificateManager:
             return max(0, min(3600, int(os.environ.get('CERTMATE_CERT_INFO_CACHE_TTL', '60'))))
         except (TypeError, ValueError):
             return 60
+
+    @staticmethod
+    def _domain_lock_timeout() -> float:
+        """Seconds to wait for the per-domain lock before reporting the domain
+        busy. Override via CERTMATE_DOMAIN_LOCK_TIMEOUT (clamped 0-60)."""
+        try:
+            return max(0.0, min(60.0, float(os.environ.get('CERTMATE_DOMAIN_LOCK_TIMEOUT', '5'))))
+        except (TypeError, ValueError):
+            return 5.0
 
     @staticmethod
     def _certificate_info_cache_key(domain: str, settings: dict | None) -> str:
@@ -734,8 +751,8 @@ class CertificateManager:
         """
         # Acquire per-domain lock to prevent concurrent create/renew operations
         domain_lock = self._get_domain_lock(domain)
-        if not domain_lock.acquire(blocking=False):
-            raise RuntimeError(f"A certificate operation for {domain} is already in progress")
+        if not domain_lock.acquire(timeout=self._domain_lock_timeout()):
+            raise DomainOperationInProgress(domain)
 
         # Track timing for metrics
         start_time = time.time()
@@ -1111,8 +1128,8 @@ class CertificateManager:
     def renew_certificate(self, domain, force=False):
         """Renew a certificate"""
         domain_lock = self._get_domain_lock(domain)
-        if not domain_lock.acquire(blocking=False):
-            raise RuntimeError(f"A certificate operation for {domain} is already in progress")
+        if not domain_lock.acquire(timeout=self._domain_lock_timeout()):
+            raise DomainOperationInProgress(domain)
         alias_hook_config = None
         credentials_file = None
         try:

--- a/modules/web/cert_routes.py
+++ b/modules/web/cert_routes.py
@@ -4,6 +4,8 @@ import tempfile
 import os
 from flask import request, jsonify, send_file, after_this_request
 
+from ..core.certificates import DomainOperationInProgress
+
 
 logger = logging.getLogger(__name__)
 
@@ -151,6 +153,8 @@ def register_cert_routes(app, managers, require_web_auth, auth_manager,
             return jsonify(result)
         except (ValueError, FileExistsError) as e:
             return jsonify({'error': str(e)}), 400
+        except DomainOperationInProgress as e:
+            return jsonify({'error': str(e), 'code': 'DOMAIN_OPERATION_IN_PROGRESS'}), 409
         except RuntimeError as e:
             logger.error(f"Certificate creation failed: {e}")
             return jsonify({'error': str(e)}), 422
@@ -329,6 +333,8 @@ def register_cert_routes(app, managers, require_web_auth, auth_manager,
             return jsonify({'message': result.get('message', 'Certificate renewed successfully')})
         except FileNotFoundError as e:
             return jsonify({'error': str(e)}), 404
+        except DomainOperationInProgress as e:
+            return jsonify({'error': str(e), 'code': 'DOMAIN_OPERATION_IN_PROGRESS'}), 409
         except RuntimeError as e:
             logger.error(f"Certificate renewal failed: {e}")
             return jsonify({'error': str(e)}), 422

--- a/tests/test_certificates_concurrency_and_alias.py
+++ b/tests/test_certificates_concurrency_and_alias.py
@@ -3,10 +3,12 @@ Targeted coverage for two specific gaps in modules/core/certificates.py:
 
 1. Concurrent issuance locking (line 561): create_certificate guards against
    two simultaneous create/renew calls for the same domain by acquiring a
-   per-domain threading.Lock in non-blocking mode and raising RuntimeError
-   if it's already held. Without this guard, two concurrent issuances would
-   race over the same data/certs/<domain>/ directory and trigger Let's
-   Encrypt rate-limit denials.
+   per-domain threading.Lock with a bounded timeout (CERTMATE_DOMAIN_LOCK_TIMEOUT,
+   default 5s) and raising DomainOperationInProgress if it can't acquire it in
+   time. Without this guard, two concurrent issuances would race over the same
+   data/certs/<domain>/ directory and trigger Let's Encrypt rate-limit denials.
+   The tests below pin the timeout to 0 so the acquire returns immediately and
+   the barrier behaviour stays fast and deterministic.
 
 2. check_dns_alias_records DNS failure paths: when the upstream DoH
    resolver (Cloudflare) is unreachable, returns a 5xx, or returns the
@@ -82,11 +84,13 @@ class TestConcurrentIssuanceLock:
         second = mgr._get_domain_lock("example.com")
         assert first is second
 
-    def test_second_create_attempt_raises_runtime_error(self, tmp_path):
+    def test_second_create_attempt_raises_runtime_error(self, tmp_path, monkeypatch):
         """The contract create_certificate enforces: if another thread is
-        already issuing for this domain, raise RuntimeError immediately
-        instead of queueing (which could pile up requests during a slow
-        ACME exchange and trigger LE rate limits)."""
+        already issuing for this domain and the lock can't be acquired within
+        the timeout, raise (a RuntimeError subclass) instead of queueing
+        forever (which could pile up requests during a slow ACME exchange and
+        trigger LE rate limits). Pin timeout to 0 so the acquire fails fast."""
+        monkeypatch.setenv("CERTMATE_DOMAIN_LOCK_TIMEOUT", "0")
         mgr = _make_manager(tmp_path)
 
         # Pre-hold the lock from the test thread to simulate an in-flight
@@ -103,12 +107,15 @@ class TestConcurrentIssuanceLock:
         finally:
             held.release()
 
-    def test_concurrent_create_attempts_only_one_proceeds(self, tmp_path):
+    def test_concurrent_create_attempts_only_one_proceeds(self, tmp_path, monkeypatch):
         """End-to-end multi-thread check: spawn two threads both trying to
         issue for the same domain. Exactly ONE must get past the lock
-        guard; the other must raise RuntimeError. The 'lucky' thread can
-        fail later for any reason (DNS provider not configured, etc.) —
-        we only assert the lock barrier behaviour."""
+        guard; the other must raise (DomainOperationInProgress). The 'lucky'
+        thread can fail later for any reason (DNS provider not configured,
+        etc.) — we only assert the lock barrier behaviour. Pin the timeout to
+        0 so the loser is rejected immediately rather than waiting for the
+        winner to release."""
+        monkeypatch.setenv("CERTMATE_DOMAIN_LOCK_TIMEOUT", "0")
         mgr = _make_manager(tmp_path)
         first_thread_in_downstream = threading.Event()
 

--- a/tests/test_domain_lock_wait.py
+++ b/tests/test_domain_lock_wait.py
@@ -1,0 +1,366 @@
+"""Coverage for the bounded per-domain lock wait + 409 mapping.
+
+Behaviour under test (modules/core/certificates.py and the create/renew
+routes):
+
+1. create_certificate / renew_certificate acquire the per-domain lock with a
+   bounded timeout (CERTMATE_DOMAIN_LOCK_TIMEOUT, default 5s). When the lock
+   can't be acquired in time they raise DomainOperationInProgress, which
+   carries the busy domain and subclasses RuntimeError (so legacy callers that
+   only catch RuntimeError keep working instead of 500-crashing).
+
+2. _domain_lock_timeout() reads/clamps the env override.
+
+3. The four create/renew routes (web + API) surface the busy condition as
+   HTTP 409 with machine code DOMAIN_OPERATION_IN_PROGRESS — distinct from the
+   422 certbot-error bucket and the generic 500.
+
+Most manager/helper tests pin the timeout to 0 so acquire returns immediately
+(False) — fast and deterministic, no real threads needed. A separate group
+(TestLockWaitGracePeriod) exercises the bounded WAIT with timeout > 0 using
+real threads and bounded sleeps: it proves the call blocks until the holder
+releases (then proceeds past the barrier) and, when nobody releases, blocks for
+~the configured timeout before giving up. The route tests run in-process via
+Flask's test client with mocked managers.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+from flask_restx import Api, Namespace
+
+from modules.core.certificates import CertificateManager, DomainOperationInProgress
+from modules.api.models import create_api_models
+from modules.api.resources import create_api_resources
+from modules.web.cert_routes import register_cert_routes
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def _make_manager(tmp_path):
+    return CertificateManager(
+        cert_dir=tmp_path,
+        settings_manager=MagicMock(),
+        dns_manager=MagicMock(),
+        storage_manager=None,
+        ca_manager=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Manager-level: lock wait -> DomainOperationInProgress
+# ---------------------------------------------------------------------------
+
+
+class TestLockWaitRaises:
+    def test_create_certificate_raises_domain_in_progress(self, tmp_path, monkeypatch):
+        """With the lock already held and timeout pinned to 0, create_certificate
+        must raise DomainOperationInProgress carrying the busy domain."""
+        monkeypatch.setenv("CERTMATE_DOMAIN_LOCK_TIMEOUT", "0")
+        mgr = _make_manager(tmp_path)
+        held = mgr._get_domain_lock("busy.example.com")
+        assert held.acquire(blocking=False) is True
+        try:
+            with pytest.raises(DomainOperationInProgress) as exc:
+                mgr.create_certificate(domain="busy.example.com",
+                                       email="t@example.com")
+            assert exc.value.domain == "busy.example.com"
+            assert "already in progress" in str(exc.value)
+        finally:
+            held.release()
+
+    def test_renew_certificate_raises_domain_in_progress(self, tmp_path, monkeypatch):
+        """Same contract for renew_certificate."""
+        monkeypatch.setenv("CERTMATE_DOMAIN_LOCK_TIMEOUT", "0")
+        mgr = _make_manager(tmp_path)
+        held = mgr._get_domain_lock("busy.example.com")
+        assert held.acquire(blocking=False) is True
+        try:
+            with pytest.raises(DomainOperationInProgress) as exc:
+                mgr.renew_certificate("busy.example.com")
+            assert exc.value.domain == "busy.example.com"
+        finally:
+            held.release()
+
+    def test_domain_operation_in_progress_is_runtime_error_subclass(self):
+        """Backward-compat: routes that still only catch RuntimeError keep
+        working (they degrade to their old status) instead of 500-crashing."""
+        assert issubclass(DomainOperationInProgress, RuntimeError)
+        err = DomainOperationInProgress("x.com")
+        assert isinstance(err, RuntimeError)
+        assert err.domain == "x.com"
+
+
+# ---------------------------------------------------------------------------
+# Bounded WAIT (timeout > 0) — the actual grace-period behaviour this PR adds.
+# These use real threads + small sleeps; total added runtime is well under 1s.
+# ---------------------------------------------------------------------------
+
+
+class TestLockWaitGracePeriod:
+    def test_create_waits_for_release_then_proceeds(self, tmp_path, monkeypatch):
+        """Hold the lock from a helper thread that releases it after a short
+        delay, with a generous timeout (2s). create_certificate must BLOCK
+        until the release, acquire the lock, and proceed past the barrier into
+        the normal flow — where the pre-staged cert.pem makes it raise
+        FileExistsError. Getting FileExistsError (not DomainOperationInProgress)
+        proves the wait succeeded and we got past the lock."""
+        monkeypatch.setenv("CERTMATE_DOMAIN_LOCK_TIMEOUT", "2")
+        mgr = _make_manager(tmp_path)
+        domain = "wait.example.com"
+
+        # Pre-stage cert.pem so the post-lock existence check fires.
+        domain_dir = Path(tmp_path) / domain
+        domain_dir.mkdir(parents=True, exist_ok=True)
+        (domain_dir / "cert.pem").write_text("dummy")
+
+        held = mgr._get_domain_lock(domain)
+        assert held.acquire(blocking=False) is True
+        released = threading.Event()
+
+        def _release_after_delay():
+            time.sleep(0.1)
+            held.release()
+            released.set()
+
+        releaser = threading.Thread(target=_release_after_delay)
+        releaser.start()
+        try:
+            with pytest.raises(FileExistsError):
+                mgr.create_certificate(domain=domain, email="t@example.com")
+            # By the time create_certificate returned, it must have acquired
+            # the lock, which is only possible after the helper released it.
+            assert released.is_set()
+        finally:
+            releaser.join(timeout=5)
+            # Lock was acquired inside create_certificate; that flow releases
+            # it in its own finally, so it should be free again here.
+            assert held.acquire(blocking=False) is True
+            held.release()
+
+    def test_create_blocks_for_timeout_then_raises(self, tmp_path, monkeypatch):
+        """Hold the lock for the whole test (never release) with a small
+        timeout. create_certificate must BLOCK for ~the timeout before raising
+        DomainOperationInProgress — proving it actually waited rather than
+        instant-rejecting."""
+        monkeypatch.setenv("CERTMATE_DOMAIN_LOCK_TIMEOUT", "0.2")
+        mgr = _make_manager(tmp_path)
+        domain = "stuck.example.com"
+
+        held = mgr._get_domain_lock(domain)
+        assert held.acquire(blocking=False) is True
+        try:
+            t0 = time.monotonic()
+            with pytest.raises(DomainOperationInProgress) as exc:
+                mgr.create_certificate(domain=domain, email="t@example.com")
+            elapsed = time.monotonic() - t0
+            assert exc.value.domain == domain
+            # Allow a little slack below 0.2 for timer granularity, but it must
+            # be clearly more than an instant reject.
+            assert elapsed >= 0.18, f"expected to block ~0.2s, blocked {elapsed:.3f}s"
+        finally:
+            held.release()
+
+    def test_renew_waits_for_release_then_proceeds(self, tmp_path, monkeypatch):
+        """Same shape as the create wait test, for renew_certificate. With no
+        cert staged, the first thing renew does after acquiring the lock is the
+        existence check, which raises 'No certificate found...'. renew's broad
+        try/except re-wraps that as a plain RuntimeError (the lock acquire sits
+        BEFORE the try, so a DomainOperationInProgress would never be wrapped).
+        Getting a RuntimeError carrying 'No certificate found' — and crucially
+        NOT a DomainOperationInProgress — proves renew waited for the release
+        and got past the barrier into its normal flow."""
+        monkeypatch.setenv("CERTMATE_DOMAIN_LOCK_TIMEOUT", "2")
+        mgr = _make_manager(tmp_path)
+        domain = "renewwait.example.com"
+
+        held = mgr._get_domain_lock(domain)
+        assert held.acquire(blocking=False) is True
+        released = threading.Event()
+
+        def _release_after_delay():
+            time.sleep(0.1)
+            held.release()
+            released.set()
+
+        releaser = threading.Thread(target=_release_after_delay)
+        releaser.start()
+        try:
+            with pytest.raises(RuntimeError) as exc:
+                mgr.renew_certificate(domain)
+            assert not isinstance(exc.value, DomainOperationInProgress)
+            assert "No certificate found" in str(exc.value)
+            assert released.is_set()
+        finally:
+            releaser.join(timeout=5)
+            assert held.acquire(blocking=False) is True
+            held.release()
+
+
+# ---------------------------------------------------------------------------
+# _domain_lock_timeout helper
+# ---------------------------------------------------------------------------
+
+
+class TestDomainLockTimeoutHelper:
+    def test_default_is_five_seconds(self, monkeypatch):
+        monkeypatch.delenv("CERTMATE_DOMAIN_LOCK_TIMEOUT", raising=False)
+        assert CertificateManager._domain_lock_timeout() == 5.0
+
+    def test_respects_env_override(self, monkeypatch):
+        monkeypatch.setenv("CERTMATE_DOMAIN_LOCK_TIMEOUT", "12.5")
+        assert CertificateManager._domain_lock_timeout() == 12.5
+
+    def test_clamps_to_zero_floor(self, monkeypatch):
+        monkeypatch.setenv("CERTMATE_DOMAIN_LOCK_TIMEOUT", "-7")
+        assert CertificateManager._domain_lock_timeout() == 0.0
+
+    def test_clamps_to_sixty_ceiling(self, monkeypatch):
+        monkeypatch.setenv("CERTMATE_DOMAIN_LOCK_TIMEOUT", "999")
+        assert CertificateManager._domain_lock_timeout() == 60.0
+
+    def test_falls_back_to_five_on_garbage(self, monkeypatch):
+        monkeypatch.setenv("CERTMATE_DOMAIN_LOCK_TIMEOUT", "not-a-number")
+        assert CertificateManager._domain_lock_timeout() == 5.0
+
+
+# ---------------------------------------------------------------------------
+# Route mapping -> 409 DOMAIN_OPERATION_IN_PROGRESS
+# ---------------------------------------------------------------------------
+
+
+def _passthrough_decorator(_min_role):
+    def deco(fn):
+        return fn
+    return deco
+
+
+def _make_route_managers(tmp_path):
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_decorator)
+    # Scope check passes: user_can_access_domain returns truthy.
+    auth_manager.user_can_access_domain.return_value = True
+
+    cert_manager = MagicMock()
+    cert_manager.cert_dir = Path(tmp_path)
+
+    settings_manager = MagicMock()
+    settings_manager.load_settings.return_value = {
+        'email': 't@example.com',
+        'dns_provider': 'cloudflare',
+        'default_ca': 'letsencrypt',
+        'challenge_type': 'dns-01',
+    }
+
+    file_ops = MagicMock(cert_dir=Path(tmp_path))
+
+    return {
+        'auth': auth_manager,
+        'settings': settings_manager,
+        'certificates': cert_manager,
+        'file_ops': file_ops,
+        'cache': MagicMock(),
+        'dns': MagicMock(),
+        'audit': None,
+    }
+
+
+def _build_api_app(managers):
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    api = Api(app, prefix='/api')
+    models = create_api_models(api)
+    resources = create_api_resources(api, models, managers)
+    ns = Namespace('certs', description='certs')
+    api.add_namespace(ns)
+    ns.add_resource(resources['CreateCertificate'], '/create')
+    ns.add_resource(resources['RenewCertificate'], '/<string:domain>/renew')
+    return app
+
+
+def _build_web_app(managers, tmp_path):
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+
+    def _sanitize_domain(domain, _cert_dir):
+        # Return a path whose .name is the domain and no error.
+        return Path(tmp_path) / domain, None
+
+    register_cert_routes(
+        app,
+        managers,
+        require_web_auth=_passthrough_decorator,
+        auth_manager=managers['auth'],
+        certificate_manager=managers['certificates'],
+        _sanitize_domain=_sanitize_domain,
+        file_ops=managers['file_ops'],
+        settings_manager=managers['settings'],
+        dns_manager=managers['dns'],
+        CERTIFICATE_FILES={},
+    )
+    return app
+
+
+class TestApiRouteMapping:
+    def test_create_returns_409(self, tmp_path):
+        managers = _make_route_managers(tmp_path)
+        managers['certificates'].create_certificate.side_effect = \
+            DomainOperationInProgress('x.com')
+        app = _build_api_app(managers)
+        r = app.test_client().post(
+            '/api/certs/create',
+            json={'domain': 'x.com', 'dns_provider': 'cloudflare'},
+        )
+        assert r.status_code == 409
+        body = r.get_json()
+        assert body['code'] == 'DOMAIN_OPERATION_IN_PROGRESS'
+
+    def test_renew_returns_409_without_failure_event(self, tmp_path):
+        managers = _make_route_managers(tmp_path)
+        managers['certificates'].renew_certificate.side_effect = \
+            DomainOperationInProgress('x.com')
+        event_bus = MagicMock()
+        app = _build_api_app(managers)
+        app.config['EVENT_BUS'] = event_bus
+        r = app.test_client().post('/api/certs/x.com/renew', json={})
+        assert r.status_code == 409
+        body = r.get_json()
+        assert body['code'] == 'DOMAIN_OPERATION_IN_PROGRESS'
+        # Busy is not a failure: no certificate_failed event is published.
+        published = [c.args[0] for c in event_bus.publish.call_args_list]
+        assert 'certificate_failed' not in published
+
+
+class TestWebRouteMapping:
+    def test_create_web_returns_409(self, tmp_path):
+        managers = _make_route_managers(tmp_path)
+        managers['certificates'].create_certificate.side_effect = \
+            DomainOperationInProgress('x.com')
+        app = _build_web_app(managers, tmp_path)
+        r = app.test_client().post(
+            '/api/web/certificates/create',
+            json={'domain': 'x.com', 'dns_provider': 'cloudflare'},
+        )
+        assert r.status_code == 409
+        body = r.get_json()
+        assert body['code'] == 'DOMAIN_OPERATION_IN_PROGRESS'
+
+    def test_renew_web_returns_409(self, tmp_path):
+        managers = _make_route_managers(tmp_path)
+        managers['certificates'].renew_certificate.side_effect = \
+            DomainOperationInProgress('x.com')
+        app = _build_web_app(managers, tmp_path)
+        r = app.test_client().post('/api/web/certificates/x.com/renew', json={})
+        assert r.status_code == 409
+        body = r.get_json()
+        assert body['code'] == 'DOMAIN_OPERATION_IN_PROGRESS'
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`create_certificate` and `renew_certificate` acquired the per-domain lock with
`acquire(blocking=False)` and failed *instantly* with a generic `RuntimeError`
when another operation for the same domain was in progress. Two problems:

- No grace period — a legitimate concurrent retry (CLI/automation) was rejected
  with no chance to wait out a brief in-flight operation.
- That generic `RuntimeError` mapped inconsistently across routes: HTTP **422**
  on create (the certbot-error bucket) and a generic **500** on the API renew
  route. "Domain busy" is neither a server error nor a certbot failure.

This change:

- **Bounded wait.** Acquire with `acquire(timeout=...)` where the timeout comes
  from `CERTMATE_DOMAIN_LOCK_TIMEOUT` (default **5s**, clamped to `[0, 60]`).
- **Distinct, backward-compatible exception.** On timeout, raise a new
  `DomainOperationInProgress`. It **subclasses `RuntimeError`**, so any route
  that still only catches `RuntimeError` keeps working (degrades to its old
  status) instead of 500-crashing.
- **409 mapping.** The four create/renew routes (web + API) now map the busy
  condition to HTTP **409** with machine code `DOMAIN_OPERATION_IN_PROGRESS` —
  distinct from the 422 certbot bucket and the generic 500. The API renew route
  does **not** publish a `certificate_failed` event for a busy domain (busy is
  not a failure).

**Behavior change:** a "domain busy" condition previously surfaced as 422
(create) or 500 (API renew); it is now **409 + `DOMAIN_OPERATION_IN_PROGRESS`**.

## Test plan

`tests/test_domain_lock_wait.py` + updates to
`tests/test_certificates_concurrency_and_alias.py` (Linux/Docker):

- [x] manager-level: create & renew raise `DomainOperationInProgress` when the
      lock can't be acquired; `.domain` is set; it `issubclass`es `RuntimeError`
- [x] `_domain_lock_timeout()`: default 5.0, env override, clamps `[0, 60]`,
      garbage → 5.0
- [x] all four routes (web + API, create + renew) return **409** with
      `code == "DOMAIN_OPERATION_IN_PROGRESS"`; API renew publishes no failure event
- [x] lock-barrier invariant (timeout 0): two concurrent creates, exactly one
      proceeds — no duplicate issuance
- [x] **the grace period itself (timeout > 0)**: a held lock released after
      ~0.1s lets `create`/`renew` wait and then proceed past the barrier; a lock
      never released makes `create` block ~the timeout (asserted via elapsed
      time) before raising
- [x] `pytest`: 29 passed
- [x] flake8 (`E9,F63,F7,F82`) clean; bandit `--severity-level medium` no findings

Note: existing concurrency tests pin `CERTMATE_DOMAIN_LOCK_TIMEOUT=0` to keep
the lock-barrier assertions fast and deterministic (`acquire(timeout=0)` is the
instant-reject equivalent of the old `blocking=False`); a separate test group
exercises the new bounded wait with a non-zero timeout.