### PR TITLE
feat(notify): Telegram, ntfy, and Gotify notification channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ CertMate solves the complexity of SSL certificate management in modern distribut
 - **Backward Compatibility** - Existing installations continue working without changes
 
 ### **Notifications & Automation**
-- **Multi-Channel Notifications** - Email (SMTP), Slack, Discord, and generic webhooks
+- **Multi-Channel Notifications** - Email (SMTP), Slack, Discord, Telegram, ntfy, Gotify, and generic webhooks
 - **Webhook HMAC Signatures** - SHA-256 signed payloads for secure webhook verification
 - **Deploy Hooks** - Post-issuance shell commands to reload Nginx/Apache or run custom scripts
 - **Weekly Digest** - Scheduled email summary of certificate status and upcoming renewals
@@ -2169,10 +2169,17 @@ CertMate includes a built-in notification system configurable from Settings > No
 - **Email (SMTP)** - Certificate expiry warnings and renewal confirmations
 - **Slack** - Incoming webhook integration for team channels
 - **Discord** - Webhook notifications for Discord servers
+- **Telegram** - Bot API messages (bot token + chat ID)
+- **ntfy** - Push to an [ntfy](https://ntfy.sh) topic (self-hostable); optional access token, per-message priority
+- **Gotify** - Push to a self-hosted [Gotify](https://gotify.net) server (server URL + app token, numeric priority)
 - **Generic Webhooks** - HTTP POST with HMAC-SHA256 signed payloads for custom integrations
 - **Weekly Digest** - Scheduled summary of certificate status and upcoming renewals
 
 All notification channels support per-event filtering (created, renewed, expiring, failed) and can be tested from the settings UI.
+
+> **Microsoft Teams:** no dedicated adapter is needed. Use a Teams channel's
+> built-in email address (channel → ... → Get email address) as a recipient on
+> the Email (SMTP) channel — Teams posts the message into the channel for you.
 
 ### Downgrades & Recovery
 

--- a/modules/core/notifier.py
+++ b/modules/core/notifier.py
@@ -250,18 +250,25 @@ class Notifier:
 
     def _send_webhook(self, cfg: dict, event: str, title: str,
                       message: str, details: Optional[dict] = None) -> dict:
-        """Send webhook notification (generic, Slack, or Discord format)."""
+        """Send a notification to a webhook-style channel.
+
+        Supported ``type`` values: ``generic`` (signed JSON), ``slack``,
+        ``discord``, ``telegram``, ``ntfy``, ``gotify``. Each formats the
+        request (URL, body, headers) for its target service. Microsoft Teams
+        is covered by the SMTP channel via a Teams channel email address — no
+        dedicated adapter.
+        """
         try:
-            url = cfg.get('url', '')
-            if not url:
-                return {'error': 'Webhook URL not configured'}
-
-            # Only allow http/https schemes to prevent file:// or other attacks
-            if not url.startswith(('https://', 'http://')):
-                return {'error': 'Webhook URL must use http or https scheme'}
-
             wh_type = cfg.get('type', 'generic')
+            url = (cfg.get('url') or '').strip()
             secret = cfg.get('secret', '')
+            headers = {'User-Agent': 'CertMate-Webhook/2.0'}
+            content_type = 'application/json'
+
+            def _detail_lines():
+                if not details:
+                    return ''
+                return '\n' + '\n'.join(f'{k}: {v}' for k, v in details.items())
 
             if wh_type == 'slack':
                 payload = {
@@ -272,50 +279,82 @@ class Notifier:
                     ]
                 }
                 if details:
-                    fields = [{'type': 'mrkdwn', 'text': f'*{k}:* {v}'}
-                              for k, v in details.items()]
-                    payload['blocks'].append({'type': 'section', 'fields': fields})
+                    payload['blocks'].append({'type': 'section', 'fields': [
+                        {'type': 'mrkdwn', 'text': f'*{k}:* {v}'} for k, v in details.items()]})
+                body = json.dumps(payload).encode('utf-8')
 
             elif wh_type == 'discord':
-                embed = {
-                    'title': title,
-                    'description': message,
-                    'color': 2067276,  # CertMate blue
-                }
+                embed = {'title': title, 'description': message, 'color': 2067276}
                 if details:
                     embed['fields'] = [{'name': k, 'value': str(v), 'inline': True}
                                        for k, v in details.items()]
-                payload = {'embeds': [embed]}
+                body = json.dumps({'embeds': [embed]}).encode('utf-8')
 
-            else:  # generic
+            elif wh_type == 'telegram':
+                # Bot API: the token is in the URL path, chat_id in the body.
+                token = (cfg.get('token') or '').strip()
+                chat_id = str(cfg.get('chat_id') or '').strip()
+                if not (token and chat_id):
+                    return {'error': 'Telegram channel requires token and chat_id'}
+                url = f'https://api.telegram.org/bot{token}/sendMessage'
+                body = json.dumps({
+                    'chat_id': chat_id,
+                    'text': f'*{title}*\n{message}{_detail_lines()}',
+                    'parse_mode': 'Markdown',
+                }).encode('utf-8')
+
+            elif wh_type == 'ntfy':
+                # url is the topic URL, e.g. https://ntfy.sh/my-topic
+                body = (message + _detail_lines()).encode('utf-8')
+                content_type = 'text/plain; charset=utf-8'
+                headers['Title'] = title
+                headers['Priority'] = str(cfg.get('priority') or 'default')
+                if cfg.get('token'):
+                    headers['Authorization'] = f"Bearer {cfg['token']}"
+
+            elif wh_type == 'gotify':
+                token = (cfg.get('token') or '').strip()
+                if not (url and token):
+                    return {'error': 'Gotify channel requires url and token'}
+                url = url.rstrip('/') + '/message'
+                headers['X-Gotify-Key'] = token
+                try:
+                    priority = int(cfg.get('priority', 5))
+                except (TypeError, ValueError):
+                    priority = 5
+                body = json.dumps({'title': title, 'message': message + _detail_lines(),
+                                   'priority': priority}).encode('utf-8')
+
+            else:  # generic — signed JSON with optional custom headers
                 payload = {
-                    'event': event,
-                    'title': title,
-                    'message': message,
+                    'event': event, 'title': title, 'message': message,
                     'details': details or {},
-                    'timestamp': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
+                    'timestamp': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
                 }
-
-            body = json.dumps(payload).encode('utf-8')
-            req = Request(url, data=body, method='POST')
-            req.add_header('Content-Type', 'application/json')
-            req.add_header('User-Agent', 'CertMate-Webhook/2.0')
-
-            # Custom headers for generic webhooks
-            if wh_type == 'generic':
+                body = json.dumps(payload).encode('utf-8')
                 for hdr_name, hdr_value in cfg.get('headers', {}).items():
-                    req.add_header(hdr_name, hdr_value)
+                    headers[hdr_name] = hdr_value
+                # HMAC-SHA256 signature with timestamp for replay protection.
+                if secret:
+                    timestamp = str(int(time.time()))
+                    sig = hmac.new(secret.encode(), f'{timestamp}.'.encode() + body,
+                                   hashlib.sha256).hexdigest()
+                    headers['X-CertMate-Signature'] = f't={timestamp},v1={sig}'
 
-            # HMAC-SHA256 signature with timestamp for replay protection
-            if secret and wh_type == 'generic':
-                timestamp = str(int(time.time()))
-                signed_payload = f'{timestamp}.'.encode() + body
-                sig = hmac.new(secret.encode(), signed_payload, hashlib.sha256).hexdigest()
-                req.add_header('X-CertMate-Signature', f't={timestamp},v1={sig}')
+            if not url:
+                return {'error': 'Webhook URL not configured'}
+            # Only allow http/https schemes to prevent file:// or other attacks.
+            if not url.startswith(('https://', 'http://')):
+                return {'error': 'Webhook URL must use http or https scheme'}
+
+            req = Request(url, data=body, method='POST')
+            req.add_header('Content-Type', content_type)
+            for hdr_name, hdr_value in headers.items():
+                req.add_header(hdr_name, hdr_value)
 
             with urlopen(req, timeout=10) as resp:  # nosec B310
                 status = resp.status
-                logger.info(f"Webhook '{cfg.get('name', 'webhook')}' sent: HTTP {status}")
+                logger.info(f"Webhook '{cfg.get('name', 'webhook')}' ({wh_type}) sent: HTTP {status}")
                 return {'success': True, 'status': status}
 
         except URLError as e:

--- a/modules/core/notifier.py
+++ b/modules/core/notifier.py
@@ -292,6 +292,12 @@ class Notifier:
 
             elif wh_type == 'telegram':
                 # Bot API: the token is in the URL path, chat_id in the body.
+                # Send PLAIN TEXT (no parse_mode). Titles/messages/details carry
+                # certbot error strings and wildcard '*' / '_acme-challenge'
+                # metacharacters; with parse_mode='Markdown' those unbalanced
+                # entities make the Bot API reject the message with HTTP 400
+                # "can't parse entities" and the alert is silently dropped —
+                # precisely on the failure events that matter most.
                 token = (cfg.get('token') or '').strip()
                 chat_id = str(cfg.get('chat_id') or '').strip()
                 if not (token and chat_id):
@@ -299,8 +305,7 @@ class Notifier:
                 url = f'https://api.telegram.org/bot{token}/sendMessage'
                 body = json.dumps({
                     'chat_id': chat_id,
-                    'text': f'*{title}*\n{message}{_detail_lines()}',
-                    'parse_mode': 'Markdown',
+                    'text': f'{title}\n{message}{_detail_lines()}',
                 }).encode('utf-8')
 
             elif wh_type == 'ntfy':

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -7,6 +7,7 @@ import os
 import re
 import threading
 import logging
+from collections import deque
 from pathlib import Path
 
 from modules import __version__ as _CERTMATE_VERSION
@@ -246,9 +247,11 @@ def _restore_masked_list_secrets(old_list, new_list):
     For every dict in ``new_list``, any secret-named field still equal to the
     sentinel is restored from the matching dict in ``old_list`` — matched first
     by identity ``(type, url, name)`` (robust to reordering/deletion), then by
-    position. With no prior match the masked field is dropped (no value to keep).
-    A blank secret is left as-is, so a deliberately cleared field stays cleared.
-    Mutates and returns ``new_list``.
+    position. Each prior dict is consumed at most once, so two webhooks sharing
+    an identity keep their own distinct secrets (the Nth new maps to the Nth
+    prior) instead of both collapsing onto the first. With no prior match the
+    masked field is dropped (no value to keep). A blank secret is left as-is, so
+    a deliberately cleared field stays cleared. Mutates and returns ``new_list``.
     """
     if not isinstance(new_list, list):
         return new_list
@@ -257,18 +260,23 @@ def _restore_masked_list_secrets(old_list, new_list):
     def _identity(d):
         return (d.get('type'), d.get('url'), d.get('name'))
 
+    # Queue prior dicts per identity so duplicate-identity webhooks are matched
+    # one-to-one rather than every duplicate resolving to the first.
     by_identity = {}
     for old in old_list:
         if isinstance(old, dict):
-            by_identity.setdefault(_identity(old), old)
+            by_identity.setdefault(_identity(old), deque()).append(old)
 
     for i, item in enumerate(new_list):
         if not isinstance(item, dict):
             continue
-        prior = by_identity.get(_identity(item))
-        if prior is None and i < len(old_list) and isinstance(old_list[i], dict):
+        queue = by_identity.get(_identity(item))
+        if queue:
+            prior = queue.popleft()
+        elif i < len(old_list) and isinstance(old_list[i], dict):
             prior = old_list[i]
-        prior = prior or {}
+        else:
+            prior = {}
         for key in list(item.keys()):
             if _is_secret_key(key) and item.get(key) == SECRET_MASK_SENTINEL:
                 if key in prior:

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -234,6 +234,50 @@ def _strip_masked_values(payload):
     return out
 
 
+def _restore_masked_list_secrets(old_list, new_list):
+    """Restore masked secrets inside a list-of-dicts replaced wholesale on save.
+
+    ``_strip_masked_values`` + ``_deep_merge_dict`` preserve masked secrets only
+    inside *dict* subtrees; a list (e.g. ``notifications.channels.webhooks``) is
+    replaced as a unit, so a secret-named field the UI rendered as
+    ``SECRET_MASK_SENTINEL`` and the user left untouched would be written back as
+    the literal sentinel — clobbering the real token/secret on disk.
+
+    For every dict in ``new_list``, any secret-named field still equal to the
+    sentinel is restored from the matching dict in ``old_list`` — matched first
+    by identity ``(type, url, name)`` (robust to reordering/deletion), then by
+    position. With no prior match the masked field is dropped (no value to keep).
+    A blank secret is left as-is, so a deliberately cleared field stays cleared.
+    Mutates and returns ``new_list``.
+    """
+    if not isinstance(new_list, list):
+        return new_list
+    old_list = old_list if isinstance(old_list, list) else []
+
+    def _identity(d):
+        return (d.get('type'), d.get('url'), d.get('name'))
+
+    by_identity = {}
+    for old in old_list:
+        if isinstance(old, dict):
+            by_identity.setdefault(_identity(old), old)
+
+    for i, item in enumerate(new_list):
+        if not isinstance(item, dict):
+            continue
+        prior = by_identity.get(_identity(item))
+        if prior is None and i < len(old_list) and isinstance(old_list[i], dict):
+            prior = old_list[i]
+        prior = prior or {}
+        for key in list(item.keys()):
+            if _is_secret_key(key) and item.get(key) == SECRET_MASK_SENTINEL:
+                if key in prior:
+                    item[key] = prior[key]
+                else:
+                    item.pop(key, None)
+    return new_list
+
+
 # Top-level settings keys whose value is a nested dict that should be
 # deep-merged rather than wholesale-replaced on save. Each of these stores
 # multiple secret-bearing subtrees (per-backend storage credentials, per-CA

--- a/modules/web/misc_routes.py
+++ b/modules/web/misc_routes.py
@@ -237,8 +237,10 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
                 # per-channel secrets/tokens the UI sent back masked must be
                 # restored from the prior on-disk list (sentinel = unchanged).
                 if isinstance(merged, dict):
-                    old_whs = existing.get('channels', {}).get('webhooks')
-                    new_whs = merged.get('channels', {}).get('webhooks')
+                    old_ch = existing.get('channels') if isinstance(existing, dict) else None
+                    new_ch = merged.get('channels')
+                    old_whs = old_ch.get('webhooks') if isinstance(old_ch, dict) else None
+                    new_whs = new_ch.get('webhooks') if isinstance(new_ch, dict) else None
                     if isinstance(new_whs, list):
                         _restore_masked_list_secrets(old_whs, new_whs)
                 s['notifications'] = merged

--- a/modules/web/misc_routes.py
+++ b/modules/web/misc_routes.py
@@ -221,15 +221,27 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
             # and deep-merge against the existing notifications block
             # so a partial UI submit (e.g. toggling `enabled` without
             # re-typing the SMTP password) does not destroy siblings.
-            from modules.core.settings import _strip_masked_values, _deep_merge_dict
+            from modules.core.settings import (
+                _strip_masked_values, _deep_merge_dict, _restore_masked_list_secrets,
+            )
             clean_data = _strip_masked_values(data)
 
             def _mutator(s):
                 existing = s.get('notifications')
                 if isinstance(existing, dict) and isinstance(clean_data, dict):
-                    s['notifications'] = _deep_merge_dict(existing, clean_data)
+                    merged = _deep_merge_dict(existing, clean_data)
                 else:
-                    s['notifications'] = clean_data
+                    existing = existing if isinstance(existing, dict) else {}
+                    merged = clean_data
+                # The webhooks list is replaced wholesale by the merge above, so
+                # per-channel secrets/tokens the UI sent back masked must be
+                # restored from the prior on-disk list (sentinel = unchanged).
+                if isinstance(merged, dict):
+                    old_whs = existing.get('channels', {}).get('webhooks')
+                    new_whs = merged.get('channels', {}).get('webhooks')
+                    if isinstance(new_whs, list):
+                        _restore_masked_list_secrets(old_whs, new_whs)
+                s['notifications'] = merged
                 return s
 
             settings_manager.update(_mutator)

--- a/templates/partials/settings_notifications.html
+++ b/templates/partials/settings_notifications.html
@@ -101,15 +101,33 @@
                                     <button type="button" @click="config.channels.webhooks.splice(idx, 1)" class="text-red-400 hover:text-red-600 text-sm"><i class="fas fa-trash"></i></button>
                                 </div>
                                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                                    <div class="sm:col-span-2"><input type="url" x-model="wh.url" placeholder="https://hooks.slack.com/..." class="w-full px-3 py-2 text-sm border text-foreground border-border rounded-lg bg-input"></div>
+                                    <div class="sm:col-span-2" x-show="wh.type !== 'telegram'"><input type="url" x-model="wh.url" :placeholder="wh.type === 'ntfy' ? 'https://ntfy.sh/your-topic' : (wh.type === 'gotify' ? 'https://gotify.example.com' : 'https://hooks.slack.com/...')" class="w-full px-3 py-2 text-sm border text-foreground border-border rounded-lg bg-input"></div>
                                     <div>
                                         <select x-model="wh.type" class="w-full px-3 py-2 text-sm border text-foreground border-border rounded-lg bg-input">
                                             <option value="generic">Generic</option>
                                             <option value="slack">Slack</option>
                                             <option value="discord">Discord</option>
+                                            <option value="telegram">Telegram</option>
+                                            <option value="ntfy">ntfy</option>
+                                            <option value="gotify">Gotify</option>
                                         </select>
                                     </div>
-                                    <div><input type="text" x-model="wh.secret" placeholder="HMAC secret (optional)" class="w-full px-3 py-2 text-sm border text-foreground border-border rounded-lg bg-input"></div>
+                                    <div x-show="wh.type === 'generic'"><input type="text" x-model="wh.secret" placeholder="HMAC secret (optional)" class="w-full px-3 py-2 text-sm border text-foreground border-border rounded-lg bg-input"></div>
+                                </div>
+                                <!-- Telegram: token is in the URL path, chat_id in the body -->
+                                <div class="grid grid-cols-1 sm:grid-cols-2 gap-2" x-show="wh.type === 'telegram'">
+                                    <div><input type="password" x-model="wh.token" placeholder="Bot token" class="w-full px-3 py-2 text-sm border text-foreground border-border rounded-lg bg-input"></div>
+                                    <div><input type="text" x-model="wh.chat_id" placeholder="Chat ID" class="w-full px-3 py-2 text-sm border text-foreground border-border rounded-lg bg-input"></div>
+                                </div>
+                                <!-- ntfy: priority header + optional access token -->
+                                <div class="grid grid-cols-1 sm:grid-cols-2 gap-2" x-show="wh.type === 'ntfy'">
+                                    <div><input type="text" x-model="wh.priority" placeholder="Priority (default/high/urgent)" class="w-full px-3 py-2 text-sm border text-foreground border-border rounded-lg bg-input"></div>
+                                    <div><input type="password" x-model="wh.token" placeholder="Access token (optional)" class="w-full px-3 py-2 text-sm border text-foreground border-border rounded-lg bg-input"></div>
+                                </div>
+                                <!-- Gotify: app token + numeric priority -->
+                                <div class="grid grid-cols-1 sm:grid-cols-2 gap-2" x-show="wh.type === 'gotify'">
+                                    <div><input type="password" x-model="wh.token" placeholder="App token" class="w-full px-3 py-2 text-sm border text-foreground border-border rounded-lg bg-input"></div>
+                                    <div><input type="number" x-model.number="wh.priority" placeholder="Priority (0-10)" class="w-full px-3 py-2 text-sm border text-foreground border-border rounded-lg bg-input"></div>
                                 </div>
                                 <!-- Per-webhook event filtering -->
                                 <div class="mt-1">

--- a/tests/test_notification_channels.py
+++ b/tests/test_notification_channels.py
@@ -1,0 +1,104 @@
+"""First-class notification channels: Telegram, ntfy, Gotify.
+
+These ride the existing webhooks framework (per-type formatting in
+_send_webhook). The tests capture the actual urllib Request so a wrong
+URL/body/header — which would silently fail to deliver — breaks the build.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modules.core.notifier import Notifier
+
+pytestmark = [pytest.mark.unit]
+
+
+class _Resp:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _notifier(tmp_path):
+    return Notifier(settings_manager=MagicMock(), data_dir=str(tmp_path))
+
+
+def _send(n, cfg):
+    cap = {}
+
+    def fake_urlopen(req, timeout=None):
+        cap['url'] = req.full_url
+        cap['data'] = req.data
+        cap['headers'] = {k.lower(): v for k, v in req.header_items()}
+        return _Resp()
+
+    with patch('modules.core.notifier.urlopen', side_effect=fake_urlopen):
+        res = n._send_webhook(cfg, 'renewal_failed', 'Cert expiring',
+                              'example.com expires in 3 days', {'domain': 'example.com'})
+    return res, cap
+
+
+def test_telegram_uses_bot_api_url_and_body(tmp_path):
+    res, cap = _send(_notifier(tmp_path),
+                     {'type': 'telegram', 'token': 'BOTTOK', 'chat_id': '12345'})
+    assert res.get('success')
+    assert cap['url'] == 'https://api.telegram.org/botBOTTOK/sendMessage'
+    payload = json.loads(cap['data'])
+    assert payload['chat_id'] == '12345'
+    assert payload['parse_mode'] == 'Markdown'
+    assert 'Cert expiring' in payload['text'] and 'example.com' in payload['text']
+
+
+def test_telegram_requires_token_and_chat_id(tmp_path):
+    res, _ = _send(_notifier(tmp_path), {'type': 'telegram', 'token': 'X'})  # no chat_id
+    assert 'error' in res and 'chat_id' in res['error']
+
+
+def test_ntfy_posts_to_topic_with_title_and_priority(tmp_path):
+    res, cap = _send(_notifier(tmp_path),
+                     {'type': 'ntfy', 'url': 'https://ntfy.sh/certmate', 'priority': 'high'})
+    assert res.get('success')
+    assert cap['url'] == 'https://ntfy.sh/certmate'
+    assert b'example.com expires in 3 days' in cap['data']
+    assert cap['headers']['title'] == 'Cert expiring'
+    assert cap['headers']['priority'] == 'high'
+
+
+def test_ntfy_optional_token_sets_bearer_auth(tmp_path):
+    _, cap = _send(_notifier(tmp_path),
+                   {'type': 'ntfy', 'url': 'https://ntfy.example/t', 'token': 'tk_secret'})
+    assert cap['headers']['authorization'] == 'Bearer tk_secret'
+
+
+def test_gotify_posts_to_message_endpoint_with_key(tmp_path):
+    res, cap = _send(_notifier(tmp_path),
+                     {'type': 'gotify', 'url': 'https://gotify.example/', 'token': 'GTOK', 'priority': 8})
+    assert res.get('success')
+    assert cap['url'] == 'https://gotify.example/message'
+    assert cap['headers']['x-gotify-key'] == 'GTOK'
+    payload = json.loads(cap['data'])
+    assert payload['title'] == 'Cert expiring'
+    assert payload['priority'] == 8
+
+
+def test_gotify_requires_url_and_token(tmp_path):
+    res, _ = _send(_notifier(tmp_path), {'type': 'gotify', 'url': 'https://g.example'})  # no token
+    assert 'error' in res and 'token' in res['error']
+
+
+def test_existing_slack_discord_generic_unchanged(tmp_path):
+    n = _notifier(tmp_path)
+    _, slack = _send(n, {'type': 'slack', 'url': 'https://hooks.slack.com/x'})
+    assert 'blocks' in json.loads(slack['data'])
+    _, discord = _send(n, {'type': 'discord', 'url': 'https://discord.com/api/webhooks/x'})
+    assert json.loads(discord['data']).get('embeds')
+    # generic still signs with HMAC and applies custom headers
+    _, generic = _send(n, {'type': 'generic', 'url': 'https://x.example',
+                           'secret': 's3cr3t', 'headers': {'X-Env': 'prod'}})
+    assert generic['headers'].get('x-certmate-signature')
+    assert generic['headers'].get('x-env') == 'prod'

--- a/tests/test_notification_channels.py
+++ b/tests/test_notification_channels.py
@@ -50,7 +50,8 @@ def test_telegram_uses_bot_api_url_and_body(tmp_path):
     assert cap['url'] == 'https://api.telegram.org/botBOTTOK/sendMessage'
     payload = json.loads(cap['data'])
     assert payload['chat_id'] == '12345'
-    assert payload['parse_mode'] == 'Markdown'
+    # Plain text, no parse_mode (see test_telegram_sends_plain_text_no_markdown_parsing)
+    assert 'parse_mode' not in payload
     assert 'Cert expiring' in payload['text'] and 'example.com' in payload['text']
 
 
@@ -102,3 +103,28 @@ def test_existing_slack_discord_generic_unchanged(tmp_path):
                            'secret': 's3cr3t', 'headers': {'X-Env': 'prod'}})
     assert generic['headers'].get('x-certmate-signature')
     assert generic['headers'].get('x-env') == 'prod'
