### PR TITLE
ci: route docker-multiplatform, CI, CodeQL to self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions: read-all
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       matrix:
         # 3.12 matches the production Dockerfile. Python 3.14 is temporarily
@@ -86,7 +86,7 @@ jobs:
   # rebuild. This job rebuilds from source and fails if the committed output
   # drifts, forcing `npm run css:build` to be part of every CSS-touching PR.
   frontend-css:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ permissions: read-all
 jobs:
   analyze:
     name: Analyze ${{ matrix.language }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     permissions:
       # Required to upload results to the Security tab.
       security-events: write

--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -31,7 +31,7 @@ permissions: read-all
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     
     steps:
     - name: Checkout repository
@@ -129,7 +129,7 @@ jobs:
       run: echo ${{ steps.build.outputs.digest }}
       
   security-scan:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: build
     if: github.event_name != 'pull_request'
     # Job-level permission override: the workflow default is read-all


### PR DESCRIPTION
Sposta i 3 workflow più carichi (~700 run/mese) su `runs-on: [self-hosted, Linux, X64]`.

Setup: 4 listener Contabo (`vmi3020113-contabo-certmate-1..4`) già registrati e online su questo repo. GitHub assegna i job al primo idle.

Pattern validato in precedenza su `proxxx/docs.yml` (PR #129 merged) e `zion` (PR #144 merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)