### PR TITLE
feat(dns): add deSEC and Scaleway DNS providers (EU)

### DIFF
--- a/modules/core/dns_providers.py
+++ b/modules/core/dns_providers.py
@@ -28,6 +28,7 @@ class DNSManager:
         'hetzner-cloud', 'rfc2136', 'powerdns', 'edgedns', 'gandi',
         'arvancloud', 'infomaniak', 'acme-dns', 'duckdns', 'vultr',
         'dnsmadeeasy', 'nsone', 'porkbun', 'he-ddns', 'dynudns',
+        'desec', 'scaleway',
         'custom-script',
     ]
 

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -987,7 +987,7 @@ class SettingsManager:
                 # Validate dns_provider against supported set.
                 # IMPORTANT: when adding a provider, also update tests/test_provider_wiring_consistency.py
                 # which extracts this literal via inspect.getsource.
-                supported_providers = {'cloudflare','route53','azure','google','powerdns','digitalocean','linode','edgedns','gandi','ovh','namecheap','vultr','dnsmadeeasy','nsone','rfc2136','hetzner','hetzner-cloud','porkbun','godaddy','he-ddns','dynudns','arvancloud','infomaniak','acme-dns','duckdns','custom-script'}
+                supported_providers = {'cloudflare','route53','azure','google','powerdns','digitalocean','linode','edgedns','gandi','ovh','namecheap','vultr','dnsmadeeasy','nsone','rfc2136','hetzner','hetzner-cloud','porkbun','godaddy','he-ddns','dynudns','arvancloud','infomaniak','acme-dns','duckdns','desec','scaleway','custom-script'}
                 if 'dns_provider' in settings and settings['dns_provider'] not in supported_providers:
                     logger.error(f"Invalid dns_provider: {settings['dns_provider']}")
                     return False
@@ -1065,6 +1065,8 @@ class SettingsManager:
                     'duckdns': 60,
                     'edgedns': 90,
                     'hetzner-cloud': 120,
+                    'desec': 80,
+                    'scaleway': 60,
                     'custom-script': 120
                 }
                 if 'dns_propagation_seconds' not in settings or not isinstance(settings['dns_propagation_seconds'], dict):

--- a/modules/core/utils.py
+++ b/modules/core/utils.py
@@ -70,6 +70,8 @@ _DNS_PROVIDER_CREDENTIALS = {
     'he-ddns': ['username', 'password'],
     'dynudns': ['token'],
     'edgedns': ['client_token', 'client_secret', 'access_token', 'host'],
+    'desec': ['api_token'],
+    'scaleway': ['application_token'],
     # Admin-supplied hook scripts (#286): the auth hook is the only hard
     # requirement; the cleanup hook is optional.
     'custom-script': ['auth_hook']
@@ -80,7 +82,7 @@ _MULTI_PROVIDER_PLUGIN_FILES = {
     'vultr': 'vultr.ini', 'dnsmadeeasy': 'dnsmadeeasy.ini', 'nsone': 'nsone.ini',
     'rfc2136': 'rfc2136.ini', 'hetzner': 'hetzner.ini', 'hetzner-cloud': 'hetzner-cloud.ini',
     'porkbun': 'porkbun.ini', 'godaddy': 'godaddy.ini', 'he-ddns': 'he-ddns.ini',
-    'dynudns': 'dynudns.ini'
+    'dynudns': 'dynudns.ini', 'desec': 'desec.ini', 'scaleway': 'scaleway.ini'
 }
 
 # A data-driven template for building multi-provider config files.
@@ -102,6 +104,8 @@ _MULTI_PROVIDER_TEMPLATE_MAP = {
     'godaddy': {'dns_godaddy_key': 'api_key', 'dns_godaddy_secret': 'secret'},
     'he-ddns': {'dns_he_ddns_username': 'username', 'dns_he_ddns_password': 'password'},
     'dynudns': {'dns_dynudns_token': 'token'},
+    'desec': {'dns_desec_token': 'api_token'},
+    'scaleway': {'dns_scaleway_application_token': 'application_token'},
 }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,13 @@ certbot-dns-duckdns==1.8.0
 # Akamai Edge DNS (enterprise) — separate from certbot-dns-linode (Akamai Connected Cloud).
 # Pinned at 0.1.0 because 0.2.0 requires certbot>=5.2.2 (incompatible with our certbot==2.10.0).
 certbot-plugin-edgedns==0.1.0
+# deSEC: free German DNSSEC provider. Official plugin, no certbot upper bound, no lexicon dep
+# (verified compatible with certbot==2.10.0). Writes _acme-challenge TXT via the deSEC REST API.
+certbot-dns-desec==1.3.2
+# Scaleway: French sovereign cloud. The community plugin certbot-dns-scaleway==0.0.7 is alpha
+# (last released 2022) — NOT pinned in core to avoid pulling an unmaintained dep into every
+# image. The 'scaleway' provider is wired and selectable; install the plugin separately to use it:
+#   pip install certbot-dns-scaleway==0.0.7
 
 # Cloud SDK dependencies
 boto3==1.34.144                    # AWS support

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -391,6 +391,8 @@
             'infomaniak': ['infomaniak_api_token'],
             'acme-dns': ['acme-dns_api_url', 'acme-dns_username', 'acme-dns_password', 'acme-dns_subdomain'],
             'hetzner-cloud': ['hetzner-cloud_api_token'],
+            'desec': ['desec_api_token'],
+            'scaleway': ['scaleway_application_token'],
             'custom-script': ['custom-script_auth_hook', 'custom-script_cleanup_hook']
         };
 
