### PR TITLE
feat(monitoring): Grafana dashboard + Prometheus alerts; fix /metrics population

### DIFF
--- a/README.md
+++ b/README.md
@@ -2107,6 +2107,11 @@ def metrics():
  return generate_latest()
 ```
 
+A ready-to-import **Grafana dashboard**, **Prometheus alert rules**, and an
+authenticated **scrape config** ship in [`monitoring/`](monitoring/) — see
+[monitoring/README.md](monitoring/README.md). The `/metrics` endpoint requires
+the admin role, so scrape it with an admin-scoped API token (Bearer).
+
 #### Log Aggregation
 ```yaml
 # docker-compose.logging.yml

--- a/modules/web/misc_routes.py
+++ b/modules/web/misc_routes.py
@@ -43,9 +43,31 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
     @app.route('/metrics')
     @auth_manager.require_role('admin')
     def metrics():
-        """Prometheus metrics endpoint"""
+        """Prometheus metrics endpoint.
+
+        Builds the collection context from the managers so the certificate,
+        DNS-provider and cache gauges are actually populated. Without a
+        context, generate_metrics_response only emits application_uptime and
+        every labelled inventory metric stays empty ('No data' at scrape).
+        """
         try:
-            return generate_metrics_response()
+            app_context = None
+            settings_manager = managers.get('settings')
+            file_ops = managers.get('file_ops')
+            cert_manager = managers.get('certificates')
+            if settings_manager and file_ops and cert_manager:
+                try:
+                    app_context = {
+                        'settings': settings_manager.load_settings(),
+                        'cert_dir': file_ops.cert_dir,
+                        'get_certificate_info': cert_manager.get_certificate_info,
+                        'cache': managers.get('cache'),
+                    }
+                except Exception as ctx_err:
+                    logger.warning(
+                        "Metrics context unavailable, emitting base metrics "
+                        f"only: {ctx_err}")
+            return generate_metrics_response(app_context)
         except Exception as e:
             logger.error(f"Metrics error: {e}")
             return jsonify({'error': 'Internal Server Error'}), 500

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -7,8 +7,8 @@ for CertMate's Prometheus endpoint (`GET /metrics`).
 
 | File | What it is |
 | --- | --- |
-| `grafana-dashboard.json` | Grafana dashboard (19 panels) — certificate health, issuance/renewal outcomes, ACME errors, DNS API calls, cache, uptime |
-| `prometheus-alerts.yml` | Prometheus alerting rules — expiry, expired/failed states, ACME errors, rate limits, scrape-down |
+| `grafana-dashboard.json` | Grafana dashboard (11 panels) — certificate inventory, days-until-expiry, status & provider breakdowns, cache, uptime, version |
+| `prometheus-alerts.yml` | Prometheus alerting rules (4) — expiring soon/critical, expired, scrape-down |
 | `prometheus-scrape.example.yml` | Example authenticated scrape job |
 
 ## Scrape setup
@@ -31,27 +31,35 @@ your Prometheus datasource when prompted. The dashboard is keyed by uid
 
 ## Metric coverage
 
-The dashboard and alerts use only metrics CertMate emits today:
+The dashboard and alerts use **only metrics the `/metrics` endpoint actually
+populates** — the certificate inventory gauges, refreshed on every scrape:
+`certmate_domains_total`, `certmate_certificates_total`,
+`certmate_certificates_by_status` (`valid`, `expiring_soon`, `expired`,
+`missing`), `certmate_certificates_by_provider`,
+`certmate_certificate_expiry_days` (clamped at 0 — an expired cert reads 0),
+`certmate_dns_provider_accounts`, `certmate_application_uptime_seconds`,
+`certmate_cache_entries`, `certmate_version_info`.
 
-- **Inventory (gauges, refreshed every scrape):** `certmate_domains_total`,
-  `certmate_certificates_total`, `certmate_certificates_by_status` (`valid`,
-  `expiring_soon`, `expired`, `missing`, `renewal_failed`),
-  `certmate_certificates_by_provider`, `certmate_certificate_expiry_days`
-  (clamped at 0 — an expired cert reads 0), `certmate_dns_provider_accounts`,
-  `certmate_application_uptime_seconds`, `certmate_cache_entries`,
-  `certmate_version_info`.
-- **Operations (counters/histograms, on real events):**
-  `certmate_certificate_requests_total`, `certmate_certificate_renewals_total`,
-  `certmate_certificate_creation_duration_seconds`,
-  `certmate_certificate_renewal_duration_seconds`, `certmate_acme_errors_total`,
-  `certmate_acme_rate_limit_hits_total`, `certmate_dns_provider_api_calls_total`,
-  `certmate_cache_hits_total`, `certmate_cache_misses_total`.
+> Populating these requires the `/metrics` route to pass a collection context
+> (settings, cert dir, cache). That wiring ships alongside this bundle; without
+> it the endpoint emits only `application_uptime`.
 
