### PR TITLE
CI regression net: real-container readiness + staging-safe real-cert E2E

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -1,0 +1,88 @@
+name: E2E (staging)
+
+# Real-certificate end-to-end: issue + force-renew a cert against Let's
+# Encrypt STAGING via Cloudflare DNS-01, on the real built image. This is the
+# regression net for the DNS / provider / ACME wiring that the mocked unit
+# suite cannot exercise (the class of bug behind most recent cert churn).
+#
+# Opt-in only. It needs a Cloudflare secret and is NOT a required PR check:
+# real ACME + DNS propagation are slow and externally flaky, and it runs on
+# the single self-hosted host. Trigger it by hand (workflow_dispatch) or let
+# the weekly schedule catch wiring regressions proactively.
+#
+# To activate, add these repository secrets:
+#   CLOUDFLARE_API_TOKEN  - token with Zone:DNS:Edit on the test zone (required)
+#   CERTMATE_TEST_DOMAIN  - the Cloudflare-managed zone, e.g. example.org (required)
+#   CERTMATE_TEST_EMAIL   - ACME account email (optional; a default is used)
+# Issuance defaults to Let's Encrypt STAGING (tests/e2e_support.py), so a run
+# never consumes a production rate limit or mints a publicly trusted cert.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '37 4 * * 1'  # Mondays 04:37 UTC
+
+permissions: read-all
+
+concurrency:
+  # Share the host-global container lock with the CI `test` job: both bind the
+  # fixed-name certmate-test-suite container on port 18888, so they must never
+  # run at once on the self-hosted host (see ci.yml / #295).
+  group: certmate-selfhosted-test-container
+  cancel-in-progress: false
+
+jobs:
+  e2e-staging:
+    name: e2e-staging
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+    - name: Preflight - require Cloudflare secret
+      id: preflight
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      run: |
+        if [ -z "${CLOUDFLARE_API_TOKEN}" ]; then
+          echo "::notice::CLOUDFLARE_API_TOKEN is not configured - skipping real-cert E2E."
+          echo "run=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "run=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Set up Python 3.12
+      if: steps.preflight.outputs.run == 'true'
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      with:
+        python-version: '3.12'
+
+    - name: Cache pip dependencies
+      if: steps.preflight.outputs.run == 'true'
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      if: steps.preflight.outputs.run == 'true'
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-test.txt
+
+    - name: Real-cert E2E against Let's Encrypt staging
+      if: steps.preflight.outputs.run == 'true'
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        CERTMATE_TEST_DOMAIN: ${{ secrets.CERTMATE_TEST_DOMAIN }}
+        CERTMATE_TEST_EMAIL: ${{ secrets.CERTMATE_TEST_EMAIL }}
+        # Belt-and-suspenders: the tests default to staging, pin it here too.
+        CERTMATE_E2E_CA_PROVIDER: letsencrypt_staging
+      run: |
+        python -m pytest -v -m e2e \
+          tests/test_health_ready_e2e.py \
+          tests/test_cert_lifecycle.py \
+          tests/test_async_issuance_e2e.py