@@ -598,6 +600,7 @@
             'vultr', 'dnsmadeeasy', 'nsone', 'rfc2136', 'hetzner',
             'porkbun', 'godaddy', 'he-ddns', 'dynudns', 'duckdns',
             'arvancloud', 'infomaniak', 'acme-dns', 'hetzner-cloud',
+            'desec', 'scaleway',
             'custom-script'
         ];
 

--- a/static/js/setup-wizard.js
+++ b/static/js/setup-wizard.js
@@ -36,6 +36,8 @@
         infomaniak:    { label: 'Infomaniak', icon: 'fa-cloud', fields: [{ key: 'api_token', label: 'API Token', type: 'password' }] },
         'acme-dns':    { label: 'ACME-DNS', icon: 'fa-network-wired', fields: [{ key: 'api_url', label: 'API URL', type: 'text' }, { key: 'username', label: 'Username', type: 'text' }, { key: 'password', label: 'Password', type: 'password' }, { key: 'subdomain', label: 'Subdomain', type: 'text' }] },
         'hetzner-cloud': { label: 'Hetzner Cloud', icon: 'fa-server', fields: [{ key: 'api_token', label: 'API Token', type: 'password' }] },
+        desec:         { label: 'deSEC', icon: 'fa-shield-alt', fields: [{ key: 'api_token', label: 'API Token', type: 'password' }] },
+        scaleway:      { label: 'Scaleway', icon: 'fa-cloud', fields: [{ key: 'application_token', label: 'API Secret Key', type: 'password' }] },
         duckdns:       { label: 'DuckDNS', icon: 'fa-cloud', fields: [{ key: 'api_token', label: 'Account Token', type: 'password', placeholder: 'UUID-format token from your DuckDNS account page' }] }
     };
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -192,6 +192,8 @@
                                     <option value="arvancloud">ArvanCloud</option>
                                     <option value="infomaniak">Infomaniak</option>
                                     <option value="acme-dns">ACME-DNS</option>
+                                    <option value="desec">deSEC</option>
+                                    <option value="scaleway">Scaleway</option>
                                     <option value="custom-script">Custom Script (your own DNS hooks)</option>
                                 </select>
                                 <p class="mt-1 text-xs text-muted">

--- a/templates/partials/settings_dns.html
+++ b/templates/partials/settings_dns.html
@@ -242,6 +242,26 @@
                                     </div>
                                 </label>
                                 <label class="relative">
