### PR TITLE
feat(backup): off-site backup copy to S3-compatible storage

### DIFF
--- a/modules/core/file_operations.py
+++ b/modules/core/file_operations.py
@@ -343,11 +343,50 @@ class FileOperations:
             enc_tag = 'encrypted' if passphrase else 'cleartext'
             logger.info(f"Unified backup created: {backup_filename} (contains {len(domains)} domains; secrets={mode_tag}; at-rest={enc_tag})")
             self._prune_unified_backups()
+            self._upload_backup_offsite(backup_path, backup_filename, settings_data)
             return backup_filename
 
         except Exception as e:
             logger.error(f"Error creating unified backup: {e}")
             return None
+
+    def _upload_backup_offsite(self, backup_path, backup_filename, settings_data):
+        """Best-effort off-site copy of the unified backup to an S3-compatible
+        target. NEVER raises: the local backup is authoritative; the S3 copy is
+        a disaster-recovery convenience. Enabled via settings
+        ``backup_storage`` = {'backend': 's3_compatible', 's3_compatible': {...}}.
+        Works with any S3 endpoint (Hetzner, Contabo, OVHcloud, Scaleway, Wasabi,
+        MinIO, AWS); boto3 is already a core dependency.
+        """
+        try:
+            cfg = (settings_data or {}).get('backup_storage') or {}
+            if cfg.get('backend') != 's3_compatible':
+                return
+            s3 = cfg.get('s3_compatible') or {}
+            endpoint = (s3.get('endpoint_url') or '').strip()
+            bucket = (s3.get('bucket') or '').strip()
+            access_key = (s3.get('access_key_id') or '').strip()
+            secret_key = (s3.get('secret_access_key') or '').strip()
+            if not all([endpoint, bucket, access_key, secret_key]):
+                return
+            prefix = (s3.get('prefix') or 'certmate/backups').strip().strip('/')
+            region = (s3.get('region') or 'us-east-1').strip()
+
+            import boto3
+            client = boto3.client(
+                's3', endpoint_url=endpoint, aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key, region_name=region)
+            with open(backup_path, 'rb') as fh:
+                client.put_object(
+                    Bucket=bucket, Key=f"{prefix}/{backup_filename}", Body=fh.read())
+            logger.info("Backup %s copied off-site to s3://%s/%s/%s",
+                        backup_filename, bucket, prefix, backup_filename)
+        except Exception as e:
+            # Log the type only — never the message/config — and keep the
+            # local backup. Off-site is a convenience, not a hard dependency.
+            logger.warning(
+                "Off-site backup upload failed (local backup is intact): %s",
+                type(e).__name__)
 
     def _prune_unified_backups(self):
         """Enforce backup retention: keep at most MAX_BACKUPS_PER_TYPE files,

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -39,6 +39,7 @@ PUBLIC_SETTINGS_WRITABLE_KEYS = frozenset({
     'renewal_threshold_days',
     'challenge_type',
     'certificate_storage',
+    'backup_storage',          # off-site backup target (S3-compatible)
     'notifications',
     'setup_completed',
     # Per-install "stop nagging me with the first-run wizard" flag. Distinct
@@ -250,6 +251,7 @@ def _strip_masked_values(payload):
 # (the same shape as the settings POST path) closes the gap.
 _DEEP_MERGE_SETTINGS_KEYS = frozenset({
     'certificate_storage',
+    'backup_storage',
     'ca_providers',
     'notifications',
 })
@@ -622,6 +624,17 @@ class SettingsManager:
                         'secret_access_key': '',
                         'region': 'us-east-1',
                         'prefix': 'certmate/certificates'
+                    }
+                },
+                'backup_storage': {  # Optional off-site copy of unified backups (best-effort)
+                    'backend': 'none',
+                    's3_compatible': {
+                        'endpoint_url': '',
+                        'bucket': '',
+                        'access_key_id': '',
+                        'secret_access_key': '',
+                        'region': 'us-east-1',
+                        'prefix': 'certmate/backups'
                     }
                 },
                 # OIDC/SSO identity source. Disabled by default; opt-in via

--- a/tests/test_backup_offsite_s3.py
+++ b/tests/test_backup_offsite_s3.py
@@ -1,0 +1,66 @@
+"""Off-site backup copy to an S3-compatible target.
+
+After create_unified_backup writes the local .zip(.enc), it best-effort copies
+it to a configured S3 target (settings.backup_storage). The local backup is
+authoritative; the S3 copy must never break backup creation.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modules.core.file_operations import FileOperations
+
+pytestmark = [pytest.mark.unit]
+
+_S3_CFG = {'backup_storage': {'backend': 's3_compatible', 's3_compatible': {
+    'endpoint_url': 'https://s3.eu-central.example',
+    'bucket': 'cm-backups', 'access_key_id': 'AK', 'secret_access_key': 'SK',
+    'prefix': 'certmate/backups'}}}
+
+
+def _fo(tmp_path):
+    for d in ('certs', 'data', 'backups', 'logs'):
+        (tmp_path / d).mkdir(exist_ok=True)
+    return FileOperations(
+        cert_dir=tmp_path / 'certs', data_dir=tmp_path / 'data',
+        backup_dir=tmp_path / 'backups', logs_dir=tmp_path / 'logs')
+
+
+def _backup(tmp_path):
+    p = tmp_path / 'backup_20260614.zip'
+    p.write_bytes(b'UNIFIED-BACKUP-ZIP-BYTES')
+    return p
+
+
+def test_uploads_when_configured(tmp_path):
+    fo, path = _fo(tmp_path), _backup(tmp_path)
+    fake = MagicMock()
+    with patch('boto3.client', return_value=fake) as mk:
+        fo._upload_backup_offsite(path, path.name, _S3_CFG)
+    assert mk.call_args.kwargs['endpoint_url'] == 'https://s3.eu-central.example'
+    fake.put_object.assert_called_once()
+    kw = fake.put_object.call_args.kwargs
+    assert kw['Bucket'] == 'cm-backups'
+    assert kw['Key'] == 'certmate/backups/backup_20260614.zip'
+    assert kw['Body'] == b'UNIFIED-BACKUP-ZIP-BYTES'
+
+
+def test_no_upload_when_off_or_unconfigured(tmp_path):
+    fo, path = _fo(tmp_path), _backup(tmp_path)
+    with patch('boto3.client') as mk:
+        fo._upload_backup_offsite(path, path.name, {'backup_storage': {'backend': 'none'}})
+        fo._upload_backup_offsite(path, path.name, {})            # no backup_storage at all
+        fo._upload_backup_offsite(path, path.name, None)          # no settings at all
+        # configured backend but missing credentials -> skip
+        fo._upload_backup_offsite(path, path.name, {'backup_storage': {
+            'backend': 's3_compatible', 's3_compatible': {'endpoint_url': 'https://x', 'bucket': 'b'}}})
+    mk.assert_not_called()
+
+
+def test_upload_failure_is_best_effort(tmp_path):
+    """An S3 outage must NOT break backup creation — never raises."""
+    fo, path = _fo(tmp_path), _backup(tmp_path)
+    fake = MagicMock()
+    fake.put_object.side_effect = RuntimeError('s3 unreachable')
+    with patch('boto3.client', return_value=fake):
+        fo._upload_backup_offsite(path, path.name, _S3_CFG)  # no exception


### PR DESCRIPTION
Unified backups were **local-only** — lost if the host dies (the exact disaster they exist to survive). This adds a **best-effort off-site copy to any S3-compatible target** (Hetzner, Contabo, OVHcloud, Scaleway, Wasabi, MinIO, AWS) via a configurable `endpoint_url`. **No new dependency** (boto3 is already core); reuses the same `put_object` proven against MinIO in #304.

- Enabled via `settings.backup_storage = {backend: 's3_compatible', s3_compatible: {...}}` (writable + deep-merged for secret-preserve, default **off**).
- After the local backup is written, `_upload_backup_offsite` uploads it. It **never raises**: a failed/unreachable S3 leaves the authoritative local backup intact and logs only the exception **type** (never the config/secret).

## Validation
- New mock test (3): uploads with right Bucket/Key/Body when configured; no-op when off/unconfigured/incomplete; **best-effort on S3 failure** (no exception).
- Existing backup tests green (the hook is a no-op without config); full suite **1346 passed**; flake8 clean.

**Follow-up:** a settings UI panel for the off-site target (configurable via the settings API today).