### PR TITLE
Reliability: zero silent renewal misses + storage-failure visibility

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -1475,17 +1475,31 @@ class CertificateManager:
             domain_lock.release()
 
     def check_renewals(self):
-        """Check and renew certificates that are about to expire"""
+        """Check and renew certificates that are about to expire.
+
+        Returns a summary dict (checked / renewed / failed / skipped_disabled
+        / skipped_invalid) so the outcome is observable rather than silent.
+        A malformed domain entry used to be skipped with no signal (or only a
+        debug-level one), so a typo in settings.json could quietly exclude a
+        domain from renewal forever; every skip and failure is now counted
+        and logged.
+        """
         settings = self.settings_manager.load_settings()
-            
+
         if not settings.get('auto_renew', True):
-            return
-        
+            logger.info("Automatic renewal is globally disabled; skipping renewal check")
+            return {'checked': 0, 'renewed': 0, 'failed': 0,
+                    'skipped_disabled': 0, 'skipped_invalid': 0,
+                    'auto_renew_disabled': True}
+
         # Migrate settings format if needed
         settings = self.settings_manager.migrate_domains_format(settings)
-        
+
         logger.info("Checking for certificates that need renewal")
-        
+
+        summary = {'checked': 0, 'renewed': 0, 'failed': 0,
+                   'skipped_disabled': 0, 'skipped_invalid': 0}
+
         for domain_entry in settings.get('domains', []):
             try:
                 # Handle both old and new domain formats
@@ -1496,10 +1510,13 @@ class CertificateManager:
                     domain = domain_entry.get('domain')
                     per_cert_auto_renew = domain_entry.get('auto_renew', True)
                 else:
-                    logger.warning(f"Invalid domain entry format: {domain_entry}")
+                    logger.warning(f"Skipping malformed domain entry (not str/dict): {domain_entry!r}")
+                    summary['skipped_invalid'] += 1
                     continue
 
                 if not domain:
+                    logger.warning(f"Skipping domain entry with no domain name: {domain_entry!r}")
+                    summary['skipped_invalid'] += 1
                     continue
 
                 # Per-certificate opt-out: skip when auto_renew is explicitly
@@ -1507,6 +1524,7 @@ class CertificateManager:
                 # checked above; this is the per-cert override (issue #111).
                 if not per_cert_auto_renew:
                     logger.info(f"Skipping renewal for {domain}: auto_renew disabled for this certificate")
+                    summary['skipped_disabled'] += 1
                     continue
 
                 # Pass the once-loaded settings into get_certificate_info so
@@ -1517,18 +1535,38 @@ class CertificateManager:
                 # use_cache=False: this loop visits each domain exactly once
                 # per run, so populating _certificate_info_cache would only
                 # add a deepcopy-on-set with no possible read hit.
+                summary['checked'] += 1
                 cert_info = self.get_certificate_info(domain, settings=settings, use_cache=False)
 
                 if cert_info and cert_info.get('needs_renewal'):
                     logger.info(f"Renewing certificate for {domain}")
                     try:
                         self.renew_certificate(domain)
+                        summary['renewed'] += 1
                         logger.info(f"Successfully renewed certificate for {domain}")
                     except Exception as e:
+                        summary['failed'] += 1
                         logger.error(f"Failed to renew certificate for {domain}: {e}")
-                        
+
             except Exception as e:
+                summary['failed'] += 1
                 logger.error(f"Error checking renewal for domain entry {domain_entry}: {e}")
+
+        if summary['skipped_invalid']:
+            logger.warning(
+                "Renewal check skipped %d malformed domain entr%s — fix "
+                "settings.json so these domains are not silently excluded "
+                "from renewal",
+                summary['skipped_invalid'],
+                'y' if summary['skipped_invalid'] == 1 else 'ies',
+            )
+        logger.info(
+            "Renewal check complete: %d checked, %d renewed, %d failed, "
+            "%d disabled, %d invalid",
+            summary['checked'], summary['renewed'], summary['failed'],
+            summary['skipped_disabled'], summary['skipped_invalid'],
+        )
+        return summary
 
     def create_certificate_legacy(self, domain, email, cloudflare_token):
         """Legacy function for backward compatibility"""

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -706,7 +706,10 @@ class CertificateManager:
                 'expiry_date': expiry_date.strftime('%Y-%m-%d %H:%M:%S'),
                 'days_left': days_left,
                 'days_until_expiry': days_left,