+
+
+def test_telegram_sends_plain_text_no_markdown_parsing(tmp_path):
+    # Failure events carry '_acme-challenge', '*.example.com', backticks etc.
+    # parse_mode=Markdown would make the Bot API reject the message with HTTP 400
+    # "can't parse entities" and silently drop the alert, so the request must NOT
+    # set parse_mode and must carry the raw text verbatim.
+    n = _notifier(tmp_path)
+    cap = {}
+
+    def fake_urlopen(req, timeout=None):
+        cap['data'] = req.data
+        return _Resp()
+
+    nasty_title = 'Renewal failed for *.example.com'
+    nasty_msg = 'DNS problem: NXDOMAIN looking up TXT for _acme-challenge.example.com'
+    with patch('modules.core.notifier.urlopen', side_effect=fake_urlopen):
+        res = n._send_webhook({'type': 'telegram', 'token': 'T', 'chat_id': '1'},
+                              'certificate_failed', nasty_title, nasty_msg,
+                              {'error': 'see `certbot` log [details]'})
+    assert res.get('success')
+    payload = json.loads(cap['data'])
+    assert 'parse_mode' not in payload            # no Markdown parsing -> no 400
+    assert nasty_title in payload['text']          # raw content preserved verbatim
+    assert '_acme-challenge.example.com' in payload['text']

