### PR TITLE
feat(storage): S3-compatible object storage backend (EU sovereign)

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -362,15 +362,26 @@ def create_api_models(api):
         'environment': fields.String(description='Infisical Environment', default='prod')
     })
 
+    s3_compatible_storage_model = api.model('S3CompatibleStorage', {
+        'endpoint_url': fields.String(description='S3-compatible endpoint URL '
+                                      '(Hetzner / Contabo / OVHcloud / Scaleway / Wasabi / MinIO / AWS)'),
+        'bucket': fields.String(description='Bucket name'),
+        'access_key_id': fields.String(description='S3 access key ID'),
+        'secret_access_key': fields.String(description='S3 secret access key'),
+        'region': fields.String(description='Region', default='us-east-1'),
+        'prefix': fields.String(description='Object key prefix', default='certmate/certificates')
+    })
+
     storage_config_model = api.model('StorageConfig', {
         'backend': fields.String(description='Storage backend type',
                                  enum=['local_filesystem', 'azure_keyvault', 'aws_secrets_manager',
-                                       'hashicorp_vault', 'infisical']),
+                                       'hashicorp_vault', 'infisical', 's3_compatible']),
         'cert_dir': fields.String(description='Certificate directory for local filesystem'),
         'azure_keyvault': fields.Nested(azure_keyvault_storage_model),
         'aws_secrets_manager': fields.Nested(aws_secrets_manager_storage_model),
         'hashicorp_vault': fields.Nested(hashicorp_vault_storage_model),
-        'infisical': fields.Nested(infisical_storage_model)
+        'infisical': fields.Nested(infisical_storage_model),
+        's3_compatible': fields.Nested(s3_compatible_storage_model)
     })
 
     storage_test_config_model = api.model('StorageTestConfig', {

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -2451,7 +2451,8 @@ def create_api_resources(api, models, managers):
                         'azure_keyvault',
                         'aws_secrets_manager',
                         'hashicorp_vault',
-                        'infisical'
+                        'infisical',
+                        's3_compatible'
                     ],
                     'configuration': {
                         'backend': storage_config.get('backend', 'local_filesystem'),
@@ -2473,7 +2474,7 @@ def create_api_resources(api, models, managers):
                 backend_type = data.get('backend')
                 valid_backends = [
                     'local_filesystem', 'azure_keyvault', 'aws_secrets_manager',
-                    'hashicorp_vault', 'infisical'
+                    'hashicorp_vault', 'infisical', 's3_compatible'
                 ]
                 if backend_type not in valid_backends:
                     return {'error': 'Invalid backend type'}, 400
@@ -2502,6 +2503,8 @@ def create_api_resources(api, models, managers):
                     storage_update['hashicorp_vault'] = data.get('hashicorp_vault', {})
                 elif backend_type == 'infisical':
                     storage_update['infisical'] = data.get('infisical', {})
+                elif backend_type == 's3_compatible':
+                    storage_update['s3_compatible'] = data.get('s3_compatible', {})
 
                 clean_payload = _strip_masked_values({'certificate_storage': storage_update})
                 success = settings_manager.atomic_update(clean_payload)
@@ -2574,7 +2577,7 @@ def create_api_resources(api, models, managers):
                 from ..core.storage_backends import (
                     LocalFileSystemBackend, AzureKeyVaultBackend,
                     AWSSecretsManagerBackend, HashiCorpVaultBackend,
-                    InfisicalBackend
+                    InfisicalBackend, S3CompatibleBackend
                 )
 
                 # Test connection based on backend type
@@ -2593,6 +2596,9 @@ def create_api_resources(api, models, managers):
 
                     elif backend_type == 'infisical':
                         test_backend = InfisicalBackend(config)
+
+                    elif backend_type == 's3_compatible':
+                        test_backend = S3CompatibleBackend(config)
 
                     else:
                         return {'error': 'Invalid backend type'}, 400
@@ -2940,7 +2946,7 @@ def create_api_resources(api, models, managers):
             from ..core.storage_backends import (
                 LocalFileSystemBackend, AzureKeyVaultBackend,
                 AWSSecretsManagerBackend, HashiCorpVaultBackend,
-                InfisicalBackend
+                InfisicalBackend, S3CompatibleBackend
             )
 
             backend_classes = {
@@ -2949,6 +2955,7 @@ def create_api_resources(api, models, managers):
                 'aws_secrets_manager': AWSSecretsManagerBackend,
                 'hashicorp_vault': HashiCorpVaultBackend,
                 'infisical': InfisicalBackend,
+                's3_compatible': S3CompatibleBackend,
             }
 
             def _resolve_config(backend_type, raw):

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -614,6 +614,14 @@ class SettingsManager:
                         'client_secret': '',
                         'project_id': '',
                         'environment': 'prod'
+                    },
+                    's3_compatible': {
+                        'endpoint_url': '',
+                        'bucket': '',
+                        'access_key_id': '',
+                        'secret_access_key': '',
+                        'region': 'us-east-1',
+                        'prefix': 'certmate/certificates'
                     }
                 },
                 # OIDC/SSO identity source. Disabled by default; opt-in via