-                'needs_renewal': days_left < renewal_threshold_days,
+                # Inclusive boundary: a cert with exactly renewal_threshold_days
+                # left must renew. Using `<` skipped the boundary, delaying
+                # renewal by a day; digest.py and metrics.py already use `<=`.
+                'needs_renewal': days_left <= renewal_threshold_days,
                 'dns_provider': dns_provider,
                 'domain_alias': domain_alias,
                 'alias_dns_provider': alias_dns_provider,

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -731,7 +731,11 @@ class CertificateManager:
                 'san_domains': san_domains,
                 'ca_provider': ca_provider,
                 'challenge_type': challenge_type,
-                'account_id': account_id
+                'account_id': account_id,
+                # Surfaced so a failed external-storage save (DR copy missing
+                # or stale) is visible on GET, not just buried in the logs.
+                # None when the last issuance stored cleanly.
+                'storage_warning': metadata.get('storage_warning'),
             }
         except Exception as e:
             logger.error(f"Error parsing certificate for {domain}: {e}")
@@ -750,7 +754,8 @@ class CertificateManager:
             'san_domains': san_domains,
             'ca_provider': ca_provider,
             'challenge_type': challenge_type,
-            'account_id': account_id
+            'account_id': account_id,
+            'storage_warning': metadata.get('storage_warning'),
         }
 
     def _create_empty_cert_info(self, domain):
@@ -1221,25 +1226,49 @@ class CertificateManager:
                 metadata['domain_alias'] = domain_alias
                 metadata['alias_dns_provider'] = alias_dns_provider or dns_provider
             
+            # External storage is the disaster-recovery copy: if the local
+            # cert_dir is on ephemeral storage and is lost, the cert is only
+            # recoverable from the configured backend. A failed store used to
+            # be a log line only — the API still returned success=True, so the
+            # operator had no signal their backup never landed. Capture a
+            # generic warning (no raw exception text — it can carry backend
+            # credentials/URLs) and surface it on the result and in metadata.
+            storage_warning = None
             if self.storage_manager:
+                try:
+                    backend_name = self.storage_manager.get_backend_name()
+                except Exception:
+                    backend_name = 'external'
                 try:
                     storage_success = self.storage_manager.store_certificate(domain, cert_files, metadata)
                     if storage_success:
-                        logger.info(f"Certificate stored in {self.storage_manager.get_backend_name()} backend for {domain}")
+                        logger.info(f"Certificate stored in {backend_name} backend for {domain}")
                     else:
-                        logger.warning(f"Failed to store certificate in {self.storage_manager.get_backend_name()} backend for {domain}")
+                        storage_warning = (
+                            f"Certificate issued but NOT saved to the {backend_name} storage "
+                            f"backend — the external copy is missing or stale. Check the backend "
+                            f"credentials and connectivity."
+                        )
+                        logger.warning(f"Failed to store certificate in {backend_name} backend for {domain}")
                 except Exception as e:
+                    storage_warning = (
+                        f"Certificate issued but saving it to the {backend_name} storage backend "
+                        f"failed — the external copy is missing or stale. See server logs for details."
+                    )
                     logger.error(f"Error storing certificate in storage backend for {domain}: {e}")
-            
+
+            if storage_warning:
+                metadata['storage_warning'] = storage_warning
+
             if self._save_metadata(domain, metadata):
                 logger.info(f"Saved certificate metadata to {self._metadata_path(domain)}")
-            
+
             duration = time.time() - start_time
             logger.info(f"Certificate created successfully for {domain} in {duration:.2f} seconds")
             self._invalidate_certificate_info_cache(domain)
             self._write_pfx(domain)
 