-Deliberately **not** used:
+### Not yet included (needs instrumentation)
 
+These metrics are **defined but never recorded at runtime**, so any panel or
+alert on them would read "No data" / never fire. They are deliberately left
+out until the code is instrumented, at which point the operations row and the
+renewal/ACME alerts can be added back:
+
+- Operations counters/histograms — `certmate_certificate_requests_total`,
+  `certmate_certificate_renewals_total`, the `*_duration_seconds` histograms,
+  `certmate_acme_errors_total`, `certmate_acme_rate_limit_hits_total`,
+  `certmate_dns_provider_api_calls_total`, `certmate_cache_hits_total` /
+  `_misses_total`: no `record_*` caller exists yet.
+- `certmate_certificates_by_status{status="renewal_failed"}`: the status is
+  never assigned, so it is constant 0.
 - `certmate_certificate_last_renewal_timestamp` /
-  `certmate_certificate_next_renewal_timestamp` — currently derived from the
-  renewal threshold rather than real renewal events, so they would mislead.
-- `certmate_background_job_last_run_timestamp` /
-  `certmate_background_job_duration_seconds` — reserved; not emitted yet (no
-  caller records background-job runs). Don't build alerts on them until they are.
+  `_next_renewal_timestamp`: derived from the renewal threshold, not real
+  events — would mislead.
+- `certmate_background_job_last_run_timestamp` / `_duration_seconds`:
+  reserved; no caller records background-job runs.

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,57 @@
+# CertMate monitoring
+
+Ready-to-import Grafana dashboard, Prometheus alert rules, and a scrape config
+for CertMate's Prometheus endpoint (`GET /metrics`).
+
+## Files
+
+| File | What it is |
+| --- | --- |
+| `grafana-dashboard.json` | Grafana dashboard (19 panels) — certificate health, issuance/renewal outcomes, ACME errors, DNS API calls, cache, uptime |
+| `prometheus-alerts.yml` | Prometheus alerting rules — expiry, expired/failed states, ACME errors, rate limits, scrape-down |
+| `prometheus-scrape.example.yml` | Example authenticated scrape job |
+
+## Scrape setup
+
+`/metrics` requires the **admin** role. Create a dedicated admin-scoped API
+token (Settings > API Keys) and present it as a Bearer credential — see
+`prometheus-scrape.example.yml`. Then load the alert rules:
+
+```yaml
+# prometheus.yml
+rule_files:
+  - /etc/prometheus/certmate-alerts.yml
+```
+
+## Import the dashboard
+
+Grafana > Dashboards > New > Import > Upload `grafana-dashboard.json`, then pick
+your Prometheus datasource when prompted. The dashboard is keyed by uid
+`certmate-overview` and tagged `certmate`.
+
+## Metric coverage
+
+The dashboard and alerts use only metrics CertMate emits today:
+
+- **Inventory (gauges, refreshed every scrape):** `certmate_domains_total`,
+  `certmate_certificates_total`, `certmate_certificates_by_status` (`valid`,
+  `expiring_soon`, `expired`, `missing`, `renewal_failed`),
+  `certmate_certificates_by_provider`, `certmate_certificate_expiry_days`
+  (clamped at 0 — an expired cert reads 0), `certmate_dns_provider_accounts`,
+  `certmate_application_uptime_seconds`, `certmate_cache_entries`,
+  `certmate_version_info`.
+- **Operations (counters/histograms, on real events):**
+  `certmate_certificate_requests_total`, `certmate_certificate_renewals_total`,
+  `certmate_certificate_creation_duration_seconds`,
+  `certmate_certificate_renewal_duration_seconds`, `certmate_acme_errors_total`,
+  `certmate_acme_rate_limit_hits_total`, `certmate_dns_provider_api_calls_total`,
+  `certmate_cache_hits_total`, `certmate_cache_misses_total`.
+
+Deliberately **not** used:
+
+- `certmate_certificate_last_renewal_timestamp` /
+  `certmate_certificate_next_renewal_timestamp` — currently derived from the
+  renewal threshold rather than real renewal events, so they would mislead.
+- `certmate_background_job_last_run_timestamp` /
+  `certmate_background_job_duration_seconds` — reserved; not emitted yet (no
+  caller records background-job runs). Don't build alerts on them until they are.

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1,0 +1,276 @@
+{
+  "__comment": "CertMate observability dashboard. Import via Grafana > Dashboards > New > Import. Pick your Prometheus datasource when prompted. Built only on metrics CertMate actually emits at /metrics.",
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": ["certmate", "tls", "certificates"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "CertMate - Certificates & ACME",
+  "uid": "certmate-overview",
+  "version": 1,
+  "weekStart": "",
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_domains_total", "refId": "A" }],
+      "title": "Managed domains",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+      "id": 2,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_certificates_total", "refId": "A" }],
+      "title": "Total certificates",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "green" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+      "id": 3,
+      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(certmate_certificates_by_status{status=\"valid\"})", "refId": "A" }],
+      "title": "Valid",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
+      "id": 4,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(certmate_certificates_by_status{status=\"expiring_soon\"})", "refId": "A" }],
+      "title": "Expiring soon",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
+      "id": 5,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(certmate_certificates_by_status{status=\"expired\"})", "refId": "A" }],
+      "title": "Expired",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
+      "id": 6,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(certmate_certificates_by_status{status=\"renewal_failed\"})", "refId": "A" }],
+      "title": "Renewal failed",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Days remaining per certificate. Red < 7, amber < 30, green otherwise. Sorted soonest-first.",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "thresholds" }, "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "filterable": true, "inspect": false }, "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 7 }, { "color": "green", "value": 30 }] }, "unit": "d" },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Days left" }, "properties": [{ "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "gradient" } }] }
+        ]
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 4 },
+      "id": 7,
+      "options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false }, "showHeader": true, "sortBy": [{ "displayName": "Days left", "desc": false }] },
+      "pluginVersion": "10.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_certificate_expiry_days", "format": "table", "instant": true, "refId": "A" }],
+      "title": "Days until expiry (per certificate)",
+      "transformations": [
+        { "id": "organize", "options": { "excludeByName": { "Time": true, "__name__": true, "job": true, "instance": true }, "indexByName": {}, "renameByName": { "domain": "Domain", "dns_provider": "DNS Provider", "Value": "Days left" } } }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" }, "overrides": [{ "matcher": { "id": "byName", "options": "valid" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] }, { "matcher": { "id": "byName", "options": "expiring_soon" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }] }, { "matcher": { "id": "byName", "options": "expired" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] }, { "matcher": { "id": "byName", "options": "renewal_failed" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "dark-red" } }] }] },
+      "gridPos": { "h": 9, "w": 6, "x": 12, "y": 4 },
+      "id": 8,
+      "options": { "displayLabels": ["percent"], "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "values": ["value"] }, "pieType": "donut", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "tooltip": { "mode": "single", "sort": "none" } },
+      "pluginVersion": "10.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_certificates_by_status", "instant": true, "legendFormat": "{{status}}", "refId": "A" }],
+      "title": "Certificates by status",
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "continuous-GrYlRd" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 6, "x": 18, "y": 4 },
+      "id": 9,
+      "options": { "displayMode": "gradient", "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false }, "minVizHeight": 10, "minVizWidth": 0, "orientation": "horizontal", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "showUnfilled": true, "valueMode": "color" },
+      "pluginVersion": "10.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_certificates_by_provider", "instant": true, "legendFormat": "{{provider}}", "refId": "A" }],
+      "title": "Certificates by DNS provider",
+      "type": "bargauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Renewal attempts per hour by outcome. CertMate emits these on real renewal events.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 50, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "auto", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } }, "unit": "short" }, "overrides": [{ "matcher": { "id": "byName", "options": "success" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] }, { "matcher": { "id": "byName", "options": "failed" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] }] },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 13 },
+      "id": 10,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (status) (increase(certmate_certificate_renewals_total[1h]))", "legendFormat": "{{status}}", "refId": "A" }],
+      "title": "Renewal outcomes (per hour)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Issuance (first request) attempts per hour by outcome.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 50, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "auto", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } }, "unit": "short" }, "overrides": [{ "matcher": { "id": "byName", "options": "success" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] }, { "matcher": { "id": "byName", "options": "failed" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] }] },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 13 },
+      "id": 11,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (status) (increase(certmate_certificate_requests_total[1h]))", "legendFormat": "{{status}}", "refId": "A" }],
+      "title": "Issuance outcomes (per hour)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Certificate renewal wall-clock latency (DNS-01 propagation dominates).",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "auto", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 13 },
+      "id": 12,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(certmate_certificate_renewal_duration_seconds_bucket[6h])))", "legendFormat": "p50", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(certmate_certificate_renewal_duration_seconds_bucket[6h])))", "legendFormat": "p95", "refId": "B" }
+      ],
+      "title": "Renewal duration (p50 / p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "ACME errors per hour by type. A sustained non-zero line means issuance/renewal is failing upstream.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 60, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "auto", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 21 },
+      "id": 13,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (error_type) (increase(certmate_acme_errors_total[1h]))", "legendFormat": "{{error_type}}", "refId": "A" }],
+      "title": "ACME errors (per hour)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "ACME rate-limit hits in the last 24h. Non-zero means you risked a Let's Encrypt lockout.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 4, "x": 8, "y": 21 },
+      "id": 14,
+      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(increase(certmate_acme_rate_limit_hits_total[24h]))", "refId": "A" }],
+      "title": "ACME rate-limit hits (24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "DNS provider API call rate by provider and outcome.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "auto", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
+      "id": 15,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (provider, status) (rate(certmate_dns_provider_api_calls_total[5m]))", "legendFormat": "{{provider}} {{status}}", "refId": "A" }],
+      "title": "DNS provider API calls",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }, "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 29 },
+      "id": 16,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_application_uptime_seconds", "refId": "A" }],
+      "title": "Uptime",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "In-process cache hit ratio over 5m.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "max": 1, "min": 0, "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 0.5 }, { "color": "green", "value": 0.8 }] }, "unit": "percentunit" }, "overrides": [] },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 29 },
+      "id": 17,
+      "options": { "minVizHeight": 75, "minVizWidth": 75, "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "showThresholdLabels": false, "showThresholdMarkers": true },
+      "pluginVersion": "10.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(certmate_cache_hits_total[5m])) / clamp_min(sum(rate(certmate_cache_hits_total[5m])) + sum(rate(certmate_cache_misses_total[5m])), 1)", "refId": "A" }],
+      "title": "Cache hit ratio",
+      "type": "gauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 29 },
+      "id": 18,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_cache_entries", "refId": "A" }],
+      "title": "Cache entries",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Running CertMate version (from certmate_version_info).",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 29 },
+      "id": 19,
+      "options": { "colorMode": "none", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "/^version$/", "values": false }, "textMode": "value" },
+      "pluginVersion": "10.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_version_info", "format": "table", "instant": true, "refId": "A" }],
+      "title": "Version",
+      "type": "stat"
+    }
+  ]
+}

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1,10 +1,13 @@
 {
-  "__comment": "CertMate observability dashboard. Import via Grafana > Dashboards > New > Import. Pick your Prometheus datasource when prompted. Built only on metrics CertMate actually emits at /metrics.",
+  "__comment": "CertMate observability dashboard. Import via Grafana > Dashboards > New > Import; pick your Prometheus datasource when prompted. Panels use only metrics the /metrics endpoint populates today: certificate inventory, expiry, status, provider, cache, uptime, version.",
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -21,7 +24,11 @@
   "liveNow": false,
   "refresh": "1m",
   "schemaVersion": 39,
-  "tags": ["certmate", "tls", "certificates"],
+  "tags": [
+    "certmate",
+    "tls",
+    "certificates"
+  ],
   "templating": {
     "list": [
       {
@@ -40,7 +47,10 @@
       }
     ]
   },
-  "time": { "from": "now-24h", "to": "now" },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "",
   "title": "CertMate - Certificates & ACME",
@@ -49,226 +59,784 @@
   "weekStart": "",
   "panels": [
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }, "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "10.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_domains_total", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "certmate_domains_total",
+          "refId": "A"
+        }
+      ],
       "title": "Managed domains",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }, "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 5,