--- a/modules/core/storage_backends.py
+++ b/modules/core/storage_backends.py
@@ -1613,6 +1613,136 @@ class InfisicalBackend(CertificateStorageBackend):
         return "infisical"
 
 
+class S3CompatibleBackend(CertificateStorageBackend):
+    """S3-compatible object-storage backend.
+
+    One backend for every S3-compatible provider via a configurable
+    ``endpoint_url`` — covers EU-sovereign object storage (Hetzner, Contabo,
+    OVHcloud, Scaleway, Exoscale, Wasabi) and self-hosted MinIO/Ceph, with no
+    new dependency (boto3 is already core). Each domain is stored as a single
+    JSON object ``<prefix>/<domain>.json`` holding the cert files + metadata,
+    mirroring the AWS Secrets Manager blob shape.
+    """
+
+    def __init__(self, config: Dict[str, str]):
+        self.endpoint_url = (config.get('endpoint_url') or '').strip()
+        self.bucket = (config.get('bucket') or '').strip()
+        self.access_key_id = (config.get('access_key_id') or '').strip()
+        self.secret_access_key = (config.get('secret_access_key') or '').strip()
+        self.region = (config.get('region') or 'us-east-1').strip()
+        # Key namespace inside the bucket; trailing slashes normalised away.
+        self.prefix = (config.get('prefix') or 'certmate/certificates').strip().strip('/')
+        if not all([self.endpoint_url, self.bucket, self.access_key_id, self.secret_access_key]):
+            raise ValueError(
+                "S3-compatible backend requires endpoint_url, bucket, "
+                "access_key_id and secret_access_key")
+        self._client = None
+        logger.info("S3CompatibleBackend initialized for endpoint %s bucket %s",
+                    self.endpoint_url, self.bucket)
+
+    def _get_client(self):
+        if self._client is None:
+            try:
+                import boto3
+                self._client = boto3.client(
+                    's3',
+                    endpoint_url=self.endpoint_url,
+                    aws_access_key_id=self.access_key_id,
+                    aws_secret_access_key=self.secret_access_key,
+                    region_name=self.region,
+                )
+            except ImportError:
+                raise ImportError("S3-compatible backend requires 'boto3' package")
+        return self._client
+
+    def _key(self, domain: str) -> str:
+        return f"{self.prefix}/{domain}.json"
+
+    def store_certificate(self, domain: str, cert_files: Dict[str, bytes], metadata: Dict[str, Any]) -> bool:
+        try:
+            return self._store_certificate_attempt(domain, cert_files, metadata)
+        except Exception as e:
+            logger.error(f"Failed to store certificate in S3 for {domain}: {e}")
+            return False
+
+    @_with_retry()
+    def _store_certificate_attempt(self, domain: str, cert_files: Dict[str, bytes], metadata: Dict[str, Any]) -> bool:
+        _validate_storage_domain(domain)
+        client = self._get_client()
+        secret_data = {
+            'files': {k: v.decode('utf-8', errors='replace') for k, v in cert_files.items()},
+            'metadata': metadata,
+        }
+        client.put_object(
+            Bucket=self.bucket,
+            Key=self._key(domain),
+            Body=json.dumps(secret_data).encode('utf-8'),
+            ContentType='application/json',
+        )
+        logger.info(f"Certificate stored successfully in S3 for {domain}")
+        return True
+
+    def retrieve_certificate(self, domain: str) -> Optional[Tuple[Dict[str, bytes], Dict[str, Any]]]:
+        try:
+            return self._retrieve_certificate_attempt(domain)
+        except Exception as e:
+            logger.error(f"Failed to retrieve certificate from S3 for {domain}: {e}")
+            return None
+
+    @_with_retry()
+    def _retrieve_certificate_attempt(self, domain: str) -> Optional[Tuple[Dict[str, bytes], Dict[str, Any]]]:
+        client = self._get_client()
+        try:
+            response = client.get_object(Bucket=self.bucket, Key=self._key(domain))
+        except client.exceptions.NoSuchKey:
+            return None
+        secret_data = json.loads(response['Body'].read().decode('utf-8'))
+        cert_files = {k: v.encode('utf-8') for k, v in secret_data.get('files', {}).items()}
+        metadata = secret_data.get('metadata', {})
+        return cert_files, metadata
+
+    def list_certificates(self) -> List[str]:
+        try:
+            return self._list_certificates_attempt()
+        except Exception as e:
+            logger.error(f"Failed to list certificates from S3: {e}")
+            return []
+
+    @_with_retry()
+    def _list_certificates_attempt(self) -> List[str]:
+        client = self._get_client()
+        domains = []
+        prefix = f"{self.prefix}/"
+        paginator = client.get_paginator('list_objects_v2')
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=prefix):
+            for obj in page.get('Contents', []) or []:
+                key = obj['Key']
+                if key.startswith(prefix) and key.endswith('.json'):
+                    domains.append(key[len(prefix):-len('.json')])
+        return sorted(domains)
+
+    def delete_certificate(self, domain: str) -> bool:
+        try:
+            client = self._get_client()
+            client.delete_object(Bucket=self.bucket, Key=self._key(domain))
+            logger.info(f"Certificate deleted from S3 for {domain}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to delete certificate from S3 for {domain}: {e}")
+            return False
+
+    def certificate_exists(self, domain: str) -> bool:
+        try:
+            client = self._get_client()
+            client.head_object(Bucket=self.bucket, Key=self._key(domain))
+            return True
+        except Exception:
+            return False
+
+    def get_backend_name(self) -> str:
+        return "s3_compatible"
+
+
 class StorageManager:
     """Manager class for certificate storage backends"""
 
