### PR TITLE
Provider single-source-of-truth (2/2): close frontend provider drift + ratchet

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -387,6 +387,10 @@
             'duckdns': ['duckdns_api_token'],
             'dnsmadeeasy': ['dnsmadeeasy_api_key', 'dnsmadeeasy_secret_key'],
             'nsone': ['nsone_api_key'],
+            'arvancloud': ['arvancloud_api_key'],
+            'infomaniak': ['infomaniak_api_token'],
+            'acme-dns': ['acme-dns_api_url', 'acme-dns_username', 'acme-dns_password', 'acme-dns_subdomain'],
+            'hetzner-cloud': ['hetzner-cloud_api_token'],
             'custom-script': ['custom-script_auth_hook', 'custom-script_cleanup_hook']
         };
 
@@ -593,6 +597,7 @@
             'digitalocean', 'linode', 'edgedns', 'gandi', 'ovh', 'namecheap',
             'vultr', 'dnsmadeeasy', 'nsone', 'rfc2136', 'hetzner',
             'porkbun', 'godaddy', 'he-ddns', 'dynudns', 'duckdns',
+            'arvancloud', 'infomaniak', 'acme-dns', 'hetzner-cloud',
             'custom-script'
         ];
 
@@ -1140,6 +1145,9 @@
             ],
             'nsone': [
                 { name: 'api_key', label: 'API Key', type: 'password', placeholder: 'Your NS1 API key', required: true }
+            ],
+            'vultr': [
+                { name: 'api_key', label: 'API Key', type: 'password', placeholder: 'Your Vultr API key', required: true }
             ],
             'duckdns': [
                 { name: 'api_token', label: 'Account Token', type: 'password', placeholder: 'UUID-format token from your DuckDNS account page', required: true }

--- a/static/js/setup-wizard.js
+++ b/static/js/setup-wizard.js
@@ -32,6 +32,10 @@
         nsone:         { label: 'NS1', icon: 'fa-network-wired', fields: [{ key: 'api_key', label: 'API Key', type: 'password' }] },
         'he-ddns':     { label: 'Hurricane Electric', icon: 'fa-bolt', fields: [{ key: 'username', label: 'Username', type: 'text' }, { key: 'password', label: 'Password', type: 'password' }] },
         dynudns:       { label: 'Dynu', icon: 'fa-globe', fields: [{ key: 'token', label: 'API Token', type: 'password' }] },
+        arvancloud:    { label: 'ArvanCloud', icon: 'fa-cloud', fields: [{ key: 'api_key', label: 'API Key', type: 'password' }] },
+        infomaniak:    { label: 'Infomaniak', icon: 'fa-cloud', fields: [{ key: 'api_token', label: 'API Token', type: 'password' }] },
+        'acme-dns':    { label: 'ACME-DNS', icon: 'fa-network-wired', fields: [{ key: 'api_url', label: 'API URL', type: 'text' }, { key: 'username', label: 'Username', type: 'text' }, { key: 'password', label: 'Password', type: 'password' }, { key: 'subdomain', label: 'Subdomain', type: 'text' }] },
+        'hetzner-cloud': { label: 'Hetzner Cloud', icon: 'fa-server', fields: [{ key: 'api_token', label: 'API Token', type: 'password' }] },
         duckdns:       { label: 'DuckDNS', icon: 'fa-cloud', fields: [{ key: 'api_token', label: 'Account Token', type: 'password', placeholder: 'UUID-format token from your DuckDNS account page' }] }
     };
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -188,6 +188,10 @@
                                     <option value="he-ddns">🌪️ Hurricane Electric</option>
                                     <option value="dynudns">🔄 Dynu</option>
                                     <option value="duckdns">🦆 DuckDNS (free subdomain)</option>
+                                    <option value="hetzner-cloud">Hetzner Cloud</option>
+                                    <option value="arvancloud">ArvanCloud</option>
+                                    <option value="infomaniak">Infomaniak</option>
+                                    <option value="acme-dns">ACME-DNS</option>
                                     <option value="custom-script">Custom Script (your own DNS hooks)</option>
                                 </select>
                                 <p class="mt-1 text-xs text-muted">