+        "y": 0
+      },
       "id": 2,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "10.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_certificates_total", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "certmate_certificates_total",
+          "refId": "A"
+        }
+      ],
       "title": "Total certificates",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "green" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "green"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 10,
+        "y": 0
+      },
       "id": 3,
-      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "10.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(certmate_certificates_by_status{status=\"valid\"})", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(certmate_certificates_by_status{status=\"valid\"})",
+          "refId": "A"
+        }
+      ],
       "title": "Valid",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }] }, "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 14,
+        "y": 0
+      },
       "id": 4,
-      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "10.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(certmate_certificates_by_status{status=\"expiring_soon\"})", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(certmate_certificates_by_status{status=\"expiring_soon\"})",
+          "refId": "A"
+        }
+      ],
       "title": "Expiring soon",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] }, "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 19,
+        "y": 0
+      },
       "id": 5,
-      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "10.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(certmate_certificates_by_status{status=\"expired\"})", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(certmate_certificates_by_status{status=\"expired\"})",
+          "refId": "A"
+        }
+      ],
       "title": "Expired",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] }, "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
-      "id": 6,
-      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
-      "pluginVersion": "10.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(certmate_certificates_by_status{status=\"renewal_failed\"})", "refId": "A" }],
-      "title": "Renewal failed",
-      "type": "stat"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "Days remaining per certificate. Red < 7, amber < 30, green otherwise. Sorted soonest-first.",
       "fieldConfig": {
-        "defaults": { "color": { "mode": "thresholds" }, "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "filterable": true, "inspect": false }, "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 7 }, { "color": "green", "value": 30 }] }, "unit": "d" },
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 7
+              },
+              {
+                "color": "green",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "d"
+        },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "Days left" }, "properties": [{ "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "gradient" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Days left"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "gradient"
+                }
+              }
+            ]
+          }
         ]
       },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 4 },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
       "id": 7,
