### PR TITLE
CI: serialize self-hosted test + CodeQL jobs to stop cross-PR container clobber

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,28 @@ on:
 # token, not the GITHUB_TOKEN), so no job needs write here.
 permissions: read-all
 
-# One CI run per ref at a time. The e2e suite (tests/conftest.py) starts a
-# container with a FIXED name (certmate-test-suite) and port (18888) and runs
-# `docker rm -f` on startup, so two CI runs on the same self-hosted host cycle
-# each other's container mid-run and intermittently fail HTTP e2e tests (seen on
-# the v2.11.2 bump overlapping the #278 merge run). Serializing per-ref removes
-# the clobber; a newer push supersedes an older in-flight run on the same branch.
+# Per-ref: a newer push to a branch supersedes that branch's own older
+# in-flight run. This does NOT cover the shared-container clobber across
+# DIFFERENT refs (two open PRs) — that is handled by a host-global group on
+# the `test` job below.
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   test:
+    # Host-global serialization. The e2e suite (tests/conftest.py) binds a
+    # FIXED-name container (certmate-test-suite) and port (18888) on the
+    # self-hosted host and `docker rm -f`s it on startup, so two test jobs from
+    # DIFFERENT refs/PRs running at once cycle each other's container mid-run
+    # and the HTTP e2e tests fail with connection-refused (observed when two
+    # PRs were opened together). The per-ref group above cannot see across
+    # refs; this single host-wide group makes every test job — regardless of
+    # branch — queue and run one at a time. cancel-in-progress:false so a
+    # waiting PR's tests are queued, never dropped.
+    concurrency:
+      group: certmate-selfhosted-test-container
+      cancel-in-progress: false
     runs-on: [self-hosted, Linux, X64]
     strategy:
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,15 @@ on:
 
 permissions: read-all
 
+# CodeQL runs on the same self-hosted host as CI. Two analysis runs from
+# different PRs overlapping there collide on the shared per-host CodeQL state
+# and one fails fast (observed: one PR's "CodeQL" check passing while a
+# concurrent PR's failed in ~1s). Serialize host-wide and queue rather than
+# cancel so each PR's analysis still completes.
+concurrency:
+  group: certmate-selfhosted-codeql
+  cancel-in-progress: false
+
 jobs:
   analyze:
     name: Analyze ${{ matrix.language }}


### PR DESCRIPTION
## Why

Opening two PRs at once surfaced a CI infrastructure bug: their `test (3.12)` jobs failed with `Connection refused` to the e2e container, and one PR's CodeQL check failed in ~1s while the other's passed. Neither was a code regression.

Root cause: the `test` job runs the e2e suite, which binds a fixed-name container (`certmate-test-suite`) and port (18888) on the self-hosted host and `docker rm -f`s it on startup. The existing workflow concurrency group is keyed on `github.ref`, so it serializes only runs of the same branch. Two PRs are different refs, so their test jobs ran together on the same host and cycled each other's container mid-run. CodeQL had no concurrency group at all and collided on the shared per-host state the same way.

## What

- `ci.yml`: pin the `test` job to a single host-wide concurrency group (`certmate-selfhosted-test-container`), `cancel-in-progress: false`, so test jobs across all PRs queue and run one at a time on the shared container. The per-ref workflow group is kept for same-branch supersession.
- `codeql.yml`: add a host-wide concurrency group (`certmate-selfhosted-codeql`), `cancel-in-progress: false`, so concurrent analyses queue instead of colliding.

`cancel-in-progress: false` is deliberate: a waiting PR's run must queue, not be dropped.

## Testing

- Both workflow files parse as valid YAML with the concurrency blocks correctly placed (workflow-level for CodeQL, job-level on `test`).
- This is the fix for the clobber seen on PRs #293 and #294; once merged, re-running their jobs (or any future concurrent PRs) serializes on the shared host instead of failing.

No merge/tag here.