-            return {
+            result = {
                 'success': True,
                 'domain': domain,
                 'dns_provider': dns_provider,
@@ -1247,6 +1276,9 @@ class CertificateManager:
                 'staging': staging,
                 'ca_provider': ca_provider
             }
+            if storage_warning:
+                result['storage_warning'] = storage_warning
+            return result
             
         except subprocess.TimeoutExpired:
             logger.error(f"Certificate creation timeout for {domain}")

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -104,13 +104,25 @@ class CertificateManager:
             return 5.0
 
     @staticmethod
+    def _coerce_renewal_threshold_days(settings: dict | None, default: int = 30) -> int:
+        """Return a usable renewal threshold in days from settings.
+
+        A non-int, zero, or negative ``renewal_threshold_days`` (a typo via
+        the API, a hand-edited settings.json, or a stringified JSON number)
+        would otherwise make ``days_left <= threshold`` permanently False —
+        silently disabling renewal — or raise TypeError in the renewal
+        worker. Clamp to a sane [1, 365] window so the renewal decision is
+        always well-defined; fall back to *default* on anything uncoercible.
+        """
+        raw = settings.get('renewal_threshold_days', default) if isinstance(settings, dict) else default
+        try:
+            return max(1, min(365, int(raw)))
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
     def _certificate_info_cache_key(domain: str, settings: dict | None) -> str:
-        threshold = 30
-        if isinstance(settings, dict):
-            try:
-                threshold = int(settings.get('renewal_threshold_days', 30))
-            except (TypeError, ValueError):
-                threshold = 30
+        threshold = CertificateManager._coerce_renewal_threshold_days(settings)
         return f"{domain}|renewal_threshold_days={threshold}|date={utc_now().date().isoformat()}"
 
     def _get_cached_certificate_info(self, domain: str, settings: dict | None = None):
@@ -682,8 +694,11 @@ class CertificateManager:
             # Fall back to current settings
             dns_provider = self.settings_manager.get_domain_dns_provider(domain, settings)
 
-        # Get configurable renewal threshold (default 30 days for backward compatibility)
-        renewal_threshold_days = settings.get('renewal_threshold_days', 30)
+        # Get configurable renewal threshold (default 30 days for backward
+        # compatibility). Coerced/clamped so a malformed persisted value
+        # (0, negative, or a string) can never silently disable renewal or
+        # raise TypeError in the comparison below.
+        renewal_threshold_days = self._coerce_renewal_threshold_days(settings)
 
         try:
             # Parse the certificate in-process with `cryptography` (already a

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -619,7 +619,7 @@ def setup_scheduler(container: AppContainer):
         }
         container.managers['scheduler_status'] = container.scheduler_status
     except Exception as e:
-        logger.error(f"Scheduler setup failed — automatic certificate renewal will NOT run: {e}")
+        logger.critical(f"Scheduler setup failed — automatic certificate renewal will NOT run: {e}")
         import warnings
         warnings.warn(
             f"CertMate scheduler failed to start: {e}. "

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -318,6 +318,21 @@ def validate_settings_post(payload, current=None):
             filtered[key] = value
         else:
             unknown.append(key)
+
+    # Reject a malformed renewal threshold at the door rather than letting
+    # it persist and silently break renewal. A 0/negative/non-numeric value
+    # would make `days_left <= threshold` permanently False (no cert ever
+    # renews) — the worst possible failure for a cert manager. Only a
+    # genuinely changed value reaches here (no-op echoes were dropped above).
+    if 'renewal_threshold_days' in filtered:
+        try:
+            coerced = int(filtered['renewal_threshold_days'])
+        except (TypeError, ValueError):
+            raise ValueError("renewal_threshold_days must be an integer between 1 and 365")
+        if not 1 <= coerced <= 365:
+            raise ValueError("renewal_threshold_days must be between 1 and 365")
+        filtered['renewal_threshold_days'] = coerced
+
     return filtered, rejected, unknown
 
 

--- a/modules/web/misc_routes.py
+++ b/modules/web/misc_routes.py
@@ -104,6 +104,33 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
             'checks': checks
         })
 