--- a/templates/partials/settings_dns.html
+++ b/templates/partials/settings_dns.html
@@ -202,6 +202,46 @@
                                     </div>
                                 </label>
                                 <label class="relative">
+                                    <input type="radio" name="dns_provider" value="hetzner-cloud" class="sr-only peer">
+                                    <div class="p-2 border-2 border-border rounded-lg cursor-pointer transition-all peer-checked:border-primary peer-checked:bg-blue-50 dark:bg-blue-900/20 dark:peer-checked:bg-blue-900/30 hover:border-border-strong">
+                                        <div class="text-center">
+                                            <i class="fas fa-server text-lg text-red-600 mb-1"></i>
+                                            <div class="text-xs font-medium dark:text-white">Hetzner Cloud</div>
+                                            <div class="text-xs text-muted mt-1" id="hetzner-cloud-status">Not configured</div>
+                                        </div>
+                                    </div>
+                                </label>
+                                <label class="relative">
+                                    <input type="radio" name="dns_provider" value="arvancloud" class="sr-only peer">
+                                    <div class="p-2 border-2 border-border rounded-lg cursor-pointer transition-all peer-checked:border-primary peer-checked:bg-blue-50 dark:bg-blue-900/20 dark:peer-checked:bg-blue-900/30 hover:border-border-strong">
+                                        <div class="text-center">
+                                            <i class="fas fa-cloud text-lg text-blue-600 mb-1"></i>
+                                            <div class="text-xs font-medium dark:text-white">ArvanCloud</div>
+                                            <div class="text-xs text-muted mt-1" id="arvancloud-status">Not configured</div>
+                                        </div>
+                                    </div>
+                                </label>
+                                <label class="relative">
+                                    <input type="radio" name="dns_provider" value="infomaniak" class="sr-only peer">
+                                    <div class="p-2 border-2 border-border rounded-lg cursor-pointer transition-all peer-checked:border-primary peer-checked:bg-blue-50 dark:bg-blue-900/20 dark:peer-checked:bg-blue-900/30 hover:border-border-strong">
+                                        <div class="text-center">
+                                            <i class="fas fa-cloud text-lg text-purple-600 mb-1"></i>
+                                            <div class="text-xs font-medium dark:text-white">Infomaniak</div>
+                                            <div class="text-xs text-muted mt-1" id="infomaniak-status">Not configured</div>
+                                        </div>
+                                    </div>
+                                </label>
+                                <label class="relative">
+                                    <input type="radio" name="dns_provider" value="acme-dns" class="sr-only peer">
+                                    <div class="p-2 border-2 border-border rounded-lg cursor-pointer transition-all peer-checked:border-primary peer-checked:bg-blue-50 dark:bg-blue-900/20 dark:peer-checked:bg-blue-900/30 hover:border-border-strong">
+                                        <div class="text-center">
+                                            <i class="fas fa-network-wired text-lg text-green-600 mb-1"></i>
+                                            <div class="text-xs font-medium dark:text-white">ACME-DNS</div>
+                                            <div class="text-xs text-muted mt-1" id="acme-dns-status">Not configured</div>
+                                        </div>
+                                    </div>
+                                </label>
+                                <label class="relative">
                                     <input type="radio" name="dns_provider" value="gandi" class="sr-only peer">
                                     <div class="p-2 border-2 border-border rounded-lg cursor-pointer transition-all peer-checked:border-primary peer-checked:bg-blue-50 dark:bg-blue-900/20 dark:peer-checked:bg-blue-900/30 hover:border-border-strong">
                                         <div class="text-center">
@@ -691,6 +731,122 @@
                             </div>
                             <p class="mt-2 text-sm text-muted">
                                 Create a personal access token from your Akamai Connected Cloud (Linode) account with read/write access to DNS records. For Akamai Edge DNS (enterprise), select the dedicated <em>Akamai Edge DNS</em> provider instead.
