### PR TITLE
chore: review follow-ups for #303/#304 (storage ratchet + docs + wizard note)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ CertMate solves the complexity of SSL certificate management in modern distribut
 - **AWS Secrets Manager** - Scalable secret storage with AWS ecosystem integration and cross-region replication
 - **HashiCorp Vault** - Industry-standard secret management with versioning, audit logging, and fine-grained policies
 - **Infisical** - Modern open-source secret management with team collaboration and end-to-end encryption
+- **S3-Compatible Object Storage** - One backend for any S3 endpoint via a configurable endpoint URL (Hetzner, Contabo, OVHcloud, Scaleway, Exoscale, Wasabi, MinIO, AWS) — ideal for EU-sovereign object storage; no extra dependency
 - **Pluggable Architecture** - Easy to extend with additional storage backends
 - **Migration Support** - Seamless migration between storage backends without downtime
 - **Backward Compatibility** - Existing installations continue working without changes
@@ -258,7 +259,7 @@ HOST=0.0.0.0
 PORT=8000
 ```
 
-> **Storage Backends**: By default, certificates are stored locally. For enterprise deployments, you can configure Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, or Infisical via the web interface after startup. See [Storage Backends](#certificate-storage-configuration) for details.
+> **Storage Backends**: By default, certificates are stored locally. For enterprise deployments, you can configure Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical, or any S3-compatible object storage via the web interface after startup. See [Storage Backends](#certificate-storage-configuration) for details.
 
 > **Backup Best Practices**: CertMate includes a unified backup system that creates atomic snapshots of both settings and certificates. After setup, create your first backup from Settings → Backup Management.
 

--- a/docs/dns-providers.md
+++ b/docs/dns-providers.md
@@ -33,6 +33,8 @@ CertMate supports a wide range of DNS providers for Let's Encrypt DNS-01 challen
 | **Hurricane Electric** | `certbot-dns-he-ddns` | Username, Password | Free DNS |
 | **Dynu** | `certbot-dns-dynudns` | API Token | Dynamic DNS |
 | **DuckDNS** | `certbot-dns-duckdns` | Account Token | Free DDNS (no domain required) |
+| **deSEC** | `certbot-dns-desec` | API Token | Free, EU (DE), DNSSEC — delegate NS to `ns1.desec.io` / `ns2.desec.org` |
+| **Scaleway** | `certbot-dns-scaleway` | API Secret Key | EU (FR) sovereign cloud — community plugin (alpha), install separately: `pip install certbot-dns-scaleway` |
 | **Custom Script** | none (certbot core `--manual`) | Auth hook script path (+ optional cleanup hook) | Bring your own |
 
 ---

--- a/static/js/setup-wizard.js
+++ b/static/js/setup-wizard.js
@@ -37,7 +37,7 @@
         'acme-dns':    { label: 'ACME-DNS', icon: 'fa-network-wired', fields: [{ key: 'api_url', label: 'API URL', type: 'text' }, { key: 'username', label: 'Username', type: 'text' }, { key: 'password', label: 'Password', type: 'password' }, { key: 'subdomain', label: 'Subdomain', type: 'text' }] },
         'hetzner-cloud': { label: 'Hetzner Cloud', icon: 'fa-server', fields: [{ key: 'api_token', label: 'API Token', type: 'password' }] },
         desec:         { label: 'deSEC', icon: 'fa-shield-alt', fields: [{ key: 'api_token', label: 'API Token', type: 'password' }] },
-        scaleway:      { label: 'Scaleway', icon: 'fa-cloud', fields: [{ key: 'application_token', label: 'API Secret Key', type: 'password' }] },
+        scaleway:      { label: 'Scaleway', icon: 'fa-cloud', fields: [{ key: 'application_token', label: 'API Secret Key', type: 'password', placeholder: 'Requires: pip install certbot-dns-scaleway (community alpha plugin)' }] },
         duckdns:       { label: 'DuckDNS', icon: 'fa-cloud', fields: [{ key: 'api_token', label: 'Account Token', type: 'password', placeholder: 'UUID-format token from your DuckDNS account page' }] }
     };
 

--- a/tests/test_storage_wiring_consistency.py
+++ b/tests/test_storage_wiring_consistency.py
@@ -1,0 +1,127 @@
+"""Cross-validate that every certificate-storage backend is wired across all
+backend-set surfaces.
+
+The DNS subsystem is guarded by test_provider_wiring_consistency.py +
+test_frontend_provider_coverage.py. Storage had no equivalent: the
+s3_compatible backend (#304) is wired by hand into ~6 independent backend-set
+literals, and the next backend (or a typo dropping one from a list) could ship
+a backend that is selectable in the UI but 400s on config/test/migrate, or is
+dispatched but never offered — with no failing test. This ratchet pins them to
+the canonical set (what StorageManager can actually dispatch).
+"""
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+from modules.core import storage_backends as sb
+
+pytestmark = [pytest.mark.unit]
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _read(rel):
+    return (_ROOT / rel).read_text()
+
+
+def _canonical():
+    """Backends StorageManager._initialize_backend can dispatch — the source of truth."""
+    src = inspect.getsource(sb.StorageManager._initialize_backend)
+    return set(re.findall(r"backend_type == '([a-z0-9_-]+)'", src))
+
+
+def _literal_after(text, marker, open_b, close_b):
+    """Quoted lowercase identifiers inside the bracketed literal that follows
+    *marker* (bracket-matched so nested structures are handled)."""
+    start = text.index(marker)
+    k = text.index(open_b, start)
+    depth = 0
+    end = k
+    for end in range(k, len(text)):
+        if text[end] == open_b:
+            depth += 1
+        elif text[end] == close_b:
+            depth -= 1
+            if depth == 0:
+                break
+    return set(re.findall(r"'([a-z0-9_-]+)'", text[k:end + 1]))
+
+
+def _model_enum():
+    from flask import Flask
+    from flask_restx import Api
+    from modules.api.models import create_api_models
+    api = Api(Flask(__name__))
+    create_api_models(api)
+    return set(api.models['StorageConfig']['backend'].enum)
+
+
+# Guard against a broken regex making every assertion vacuously pass.
+def test_canonical_set_is_sane():
+    canonical = _canonical()
+    assert {'local_filesystem', 'aws_secrets_manager', 's3_compatible'} <= canonical
+    assert len(canonical) >= 6
+
+
+def test_api_model_enum_matches_dispatch():
+    enum = _model_enum()
+    canonical = _canonical()
+    assert enum == canonical, (
+        f"StorageConfig.backend enum (api/models.py) != dispatchable backends: "
+        f"missing={sorted(canonical - enum)} extra={sorted(enum - canonical)}"
+    )
+
+
+def test_resources_available_backends_matches_dispatch():
+    src = _read('modules/api/resources.py')
+    available = _literal_after(src, "'available_backends': [", '[', ']')
+    canonical = _canonical()
+    assert available == canonical, (
+        f"resources.py StorageBackendInfo available_backends != dispatchable: "
+        f"missing={sorted(canonical - available)} extra={sorted(available - canonical)}"
+    )
+
+
+def test_resources_valid_backends_matches_dispatch():
+    src = _read('modules/api/resources.py')
+    valid = _literal_after(src, "valid_backends = [", '[', ']')
+    canonical = _canonical()
+    assert valid == canonical, (
+        f"resources.py StorageBackendConfig valid_backends != dispatchable: "
+        f"missing={sorted(canonical - valid)} extra={sorted(valid - canonical)}"
+    )
+
+
+def test_resources_migrate_backend_classes_matches_dispatch():
+    src = _read('modules/api/resources.py')
+    classes = _literal_after(src, "backend_classes = {", '{', '}')
+    canonical = _canonical()
+    # local_filesystem is built specially in _build_backend, not via backend_classes.
+    assert classes == canonical - {'local_filesystem'} or classes == canonical, (
+        f"resources.py migrate backend_classes != dispatchable: "
+        f"missing={sorted((canonical - {'local_filesystem'}) - classes)} extra={sorted(classes - canonical)}"
+    )
+
+
+def test_settings_storage_select_matches_dispatch():
+    html = _read('templates/partials/settings_storage.html')
+    m = re.search(r'id="storage-backend".*?</select>', html, re.S)
+    assert m, "could not locate the storage-backend <select> in settings_storage.html"
+    options = set(re.findall(r'<option value="([a-z0-9_-]+)"', m.group(0)))
+    canonical = _canonical()
+    assert options == canonical, (
+        f"settings_storage.html backend <select> != dispatchable: "
+        f"missing={sorted(canonical - options)} extra={sorted(options - canonical)}"
+    )
+
+
+def test_settings_js_panel_map_matches_dispatch():
+    js = _read('static/js/settings.js')
+    panel_keys = set(re.findall(r"'([a-z0-9_-]+)':\s*'storage-[a-z0-9-]+-config'", js))
+    canonical = _canonical()
+    assert panel_keys == canonical, (
+        f"settings.js storage panel map != dispatchable: "
+        f"missing={sorted(canonical - panel_keys)} extra={sorted(panel_keys - canonical)}"
+    )


### PR DESCRIPTION
Addresses the four follow-ups from the draconian review of #303 + #304 (which found **zero code bugs**). All low-risk hardening + docs.

- **test(storage): storage wiring-consistency ratchet** — storage had no equivalent to the DNS ratchets. Pins every backend across the 6 backend-set surfaces (StorageConfig enum, resources.py available/valid/migrate-classes, settings_storage.html select, settings.js panel map) to the canonical dispatch set. This **de-risks the upcoming EU Secret-Manager backends** (it'll force them to wire every surface, exactly as the DNS ratchet did for deSEC/Scaleway). 7 tests, green.
- **docs:** deSEC + Scaleway rows in `docs/dns-providers.md` (NS-delegation + Scaleway alpha separate-install notes); S3-Compatible in the README storage list + summary.
- **fix(wizard):** disclose Scaleway's separate-install/alpha plugin in the first-run wizard (the settings page already warned; the wizard didn't).

Full suite **1343 passed**, no CSS drift.