+    @app.route('/health/ready')
+    def readiness_check():
+        """Readiness probe for orchestrators (Kubernetes readiness, compose
+        healthcheck, deploy gates).
+
+        Distinct from /health on purpose: /health is *liveness* and stays
+        200 whenever Flask serves requests, so a load balancer keeps routing
+        traffic to a process that is otherwise fine. But if APScheduler — the
+        only thing that runs automatic renewals on this single-instance
+        build — failed to start, the instance is serving yet quietly never
+        renewing anything. That used to be invisible to every probe because
+        /health returned 200. This endpoint returns 503 in exactly that case
+        so the failure becomes loud: a deploy gate fails, a readiness probe
+        flips the pod out of rotation, an alert fires.
+        """
+        scheduler = managers.get('scheduler')
+        scheduler_status = managers.get('scheduler_status') or {}
+        running = bool(scheduler and getattr(scheduler, 'running', False))
+        ready = running and scheduler_status.get('state') != 'failed'
+        body = {
+            'ready': ready,
+            'scheduler': 'running' if running else (scheduler_status.get('state') or 'not_running'),
+        }
+        if not ready and scheduler_status.get('error'):
+            body['scheduler_error'] = scheduler_status.get('error')
+        return jsonify(body), (200 if ready else 503)
+
     @app.route('/api/events/stream')
     def events_stream():
         """SSE: stream certificate lifecycle events to authenticated browsers.

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,4 +73,8 @@ prometheus_client==0.21.0
 
 # Testing
 requests_mock==1.12.1
-SQLAlchemy>=2.0.0
+# APScheduler's SQLAlchemyJobStore backs the persistent renewal schedule.
+# Cap below 3.0.0: a major SQLAlchemy bump can break create_engine / the
+# jobstore and would silently stop automatic renewals on an unattended
+# `pip install -U`. Raise the ceiling only after testing against 3.x.
+SQLAlchemy>=2.0.0,<3.0.0

--- a/tests/test_cert_info_inproc_parse.py
+++ b/tests/test_cert_info_inproc_parse.py
@@ -109,6 +109,36 @@ def test_near_expiry_flags_needs_renewal(cert_manager):
     cert_manager.shell_executor.run.assert_not_called()
 
 
+def test_renewal_boundary_is_inclusive(cert_manager):
+    """A cert with exactly renewal_threshold_days left MUST renew.
+
+    Regression for the off-by-one at certificates.py: `days_left <
+    renewal_threshold_days` skipped the boundary, so a cert sitting at
+    exactly 30 days (the default threshold) would not renew until it
+    dropped to 29 — a silent one-day delay. The +12h offset makes the
+    truncating `.days` land on exactly 30 regardless of sub-second skew.
+    """
+    not_after = datetime.now(timezone.utc) + timedelta(days=30, hours=12)
+    _write_cert(cert_manager, "boundary.example.com", _make_cert_pem(not_after))
+
+    info = cert_manager.get_certificate_info("boundary.example.com")
+
+    assert info["days_left"] == 30  # exactly the default threshold
+    assert info["needs_renewal"] is True
+
+
+def test_just_above_threshold_does_not_renew(cert_manager):
+    """One day past the threshold must NOT renew — guards against the fix
+    over-correcting into premature renewal."""
+    not_after = datetime.now(timezone.utc) + timedelta(days=31, hours=12)
+    _write_cert(cert_manager, "above.example.com", _make_cert_pem(not_after))
+
+    info = cert_manager.get_certificate_info("above.example.com")
+
+    assert info["days_left"] == 31
+    assert info["needs_renewal"] is False
+
+
 def test_unparseable_cert_marks_exists_without_crashing(cert_manager):
     _write_cert(cert_manager, "garbage.example.com", b"not a real certificate")
 

--- a/tests/test_check_renewals_summary.py
+++ b/tests/test_check_renewals_summary.py
@@ -1,0 +1,82 @@
+"""check_renewals must never skip a domain silently.
+
+A malformed entry in settings['domains'] (a bare int, a dict with no
+'domain' key, an empty domain string) used to be dropped with no
+operator-visible signal, so a typo could silently exclude a domain from
+automatic renewal forever. check_renewals now counts every checked /
+renewed / failed / skipped entry and returns the summary.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.certificates import CertificateManager
+
+pytestmark = [pytest.mark.unit]
+
+
+def _manager(tmp_path, settings):
+    mgr = CertificateManager(
+        cert_dir=tmp_path,
+        settings_manager=MagicMock(),
+        dns_manager=MagicMock(),
+        shell_executor=MagicMock(),
+    )
+    mgr.settings_manager.load_settings.return_value = settings
+    mgr.settings_manager.migrate_domains_format.side_effect = lambda s: s
+    return mgr
+
+
+def test_summary_counts_every_kind_of_entry(tmp_path):
+    settings = {
+        'auto_renew': True,
+        'domains': [
+            'good.com',                                   # str -> checked, needs renewal
+            'fresh.com',                                  # str -> checked, no renewal
+            {'domain': 'disabled.com', 'auto_renew': False},  # per-cert opt-out
+            {'domain': '', 'auto_renew': True},           # empty domain -> invalid
+            {'no_domain_key': True},                      # dict w/o domain -> invalid
+            12345,                                        # not str/dict -> invalid
+        ],
+    }
+    mgr = _manager(tmp_path, settings)
+    mgr.get_certificate_info = MagicMock(
+        side_effect=lambda domain, **kw: {'needs_renewal': domain == 'good.com'}
+    )
+    mgr.renew_certificate = MagicMock()
+
+    summary = mgr.check_renewals()
+
+    assert summary == {
+        'checked': 2,           # good.com + fresh.com
+        'renewed': 1,           # good.com
+        'failed': 0,
+        'skipped_disabled': 1,  # disabled.com
+        'skipped_invalid': 3,   # empty, dict-without-domain, int
+    }
+    mgr.renew_certificate.assert_called_once_with('good.com')
+
+
+def test_renew_failure_is_counted_not_swallowed(tmp_path):
+    settings = {'auto_renew': True, 'domains': ['boom.com']}
+    mgr = _manager(tmp_path, settings)
+    mgr.get_certificate_info = MagicMock(return_value={'needs_renewal': True})
+    mgr.renew_certificate = MagicMock(side_effect=RuntimeError("certbot failed"))
+
+    summary = mgr.check_renewals()
+
+    assert summary['checked'] == 1
+    assert summary['renewed'] == 0
+    assert summary['failed'] == 1
+
+
+def test_global_auto_renew_disabled_short_circuits(tmp_path):
+    settings = {'auto_renew': False, 'domains': ['x.com']}
+    mgr = _manager(tmp_path, settings)
+    mgr.get_certificate_info = MagicMock()
+
+    summary = mgr.check_renewals()
+
+    assert summary['auto_renew_disabled'] is True
+    mgr.get_certificate_info.assert_not_called()

