### PR TITLE
UI: durable first-run wizard dismissal + stop form-field wobble

### DIFF
--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -41,6 +41,11 @@ PUBLIC_SETTINGS_WRITABLE_KEYS = frozenset({
     'certificate_storage',
     'notifications',
     'setup_completed',
+    # Per-install "stop nagging me with the first-run wizard" flag. Distinct
+    # from setup_completed, which must stay truthful for recovery/downgrade
+    # detection: a user can dismiss the wizard without having completed setup
+    # through it. Boolean, no side effects.
+    'wizard_dismissed',
     'cloudflare_token',         # legacy single-provider token
     'ca_providers',             # CA provider configuration
     'default_ca',               # selected CA provider
@@ -555,6 +560,7 @@ class SettingsManager:
                 'renewal_threshold_days': 30,  # Configurable certificate expiry threshold (days)
                 'api_bearer_token': _bearer_token_from_env_or_generate(),
                 'setup_completed': False,  # Track if initial setup is done
+                'wizard_dismissed': False,  # First-run wizard dismissed by the user (durable across browsers)
                 'dns_provider': 'cloudflare',
                 'challenge_type': 'dns-01',  # 'dns-01' or 'http-01'
                 # Default certificate key shape applied to any cert that does

--- a/static/js/setup-wizard.js
+++ b/static/js/setup-wizard.js
@@ -53,6 +53,30 @@
         try { window.localStorage.setItem(SKIP_KEY, '1'); } catch (e) { /* storage unavailable (private mode) — skip lasts for this page only */ }
     }
 
+    function persistDismissal() {
+        // Durable, cross-browser "stop showing the wizard". The localStorage
+        // skip above only covers THIS browser, so the modal re-appeared on
+        // another device/profile or after storage was cleared — the reported
+        // bug. Persist a dedicated server-side flag instead of flipping
+        // setup_completed (which must stay truthful for recovery/downgrade
+        // detection). Best-effort: the browser auto-sends Origin, satisfying
+        // the CSRF guard; a failure still leaves the per-browser skip in place.
+        try {
+            fetch('/api/web/settings', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'same-origin',
+                body: JSON.stringify({ wizard_dismissed: true })
+            }).catch(function() {});
+        } catch (e) { /* fetch unavailable — localStorage skip still applies */ }
+    }
+
+    function dismissWizard() {
+        rememberSkip();
+        persistDismissal();
+        closeWizard();
+    }
+
     function checkSetup() {
         var t = new Date().getTime();
         fetch('/api/web/settings?t=' + t, { credentials: 'same-origin', cache: 'no-store' })
@@ -60,7 +84,7 @@
             .then(function(data) {
                 if (data && data.certmate_recovery_suggested) {
                     showRecoveryPrompt();
-                } else if (data && data.setup_completed === false && !wizardSkipped()) {
+                } else if (data && data.setup_completed === false && !data.wizard_dismissed && !wizardSkipped()) {
                     showWizard();
                 }
             })
@@ -147,7 +171,10 @@
                             '<h2 id="wizardTitle" class="text-xl font-bold text-foreground">Welcome to CertMate</h2>' +
                             '<p class="text-sm text-muted mt-1">Let\'s get you set up in a few steps</p>' +
                         '</div>' +
-                        '<div class="flex items-center gap-1.5" id="wizardSteps"></div>' +
+                        '<div class="flex items-center gap-3">' +
+                            '<div class="flex items-center gap-1.5" id="wizardSteps"></div>' +
+                            '<button type="button" id="wizClose" aria-label="Dismiss setup wizard" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-2xl leading-none px-1">&times;</button>' +
+                        '</div>' +
                     '</div>' +
                 '</div>' +
                 '<div id="wizardBody" class="px-6 py-6"></div>' +
@@ -155,8 +182,19 @@
             '</div>';
         document.body.appendChild(overlay);
 
-        // Focus trapping within the wizard overlay
+        // Dismissing the wizard (the X, Esc, or a click on the dimmed
+        // backdrop) persists across browsers via dismissWizard so it stops
+        // nagging — this is the universal exit, available on every step
+        // (step 1's "Skip" is no longer the only way out).
+        var wizClose = document.getElementById('wizClose');
+        if (wizClose) wizClose.addEventListener('click', dismissWizard);
+        overlay.addEventListener('click', function(e) {
+            if (e.target === overlay) dismissWizard();  // backdrop only, not the card
+        });
+
+        // Esc dismisses; Tab is trapped within the overlay.
         overlay.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape') { e.preventDefault(); dismissWizard(); return; }
             if (e.key !== 'Tab') return;
             var focusable = overlay.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
             if (!focusable.length) return;
@@ -239,10 +277,7 @@
             renderStep();
         });
 