+                                    <input type="radio" name="dns_provider" value="desec" class="sr-only peer">
+                                    <div class="p-2 border-2 border-border rounded-lg cursor-pointer transition-all peer-checked:border-primary peer-checked:bg-blue-50 dark:bg-blue-900/20 dark:peer-checked:bg-blue-900/30 hover:border-border-strong">
+                                        <div class="text-center">
+                                            <i class="fas fa-shield-alt text-lg text-green-600 mb-1"></i>
+                                            <div class="text-xs font-medium dark:text-white">deSEC</div>
+                                            <div class="text-xs text-muted mt-1" id="desec-status">Not configured</div>
+                                        </div>
+                                    </div>
+                                </label>
+                                <label class="relative">
+                                    <input type="radio" name="dns_provider" value="scaleway" class="sr-only peer">
+                                    <div class="p-2 border-2 border-border rounded-lg cursor-pointer transition-all peer-checked:border-primary peer-checked:bg-blue-50 dark:bg-blue-900/20 dark:peer-checked:bg-blue-900/30 hover:border-border-strong">
+                                        <div class="text-center">
+                                            <i class="fas fa-cloud text-lg text-purple-600 mb-1"></i>
+                                            <div class="text-xs font-medium dark:text-white">Scaleway</div>
+                                            <div class="text-xs text-muted mt-1" id="scaleway-status">Not configured</div>
+                                        </div>
+                                    </div>
+                                </label>
+                                <label class="relative">
                                     <input type="radio" name="dns_provider" value="gandi" class="sr-only peer">
                                     <div class="p-2 border-2 border-border rounded-lg cursor-pointer transition-all peer-checked:border-primary peer-checked:bg-blue-50 dark:bg-blue-900/20 dark:peer-checked:bg-blue-900/30 hover:border-border-strong">
                                         <div class="text-center">
@@ -847,6 +867,52 @@
                             </div>
                             <p class="mt-2 text-sm text-muted">
                                 Register an ACME-DNS account first, then enter the returned credentials so certbot can answer the CNAME-delegated challenge.
+                            </p>
+                        </div>
+                    </div>
+
+                    <!-- deSEC Configuration -->
+                    <div id="desec-config" class="dns-config hidden">
+                        <div class="border border-orange-200 dark:border-orange-600 rounded-lg p-4 bg-orange-50 dark:bg-orange-900/20">
+                            <h4 class="text-lg font-medium text-foreground mb-4">
+                                <i class="fas fa-shield-alt mr-2 text-green-600"></i>
+                                deSEC DNS Configuration
+                            </h4>
+                            <div class="grid grid-cols-1 gap-4">
+                                <div>
+                                    <label for="desec_api_token" class="block text-sm font-medium text-label">
+                                        API Token
+                                    </label>
+                                    <input type="password" id="desec_api_token" name="desec_api_token"
+                                           class="mt-1 block w-full border border-border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-primary focus:border-primary dark:bg-gray-700 dark:text-white"
+                                           placeholder="Your deSEC API token (desec.io, Token Management)">
+                                </div>
+                            </div>
+                            <p class="mt-2 text-sm text-muted">
+                                Free German DNSSEC provider. Create a token at desec.io with permission to write the zone's RRsets; the domain's nameservers must be delegated to deSEC (ns1.desec.io / ns2.desec.org).
+                            </p>
+                        </div>
+                    </div>
+
+                    <!-- Scaleway Configuration -->
+                    <div id="scaleway-config" class="dns-config hidden">
+                        <div class="border border-orange-200 dark:border-orange-600 rounded-lg p-4 bg-orange-50 dark:bg-orange-900/20">
+                            <h4 class="text-lg font-medium text-foreground mb-4">
+                                <i class="fas fa-cloud mr-2 text-purple-600"></i>
+                                Scaleway DNS Configuration
+                            </h4>
+                            <div class="grid grid-cols-1 gap-4">
+                                <div>
+                                    <label for="scaleway_application_token" class="block text-sm font-medium text-label">
+                                        API Secret Key
+                                    </label>
+                                    <input type="password" id="scaleway_application_token" name="scaleway_application_token"
+                                           class="mt-1 block w-full border border-border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-primary focus:border-primary dark:bg-gray-700 dark:text-white"
+                                           placeholder="Your Scaleway API Secret Key">
+                                </div>
+                            </div>
+                            <p class="mt-2 text-sm text-muted">
+                                French sovereign cloud. Use a Scaleway API Secret Key with DNS permissions; the domain's DNS zone must be hosted on Scaleway. Community certbot plugin (alpha).
                             </p>
                         </div>
                     </div>