--- a/tests/test_renewal_threshold_validation.py
+++ b/tests/test_renewal_threshold_validation.py
@@ -1,0 +1,72 @@
+"""renewal_threshold_days must never silently disable renewal.
+
+A 0/negative/non-numeric threshold makes `days_left <= threshold`
+permanently False — no certificate ever renews — or raises TypeError in
+the renewal worker. Two layers guard against this:
+
+  - write path: validate_settings_post() rejects an out-of-range or
+    non-numeric value at the API boundary so it never persists;
+  - read path: CertificateManager._coerce_renewal_threshold_days()
+    clamps any value that slipped in via a hand-edited settings.json.
+"""
+
+import pytest
+
+from modules.core.settings import validate_settings_post
+from modules.core.certificates import CertificateManager
+
+pytestmark = [pytest.mark.unit]
+
+
+# --- write path ------------------------------------------------------------
+
+@pytest.mark.parametrize("bad", [0, -5, 366, 1000])
+def test_validate_rejects_out_of_range(bad):
+    with pytest.raises(ValueError):
+        validate_settings_post({"renewal_threshold_days": bad})
+
+
+@pytest.mark.parametrize("bad", ["abc", None, [], {}])
+def test_validate_rejects_non_numeric(bad):
+    with pytest.raises(ValueError):
+        validate_settings_post({"renewal_threshold_days": bad})
+
+
+@pytest.mark.parametrize("good,expected", [(1, 1), (30, 30), (365, 365), ("45", 45)])
+def test_validate_accepts_and_coerces_in_range(good, expected):
+    filtered, rejected, unknown = validate_settings_post({"renewal_threshold_days": good})
+    assert filtered["renewal_threshold_days"] == expected
+    assert not rejected and not unknown
+
+
+def test_noop_echo_of_existing_value_is_not_revalidated():
+    """A GET-then-POST-back of an already-persisted (even legacy) value is a
+    no-op echo and must pass straight through without a spurious 400."""
+    filtered, rejected, unknown = validate_settings_post(
+        {"renewal_threshold_days": 30}, current={"renewal_threshold_days": 30}
+    )
+    assert "renewal_threshold_days" not in filtered  # dropped as echo
+    assert not rejected and not unknown
+
+
+# --- read path -------------------------------------------------------------
+
+@pytest.mark.parametrize("settings,expected", [
+    ({}, 30),                                   # absent -> default
+    ({"renewal_threshold_days": 30}, 30),       # valid passthrough
+    ({"renewal_threshold_days": "30"}, 30),     # stringified JSON number
+    ({"renewal_threshold_days": 0}, 1),         # clamp up from zero
+    ({"renewal_threshold_days": -10}, 1),       # clamp up from negative
+    ({"renewal_threshold_days": 999}, 365),     # clamp down
+    ({"renewal_threshold_days": "junk"}, 30),   # uncoercible -> default
+    (None, 30),                                  # not a dict -> default
+])
+def test_coerce_renewal_threshold_days(settings, expected):
+    assert CertificateManager._coerce_renewal_threshold_days(settings) == expected
+
+
+def test_zero_threshold_does_not_disable_renewal_via_cache_key():
+    """The cache key reflects the coerced threshold, not the raw 0, so a
+    near-expiry cert is never bucketed under an always-False threshold."""
+    key = CertificateManager._certificate_info_cache_key("ex.com", {"renewal_threshold_days": 0})
+    assert "renewal_threshold_days=1" in key

