### PR TITLE
Provider single-source-of-truth (1/2): pin wiring invariants + derive api enum

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -167,6 +167,15 @@ def create_api_models(api):
         'oldest_active_issuance': fields.String(description='Oldest active issuance timestamp')
     })
 
+    # Single source of truth: the dns_provider enum is derived from the
+    # canonical advertised provider list (DNSManager.SUPPORTED_PROVIDERS) so it
+    # cannot drift. The previous hand-maintained literal listed 24 of the 26
+    # providers, silently omitting hetzner-cloud and infomaniak from the API
+    # contract / Swagger. Pinned by
+    # test_api_models_dns_provider_enum_matches_supported.
+    from modules.core.dns_providers import DNSManager
+    dns_provider_enum = list(DNSManager.SUPPORTED_PROVIDERS)
+
     settings_model = api.model('Settings', {
         'cloudflare_token': MaskedString(description='Cloudflare API token (deprecated, use dns_providers)'),
         'domains': fields.List(fields.Raw, description='List of domains (can be strings or objects)'),
@@ -175,13 +184,7 @@ def create_api_models(api):
         'api_bearer_token': MaskedString(description='API bearer token for authentication'),
         'dns_provider': fields.String(
             description='Active DNS provider',
-            enum=[
-                'cloudflare', 'route53', 'azure', 'google', 'powerdns',
-                'digitalocean', 'linode', 'gandi', 'ovh', 'namecheap',
-                'vultr', 'dnsmadeeasy', 'nsone', 'rfc2136', 'hetzner',
-                'porkbun', 'godaddy', 'he-ddns', 'dynudns', 'arvancloud',
-                'acme-dns', 'duckdns', 'edgedns', 'custom-script'
-            ]
+            enum=dns_provider_enum
         ),
         'dns_providers': fields.Nested(dns_providers_model, description='DNS provider configurations'),
         'default_key_type': fields.String(
@@ -204,13 +207,7 @@ def create_api_models(api):
                                    description='Additional SANs (e.g., ["*.example.com"])'),
         'dns_provider': fields.String(
             description='DNS provider to use (optional, uses default from settings)',
-            enum=[
-                'cloudflare', 'route53', 'azure', 'google', 'powerdns',
-                'digitalocean', 'linode', 'gandi', 'ovh', 'namecheap',
-                'vultr', 'dnsmadeeasy', 'nsone', 'rfc2136', 'hetzner',
-                'porkbun', 'godaddy', 'he-ddns', 'dynudns', 'arvancloud',
-                'acme-dns', 'duckdns', 'edgedns', 'custom-script'
-            ]
+            enum=dns_provider_enum
         ),
         'account_id': fields.String(description='DNS provider account ID'),
         'ca_provider': fields.String(description='CA provider (optional)',

--- a/tests/test_provider_wiring_consistency.py
+++ b/tests/test_provider_wiring_consistency.py
@@ -175,6 +175,38 @@ def test_dns_alias_required_fields_match_credential_schema():
     )
 
 
+def _api_model_field_enum(model_name, field_name='dns_provider'):
+    """Build the flask-restx models on a throwaway Api and read a field enum.
+
+    Reads the ACTUAL enum on the registered model so the test pins the real
+    API contract (it would also catch someone re-hardcoding a drifting literal,
+    not just the derivation)."""
+    from flask import Flask
+    from flask_restx import Api
+    from modules.api.models import create_api_models
+
+    api = Api(Flask(__name__))
+    create_api_models(api)
+    return set(api.models[model_name][field_name].enum)
+
+
+def test_api_models_dns_provider_enum_matches_supported():
+    """The dns_provider enum advertised by the API models (Swagger / request
+    contract) must equal the canonical provider set. It previously hand-listed
+    24 of 26, silently omitting hetzner-cloud and infomaniak."""
+    from modules.core.dns_providers import DNSManager
+    supported = set(DNSManager.SUPPORTED_PROVIDERS)
+    for model_name in ('Settings', 'CreateCertificate'):
+        enum = _api_model_field_enum(model_name)
+        missing = supported - enum
+        extra = enum - supported
+        assert not (missing or extra), (
+            f"modules/api/models.py {model_name}.dns_provider enum drifted from "
+            f"DNSManager.SUPPORTED_PROVIDERS: missing={sorted(missing)} "
+            f"extra={sorted(extra)}"
+        )
+
+
 def test_every_alias_provider_is_dispatchable():
     """Every alias provider must be dispatchable at change-time: it either has
     a Lexicon adapter name or is one of the native adapters. A provider in the

--- a/tests/test_provider_wiring_consistency.py
+++ b/tests/test_provider_wiring_consistency.py
@@ -117,3 +117,79 @@ def test_dns_manager_advertised_providers_match_factory():
     )
 
 
+# ---------------------------------------------------------------------------
+# DNS-alias (CNAME-delegation) subsystem. A deliberately smaller subset of
+# providers, wired through three more registries that must stay in lockstep:
+#   certificates.DNS_ALIAS_SUPPORTED_PROVIDERS  (the gate),
+#   certificates.DNS_ALIAS_REQUIRED_FIELDS      (per-provider creds),
+#   dns_alias_hook.LEXICON_PROVIDER_MAP         (Lexicon adapter names),
+# plus two providers (edgedns, acme-dns) dispatched to native, non-Lexicon
+# adapters. These sets are consistent today but were UNGUARDED — the exact
+# #99 failure mode (a provider added to one map and forgotten in another) was
+# free to recur in the alias subsystem. These ratchets lock the contract.
+# ---------------------------------------------------------------------------
+
+# edgedns and acme-dns are alias-capable but handled by dedicated change
+# functions (_edgedns_change / _acme_dns_change) rather than a Lexicon adapter,
+# so they are intentionally absent from LEXICON_PROVIDER_MAP.
+_ALIAS_NATIVE_ADAPTERS = {'edgedns', 'acme-dns'}
+
+
+def test_dns_alias_supported_set_matches_required_fields():
+    """DNS_ALIAS_SUPPORTED_PROVIDERS and DNS_ALIAS_REQUIRED_FIELDS are the
+    exact symbol pair behind #99 (a provider gated as supported but with no
+    field schema, or vice versa). They must list the same providers."""
+    from modules.core.certificates import (
+        DNS_ALIAS_SUPPORTED_PROVIDERS, DNS_ALIAS_REQUIRED_FIELDS)
+    only_supported = DNS_ALIAS_SUPPORTED_PROVIDERS - set(DNS_ALIAS_REQUIRED_FIELDS)
+    only_fields = set(DNS_ALIAS_REQUIRED_FIELDS) - DNS_ALIAS_SUPPORTED_PROVIDERS
+    assert not (only_supported or only_fields), (
+        f"DNS_ALIAS_SUPPORTED_PROVIDERS and DNS_ALIAS_REQUIRED_FIELDS disagree "
+        f"(certificates.py): only-supported={sorted(only_supported)} "
+        f"only-required-fields={sorted(only_fields)}"
+    )
+
+
+def test_dns_alias_providers_are_real_providers():
+    """Every alias-capable provider must be a real, issuable DNS provider."""
+    from modules.core.certificates import DNS_ALIAS_SUPPORTED_PROVIDERS
+    orphans = DNS_ALIAS_SUPPORTED_PROVIDERS - _factory_dns_providers()
+    assert not orphans, (
+        f"DNS_ALIAS_SUPPORTED_PROVIDERS lists providers with no strategy in "
+        f"DNSStrategyFactory: {sorted(orphans)}"
+    )
+
+
+def test_dns_alias_required_fields_match_credential_schema():
+    """An alias provider's required fields must equal its canonical credential
+    schema — otherwise alias setup validates against a different contract than
+    normal issuance (a silent way to accept an unusable config)."""
+    from modules.core.certificates import DNS_ALIAS_REQUIRED_FIELDS
+    mismatched = {}
+    for provider, alias_fields in DNS_ALIAS_REQUIRED_FIELDS.items():
+        creds = _DNS_PROVIDER_CREDENTIALS.get(provider)
+        if creds is None or tuple(creds) != tuple(alias_fields):
+            mismatched[provider] = {'alias': tuple(alias_fields), 'credentials': creds}
+    assert not mismatched, (
+        f"DNS_ALIAS_REQUIRED_FIELDS diverged from _DNS_PROVIDER_CREDENTIALS: {mismatched}"
+    )
+
+
+def test_every_alias_provider_is_dispatchable():
+    """Every alias provider must be dispatchable at change-time: it either has
+    a Lexicon adapter name or is one of the native adapters. A provider in the
+    supported set but neither would hit the 'Unsupported DNS alias provider'
+    branch at runtime (the alias analogue of #99). Also pins that no Lexicon
+    entry exists for a provider outside the alias set."""
+    from modules.core.certificates import DNS_ALIAS_SUPPORTED_PROVIDERS
+    from modules.core.dns_alias_hook import LEXICON_PROVIDER_MAP
+    dispatchable = set(LEXICON_PROVIDER_MAP) | _ALIAS_NATIVE_ADAPTERS
+    undispatchable = DNS_ALIAS_SUPPORTED_PROVIDERS - dispatchable
+    dispatch_without_support = dispatchable - DNS_ALIAS_SUPPORTED_PROVIDERS
+    assert not (undispatchable or dispatch_without_support), (
+        f"alias dispatch coverage drifted from DNS_ALIAS_SUPPORTED_PROVIDERS: "
+        f"undispatchable={sorted(undispatchable)} "
+        f"dispatch-without-support={sorted(dispatch_without_support)}"
+    )
+
+


### PR DESCRIPTION
## Summary

Tier D part 1 — the **low-risk backend half** of the provider single-source-of-truth work. A refute-first re-verification found the backend is already a de-facto SSOT and already test-pinned (`test_provider_wiring_consistency.py`); the audit's "3-way backend divergence" and the desec/#99 claims are already fixed (#288, #99 fix). So this PR (a) locks the remaining unpinned backend invariants and (b) fixes the one real backend-surface drift. The frontend gaps are a separate, larger PR.

### 1. Pin the DNS-alias wiring invariants (ratchets)
The alias (CNAME-delegation) subsystem is wired through three more registries — `DNS_ALIAS_SUPPORTED_PROVIDERS`, `DNS_ALIAS_REQUIRED_FIELDS` (certificates.py), `LEXICON_PROVIDER_MAP` (dns_alias_hook.py) — plus two providers on native adapters (`edgedns`, `acme-dns`). They are consistent today but **nothing asserted it**, so the exact #99 failure mode (added to one map, forgotten in another) was free to recur. Four new ratchets pin: supported-set == required-fields keys (the #99 symbol pair), alias providers are real factory providers, alias required fields == the canonical credential schema, and every alias provider is dispatchable (Lexicon or native). All pass on main — pure invariant locks, no behavior change.

### 2. Derive the API `dns_provider` enum from the canonical list
`modules/api/models.py` hand-listed the `dns_provider` enum **twice** as a 24-entry literal that had drifted: `hetzner-cloud` and `infomaniak` were silently absent from the API contract / Swagger, despite being fully wired everywhere else. Both literals now derive from `DNSManager.SUPPORTED_PROVIDERS` — one fewer hand-maintained list, and the two missing providers are picked up automatically. A new test builds the models and asserts the actual enum equals the canonical set (red before, green after).

## Validation
Full non-e2e suite green (**1324 passed, 2 skipped**); the consistency suite is 9 passed (4 existing + 5 new). The enum now resolves to all 26 providers including hetzner-cloud and infomaniak.

## Not in this PR (next, larger)
The frontend is the real drift surface: 4 providers (`arvancloud`, `infomaniak`, `acme-dns`, `hetzner-cloud`) are absent from the UI entirely and `vultr` renders an empty Add-Account modal. The clean fix is to render the picker/forms from the existing `/api/web/certificates/dns-providers` endpoint (extended with a field schema) instead of the hand-maintained HTML/JS lists. Tracked for a follow-up PR so this safe backend change can land independently.