-        document.getElementById('wizSkip').addEventListener('click', function() {
-            rememberSkip();
-            closeWizard();
-        });
+        document.getElementById('wizSkip').addEventListener('click', dismissWizard);
         document.getElementById('wizEmail').addEventListener('keydown', function(e) {
             if (e.key === 'Enter') document.getElementById('wizNext1').click();
         });

--- a/templates/index.html
+++ b/templates/index.html
@@ -88,7 +88,7 @@
                                 </label>
                                 <input type="text" id="domain" name="domain"
                                        autocomplete="off"
-                                       class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg shadow-sm py-3 px-4 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all duration-200 placeholder-gray-400"
+                                       class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg shadow-sm py-3 px-4 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors duration-200 placeholder-gray-400"
                                        placeholder="example.com or *.example.com" required>
                                 <p class="mt-1 text-xs text-muted">
                                     <i class="fas fa-info-circle mr-1"></i>
@@ -105,7 +105,7 @@
                                 </label>
                                 <input type="text" id="san_domains" name="san_domains"
                                        autocomplete="off"
-                                       class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg shadow-sm py-3 px-4 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all duration-200 placeholder-gray-400"
+                                       class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg shadow-sm py-3 px-4 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors duration-200 placeholder-gray-400"
                                        placeholder="www.example.com, mail.example.com, *.api.example.com">
                                 <p class="mt-1 text-xs text-muted">
                                     <i class="fas fa-info-circle mr-1"></i>
@@ -119,7 +119,7 @@
                                     Certificate Authority
                                 </label>
                                 <select id="ca_provider_select" name="ca_provider" 
-                                        class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg shadow-sm py-3 px-4 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all duration-200"
+                                        class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg shadow-sm py-3 px-4 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors duration-200"
                                         onchange="updateCAProviderInfo()">
                                     <option value="">Use default from settings</option>
                                     <option value="letsencrypt">Let's Encrypt (Free, DV certificates)</option>
@@ -145,7 +145,7 @@
                                     Challenge Type
                                 </label>
                                 <select id="challenge_type_select" name="challenge_type"
-                                        class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg shadow-sm py-3 px-4 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all duration-200"
+                                        class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg shadow-sm py-3 px-4 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors duration-200"
                                         onchange="toggleDnsProviderVisibility()">
                                     <option value="">Use default from settings</option>
                                     <option value="dns-01">DNS-01 (DNS provider credentials)</option>
@@ -164,7 +164,7 @@
                                     DNS Provider
                                 </label>
                                 <select id="dns_provider_select" name="dns_provider"
-                                        class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg shadow-sm py-3 px-4 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all duration-200"
+                                        class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg shadow-sm py-3 px-4 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors duration-200"
                                         onchange="updateAccountSelection()">
                                     <option value="">🔧 Use default from settings</option>
                                     <option value="cloudflare">☁️ Cloudflare</option>
@@ -202,7 +202,7 @@
                                     Account
                                 </label>
                                 <select id="account_select" name="account_id"
-                                        class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg shadow-sm py-3 px-4 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all duration-200">
+                                        class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg shadow-sm py-3 px-4 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors duration-200">
                                     <option value="">🔧 Use default account</option>
                                 </select>
                                 <p class="mt-1 text-xs text-muted">

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -33,7 +33,7 @@
                             <i class="fas fa-user text-gray-400"></i>
                         </div>
                         <input type="text" name="username" id="username" required