--- a/tests/test_scheduler_status_health.py
+++ b/tests/test_scheduler_status_health.py
@@ -115,5 +115,58 @@ def test_health_falls_back_to_not_running_when_status_unset():
     assert body['checks']['scheduler'] == 'not_running'
 
 
+def test_readiness_returns_503_when_scheduler_failed():
+    """A broken renewal engine must FAIL readiness so orchestrators react.
+
+    /health stays 200 (liveness), but /health/ready returns 503 so a
+    Kubernetes readiness probe / deploy gate catches a scheduler that
+    exploded on startup — the bug being that automatic renewal silently
+    never runs while every health check passes."""
+    managers = {
+        'scheduler': None,
+        'scheduler_status': {
+            'state': 'failed',
+            'error': 'sqlite3.OperationalError: unable to open database file',
+            'timestamp': '2026-05-16T12:00:00Z',
+        },
+    }
+    app = _build_app(managers)
+    client = app.test_client()
+
+    # Liveness unaffected.
+    assert client.get('/health').status_code == 200
+
+    resp = client.get('/health/ready')
+    assert resp.status_code == 503
+    body = resp.get_json()
+    assert body['ready'] is False
+    assert body['scheduler'] == 'failed'
+    assert body['scheduler_error'] == (
+        'sqlite3.OperationalError: unable to open database file'
+    )
+
+
+def test_readiness_returns_200_when_scheduler_running():
+    mock_scheduler = MagicMock()
+    mock_scheduler.running = True
+    managers = {
+        'scheduler': mock_scheduler,
+        'scheduler_status': {'state': 'running', 'error': None, 'timestamp': 't'},
+    }
+    resp = _build_app(managers).test_client().get('/health/ready')
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body['ready'] is True
+    assert body['scheduler'] == 'running'
+    assert 'scheduler_error' not in body
+
+
+def test_readiness_returns_503_when_status_absent():
+    """No recorded status (scheduler never set up) is also not-ready."""
+    resp = _build_app({'scheduler': None}).test_client().get('/health/ready')
+    assert resp.status_code == 503
+    assert resp.get_json()['ready'] is False
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])