-      "options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false }, "showHeader": true, "sortBy": [{ "displayName": "Days left", "desc": false }] },
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Days left",
+            "desc": false
+          }
+        ]
+      },
       "pluginVersion": "10.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_certificate_expiry_days", "format": "table", "instant": true, "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "certmate_certificate_expiry_days",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
       "title": "Days until expiry (per certificate)",
       "transformations": [
-        { "id": "organize", "options": { "excludeByName": { "Time": true, "__name__": true, "job": true, "instance": true }, "indexByName": {}, "renameByName": { "domain": "Domain", "dns_provider": "DNS Provider", "Value": "Days left" } } }
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "domain": "Domain",
+              "dns_provider": "DNS Provider",
+              "Value": "Days left"
+            }
+          }
+        }
       ],
       "type": "table"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" }, "overrides": [{ "matcher": { "id": "byName", "options": "valid" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] }, { "matcher": { "id": "byName", "options": "expiring_soon" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }] }, { "matcher": { "id": "byName", "options": "expired" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] }, { "matcher": { "id": "byName", "options": "renewal_failed" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "dark-red" } }] }] },
-      "gridPos": { "h": 9, "w": 6, "x": 12, "y": 4 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "valid"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "expiring_soon"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "expired"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "renewal_failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "dark-red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 4
+      },
       "id": 8,
