### PR TITLE
build(docker): bump base image to patch openssl CVE-2026-45447 (HIGH)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # moving target on Docker Hub, the digest is content-addressed and
 # guarantees byte-identical bytes. Bump deliberately when there's a
 # CVE fix or feature reason — not implicitly on every rebuild.
-FROM python:3.12-slim-trixie@sha256:401f6e1a67dad31a1bd78e9ad22d0ee0a3b52154e6bd30e90be696bb6a3d7461 AS builder
+FROM python:3.12-slim-trixie@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9 AS builder
 
 # Set working directory for build stage
 WORKDIR /build
@@ -47,7 +47,7 @@ RUN pip install -U pip setuptools wheel && \
     fi
 
 # Production stage — same digest pin as the builder stage above.
-FROM python:3.12-slim-trixie@sha256:401f6e1a67dad31a1bd78e9ad22d0ee0a3b52154e6bd30e90be696bb6a3d7461
+FROM python:3.12-slim-trixie@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## Summary

Supply-chain quick-win. Re-pin both Dockerfile stages from `python:3.12-slim-trixie@401f6e1a` to `@d764629c`, which ships `openssl 3.5.6-1~deb13u2` — the fixed version for **CVE-2026-45447 (HIGH)**.

## Validation
Built and scanned with **Trivy 0.70.0** (the same version CI's `security-scan` uses):
- `CVE-2026-45447` (openssl, HIGH) — **gone** after the bump.
- Boot smoke on the patched image: `/health` 200, `/health/ready` `{ready:true, scheduler:"running"}`, version 2.13.2.

## Remaining base CVEs (no action possible yet)
The other base-image HIGH/CRITICAL CVEs have **no fixed version published by Debian** (`fixable: 0` in Trivy) — the latest base already carries the newest `perl-base 5.40.1-6`, so `apt-get upgrade` is a no-op:
- CRITICAL: `perl-base` `CVE-2026-42496`, `CVE-2026-8376`
- HIGH: `perl-base` `CVE-2026-42497`/`48959`/`48962`/`9538`, `libsqlite3-0` `CVE-2026-11822`/`11824`, ncurses `CVE-2025-69720`

They will clear on a future base bump once upstream patches land.

## Related (not in this PR)
- The audit's `py/path-injection` HIGH alerts in `resources.py` (9 of them) were **re-verified as false positives** — every flagged read is behind `_validate_domain_path` / `_validate_backup_filename` (a `realpath().startswith(base)` barrier CodeQL doesn't model) with allow-listed filenames. No code change warranted; dismissal of those alerts is left to a maintainer.
- Trivy also flags ~2 fixable HIGHs in Python deps (separate from the base image) — a possible `requirements.txt` follow-up.