--- a/tests/test_notification_channels.py
+++ b/tests/test_notification_channels.py
@@ -52,7 +52,11 @@ def test_telegram_uses_bot_api_url_and_body(tmp_path):
     assert payload['chat_id'] == '12345'
     # Plain text, no parse_mode (see test_telegram_sends_plain_text_no_markdown_parsing)
     assert 'parse_mode' not in payload
-    assert 'Cert expiring' in payload['text'] and 'example.com' in payload['text']
+    # Assert on the whole title + message lines. A bare-host substring check
+    # ('example.com' in ...) trips CodeQL's url-sanitization heuristic — a false
+    # positive in a content assertion — and the full-line check is stronger.
+    assert 'Cert expiring' in payload['text']
+    assert 'example.com expires in 3 days' in payload['text']
 
 
 def test_telegram_requires_token_and_chat_id(tmp_path):

--- a/tests/test_notifications_config_route.py
+++ b/tests/test_notifications_config_route.py
@@ -1,0 +1,245 @@
+"""End-to-end route test for the masked webhook-secret fix.
+
+This proves the fix works THROUGH the real Flask POST route
+``/api/notifications/config`` (modules/web/misc_routes.py::api_notifications_config),
+not just the ``_restore_masked_list_secrets`` helper in isolation.
+
+It drives the REAL route + REAL ``Notifier`` + REAL settings pipeline
+(``_strip_masked_values`` -> ``_deep_merge_dict`` -> ``_restore_masked_list_secrets``)
+via the Flask test client, and verifies the result by reading the
+ON-DISK settings JSON after each POST.
+
+Auth pattern mirrors tests/test_audit_notifications_and_acmedns_masking.py:
+``require_role`` is bypassed with a passthrough decorator so the test pins
+the data flow (the masking/restore contract), not the RBAC gate — which is
+already covered by the e2e admin-session tests in
+tests/test_notifications_routes.py.
+
+Backing store: a real settings.json on a tmp path. The ``settings_manager``
+stub's ``load_settings``/``update`` read+write that file using the same
+read -> mutate -> persist contract as the real
+``modules.core.settings.SettingsManager.update`` (settings.py:515), so an
+assertion that reads the file back is genuinely reading on-disk state.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from modules.core.notifier import Notifier
+from modules.core.settings import SECRET_MASK_SENTINEL
+
+pytestmark = [pytest.mark.unit]
+
+MASK = SECRET_MASK_SENTINEL  # '********'
+
+
+def _passthrough_role(_min_role):
+    def deco(fn):
+        return fn
+    return deco
+
+
+@pytest.fixture
+def route_client(tmp_path):
+    """Real route + real Notifier over an on-disk settings.json.
+
+    Returns ``(client, settings_path, seed)`` where ``client`` is a Flask
+    test client bound to the real ``/api/notifications/config`` route,
+    ``settings_path`` is the file on disk, and ``seed(dict)`` writes the
+    full settings document to disk.
+    """
+    settings_path = tmp_path / "settings.json"
+
+    def _read_disk():
+        if not settings_path.exists():
+            return {}
+        return json.loads(settings_path.read_text())
+
+    def _write_disk(doc):
+        settings_path.write_text(json.dumps(doc, indent=2))
+
+    def seed(doc):
+        _write_disk(doc)
+
+    settings_manager = MagicMock()
+    # Real Notifier._get_config() calls load_settings()['notifications'].
+    settings_manager.load_settings.side_effect = _read_disk
+
+    def _update(mutator, reason="auto_save"):
+        # Mirror SettingsManager.update: read -> mutate in place -> persist.
+        doc = _read_disk()
+        mutator(doc)
+        _write_disk(doc)
+        return True
+
+    settings_manager.update.side_effect = _update
+
+    # Real Notifier wired to the on-disk-backed settings manager.
+    notifier = Notifier(settings_manager, data_dir=str(tmp_path))
+
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_role)
+
+    managers = {
+        "auth": auth_manager,
+        "settings": settings_manager,
+        "notifier": notifier,
+        "digest": MagicMock(),
+        "audit": MagicMock(),
+        "cache": MagicMock(),
+        "metrics": MagicMock(),
+        "dns": MagicMock(),
+        "deployer": MagicMock(),
+    }
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    from modules.web.misc_routes import register_misc_routes
+    register_misc_routes(app, managers, lambda fn: fn, auth_manager)
+
+    return app.test_client(), settings_path, seed
+
+
+def _disk_webhooks(settings_path):
+    doc = json.loads(settings_path.read_text())
+    return doc["notifications"]["channels"]["webhooks"]
+
+
+def _seed_one_webhook(seed, token="REAL-TOKEN", **extra):
+    wh = {
+        "name": "ops",
+        "type": "generic",
+        "url": "https://hooks.example.com/ops",
+        "token": token,
+        "priority": "low",
+        "enabled": True,
+    }
+    wh.update(extra)
+    seed({
+        "notifications": {
+            "enabled": True,
+            "events": ["certificate_renewed"],
+            "channels": {"webhooks": [wh]},
+        }
+    })
+
+
+# ---------------------------------------------------------------------------
+# (1)+(2) GET returns the token masked as '********'
+# ---------------------------------------------------------------------------
+def test_get_masks_real_webhook_token(route_client):
+    client, settings_path, seed = route_client
+    _seed_one_webhook(seed, token="REAL-TOKEN")
+
+    r = client.get("/api/notifications/config")
+    assert r.status_code == 200, r.data
+    body = r.get_json()
+    wh = body["channels"]["webhooks"][0]
+
+    # (2) the token comes back MASKED, never the real value.
+    assert wh["token"] == MASK
+    assert b"REAL-TOKEN" not in r.data
+    # Non-secret fields survive the GET so the UI can re-render them.
+    assert wh["url"] == "https://hooks.example.com/ops"
+    assert wh["priority"] == "low"
+
+
+# ---------------------------------------------------------------------------
+# (3)+(4) POST the masked config back verbatim + a non-secret edit:
+#         the on-disk token is STILL the real value, not the sentinel.
+# ---------------------------------------------------------------------------
+def test_masked_round_trip_preserves_on_disk_token(route_client):
+    client, settings_path, seed = route_client
+    _seed_one_webhook(seed, token="REAL-TOKEN")
+
+    # The UI loads the masked GET response...
+    got = client.get("/api/notifications/config").get_json()
+    masked_wh = got["channels"]["webhooks"][0]
+    assert masked_wh["token"] == MASK  # precondition: UI holds the sentinel
+
+    # ...flips a non-secret field (priority) and re-POSTs verbatim.
+    masked_wh["priority"] = "high"
+    masked_wh["enabled"] = False
+    r = client.post("/api/notifications/config", json={
+        "enabled": True,
+        "events": ["certificate_renewed"],
+        "channels": {"webhooks": [masked_wh]},
+    })
+    assert r.status_code == 200, r.data
+
+    # (4) ON DISK: the real token SURVIVED the masked round-trip.
+    disk_wh = _disk_webhooks(settings_path)[0]
+    assert disk_wh["token"] == "REAL-TOKEN"
+    assert disk_wh["token"] != MASK
+    # The operator's non-secret edits landed.
+    assert disk_wh["priority"] == "high"
+    assert disk_wh["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# (5) A re-typed token persists (rotation still works).
+# ---------------------------------------------------------------------------
+def test_retyped_token_persists(route_client):
+    client, settings_path, seed = route_client
+    _seed_one_webhook(seed, token="REAL-TOKEN")
+
+    got = client.get("/api/notifications/config").get_json()
+    wh = got["channels"]["webhooks"][0]
+    wh["token"] = "NEW-TOKEN"  # operator re-typed a fresh secret
+
+    r = client.post("/api/notifications/config", json={
+        "enabled": True,
+        "channels": {"webhooks": [wh]},
+    })
+    assert r.status_code == 200, r.data
+
+    disk_wh = _disk_webhooks(settings_path)[0]
+    assert disk_wh["token"] == "NEW-TOKEN"
+
+
+# ---------------------------------------------------------------------------
+# (6) A brand-new webhook arriving with a masked token: the field is
+#     DROPPED, never persisted as the literal sentinel.
+# ---------------------------------------------------------------------------
+def test_new_webhook_with_masked_token_drops_the_field(route_client):
+    client, settings_path, seed = route_client
+    # Seed an EXISTING (different) webhook so the prior list is non-empty;
+    # the new one must still not borrow a secret it has no business holding.
+    _seed_one_webhook(seed, token="REAL-TOKEN")
+
+    # A brand-new webhook (distinct identity) the UI somehow sent masked.
+    new_wh = {
+        "name": "fresh",
+        "type": "generic",
+        "url": "https://hooks.example.com/fresh",
+        "token": MASK,
+        "priority": "low",
+        "enabled": True,
+    }
+    # Keep the existing one (re-typed token so it's unambiguous) + the new one.
+    r = client.post("/api/notifications/config", json={
+        "enabled": True,
+        "channels": {"webhooks": [
+            {
+                "name": "ops", "type": "generic",
+                "url": "https://hooks.example.com/ops",
+                "token": "REAL-TOKEN", "priority": "low", "enabled": True,
+            },
+            new_wh,
+        ]},
+    })
+    assert r.status_code == 200, r.data
+
+    disk = _disk_webhooks(settings_path)
+    fresh = next(w for w in disk if w["name"] == "fresh")
+    # The sentinel was NOT persisted; with no prior secret to restore, the
+    # field is dropped entirely.
+    assert fresh.get("token") != MASK
+    assert "token" not in fresh
+    # Non-secret fields on the new webhook still landed.
+    assert fresh["url"] == "https://hooks.example.com/fresh"
+    assert fresh["priority"] == "low"

--- a/tests/test_webhook_secret_preservation.py
+++ b/tests/test_webhook_secret_preservation.py
@@ -1,0 +1,70 @@
+"""Masked webhook secrets/tokens survive a settings round-trip.
+
+The notifications UI renders existing secrets as '********' and POSTs the whole
+webhooks list back. Without per-item restore, an untouched secret is written to
+disk as the literal sentinel — silently breaking the channel. These tests pin
+the restore rule (identity match, index fallback, sentinel-only).
+"""
+import pytest
+
+from modules.core.settings import (
+    SECRET_MASK_SENTINEL as MASK,
+    _restore_masked_list_secrets,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_masked_token_preserved_from_prior():
+    old = [{'name': 'tg', 'type': 'telegram', 'url': '', 'token': 'REAL-BOT-TOKEN', 'chat_id': '42'}]
+    new = [{'name': 'tg', 'type': 'telegram', 'url': '', 'token': MASK, 'chat_id': '42'}]
+    _restore_masked_list_secrets(old, new)
+    assert new[0]['token'] == 'REAL-BOT-TOKEN'
+
+
+def test_retyped_token_overrides_prior():
+    old = [{'name': 'g', 'type': 'gotify', 'url': 'https://g', 'token': 'OLD'}]
+    new = [{'name': 'g', 'type': 'gotify', 'url': 'https://g', 'token': 'NEW'}]
+    _restore_masked_list_secrets(old, new)
+    assert new[0]['token'] == 'NEW'
+
+
+def test_blank_token_left_as_is_so_user_can_clear():
+    old = [{'name': 'n', 'type': 'ntfy', 'url': 'https://ntfy.sh/t', 'token': 'OLD'}]
+    new = [{'name': 'n', 'type': 'ntfy', 'url': 'https://ntfy.sh/t', 'token': ''}]
+    _restore_masked_list_secrets(old, new)
+    assert new[0]['token'] == ''
+
+
+def test_new_webhook_with_no_prior_drops_masked_field():
+    # A masked secret with no source to restore from must not persist '********'.
+    new = [{'name': 'fresh', 'type': 'generic', 'url': 'https://x', 'secret': MASK}]
+    _restore_masked_list_secrets([], new)
+    assert 'secret' not in new[0]
+
+
+def test_identity_match_survives_reorder_and_delete():
+    old = [
+        {'name': 'a', 'type': 'gotify', 'url': 'https://a', 'token': 'TA'},
+        {'name': 'b', 'type': 'gotify', 'url': 'https://b', 'token': 'TB'},
+    ]
+    # User deleted 'a' and kept 'b' (now index 0) without re-typing its token.
+    new = [{'name': 'b', 'type': 'gotify', 'url': 'https://b', 'token': MASK}]
+    _restore_masked_list_secrets(old, new)
+    assert new[0]['token'] == 'TB'  # identity, not index, picks the right secret
+
+
+def test_index_fallback_when_identity_changed():
+    old = [{'name': 'old-name', 'type': 'gotify', 'url': 'https://g', 'token': 'KEEP'}]
+    # User renamed the webhook but left the token masked -> fall back to index.
+    new = [{'name': 'new-name', 'type': 'gotify', 'url': 'https://g', 'token': MASK}]
+    _restore_masked_list_secrets(old, new)
+    assert new[0]['token'] == 'KEEP'
+
+
+def test_non_secret_fields_untouched():
+    old = [{'name': 'n', 'type': 'ntfy', 'url': 'https://ntfy.sh/t', 'priority': 'high', 'token': 'T'}]
+    new = [{'name': 'n', 'type': 'ntfy', 'url': 'https://ntfy.sh/t', 'priority': 'urgent', 'token': MASK}]
+    _restore_masked_list_secrets(old, new)
+    assert new[0]['priority'] == 'urgent'  # non-secret edit preserved
+    assert new[0]['token'] == 'T'          # secret restored

--- a/tests/test_webhook_secret_preservation.py
+++ b/tests/test_webhook_secret_preservation.py
@@ -68,3 +68,18 @@ def test_non_secret_fields_untouched():
     _restore_masked_list_secrets(old, new)
     assert new[0]['priority'] == 'urgent'  # non-secret edit preserved
     assert new[0]['token'] == 'T'          # secret restored
+
+
+def test_duplicate_identity_webhooks_keep_distinct_secrets():
+    # Two webhooks sharing (type, url, name): each masked secret must restore
+    # from its OWN prior (consume-once), not both collapse onto the first.
+    old = [
+        {'name': 'dup', 'type': 'generic', 'url': 'https://x', 'secret': 'S1'},
+        {'name': 'dup', 'type': 'generic', 'url': 'https://x', 'secret': 'S2'},
+    ]
+    new = [
+        {'name': 'dup', 'type': 'generic', 'url': 'https://x', 'secret': MASK},
+        {'name': 'dup', 'type': 'generic', 'url': 'https://x', 'secret': MASK},
+    ]
+    _restore_masked_list_secrets(old, new)
+    assert [w['secret'] for w in new] == ['S1', 'S2']


### PR DESCRIPTION
## Notification channels: Telegram, ntfy, Gotify

Adds three first-class channel types to the existing webhooks framework, plus
fixes to the masked-secret round-trip surfaced by adversarial review.

### Channels (`modules/core/notifier.py`)
- **Telegram** — Bot API (token in URL path, chat_id in body). Sent as **plain text**, not Markdown: caller-supplied content (wildcard `*`, certbot `_acme-challenge` errors) would make the Bot API reject the message with HTTP 400 and silently drop the alert.
- **ntfy** — plain-text POST to a topic, `Title`/`Priority` headers, optional Bearer token.
- **Gotify** — JSON to `<server>/message`, `X-Gotify-Key` header, numeric priority.
- HMAC signing + custom headers stay generic-only. Microsoft Teams needs no adapter (point the SMTP channel at a Teams channel email address — documented).

### Settings UI (`templates/partials/settings_notifications.html`)
Type selector + per-type fields (token/chat_id/priority); secret shown only for generic; URL hidden for Telegram.

### Bug fixes (masked-secret round-trip)
- The webhooks **list** round-tripped masked secrets back as the literal sentinel, clobbering them on save (SMTP, a dict, was safe; the list was not). New `_restore_masked_list_secrets` restores untouched secrets by identity, consume-once so duplicate-identity webhooks keep distinct secrets.
- Guard the notifications POST mutator against a non-dict `channels` (was an opaque 500).

### Testing
- `tests/test_notification_channels.py`, `tests/test_webhook_secret_preservation.py`, `tests/test_notifications_config_route.py` (end-to-end route + mutation-proof). Full suite 1484 passed.
- Live: Gotify container round-trip + ntfy real-socket send.
- Docker E2E on the merged release set: webhook token preserved on disk through a real GET-masked -> POST round-trip.

Generated with [Claude Code](https://claude.com/claude-code)