--- a/tests/e2e_support.py
+++ b/tests/e2e_support.py
@@ -1,0 +1,70 @@
+"""Shared helpers for the real-cert E2E tests (staging-safe issuance).
+
+These tests issue REAL certificates against a live ACME server via Cloudflare
+DNS-01. To make that safe to run anywhere (CI, a developer laptop, a cron),
+issuance defaults to Let's Encrypt STAGING: a run can never silently burn the
+production rate limit (5 certs/registered-domain/week) or mint a publicly
+trusted certificate on the test domain.
+
+Two safety mechanisms, belt and suspenders:
+
+1. ``configure_e2e_provider`` writes a NON-EMPTY ``ca_providers.letsencrypt_staging``
+   entry and pins ``default_ca`` to it. An EMPTY staging entry aliases back to
+   production Let's Encrypt in ``ca_manager.get_ca_config`` (ca_manager.py:123-133),
+   so populating it is what actually keeps issuance on staging.
+2. ``assert_staging_issuer`` inspects the ISSUED leaf. The requested
+   ``ca_provider`` is echoed back on the response regardless of what the CA
+   resolution did, so the only real proof that staging was used is the issuer
+   on the certificate itself (LE staging issuers carry ``(STAGING)`` in their
+   name). If anything ever downgraded a run to production, the assertion fails
+   loudly instead of quietly issuing a trusted cert.
+"""
+import os
+
+# Default to STAGING. Override with CERTMATE_E2E_CA_PROVIDER=letsencrypt for a
+# deliberate production run (rare, and never in CI).
+E2E_CA_PROVIDER = os.environ.get("CERTMATE_E2E_CA_PROVIDER", "letsencrypt_staging")
+TEST_EMAIL = os.environ.get("CERTMATE_TEST_EMAIL", "test@gpfree.org")
+
+
+def configure_e2e_provider(api, cloudflare_token, account_id):
+    """Pin the CA to E2E_CA_PROVIDER and register a Cloudflare DNS account.
+
+    Writes both ``ca_providers.letsencrypt`` and a non-empty
+    ``ca_providers.letsencrypt_staging`` (each carrying an email) so the
+    staging selection does not alias to production, and sets ``default_ca``
+    so a create that omits ``ca_provider`` still stays on staging.
+    """
+    r = api.post_json("/api/web/settings", {
+        "email": TEST_EMAIL,
+        "dns_provider": "cloudflare",
+        "default_ca": E2E_CA_PROVIDER,
+        "ca_providers": {
+            "letsencrypt": {"email": TEST_EMAIL},
+            "letsencrypt_staging": {"email": TEST_EMAIL},
+        },
+    })
+    assert r.status_code in (200, 201), \
+        f"E2E settings setup failed: {r.status_code} {r.text[:300]}"
+    r = api.post_json("/api/dns/cloudflare/accounts", {
+        "account_id": account_id,
+        "config": {"api_token": cloudflare_token},
+    })
+    assert r.status_code in (200, 201), \
+        f"E2E Cloudflare account setup failed: {r.status_code} {r.text[:300]}"
+
+
+def assert_staging_issuer(cert_pem):
+    """Fail unless the leaf in *cert_pem* was issued by Let's Encrypt STAGING.
+
+    This is the hard safety net against the staging->production alias trap:
+    it reads the actual issuer off the issued certificate rather than trusting
+    the requested ``ca_provider`` that the API echoes back. Returns the issuer
+    string for logging.
+    """
+    from cryptography import x509
+    cert = x509.load_pem_x509_certificate(cert_pem.encode())
+    issuer = cert.issuer.rfc4514_string()
+    assert "STAGING" in issuer.upper(), \
+        f"certificate was NOT issued by Let's Encrypt staging — issuer={issuer!r}"
+    return issuer

--- a/tests/test_async_issuance_e2e.py
+++ b/tests/test_async_issuance_e2e.py
@@ -9,7 +9,9 @@ subdomains under CERTMATE_TEST_DOMAIN. Two properties:
    the background, ``/health`` stays snappy — i.e. certbot is off the request
    threads, which is the whole point of the executor.
 
-Cert burn: ~3 real Let's Encrypt certs per run (1 + 2 concurrent).
+Cert burn: ~3 Let's Encrypt STAGING certs per run (1 + 2 concurrent);
+staging by default (see tests/e2e_support.py) so no production rate limit
+is touched and no trusted cert is minted on the test domain.
 """
 import os
 import time
@@ -17,6 +19,12 @@ import uuid
 
 import pytest
 import requests
+
+from tests.e2e_support import (
+    E2E_CA_PROVIDER,
+    assert_staging_issuer,
+    configure_e2e_provider,
+)
 
 pytestmark = [pytest.mark.e2e, pytest.mark.slow]
 
@@ -27,11 +35,7 @@ _RUN = uuid.uuid4().hex[:6]
 
 @pytest.fixture(scope="module", autouse=True)
 def configure_cloudflare(api, cloudflare_token):
-    api.post_json("/api/web/settings", {
-        "email": TEST_EMAIL, "dns_provider": "cloudflare"})
-    api.post_json("/api/dns/cloudflare/accounts", {
-        "account_id": "e2e-async",
-        "config": {"api_token": cloudflare_token}})
+    configure_e2e_provider(api, cloudflare_token, "e2e-async")
     yield
     api.delete("/api/dns/cloudflare/accounts/e2e-async")
 
@@ -67,7 +71,8 @@ class TestAsyncIssuance:
         domain = f"e2e-async-{_RUN}.{BASE_DOMAIN}"
         r = api.post_json("/api/certificates/create", {
             "domain": domain, "dns_provider": "cloudflare",
-            "account_id": "e2e-async", "async": True})
+            "account_id": "e2e-async", "ca_provider": E2E_CA_PROVIDER,
+            "async": True})
         assert r.status_code == 202, f"{r.status_code} {r.text[:300]}"
         body = r.json()
         assert body["status"] == "queued"
@@ -77,6 +82,9 @@ class TestAsyncIssuance:
         job = _poll_job(api, body["status_url"])
         assert job["status"] == "succeeded", f"job failed: {job.get('error')}"
         assert domain in _domains(api), f"{domain} not listed after async create"
+        # Prove the async path also stayed on staging (never silently prod).
+        bundle = api.get(f"/api/certificates/{domain}/download?format=json").json()
+        assert_staging_issuer(bundle["cert_pem"])
 
     def test_concurrent_async_creates_keep_health_responsive(self, api):
         domains = [f"e2e-conc-{_RUN}-{i}.{BASE_DOMAIN}" for i in range(2)]
@@ -84,7 +92,8 @@ class TestAsyncIssuance:
         for d in domains:
             r = api.post_json("/api/certificates/create", {
                 "domain": d, "dns_provider": "cloudflare",
-                "account_id": "e2e-async", "async": True})
+                "account_id": "e2e-async", "ca_provider": E2E_CA_PROVIDER,
+                "async": True})
             assert r.status_code == 202, f"{r.status_code} {r.text[:300]}"
             status_urls.append(r.json()["status_url"])
 

--- a/tests/test_cert_lifecycle.py
+++ b/tests/test_cert_lifecycle.py
@@ -9,6 +9,10 @@ Requires:
 Each run generates a random subdomain (e.g. e2e-a1b2c3.gpfree.org) to avoid
 collisions. Certbot cleans up _acme-challenge TXT records automatically.
 The test order is enforced: configure → create → list → download → renew → cleanup.
+
+Issuance defaults to Let's Encrypt STAGING (see tests/e2e_support.py): no
+production rate limit is consumed and no publicly trusted certificate is
+minted on the test domain. The issuer is asserted on the cert itself.
 """
 
 import os