@@ -1696,7 +1826,11 @@ class StorageManager:
             elif backend_type == 'infisical':
                 config = storage_config.get('infisical', {})
                 self._backend = InfisicalBackend(config)
-                
+
+            elif backend_type == 's3_compatible':
+                config = storage_config.get('s3_compatible', {})
+                self._backend = S3CompatibleBackend(config)
+
             else:
                 logger.warning(f"Unknown storage backend: {backend_type}, falling back to local filesystem")
                 cert_dir = Path('certificates')

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -2158,7 +2158,8 @@
             'azure_keyvault': 'storage-azure-config',
             'aws_secrets_manager': 'storage-aws-config',
             'hashicorp_vault': 'storage-vault-config',
-            'infisical': 'storage-infisical-config'
+            'infisical': 'storage-infisical-config',
+            's3_compatible': 'storage-s3-config'
         };
 
         // Show the selected configuration panel
@@ -2328,6 +2329,15 @@
                 config.project_id = document.getElementById('infisical-project-id').value;
                 config.environment = document.getElementById('infisical-environment').value || 'prod';
                 break;
+
+            case 's3_compatible':
+                config.endpoint_url = document.getElementById('s3-endpoint-url').value;
+                config.bucket = document.getElementById('s3-bucket').value;
+                config.access_key_id = document.getElementById('s3-access-key-id').value;
+                config.secret_access_key = document.getElementById('s3-secret-access-key').value;
+                config.region = document.getElementById('s3-region').value || 'us-east-1';
+                config.prefix = document.getElementById('s3-prefix').value || 'certmate/certificates';
+                break;
         }
 
         return config;