--- a/tests/test_desec_scaleway_provider.py
+++ b/tests/test_desec_scaleway_provider.py
@@ -1,0 +1,38 @@
+"""deSEC and Scaleway DNS-01 wiring.
+
+Both are generic multi-provider entries (no dedicated strategy class). The only
+provider-specific logic is the credential -> certbot-plugin INI key mapping in
+_MULTI_PROVIDER_TEMPLATE_MAP; getting that key wrong silently breaks auth. These
+tests pin the exact INI key each plugin expects:
+  - certbot-dns-desec      -> dns_desec_token
+  - certbot-dns-scaleway   -> dns_scaleway_application_token
+"""
+import pytest
+
+from modules.core.utils import create_multi_provider_config
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_desec_config_writes_plugin_ini_key(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    path = create_multi_provider_config('desec', {'api_token': 'tok-desec-123'})
+    assert path is not None, "deSEC config not written"
+    assert path.read_text().strip() == 'dns_desec_token = tok-desec-123'
+    # credentials file carries a secret -> must be 0600
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_scaleway_config_writes_plugin_ini_key(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    path = create_multi_provider_config('scaleway', {'application_token': 'scw-secret-key'})
+    assert path is not None, "Scaleway config not written"
+    assert path.read_text().strip() == 'dns_scaleway_application_token = scw-secret-key'
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_missing_credential_returns_none(tmp_path, monkeypatch):
+    """An empty/missing credential must fail validation and write no file."""
+    monkeypatch.chdir(tmp_path)
+    assert create_multi_provider_config('desec', {'api_token': ''}) is None
+    assert create_multi_provider_config('scaleway', {}) is None

--- a/tests/test_dns_manager_coverage.py
+++ b/tests/test_dns_manager_coverage.py
@@ -110,12 +110,18 @@ class TestTestProvider:
         assert ok is False
         assert 'Unsupported' in msg
 
-    def test_phantom_desec_is_rejected(self, manager_factory):
-        """Regression pin: 'desec' used to be advertised despite having no
-        strategy/validation wiring anywhere else in the stack."""
+    def test_desec_is_now_a_real_provider(self, manager_factory):
+        """'desec' was historically a PHANTOM — advertised with no strategy or
+        validation wiring (ripped out in #288). It is now a fully wired generic
+        multi-provider (certbot-dns-desec), so a valid config is accepted and a
+        missing credential is rejected. The guard against genuinely-unknown
+        providers is covered by the 'not-a-provider' test above."""
         mgr, _ = manager_factory({})
-        ok, _ = mgr.test_provider('desec', {'api_token': 'x'})
-        assert ok is False
+        ok, msg = mgr.test_provider('desec', {'api_token': 'tok'})
+        assert ok is True, msg
+        bad, bad_msg = mgr.test_provider('desec', {})
+        assert bad is False
+        assert 'api_token' in bad_msg
 
     def test_missing_required_fields_reported(self, manager_factory):
         mgr, _ = manager_factory({})


### PR DESCRIPTION
First cluster of the EU provider sprint. Two EU DNS providers via the generic multi-provider mechanism (no new strategy class).

- **deSEC** (DE, free DNSSEC) — `certbot-dns-desec==1.3.2` (official, certbot==2.10.0-compatible, no lexicon dep). Also closes the old **phantom `desec`** loop (advertised-without-wiring, removed in #288) by wiring it properly everywhere; the phantom-rejection regression test is inverted accordingly.
- **Scaleway** (FR, sovereign cloud) — the community `certbot-dns-scaleway` plugin is alpha (2022), so it is **not** pinned in core (documented as separate-install, like powerdns/namecheap); the provider is wired and selectable.

## Validation (local)
- provider-wiring + frontend-coverage ratchets green; new INI-key wiring unit test (3); full non-e2e suite **1331 passed**; no CSS drift.
- Docker smoke: `certbot plugins` lists **dns-desec** (certbot stack intact), deSEC + Scaleway radios/config render, a deSEC save persists.

Real-cert E2E pending a deSEC account + a delegated test domain (free signup) — to run before merge per the E2E gate.