--- a/tests/test_storage_warning_surfaced.py
+++ b/tests/test_storage_warning_surfaced.py
@@ -1,0 +1,132 @@
+"""A failed external-storage save must not be silent.
+
+External storage (Azure KV / AWS Secrets / Vault / Infisical) is the
+disaster-recovery copy: if the local cert_dir is on ephemeral storage and
+is lost, the certificate is only recoverable from the backend. When
+store_certificate failed, create_certificate still returned
+success=True with only a log line — the operator had no signal the backup
+never landed. These tests pin that the failure is surfaced on the create
+result, persisted in metadata.json, and visible via get_certificate_info,
+while a clean store stays quiet and no raw exception text (which can carry
+backend credentials) leaks into the surfaced warning.
+"""
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modules.core.certificates import CertificateManager
+from modules.core.constants import CERTIFICATE_FILES
+from modules.core.shell import MockShellExecutor
+
+pytestmark = [pytest.mark.unit]
+
+_LIVE = {f: f"-----BEGIN-----\n{f}\n-----END-----\n".encode() for f in CERTIFICATE_FILES}
+
+
+class _StagingShell(MockShellExecutor):
+    """On a successful certbot run, stage the live/<domain>/ files so
+    create_certificate's copy block runs to completion."""
+
+    def __init__(self, cert_dir, domain):
+        super().__init__()
+        self._cert_dir = Path(cert_dir)
+        self._domain = domain
+        self.set_next_result(returncode=0)
+
+    def run(self, cmd, **kwargs):
+        result = super().run(cmd, **kwargs)
+        if result.returncode == 0:
+            live = self._cert_dir / self._domain / 'live' / self._domain
+            live.mkdir(parents=True, exist_ok=True)
+            for f in CERTIFICATE_FILES:
+                # No explicit chmod: this test asserts the storage_warning
+                # surface, not file modes (that is test_create_cert_io's job).
+                # An os.chmod(...0o644) here only tripped CodeQL's
+                # overly-permissive-file rule for no behavioural gain.
+                (live / f).write_bytes(_LIVE[f])
+        return result
+
+
+def _make_manager(tmp_path, domain, storage_manager):
+    settings_mgr = MagicMock()
+    settings_mgr.load_settings.return_value = {
+        'default_ca': 'letsencrypt', 'challenge_type': 'dns-01',
+        'dns_propagation_seconds': {'duckdns': 1},
+    }
+    settings_mgr.get_domain_dns_provider.return_value = 'duckdns'
+    dns_mgr = MagicMock()
+    dns_mgr.get_dns_provider_account_config.return_value = ({'api_token': 'x'}, 'default')
+    return CertificateManager(
+        cert_dir=tmp_path, settings_manager=settings_mgr, dns_manager=dns_mgr,
+        storage_manager=storage_manager, ca_manager=None,
+        shell_executor=_StagingShell(tmp_path, domain),
+    )
+
+
+def _storage_mock(backend_name, *, store_returns=None, store_raises=None):
+    storage = MagicMock()
+    storage.get_backend_name.return_value = backend_name
+    if store_raises is not None:
+        storage.store_certificate.side_effect = store_raises
+    else:
+        storage.store_certificate.return_value = store_returns
+    # Make get_certificate_info skip the storage-retrieve path and read the
+    # local file, so these tests exercise the local metadata surface.
+    storage.retrieve_certificate_info = None
+    storage.retrieve_certificate.return_value = None
+    return storage
+
+
+def _issue(mgr, domain):
+    with patch('modules.core.certificates.check_certbot_plugin_installed', return_value=True), \
+         patch.object(CertificateManager, '_write_pfx', return_value=None):
+        return mgr.create_certificate(
+            domain=domain, email='t@example.com', dns_provider='duckdns', staging=True,
+        )
+
+
+def test_storage_returns_false_surfaces_warning(tmp_path):
+    domain = 'a.example.duckdns.org'
+    storage = _storage_mock('azure_keyvault', store_returns=False)
+    mgr = _make_manager(tmp_path, domain, storage)
+
+    result = _issue(mgr, domain)
+
+    assert result['success'] is True
+    assert result.get('storage_warning')
+    assert 'azure_keyvault' in result['storage_warning']
+
+    meta = json.loads((tmp_path / domain / 'metadata.json').read_text())
+    assert meta.get('storage_warning')
+
+    info = mgr.get_certificate_info(domain)
+    assert info.get('storage_warning')
+
+
+def test_storage_raises_surfaces_generic_warning_without_secret(tmp_path):
+    domain = 'b.example.duckdns.org'
+    storage = _storage_mock('vault', store_raises=RuntimeError("token=s3cr3t connection refused"))
+    mgr = _make_manager(tmp_path, domain, storage)
+
+    result = _issue(mgr, domain)
+
+    assert result['success'] is True
+    warn = result.get('storage_warning')
+    assert warn and 'vault' in warn
+    # Raw exception text can carry backend credentials — it must never reach
+    # the surfaced warning, only the server log.
+    assert 's3cr3t' not in warn
+
+
+def test_clean_store_has_no_warning(tmp_path):
+    domain = 'c.example.duckdns.org'
+    storage = _storage_mock('aws', store_returns=True)
+    mgr = _make_manager(tmp_path, domain, storage)
+
+    result = _issue(mgr, domain)
+
+    assert result['success'] is True
+    assert result.get('storage_warning') is None
+    assert mgr.get_certificate_info(domain).get('storage_warning') is None