+                            </p>
+                        </div>
+                    </div>
+
+                    <!-- Hetzner Cloud Configuration -->
+                    <div id="hetzner-cloud-config" class="dns-config hidden">
+                        <div class="border border-orange-200 dark:border-orange-600 rounded-lg p-4 bg-orange-50 dark:bg-orange-900/20">
+                            <h4 class="text-lg font-medium text-foreground mb-4">
+                                <i class="fas fa-server mr-2 text-red-600"></i>
+                                Hetzner Cloud DNS Configuration
+                            </h4>
+                            <div class="grid grid-cols-1 gap-4">
+                                <div>
+                                    <label for="hetzner-cloud_api_token" class="block text-sm font-medium text-label">
+                                        API Token
+                                    </label>
+                                    <input type="password" id="hetzner-cloud_api_token" name="hetzner-cloud_api_token"
+                                           class="mt-1 block w-full border border-border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-primary focus:border-primary dark:bg-gray-700 dark:text-white"
+                                           placeholder="Your Hetzner Cloud DNS API token">
+                                </div>
+                            </div>
+                            <p class="mt-2 text-sm text-muted">
+                                Uses the certbot-dns-hetzner-cloud plugin. Create an API token in the Hetzner Cloud console with DNS permissions. Choose the plain <em>Hetzner</em> provider instead if you use Hetzner DNS rather than Hetzner Cloud.
+                            </p>
+                        </div>
+                    </div>
+
+                    <!-- ArvanCloud Configuration -->
+                    <div id="arvancloud-config" class="dns-config hidden">
+                        <div class="border border-orange-200 dark:border-orange-600 rounded-lg p-4 bg-orange-50 dark:bg-orange-900/20">
+                            <h4 class="text-lg font-medium text-foreground mb-4">
+                                <i class="fas fa-cloud mr-2 text-blue-600"></i>
+                                ArvanCloud DNS Configuration
+                            </h4>
+                            <div class="grid grid-cols-1 gap-4">
+                                <div>
+                                    <label for="arvancloud_api_key" class="block text-sm font-medium text-label">
+                                        API Key
+                                    </label>
+                                    <input type="password" id="arvancloud_api_key" name="arvancloud_api_key"
+                                           class="mt-1 block w-full border border-border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-primary focus:border-primary dark:bg-gray-700 dark:text-white"
+                                           placeholder="Your ArvanCloud API key">
+                                </div>
+                            </div>
+                            <p class="mt-2 text-sm text-muted">
+                                Create an API key in your ArvanCloud panel with DNS management permissions.
+                            </p>
+                        </div>
+                    </div>
+
+                    <!-- Infomaniak Configuration -->
+                    <div id="infomaniak-config" class="dns-config hidden">
+                        <div class="border border-orange-200 dark:border-orange-600 rounded-lg p-4 bg-orange-50 dark:bg-orange-900/20">
+                            <h4 class="text-lg font-medium text-foreground mb-4">
+                                <i class="fas fa-cloud mr-2 text-purple-600"></i>
+                                Infomaniak DNS Configuration
+                            </h4>
+                            <div class="grid grid-cols-1 gap-4">
+                                <div>
+                                    <label for="infomaniak_api_token" class="block text-sm font-medium text-label">
+                                        API Token
+                                    </label>
+                                    <input type="password" id="infomaniak_api_token" name="infomaniak_api_token"
+                                           class="mt-1 block w-full border border-border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-primary focus:border-primary dark:bg-gray-700 dark:text-white"
+                                           placeholder="Your Infomaniak API token">
+                                </div>
+                            </div>
+                            <p class="mt-2 text-sm text-muted">
+                                Create an API token in your Infomaniak account with the Domain scope.
+                            </p>
+                        </div>
+                    </div>
+
+                    <!-- ACME-DNS Configuration -->
+                    <div id="acme-dns-config" class="dns-config hidden">
+                        <div class="border border-orange-200 dark:border-orange-600 rounded-lg p-4 bg-orange-50 dark:bg-orange-900/20">
+                            <h4 class="text-lg font-medium text-foreground mb-4">
+                                <i class="fas fa-network-wired mr-2 text-green-600"></i>
+                                ACME-DNS Configuration
+                            </h4>
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <div>
+                                    <label for="acme-dns_api_url" class="block text-sm font-medium text-label">
+                                        API URL
+                                    </label>
+                                    <input type="text" id="acme-dns_api_url" name="acme-dns_api_url"
+                                           class="mt-1 block w-full border border-border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-primary focus:border-primary dark:bg-gray-700 dark:text-white"
+                                           placeholder="https://auth.acme-dns.io">
+                                </div>
+                                <div>
+                                    <label for="acme-dns_subdomain" class="block text-sm font-medium text-label">
+                                        Subdomain
+                                    </label>
+                                    <input type="text" id="acme-dns_subdomain" name="acme-dns_subdomain"
+                                           class="mt-1 block w-full border border-border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-primary focus:border-primary dark:bg-gray-700 dark:text-white"
+                                           placeholder="The ACME-DNS subdomain">
+                                </div>
+                                <div>
+                                    <label for="acme-dns_username" class="block text-sm font-medium text-label">
+                                        Username
+                                    </label>
+                                    <input type="text" id="acme-dns_username" name="acme-dns_username"
+                                           class="mt-1 block w-full border border-border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-primary focus:border-primary dark:bg-gray-700 dark:text-white"
+                                           placeholder="The ACME-DNS username">
+                                </div>
+                                <div>
+                                    <label for="acme-dns_password" class="block text-sm font-medium text-label">
+                                        Password
+                                    </label>
+                                    <input type="password" id="acme-dns_password" name="acme-dns_password"
+                                           class="mt-1 block w-full border border-border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-primary focus:border-primary dark:bg-gray-700 dark:text-white"
+                                           placeholder="The ACME-DNS password">
+                                </div>
+                            </div>
+                            <p class="mt-2 text-sm text-muted">
+                                Register an ACME-DNS account first, then enter the returned credentials so certbot can answer the CNAME-delegated challenge.
                             </p>
                         </div>
                     </div>