@@ -2349,6 +2359,9 @@
 
             case 'infisical':
                 return config.client_id && config.client_secret && config.project_id;
+
+            case 's3_compatible':
+                return config.endpoint_url && config.bucket && config.access_key_id && config.secret_access_key;
 
             default:
                 return false;
@@ -2525,6 +2538,15 @@
                 document.getElementById('infisical-environment').value = infisicalConfig.environment || 'prod';
                 // Don't populate client credentials for security
                 break;
+
+            case 's3_compatible':
+                var s3Config = storageConfig.s3_compatible || storageConfig;
+                document.getElementById('s3-endpoint-url').value = s3Config.endpoint_url || '';
+                document.getElementById('s3-bucket').value = s3Config.bucket || '';
+                document.getElementById('s3-region').value = s3Config.region || 'us-east-1';
+                document.getElementById('s3-prefix').value = s3Config.prefix || 'certmate/certificates';
+                // Don't populate access keys for security
+                break;
         }
     }
 
@@ -2617,6 +2639,9 @@
                 break;
             case 'infisical':
                 result.infisical = config;
+                break;
+            case 's3_compatible':
+                result.s3_compatible = config;
                 break;
         }
         return result;

--- a/templates/partials/settings_storage.html
+++ b/templates/partials/settings_storage.html
@@ -21,6 +21,7 @@
                                     <option value="aws_secrets_manager">AWS Secrets Manager</option>
                                     <option value="hashicorp_vault">HashiCorp Vault</option>
                                     <option value="infisical">Infisical</option>
+                                    <option value="s3_compatible">S3-Compatible (Hetzner, Contabo, OVH, Scaleway, MinIO, AWS)</option>
                                 </select>
                                 <p class="mt-1 text-xs text-muted">
                                     Choose where to store your SSL certificates. Local filesystem is the default and most compatible option.
@@ -235,6 +236,56 @@
                                     </div>
                                     <p class="text-xs text-success-fg mt-2">
                                         Certificates will be stored in Infisical with end-to-end encryption and team collaboration features.
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div id="storage-s3-config" class="storage-config" style="display: none;">
+                                <div class="bg-success-surface p-3 rounded-md border border-success-line">
+                                    <h5 class="text-sm font-medium text-success-strong mb-2">
+                                        <i class="fas fa-database mr-1"></i> S3-Compatible Object Storage
+                                    </h5>
+                                    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                                        <div>
+                                            <label class="block text-xs text-success-strong mb-1">Endpoint URL</label>
+                                            <input type="text" id="s3-endpoint-url"
+                                                   class="w-full px-2 py-1 text-sm border border-success-line rounded bg-surface text-foreground"
+                                                   placeholder="https://s3.eu-central-1.example.com">
+                                        </div>
+                                        <div>
+                                            <label class="block text-xs text-success-strong mb-1">Bucket</label>
+                                            <input type="text" id="s3-bucket"
+                                                   class="w-full px-2 py-1 text-sm border border-success-line rounded bg-surface text-foreground"
+                                                   placeholder="my-certmate-bucket">
+                                        </div>
+                                        <div>
+                                            <label class="block text-xs text-success-strong mb-1">Access Key ID</label>
+                                            <input type="text" id="s3-access-key-id"
+                                                   class="w-full px-2 py-1 text-sm border border-success-line rounded bg-surface text-foreground"
+                                                   placeholder="Access key" autocomplete="off">
+                                        </div>
+                                        <div>
+                                            <label class="block text-xs text-success-strong mb-1">Secret Access Key</label>
+                                            <input type="password" id="s3-secret-access-key"
+                                                   class="w-full px-2 py-1 text-sm border border-success-line rounded bg-surface text-foreground"
+                                                   placeholder="Secret key"
+                                                   autocomplete="new-password" spellcheck="false" data-lpignore="true">
+                                        </div>
+                                        <div>
+                                            <label class="block text-xs text-success-strong mb-1">Region</label>
+                                            <input type="text" id="s3-region"
+                                                   class="w-full px-2 py-1 text-sm border border-success-line rounded bg-surface text-foreground"
+                                                   placeholder="us-east-1" value="us-east-1">
+                                        </div>
+                                        <div>
+                                            <label class="block text-xs text-success-strong mb-1">Key Prefix</label>
+                                            <input type="text" id="s3-prefix"
+                                                   class="w-full px-2 py-1 text-sm border border-success-line rounded bg-surface text-foreground"
+                                                   placeholder="certmate/certificates" value="certmate/certificates">
+                                        </div>
+                                    </div>
+                                    <p class="text-xs text-success-fg mt-2">
+                                        Works with any S3-compatible object storage (Hetzner, Contabo, OVHcloud, Scaleway, Wasabi, MinIO, AWS). Certificates are stored as one JSON object per domain under the key prefix.
                                     </p>
                                 </div>
                             </div>