### PR DESCRIPTION
## Why

CertMate has one job: never let a certificate expire. A multi-dimension audit of the codebase surfaced several paths where the app believes it is working while a renewal silently never runs or a backup silently never lands. This branch closes that class of silent failure. Each commit is atomic and carries its own regression test.

## What

- **Renew on the exact threshold boundary** — `get_certificate_info` used `days_left < renewal_threshold_days`, so a cert sitting at exactly the threshold (default 30 days) skipped renewal until it dropped to threshold-1. Aligned to `<=` (digest.py and metrics.py already used it).
- **Validate and clamp `renewal_threshold_days`** — a 0/negative/non-numeric value made the renewal decision permanently false (no cert renews) or raised TypeError in the worker, with nothing validating the field. Now rejected at the API boundary and clamped defensively on read.
- **Fail readiness when the scheduler is dead** — `/health` always returned 200 even with the scheduler `failed`, so orchestrators saw a healthy instance that quietly never renewed. Added `/health/ready` (503 when the renewal engine is down); `/health` stays 200 for liveness. Boot failure now logs at CRITICAL.
- **Make `check_renewals` observable** — malformed `domains` entries were skipped with no signal. Now every checked/renewed/failed/skipped entry is counted, logged as a per-run summary, and returned.
- **Cap SQLAlchemy below 3.0.0** — the unbounded pin meant a future major bump could break APScheduler's jobstore and stop renewals on an unattended upgrade.
- **Surface failed external-storage saves** — a failed store to Azure KV / AWS / Vault / Infisical was a log line only; the API still returned success. Now a generic `storage_warning` (no raw exception text) is persisted in metadata, returned on create, and surfaced on GET.

## Testing

- Full suite green (1313 passed, 2 skipped) with new targeted tests per fix.
- Real-cert end-to-end on a local Docker stack: 3 real Let's Encrypt certificates issued via Cloudflare DNS-01 on random subdomains, and `/health/ready` validated live in the container.

Suggested as a patch release (v2.13.1). No merge/tag here.