@@ -16,6 +20,12 @@ import uuid
 import zipfile
 import io
 import pytest
+
+from tests.e2e_support import (
+    E2E_CA_PROVIDER,
+    assert_staging_issuer,
+    configure_e2e_provider,
+)
 
 pytestmark = [pytest.mark.e2e, pytest.mark.slow]
 
@@ -29,19 +39,8 @@ TEST_DOMAIN = f"e2e-{_run_id}.{BASE_DOMAIN}"
 
 @pytest.fixture(scope="module", autouse=True)
 def configure_cloudflare(api, cloudflare_token):
-    """Set up Cloudflare account and settings before cert tests."""
-    # Save settings with email + dns provider
-    api.post_json("/api/web/settings", {
-        "email": TEST_EMAIL,
-        "dns_provider": "cloudflare",
-    })
-    # Create Cloudflare account with real token
-    api.post_json("/api/dns/cloudflare/accounts", {
-        "account_id": "e2e-cloudflare",
-        "config": {
-            "api_token": cloudflare_token,
-        },
-    })
+    """Set up the Cloudflare account and STAGING-pinned CA before cert tests."""
+    configure_e2e_provider(api, cloudflare_token, "e2e-cloudflare")
     yield
     # Cleanup DNS account (cert is removed with the container)
     api.delete("/api/dns/cloudflare/accounts/e2e-cloudflare")
@@ -56,6 +55,7 @@ class TestCertificateCreation:
             "domain": TEST_DOMAIN,
             "dns_provider": "cloudflare",
             "account_id": "e2e-cloudflare",
+            "ca_provider": E2E_CA_PROVIDER,
         })
         assert r.status_code in (200, 201), f"Create failed: {r.status_code} {r.text[:300]}"
         data = r.json()
@@ -116,6 +116,14 @@ class TestCertificateDownload:
         assert "-----BEGIN CERTIFICATE-----" in payload["fullchain_pem"]
         assert "-----BEGIN" in payload["private_key_pem"]
 
+    def test_05b_certificate_issued_by_staging(self, api):
+        """Hard safety net: the issued leaf must chain to Let's Encrypt
+        STAGING, never production — proven from the certificate's own issuer,
+        not the requested ca_provider (which the API echoes back regardless)."""
+        bundle = api.get(f"/api/certificates/{TEST_DOMAIN}/download?format=json").json()
+        issuer = assert_staging_issuer(bundle["cert_pem"])
+        print(f"[e2e] issued by staging issuer: {issuer}")
+
     def test_06_invalid_format_returns_400(self, api):
         r = api.get(f"/api/certificates/{TEST_DOMAIN}/download?format=tar")
         assert r.status_code == 400
@@ -131,7 +139,11 @@ class TestCertificateDownload:
 class TestCertificateRenewal:
     """Renew the certificate."""
 
-    def test_08_renew_certificate(self, api):
-        r = api.post_json(f"/api/certificates/{TEST_DOMAIN}/renew", {})
-        # Renewal may succeed or say "not due for renewal" — both are OK
-        assert r.status_code in (200, 400), f"Renew failed: {r.status_code} {r.text[:200]}"
+    def test_08_force_renew_certificate(self, api):
+        """Force-renew actually re-issues — without --force-renewal a freshly
+        issued cert is 'not due' and the renew is a no-op — and the re-issued
+        cert must STAY on staging (a renew must never silently switch CA)."""
+        r = api.post_json(f"/api/certificates/{TEST_DOMAIN}/renew", {"force": True})
+        assert r.status_code == 200, f"Force-renew failed: {r.status_code} {r.text[:300]}"
+        bundle = api.get(f"/api/certificates/{TEST_DOMAIN}/download?format=json").json()
+        assert_staging_issuer(bundle["cert_pem"])