-      "options": { "displayLabels": ["percent"], "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "values": ["value"] }, "pieType": "donut", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "tooltip": { "mode": "single", "sort": "none" } },
+      "options": {
+        "displayLabels": [
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
       "pluginVersion": "10.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_certificates_by_status", "instant": true, "legendFormat": "{{status}}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "certmate_certificates_by_status",
+          "instant": true,
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
       "title": "Certificates by status",
       "type": "piechart"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "continuous-GrYlRd" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }, "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 9, "w": 6, "x": 18, "y": 4 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 4
+      },
       "id": 9,
-      "options": { "displayMode": "gradient", "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false }, "minVizHeight": 10, "minVizWidth": 0, "orientation": "horizontal", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "showUnfilled": true, "valueMode": "color" },
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
       "pluginVersion": "10.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_certificates_by_provider", "instant": true, "legendFormat": "{{provider}}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "certmate_certificates_by_provider",
+          "instant": true,
+          "legendFormat": "{{provider}}",
+          "refId": "A"
+        }
+      ],
       "title": "Certificates by DNS provider",
       "type": "bargauge"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "Renewal attempts per hour by outcome. CertMate emits these on real renewal events.",
-      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 50, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "auto", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } }, "unit": "short" }, "overrides": [{ "matcher": { "id": "byName", "options": "success" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] }, { "matcher": { "id": "byName", "options": "failed" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] }] },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 13 },
-      "id": 10,
-      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (status) (increase(certmate_certificate_renewals_total[1h]))", "legendFormat": "{{status}}", "refId": "A" }],
-      "title": "Renewal outcomes (per hour)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "Issuance (first request) attempts per hour by outcome.",
-      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 50, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "auto", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } }, "unit": "short" }, "overrides": [{ "matcher": { "id": "byName", "options": "success" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] }, { "matcher": { "id": "byName", "options": "failed" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] }] },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 13 },
-      "id": 11,
-      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (status) (increase(certmate_certificate_requests_total[1h]))", "legendFormat": "{{status}}", "refId": "A" }],
-      "title": "Issuance outcomes (per hour)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "Certificate renewal wall-clock latency (DNS-01 propagation dominates).",
-      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "auto", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "unit": "s" }, "overrides": [] },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 13 },
-      "id": 12,
-      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(certmate_certificate_renewal_duration_seconds_bucket[6h])))", "legendFormat": "p50", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(certmate_certificate_renewal_duration_seconds_bucket[6h])))", "legendFormat": "p95", "refId": "B" }
-      ],
-      "title": "Renewal duration (p50 / p95)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "ACME errors per hour by type. A sustained non-zero line means issuance/renewal is failing upstream.",
-      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 60, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "auto", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } }, "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 21 },
-      "id": 13,
-      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (error_type) (increase(certmate_acme_errors_total[1h]))", "legendFormat": "{{error_type}}", "refId": "A" }],
-      "title": "ACME errors (per hour)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "ACME rate-limit hits in the last 24h. Non-zero means you risked a Let's Encrypt lockout.",
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] }, "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 8, "w": 4, "x": 8, "y": 21 },
-      "id": 14,
-      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
-      "pluginVersion": "10.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(increase(certmate_acme_rate_limit_hits_total[24h]))", "refId": "A" }],
-      "title": "ACME rate-limit hits (24h)",
-      "type": "stat"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "DNS provider API call rate by provider and outcome.",
-      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "auto", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "unit": "reqps" }, "overrides": [] },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
-      "id": 15,
-      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (provider, status) (rate(certmate_dns_provider_api_calls_total[5m]))", "legendFormat": "{{provider}} {{status}}", "refId": "A" }],
-      "title": "DNS provider API calls",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }, "unit": "s" }, "overrides": [] },
-      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 29 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 13
+      },
       "id": 16,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "10.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_application_uptime_seconds", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "certmate_application_uptime_seconds",