-                            class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg pl-10 py-3 focus:outline-none focus:ring-2 focus:ring-primary transition-all duration-200"
+                            class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg pl-10 py-3 focus:outline-none focus:ring-2 focus:ring-primary transition-colors duration-200"
                             placeholder="admin">
                     </div>
                 </div>
@@ -47,7 +47,7 @@
                             <i class="fas fa-lock text-gray-400"></i>
                         </div>
                         <input type="password" name="password" id="password" required
-                            class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg pl-10 py-3 focus:outline-none focus:ring-2 focus:ring-primary transition-all duration-200"
+                            class="block w-full border border-border dark:bg-gray-700 dark:text-white rounded-lg pl-10 py-3 focus:outline-none focus:ring-2 focus:ring-primary transition-colors duration-200"
                             placeholder="••••••••">
                     </div>
                     <p class="mt-2 text-xs text-muted">

--- a/tests/test_wizard_dismissed.py
+++ b/tests/test_wizard_dismissed.py
@@ -1,0 +1,33 @@
+"""The first-run wizard must be dismissible durably (across browsers).
+
+The Skip/X/Esc/backdrop affordances POST {wizard_dismissed: true} to
+/api/web/settings so the wizard does not re-appear on another device or
+after localStorage is cleared. This pins that the flag is an accepted
+writable setting (distinct from setup_completed, which stays truthful for
+recovery/downgrade detection) and lives in the default template.
+"""
+import pytest
+
+from modules.core.settings import (
+    validate_settings_post,
+    PUBLIC_SETTINGS_WRITABLE_KEYS,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_wizard_dismissed_is_a_writable_setting():
+    assert 'wizard_dismissed' in PUBLIC_SETTINGS_WRITABLE_KEYS
+
+
+def test_post_accepts_wizard_dismissed():
+    filtered, rejected, unknown = validate_settings_post({'wizard_dismissed': True})
+    assert filtered.get('wizard_dismissed') is True
+    assert not rejected and not unknown
+
+
+def test_wizard_dismissed_does_not_touch_setup_completed():
+    """Dismissing the wizard must NOT imply setup is complete: a POST of
+    just wizard_dismissed leaves setup_completed alone."""
+    filtered, _, _ = validate_settings_post({'wizard_dismissed': True})
+    assert 'setup_completed' not in filtered


### PR DESCRIPTION
## Why

Two reported UI problems, traced to root cause.

## What

**1. First-run wizard kept re-appearing after dismissal.** "Skip wizard" persisted only a per-browser localStorage flag, and `setup_completed` (the other gate) flips to true only by finishing the wizard, never by configuring through Settings. So a user who set CertMate up via Settings and skipped the wizard got nagged again on every new browser/profile or after localStorage was cleared. "Skip" also existed only on step 1, with no X / Esc / backdrop close, so advancing a step left no way out.

Fix: a dedicated server-side `wizard_dismissed` flag (kept separate from `setup_completed`, which must stay truthful for recovery/downgrade detection), checked in `checkSetup` and written on dismissal. Added a header X, Esc, and backdrop-click, all routing through `dismissWizard` (localStorage fast-path plus the persisted flag), so the wizard is dismissible durably from any step.

**2. Form selector/input fields wobbled on focus/reflow.** The create-certificate form selects and inputs (and the first-run setup inputs) used `transition-all duration-200`. `transition-all` animates every property including box geometry, so when a field was resized (account select repopulated, or a section revealed) it visibly wobbled for 200ms. The sibling status-filter select already used `transition-shadow` and never wobbled, which was the tell.

Fix: switch those fields to `transition-colors` so only color/border animate and no geometric property is ever transitioned. Buttons that rely on `transition-all` plus `hover:scale` are left untouched.

## Testing

- Full suite green (1283 passed, 2 skipped) including a new test pinning `wizard_dismissed` as a writable setting that does not touch `setup_completed`.
- Docker smoke on a local build: both fixes confirmed baked into the image, and the `wizard_dismissed` flag round-trips through `/api/web/settings` live (default absent, POST true, persists, `setup_completed` untouched).

No merge/tag here.