--- a/tests/test_s3_compatible_backend.py
+++ b/tests/test_s3_compatible_backend.py
@@ -1,0 +1,121 @@
+"""S3-compatible object-storage backend.
+
+One backend for every S3-compatible provider via a configurable endpoint_url
+(Hetzner, Contabo, OVHcloud, Scaleway, Wasabi, MinIO, ...). boto3 is already a
+core dependency, so no new SDK.
+
+These tests inject a faithful in-memory S3 fake (the repo convention is a fake
+client, not moto) and exercise a real store -> exists -> list -> retrieve
+(byte fidelity) -> delete round-trip, plus wildcard-domain keys and config
+validation.
+"""
+import io
+
+import pytest
+
+from modules.core.storage_backends import S3CompatibleBackend
+
+pytestmark = [pytest.mark.unit]
+
+
+class _FakeS3:
+    """Minimal in-memory S3 — faithful enough for a real round-trip."""
+
+    class _NoSuchKey(Exception):
+        pass
+
+    def __init__(self):
+        self._store = {}  # (bucket, key) -> bytes
+        self.exceptions = type('Exc', (), {'NoSuchKey': self._NoSuchKey})()
+
+    def put_object(self, Bucket, Key, Body, **kw):
+        self._store[(Bucket, Key)] = Body if isinstance(Body, bytes) else Body.encode('utf-8')
+        return {}
+
+    def get_object(self, Bucket, Key):
+        if (Bucket, Key) not in self._store:
+            raise self.exceptions.NoSuchKey()
+        return {'Body': io.BytesIO(self._store[(Bucket, Key)])}
+
+    def delete_object(self, Bucket, Key):
+        self._store.pop((Bucket, Key), None)
+        return {}
+
+    def head_object(self, Bucket, Key):
+        if (Bucket, Key) not in self._store:
+            raise self._NoSuchKey()
+        return {}
+
+    def get_paginator(self, op):
+        store = self._store
+
+        class _Paginator:
+            def paginate(self, Bucket, Prefix=''):
+                contents = [{'Key': k} for (b, k) in store if b == Bucket and k.startswith(Prefix)]
+                yield {'Contents': contents}
+
+        return _Paginator()
+
+
+def _backend():
+    b = S3CompatibleBackend({
+        'endpoint_url': 'https://s3.example.eu',
+        'bucket': 'certs',
+        'access_key_id': 'AK',
+        'secret_access_key': 'SK',
+    })
+    b._client = _FakeS3()
+    return b
+
+
+def test_round_trip_with_byte_fidelity():
+    b = _backend()
+    files = {
+        'cert.pem': b'-----BEGIN CERTIFICATE-----\nA\n-----END CERTIFICATE-----\n',
+        'privkey.pem': b'-----BEGIN PRIVATE KEY-----\nB\n-----END PRIVATE KEY-----\n',
+        'chain.pem': b'chain', 'fullchain.pem': b'fullchain',
+    }
+    meta = {'issuer': 'Test CA', 'expiry_date': '2026-09-01'}
+
+    assert b.store_certificate('a.example.com', files, meta) is True
+    assert b.certificate_exists('a.example.com') is True
+    assert b.list_certificates() == ['a.example.com']
+
+    got = b.retrieve_certificate('a.example.com')
+    assert got is not None
+    got_files, got_meta = got
+    assert got_files == files          # exact bytes back
+    assert got_meta == meta
+
+    assert b.delete_certificate('a.example.com') is True
+    assert b.certificate_exists('a.example.com') is False
+    assert b.retrieve_certificate('a.example.com') is None
+    assert b.list_certificates() == []
+
+
+def test_wildcard_domain_round_trips():
+    b = _backend()
+    assert b.store_certificate('*.example.com', {'cert.pem': b'W'}, {}) is True
+    assert '*.example.com' in b.list_certificates()
+    assert b.retrieve_certificate('*.example.com')[0]['cert.pem'] == b'W'
+
+
+def test_list_isolates_to_prefix():
+    b = _backend()
+    # an unrelated object in the same bucket must not appear as a domain
+    b._client.put_object(Bucket='certs', Key='unrelated/file.json', Body=b'x')
+    b.store_certificate('only.example.com', {'cert.pem': b'C'}, {})
+    assert b.list_certificates() == ['only.example.com']
+
+
+def test_get_backend_name():
+    assert _backend().get_backend_name() == 's3_compatible'
+
+
+def test_requires_endpoint_bucket_and_keys():
+    with pytest.raises(ValueError):
+        S3CompatibleBackend({'bucket': 'x', 'access_key_id': 'a', 'secret_access_key': 'b'})  # no endpoint
+    with pytest.raises(ValueError):
+        S3CompatibleBackend({'endpoint_url': 'https://x', 'access_key_id': 'a', 'secret_access_key': 'b'})  # no bucket
+    with pytest.raises(ValueError):
+        S3CompatibleBackend({'endpoint_url': 'https://x', 'bucket': 'b'})  # no keys