+          "refId": "A"
+        }
+      ],
       "title": "Uptime",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "In-process cache hit ratio over 5m.",
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "max": 1, "min": 0, "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 0.5 }, { "color": "green", "value": 0.8 }] }, "unit": "percentunit" }, "overrides": [] },
-      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 29 },
-      "id": 17,
-      "options": { "minVizHeight": 75, "minVizWidth": 75, "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "showThresholdLabels": false, "showThresholdMarkers": true },
-      "pluginVersion": "10.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(certmate_cache_hits_total[5m])) / clamp_min(sum(rate(certmate_cache_hits_total[5m])) + sum(rate(certmate_cache_misses_total[5m])), 1)", "refId": "A" }],
-      "title": "Cache hit ratio",
-      "type": "gauge"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }, "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 29 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 13
+      },
       "id": 18,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "10.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_cache_entries", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "certmate_cache_entries",
+          "refId": "A"
+        }
+      ],
       "title": "Cache entries",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "Running CertMate version (from certmate_version_info).",
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }, "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 29 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 13
+      },
       "id": 19,
-      "options": { "colorMode": "none", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "/^version$/", "values": false }, "textMode": "value" },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^version$/",
+          "values": false
+        },
+        "textMode": "value"
+      },
       "pluginVersion": "10.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "certmate_version_info", "format": "table", "instant": true, "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "certmate_version_info",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
       "title": "Version",
       "type": "stat"
     }