--- a/tests/test_health_ready_e2e.py
+++ b/tests/test_health_ready_e2e.py
@@ -1,0 +1,38 @@
+"""Real-container readiness smoke: the scheduler must actually start.
+
+``/health`` is a liveness probe — it returns 200 as soon as Flask serves,
+even when APScheduler (the ONLY driver of automatic renewals) failed to
+start; the body merely flips ``status`` to ``degraded``. A container whose
+renewal loop is silently dead would therefore sail through any check that
+only looks at ``/health``. ``/health/ready`` is the readiness probe that
+returns 503 in that case.
+
+These run against the real built image (the session ``docker_container``
+fixture), need no Cloudflare token, and are NOT marked ``slow`` — so they
+execute on every CI run as a boot regression net, catching "image builds and
+serves pages but the scheduler never came up" before it ships.
+"""
+import pytest
+
+pytestmark = [pytest.mark.e2e]
+
+
+def test_health_liveness_200(api):
+    """/health is always 200 once Flask serves (liveness)."""
+    r = api.get("/health")
+    assert r.status_code == 200, f"/health {r.status_code}: {r.text[:200]}"
+    body = r.json()
+    assert body.get("status") in ("healthy", "degraded"), body
+
+
+def test_health_ready_scheduler_running(api):
+    """/health/ready must be 200 with the scheduler running — proving the
+    renewal driver actually started in the real container, which /health
+    alone does not."""
+    r = api.get("/health/ready")
+    assert r.status_code == 200, (
+        f"container not ready (scheduler down?): {r.status_code} {r.text[:300]}"
+    )
+    body = r.json()
+    assert body.get("ready") is True, body
+    assert body.get("scheduler") == "running", body


### PR DESCRIPTION
## Summary

Tier A of the roadmap: make CI a regression net for the DNS / provider / ACME wiring that the mocked unit suite cannot exercise (the class of bug behind most recent cert churn). Three atomic, independent changes. Mostly fixes to existing tests — minimal new YAML.

## What and why

### 1. Assert the container is READY, not just live (`test_health_ready_e2e.py`)
`/health` is a liveness probe: it returns 200 as soon as Flask serves, even when APScheduler — the **only** driver of automatic renewals — failed to start (the body just flips `status` to `degraded`). A container whose renewal loop is silently dead therefore passes every check that only looks at `/health`, including the existing e2e page tests. New `@e2e` (non-slow, no-secret) test boots the real built image and asserts `/health/ready == 200` with `scheduler == "running"`. Runs on every CI run.

### 2. Issue against Let's Encrypt **staging**, and prove it (`e2e_support.py` + the two cert e2e tests)
The real-cert e2e tests issued against **production** Let's Encrypt (no `ca_provider`, container `default_ca = letsencrypt`). The day anyone set `CLOUDFLARE_API_TOKEN` in CI they would burn the production rate limit and mint publicly trusted certs on the test domain. They also never exercised force-renew.

- Centralized staging-safe setup defaults to `letsencrypt_staging` and writes a **non-empty** `ca_providers.letsencrypt_staging` entry — an empty one aliases back to production in `ca_manager.get_ca_config` (the real footgun).
- `assert_staging_issuer()` reads the issuer off the **issued leaf** (the requested `ca_provider` is echoed back regardless, so only the cert itself proves staging was used) and fails loudly otherwise.
- `test_cert_lifecycle` now asserts the leaf chains to staging and turns the renew into a real **force-renew** that re-issues and must stay on staging. The async path asserts staging too.

### 3. Gated real-cert E2E workflow (`e2e-staging.yml`)
Opt-in only — **not** a required PR check (real ACME + DNS propagation are slow and externally flaky; runs on the single self-hosted host). `workflow_dispatch` + weekly schedule. A preflight step skips the whole run when `CLOUDFLARE_API_TOKEN` is absent (no-op until the secret is added). Shares the host-global container concurrency group with the CI test job to avoid clobber (#295). Does not run on this PR (no `pull_request` trigger).

To activate: add repo secrets `CLOUDFLARE_API_TOKEN` (Zone:DNS:Edit on the test zone) + `CERTMATE_TEST_DOMAIN`.

## Validation
Validated end to end **locally against Let's Encrypt staging** via Cloudflare DNS-01 on random `certmate.org` subdomains: **13 passed in 4m26s** — readiness, create, download, staging-issuer assertion, force-renew (stays staging), and async issuance. In this PR's required `test` job, the readiness test runs on the real container and the slow cert tests self-skip (no secret).