### PR DESCRIPTION
Second cluster of the EU provider sprint — the storage **volume play**. One backend for **every** S3-compatible provider via a configurable `endpoint_url`, with **no new dependency** (boto3 is already core).

Tags in one shot: **Hetzner, Contabo, OVHcloud, Scaleway, Exoscale (CH), Wasabi, IDrive e2, MinIO** (self-hosted) + AWS S3.

## What
- New `S3CompatibleBackend` (cert files + metadata as one JSON object per domain under a key prefix; mirrors the AWS Secrets Manager blob shape).
- Wired across every storage surface: `StorageManager` dispatch, settings defaults, `api/models` `StorageConfig` (model + enum + nested), `resources.py` (info / config / **test** / **migrate**), and the settings UI (`<select>` + config panel + JS collect/validate/load). Access/secret keys auto-mask.

## Validation (local, no accounts needed)
- 5-test in-memory round-trip: **byte fidelity**, wildcard domains, prefix isolation, config validation.
- **Real round-trip against a local MinIO server** (risk-free): store/exists/list/retrieve/delete all green, byte fidelity + metadata intact, wildcard works.
- Full non-e2e suite **1333 passed**, no CSS drift, flake8 clean.
- Docker smoke: S3 option + config panel render, dispatch resolves the backend, health 200.

Fab can E2E this against his Hetzner / Contabo / OVH / AWS accounts when he's back. **Next:** push the unified backup `.zip` to S3 (same client), then HARICA (CA) and the native Secret Manager backends.