--- a/monitoring/prometheus-alerts.yml
+++ b/monitoring/prometheus-alerts.yml
@@ -1,0 +1,78 @@
+# CertMate alerting rules for Prometheus.
+#
+# Load with, in prometheus.yml:
+#   rule_files:
+#     - /etc/prometheus/certmate-alerts.yml
+#
+# Every rule below is built on a metric CertMate actually emits at /metrics.
+# certmate_certificate_expiry_days is clamped at 0 (an expired cert reads 0,
+# never negative), so "expired" is detected via the by_status gauge.
+groups:
+  - name: certmate-availability
+    rules:
+      - alert: CertMateDown
+        expr: up{job="certmate"} == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "CertMate is not being scraped ({{ $labels.instance }})"
+          description: "Prometheus has not scraped CertMate for 5m. The automatic renewal loop may be down while the dashboard still looks healthy."
+
+  - name: certmate-certificates
+    rules:
+      - alert: CertMateCertificateExpiringSoon
+        expr: (min by (domain) (certmate_certificate_expiry_days) < 14) and (min by (domain) (certmate_certificate_expiry_days) > 2)
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Certificate for {{ $labels.domain }} expires in < 14 days"
+          description: "{{ $labels.domain }} has {{ $value | printf \"%.0f\" }} days left. Confirm automatic renewal is running."
+
+      - alert: CertMateCertificateExpiringCritical
+        expr: min by (domain) (certmate_certificate_expiry_days) <= 2
+        for: 30m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Certificate for {{ $labels.domain }} expires within 2 days"
+          description: "{{ $labels.domain }} has {{ $value | printf \"%.0f\" }} days left. Renew immediately."
+
+      - alert: CertMateCertificatesExpired
+        expr: sum(certmate_certificates_by_status{status="expired"}) > 0
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $value }} certificate(s) have expired"
+          description: "CertMate reports expired certificates. Automatic renewal has failed for at least one domain."
+
+      - alert: CertMateRenewalFailedState
+        expr: sum(certmate_certificates_by_status{status="renewal_failed"}) > 0
+        for: 30m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $value }} certificate(s) in renewal_failed state"
+          description: "At least one certificate's last renewal attempt failed. Check the CertMate logs and the ACME errors panel."
+
+  - name: certmate-acme
+    rules:
+      - alert: CertMateAcmeErrors
+        expr: sum(rate(certmate_acme_errors_total[15m])) > 0
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "CertMate is hitting sustained ACME errors"
+          description: "ACME errors over the last 30m ({{ $value | printf \"%.3f\" }}/s). Issuance or renewal is failing upstream."
+
+      - alert: CertMateAcmeRateLimited
+        expr: increase(certmate_acme_rate_limit_hits_total[1h]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "CertMate hit an ACME rate limit ({{ $labels.limit_type }})"
+          description: "Rate limit hit via {{ $labels.dns_provider }}. Back off to avoid a Let's Encrypt account/domain lockout."

--- a/monitoring/prometheus-alerts.yml
+++ b/monitoring/prometheus-alerts.yml
@@ -48,31 +48,9 @@ groups:
           summary: "{{ $value }} certificate(s) have expired"
           description: "CertMate reports expired certificates. Automatic renewal has failed for at least one domain."
 
-      - alert: CertMateRenewalFailedState
-        expr: sum(certmate_certificates_by_status{status="renewal_failed"}) > 0
-        for: 30m
-        labels:
-          severity: critical
-        annotations:
-          summary: "{{ $value }} certificate(s) in renewal_failed state"
-          description: "At least one certificate's last renewal attempt failed. Check the CertMate logs and the ACME errors panel."
-
-  - name: certmate-acme
-    rules:
-      - alert: CertMateAcmeErrors
-        expr: sum(rate(certmate_acme_errors_total[15m])) > 0
-        for: 30m
-        labels:
-          severity: warning
-        annotations:
-          summary: "CertMate is hitting sustained ACME errors"
-          description: "ACME errors over the last 30m ({{ $value | printf \"%.3f\" }}/s). Issuance or renewal is failing upstream."
-
-      - alert: CertMateAcmeRateLimited
-        expr: increase(certmate_acme_rate_limit_hits_total[1h]) > 0
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: "CertMate hit an ACME rate limit ({{ $labels.limit_type }})"
-          description: "Rate limit hit via {{ $labels.dns_provider }}. Back off to avoid a Let's Encrypt account/domain lockout."
+# NOTE: alerts on renewal/issuance outcomes, ACME errors and rate-limit hits
+# are intentionally omitted: those metrics (certmate_certificate_renewals_total,
+# certmate_acme_errors_total, certmate_acme_rate_limit_hits_total, and the
+# renewal_failed status) are defined by CertMate but not yet recorded at
+# runtime, so an alert on them could never fire. Add them back together with
+# the record_* instrumentation.

--- a/monitoring/prometheus-scrape.example.yml
+++ b/monitoring/prometheus-scrape.example.yml
@@ -1,0 +1,21 @@
+# Example Prometheus scrape job for CertMate.
+#
+# CertMate's /metrics endpoint requires the admin role, so the scrape must
+# present an admin-scoped API token as a Bearer credential. Create a dedicated
+# token in Settings > API Keys (admin role) and use it here — do not reuse a
+# human token. Prefer `credentials_file` over inlining the secret in this file.
+#
+# Drop this job into the `scrape_configs:` list of your prometheus.yml.
+scrape_configs:
+  - job_name: certmate
+    metrics_path: /metrics
+    scheme: http            # set to https when CertMate is behind TLS
+    scrape_interval: 60s
+    authorization:
+      type: Bearer
+      # credentials_file: /etc/prometheus/certmate-token   # recommended
+      credentials: "REPLACE_WITH_ADMIN_API_TOKEN"
+    static_configs:
+      - targets: ["certmate:8000"]   # host:port of your CertMate instance
+        labels:
+          instance: certmate

--- a/tests/test_metrics_endpoint_context.py
+++ b/tests/test_metrics_endpoint_context.py
@@ -1,0 +1,60 @@
+"""The /metrics route must build an app_context so inventory metrics populate.
+
+Before this fix the route called generate_metrics_response() with no context;
+metrics.py gates all certificate/DNS/cache collection behind `if app_context`,
+so the live endpoint emitted ONLY application_uptime and every labelled metric
+the Grafana dashboard draws was 'No data'. These tests drive the REAL route and
+assert the certificate inventory now carries samples.
+"""
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+from modules.web.misc_routes import register_misc_routes
+
+pytestmark = [pytest.mark.unit]
+
+
+def _passthrough(*_a, **_k):
+    def deco(fn):
+        return fn
+    return deco
+
+
+def _app(managers):
+    app = Flask(__name__)
+    auth_manager = SimpleNamespace(require_role=_passthrough)
+    register_misc_routes(app, managers, _passthrough, auth_manager)
+    return app
+
+
+def test_metrics_endpoint_populates_certificate_inventory(tmp_path):
+    (tmp_path / 'certs').mkdir()
+    managers = {
+        'settings': SimpleNamespace(load_settings=lambda: {
+            'domains': [{'domain': 'example.com'}],
+            'dns_providers': {'cloudflare': {'default': {'api_token': 'x'}}},
+        }),
+        'file_ops': SimpleNamespace(cert_dir=tmp_path / 'certs'),
+        'certificates': SimpleNamespace(
+            get_certificate_info=lambda domain, *a, **k: (
+                {'exists': True, 'days_left': 45, 'dns_provider': 'cloudflare'}
+                if domain == 'example.com' else None)),
+        'cache': SimpleNamespace(get_stats=lambda: {'total_entries': 7}),
+    }
+    body = _app(managers).test_client().get('/metrics').get_data(as_text=True)
+
+    # Previously all of these were absent (no samples) — now they carry values.
+    assert 'certmate_domains_total 1.0' in body
+    assert 'certmate_certificates_total 1.0' in body
+    assert 'certmate_certificates_by_status{status="valid"} 1.0' in body
+    assert 'certmate_certificate_expiry_days{' in body and 'example.com' in body
+    assert 'certmate_cache_entries 7.0' in body
+
+
+def test_metrics_endpoint_without_context_still_serves(tmp_path):
+    # No managers -> base metrics only, but never a 500.
+    r = _app({}).test_client().get('/metrics')
+    assert r.status_code == 200
+    assert 'certmate_application_uptime_seconds' in r.get_data(as_text=True)

--- a/tests/test_metrics_endpoint_context.py
+++ b/tests/test_metrics_endpoint_context.py
@@ -49,7 +49,11 @@ def test_metrics_endpoint_populates_certificate_inventory(tmp_path):
     assert 'certmate_domains_total 1.0' in body
     assert 'certmate_certificates_total 1.0' in body
     assert 'certmate_certificates_by_status{status="valid"} 1.0' in body
-    assert 'certmate_certificate_expiry_days{' in body and 'example.com' in body
+    # Assert the labelled metric string (a bare-host 'example.com' substring
+    # check trips CodeQL's url-sanitization heuristic — a false positive on a
+    # Prometheus exposition assertion — and the label form is more precise).
+    assert 'certmate_certificate_expiry_days{' in body
+    assert 'domain="example.com"' in body
     assert 'certmate_cache_entries 7.0' in body
 
 


### PR DESCRIPTION
## Monitoring: Grafana dashboard + Prometheus alerts, and fix /metrics population

Ships an importable observability bundle under `monitoring/`, and fixes a
pre-existing bug that left the Prometheus endpoint nearly empty.

### The /metrics fix (`modules/web/misc_routes.py`)
The route called `generate_metrics_response()` with **no `app_context`**, and
`metrics.py` gates all certificate/DNS/cache collection behind `if app_context`.
So the live endpoint emitted **only** `application_uptime` — every labelled
inventory metric was absent for any scraper. The route now builds the context
(settings, cert dir, `get_certificate_info`, cache) from the managers; falls
back to base metrics (never 500) if a manager is missing.

### Bundle (`monitoring/`)
- `grafana-dashboard.json` — 11 panels on metrics the endpoint actually populates (inventory, days-until-expiry, status/provider breakdowns, cache, uptime, version).
- `prometheus-alerts.yml` — 4 alerts that can fire (expiring soon/critical, expired, scrape-down).
- `prometheus-scrape.example.yml` — authenticated scrape job (`/metrics` needs admin role).
- README documents coverage honestly: what populates today vs what needs `record_*` instrumentation (a follow-up — the operations row + ACME alerts return once those are wired).

### Testing
- `tests/test_metrics_endpoint_context.py` drives the real route and asserts inventory metrics now carry samples.
- All PromQL (dashboard + alerts) validated with `promtool`; dashboard imported into a real Grafana 13.
- Docker E2E: `/metrics` on a running container now emits the full inventory (was only uptime).

Generated with [Claude Code](https://claude.com/claude-code)