--- a/tests/test_frontend_provider_coverage.py
+++ b/tests/test_frontend_provider_coverage.py
@@ -1,0 +1,90 @@
+"""The frontend provider lists must cover every backend DNS provider.
+
+The backend is a single, test-pinned source of truth
+(test_provider_wiring_consistency.py), but the UI hand-maintains its own
+provider lists in HTML/JS. They had silently drifted: arvancloud, infomaniak,
+acme-dns and hetzner-cloud were issuable via the API but absent from the
+settings picker entirely (a user could not configure them), and vultr had a
+radio + Add-Account button but no modal field schema, so its modal rendered
+empty.
+
+These ratchets make that drift a build break: the provider picker and the
+quick-add select must list exactly the canonical providers, and every
+Add-Account button must have a credential schema to render.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+from modules.core.dns_providers import DNSManager
+
+pytestmark = [pytest.mark.unit]
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SUPPORTED = set(DNSManager.SUPPORTED_PROVIDERS)
+
+
+def _read(rel):
+    return (_ROOT / rel).read_text()
+
+
+def test_settings_dns_radio_picker_covers_all_providers():
+    """templates/partials/settings_dns.html — the DNS provider radio picker
+    must offer exactly the canonical provider set."""
+    html = _read('templates/partials/settings_dns.html')
+    radios = set(re.findall(r'name="dns_provider"\s+value="([a-z0-9-]+)"', html))
+    missing = _SUPPORTED - radios
+    extra = radios - _SUPPORTED
+    assert not (missing or extra), (
+        f"settings_dns.html provider radios drifted from "
+        f"DNSManager.SUPPORTED_PROVIDERS: missing={sorted(missing)} "
+        f"extra={sorted(extra)}"
+    )
+
+
+def test_settings_dns_radios_have_config_blocks():
+    """Every provider radio must have a matching #<provider>-config block, or
+    selecting it shows an empty configuration panel."""
+    html = _read('templates/partials/settings_dns.html')
+    radios = set(re.findall(r'name="dns_provider"\s+value="([a-z0-9-]+)"', html))
+    config_blocks = set(re.findall(r'id="([a-z0-9-]+)-config"', html))
+    missing = radios - config_blocks
+    assert not missing, (
+        f"provider radios with no #<provider>-config block: {sorted(missing)}"
+    )
+
+
+def test_index_quick_add_select_covers_all_providers():
+    """templates/index.html — the quick-add domain DNS provider <select>
+    must offer exactly the canonical provider set."""
+    html = _read('templates/index.html')
+    m = re.search(r'updateAccountSelection\(\).*?</select>', html, re.S)
+    assert m, "could not locate the quick-add DNS provider <select> in index.html"
+    options = set(re.findall(r'<option value="([a-z0-9-]+)"', m.group(0)))
+    missing = _SUPPORTED - options
+    extra = options - _SUPPORTED
+    assert not (missing or extra), (
+        f"index.html quick-add provider select drifted from "
+        f"DNSManager.SUPPORTED_PROVIDERS: missing={sorted(missing)} "
+        f"extra={sorted(extra)}"
+    )
+
+
+def test_add_account_buttons_have_modal_field_schema():
+    """Every Add-Account button (showAddAccountModal('<provider>')) must have a
+    credential schema in settings.js getProviderFields, or its modal renders
+    no fields (the vultr bug)."""
+    html = _read('templates/partials/settings_dns.html')
+    button_providers = set(re.findall(r"showAddAccountModal\('([a-z0-9-]+)'\)", html))
+
+    js = _read('static/js/settings.js')
+    start = js.index('function getProviderFields')
+    end = js.index('var fields = fieldMappings[provider]', start)
+    schema_keys = set(re.findall(r"'([a-z0-9-]+)':\s*\[", js[start:end]))
+
+    missing = button_providers - schema_keys
+    assert not missing, (
+        f"providers with an Add-Account button but no getProviderFields schema "
+        f"(empty modal): {sorted(missing)}"
+    )


### PR DESCRIPTION
## Summary

Tier D part 2 — fixes the real, user-facing provider drift on the frontend (part 1 #299 locked the backend). The verification found four providers and a vultr bug that the UI's hand-maintained lists had drifted into.

### Fixes
- **`arvancloud`, `infomaniak`, `acme-dns`, `hetzner-cloud` were unconfigurable in the UI.** Fully wired in the backend (issuable via the API) but absent from the settings picker, the quick-add select, the JS field/status maps and the setup wizard — a UI-only user could not configure them. Added radio cards + config blocks (`settings_dns.html`), quick-add options (`index.html`), legacy-field + status entries (`settings.js`) and wizard entries (`setup-wizard.js`), with the credential fields taken from `_DNS_PROVIDER_CREDENTIALS`. They use the simple single-account config pattern (like linode/gandi); the legacy save path maps `<provider>_<field>` form names back to backend keys, matching the existing `custom-script` pattern.
- **`vultr` rendered an empty Add-Account modal** — it had a radio + Add-Account button but no `getProviderFields` schema. Added its `api_key` field.

### Ratchet (makes drift a build break)
New `tests/test_frontend_provider_coverage.py`: the settings radio picker and the quick-add select must list exactly `DNSManager.SUPPORTED_PROVIDERS`, every radio must have a matching config block, and every Add-Account button must have a `getProviderFields` schema. These would have caught all five gaps.

## Validation
- New ratchets + the existing consistency suite green; full non-e2e suite **1328 passed**.
- `frontend-css` gate: rebuilt Tailwind bundle has **no drift** (reused existing classes).
- **End-to-end on the built image**: all four new radios + config blocks render in the real settings page, and saving an `arvancloud` config persists (`dns_provider=arvancloud`, `{"message":"Settings updated"}`).

## Tier D status
This completes the chosen scope (fix gaps + ratchet). The optional structural cleanup — rendering the picker/forms from the `/api/web/certificates/dns-providers` endpoint to delete the hardcoded HTML/JS lists entirely — is deferred; the ratchet now guarantees the lists can't silently drift in the meantime.