### PR TITLE
fix(ci): install trivy on self-hosted runner, skip broken cache setup

### DIFF
--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -141,12 +141,48 @@ jobs:
       contents: read
 
     steps:
+    - name: Ensure Trivy is installed
+      # aquasecurity/trivy-action internally invokes setup-trivy, which
+      # on this self-hosted runner reports "Cache restored successfully"
+      # but does not leave a working binary on PATH — the next
+      # entrypoint.sh step fails with `trivy: command not found`
+      # (exit 127, run 26595913239). Install the versioned release
+      # tarball directly into a user-writable PATH entry and tell
+      # trivy-action to skip its own setup. Pin matches the version
+      # setup-trivy was trying to cache.
+      run: |
+        set -euo pipefail
+        if command -v trivy >/dev/null 2>&1; then
+          echo "trivy already on PATH: $(command -v trivy)"
+          exit 0
+        fi
+        TRIVY_VERSION=0.70.0
+        case "$(uname -m)" in
+          x86_64) BIN_ARCH=64bit ;;
+          aarch64|arm64) BIN_ARCH=ARM64 ;;
+          *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+        esac
+        tmp=$(mktemp -d)
+        trap 'rm -rf "$tmp"' EXIT
+        curl -fsSL \
+          "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${BIN_ARCH}.tar.gz" \
+          -o "$tmp/trivy.tgz"
+        tar -xzf "$tmp/trivy.tgz" -C "$tmp" trivy
+        install -d "$HOME/.local/bin"
+        install -m 0755 "$tmp/trivy" "$HOME/.local/bin/trivy"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        echo "Installed trivy ${TRIVY_VERSION} at $HOME/.local/bin/trivy"
+
     - name: Run Trivy vulnerability scanner
       # Pinned to v0.36.0 (was @master — never pin to a mutable branch
       # in CI; upstream HEAD changes silently bring new behaviour or
       # become an attack surface if compromised).
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
       with:
+        # Use the trivy installed by the previous step. setup-trivy's
+        # cache hit on this self-hosted runner was reporting success
+        # without producing a usable binary.
+        skip-setup-trivy: true
         image-ref: ${{ env.REGISTRY }}/${{ secrets.DOCKERHUB_USER }}/${{ env.IMAGE_NAME }}:latest
         format: 'sarif'
         output: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary

`security-scan` in `Build Multi-Platform Docker Images` has been failing on the new self-hosted runner (`vmi3020113-contabo-certmate-1`, introduced by #275) with `trivy: command not found` (exit 127). The wrapped `aquasecurity/setup-trivy` step reports `Cache restored successfully` but does not leave a working `trivy` binary on PATH, so the action's `entrypoint.sh` exits 127.

Run [26595913239](https://github.com/fabriziosalmi/certmate/actions/runs/26595913239/job/78367309307) on `main`/`push` is the visible failure. PR events skip `security-scan` via the existing `if: github.event_name != 'pull_request'` guard, so the regression surfaces only on push to main.

## Fix

Add a deterministic `Ensure Trivy is installed` step before the scan and pass `skip-setup-trivy: true` to the action.

- Pin trivy to `v0.70.0` (matches what `setup-trivy` was trying to cache).
- Download the official release tarball from a versioned GitHub URL — no `curl | sh` from a mutable branch, consistent with the existing comment on the trivy-action pin.
- Install to `~/.local/bin` (user-writable, no sudo).
- Idempotent (skipped if `trivy` is already on PATH).
- Multi-arch: x86_64 → `64bit`, aarch64 → `ARM64`.
- `$GITHUB_PATH` is updated so the next step picks the binary up.

Only `.github/workflows/docker-multiplatform.yml` is touched. No conflicts with #268-#274, #276.

## Test plan
- [ ] Merge → `push` to `main` triggers the workflow.
- [ ] `Ensure Trivy is installed` step succeeds; logs print either `trivy already on PATH: ...` (re-run cache hit) or `Installed trivy 0.70.0 at /home/runner/.local/bin/trivy`.
- [ ] `Run Trivy vulnerability scanner` step completes; `trivy-results.sarif` is produced.
- [ ] `Upload Trivy scan results to GitHub Security tab` succeeds (Security > Code scanning shows the run).