### PR TITLE
feat(mcp): cert-lifecycle agent tools + AI scheduling guide

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -6,12 +6,24 @@ CertMate includes a built-in Model Context Protocol (MCP) server written in Node
 
 The CertMate MCP server exposes the following tools to AI assistants:
 
-1. **`certmate_list_certificates`** — Lists all certificates managed by the active CertMate instance.
-2. **`certmate_create_certificate`** — Requests a new TLS certificate for a specified domain (supports optional parameters for DNS provider, account, and CA).
-3. **`certmate_renew_certificate`** — Forces renewal of an existing certificate for a domain.
-4. **`certmate_deploy_certificate`** — Manually executes all configured deployment hooks for a domain.
-5. **`certmate_get_settings`** — Retrieves global settings and configurations.
-6. **`certmate_diagnostics`** — Retrieves a comprehensive and sanitized diagnostic snapshot of the CertMate system.
+**Inventory & status**
+1. **`certmate_list_certificates`** — Lists all certificates managed by the active CertMate instance (with expiry, status, domains).
+2. **`certmate_get_certificate`** — Full detail for one domain: status, days until expiry, SANs, DNS/CA provider, auto-renew flag. Use it to decide whether a cert needs renewing.
+3. **`certmate_get_activity`** — Recent activity/audit log, to diagnose what changed or failed.
+4. **`certmate_diagnostics`** — Comprehensive, sanitized diagnostic snapshot.
+5. **`certmate_get_settings`** — Global settings and configuration.
+
+**Lifecycle operations**
+6. **`certmate_create_certificate`** — Requests a new TLS certificate for a domain (optional DNS provider, account, CA). May return a `job_id` (HTTP 202) for async issuance.
+7. **`certmate_renew_certificate`** — Forces renewal of an existing certificate (may also return a `job_id`).
+8. **`certmate_get_job`** — Polls an async create/renew job by `job_id` until it reports completed or failed.
+9. **`certmate_set_auto_renew`** — Enables or disables automatic renewal for a single domain.
+10. **`certmate_deploy_certificate`** — Manually executes all configured deployment hooks for a domain.
+11. **`certmate_download_certificate`** — Returns a domain's certificate material as JSON (fullchain, key, chain) so an agent can deploy it elsewhere.
+
+**Providers**
+12. **`certmate_list_dns_providers`** — DNS providers supported and configured on this instance.
+13. **`certmate_list_dns_accounts`** — Configured DNS provider accounts (credentials masked); use a returned account id as `account_id` when creating a certificate.
 
 ## Setup & Configuration
 
@@ -49,7 +61,51 @@ To add the CertMate MCP server to Claude Desktop, add the following to your conf
 }
 ```
 
+### Other MCP clients (Gemini, etc.)
+
+The server speaks plain MCP over stdio, so any client that supports MCP works the
+same way: point it at `node /absolute/path/to/certmate/mcp/index.js` and set the
+two environment variables. Nothing in the server is Claude-specific.
+
+## Operating CertMate with an AI agent (scheduled jobs)
+
+Most top-tier assistants now support **scheduled tasks** (Claude, Gemini, and
+others). Combine that with this MCP server and you get a hands-off "certificate
+keeper": you describe the policy in plain language with explicit conditions, the
+model schedules itself, and on each run it uses the tools above to enforce the
+policy. The pattern is model-agnostic — anything that can run a saved prompt on a
+schedule and call MCP tools will work.
+
+### The loop the agent runs
+
+1. `certmate_list_certificates` (or `certmate_get_certificate` per domain) to read `days_left` / status.
+2. Decide per your condition, e.g. *renew when `days_left < 14`*.
+3. `certmate_renew_certificate` for each due domain.
+4. If a renewal returns a `job_id`, `certmate_get_job` until it reports `completed` / `failed`.
+5. On failure, surface it — and CertMate's own notification channels (email, Slack, Discord, Telegram, ntfy, Gotify) will also fire on `certificate_failed`, so you get a push regardless.
+
+### Example scheduled prompts
+
+> **Daily, 08:00** — "Using the CertMate MCP tools, list all certificates. For any
+> with `days_left < 14`, call `certmate_renew_certificate`, then poll
+> `certmate_get_job` until done. Reply with a one-line summary per domain and call
+> out any failures."
+
+> **Weekly** — "Call `certmate_get_activity` and `certmate_diagnostics`. Summarize
+> anything unusual (failed renewals, expired certs, scheduler not running) in three
+> bullets. If nothing is wrong, say so."
+
+> **On demand** — "Issue a cert for `shop.example.com` using `certmate_list_dns_providers`
+> to pick a configured provider and `certmate_list_dns_accounts` for the account id,
+> then watch the job to completion."
+
+Because the conditions live in the prompt, you can tune the policy (threshold,
+which domains, what to do on failure) without touching any code. Give the agent a
+token scoped to exactly what it should do — `operator` for renew/deploy, `admin`
+only if it must change settings or read diagnostics.
+
 ## Security
 
 1. **Token Protection** — The MCP server requires a valid `CERTMATE_TOKEN`. It passes this token securely in the `Authorization` header for all requests to the CertMate API.
-2. **Log Sanitization Compatibility** — Tools like `certmate_diagnostics` retrieve data after the Log Sanitizer has stripped sensitive credentials, protecting keys and tokens from leaking into LLM contexts.
+2. **Least privilege** — Scope the token to what the agent needs. A scheduled renew-keeper needs `operator`; reserve `admin` tokens for agents that must change settings or pull diagnostics. Revoke the token to instantly cut the agent off.
+3. **Log Sanitization Compatibility** — Tools like `certmate_diagnostics` retrieve data after the Log Sanitizer has stripped sensitive credentials, protecting keys and tokens from leaking into LLM contexts.

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -8,7 +8,7 @@ const fetch = require("node-fetch");
 
 const server = new Server({
   name: "certmate-mcp-server",
-  version: "1.0.0"
+  version: "1.1.0"
 }, {
   capabilities: {
     tools: {}
@@ -68,6 +68,76 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "certmate_diagnostics",
         description: "Retrieve a comprehensive and sanitized diagnostic snapshot of the CertMate system.",
         inputSchema: { type: "object", properties: {} }
+      },
+      {
+        name: "certmate_get_certificate",
+        description: "Get full detail for one certificate by domain: status, days until expiry, SANs, DNS/CA provider, auto-renew flag. Use this to decide whether a cert needs renewing (e.g. renew when days_left < 14).",
+        inputSchema: {
+          type: "object",
+          properties: {
+            domain: { type: "string", description: "The domain name (e.g. example.com)" }
+          },
+          required: ["domain"]
+        }
+      },
+      {
+        name: "certmate_get_job",
+        description: "Poll the status of an asynchronous certificate job. certmate_create_certificate and certmate_renew_certificate may return a job_id (HTTP 202); call this with that job_id until status is completed or failed.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            job_id: { type: "string", description: "The job_id returned by an async create/renew" }
+          },
+          required: ["job_id"]
+        }
+      },
+      {
+        name: "certmate_download_certificate",
+        description: "Download a certificate's material as JSON (fullchain, private key, chain) for a domain, so an agent can deploy it elsewhere.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            domain: { type: "string", description: "The domain name" }
+          },
+          required: ["domain"]
+        }
+      },
+      {
+        name: "certmate_set_auto_renew",
+        description: "Enable or disable automatic renewal for a single domain.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            domain: { type: "string", description: "The domain name" },
+            enabled: { type: "boolean", description: "true to enable auto-renew, false to disable" }
+          },
+          required: ["domain", "enabled"]
+        }
+      },
+      {
+        name: "certmate_list_dns_providers",
+        description: "List the DNS providers supported and configured on this instance, so a create call can pass a valid dns_provider.",
+        inputSchema: { type: "object", properties: {} }
+      },
+      {
+        name: "certmate_list_dns_accounts",
+        description: "List configured DNS provider accounts (credentials are masked). Pass a provider to filter; omit to list all. Use a returned account id as account_id when creating a certificate.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            provider: { type: "string", description: "Optional DNS provider key to filter by (e.g. cloudflare)" }
+          }
+        }
+      },
+      {
+        name: "certmate_get_activity",
+        description: "Read the recent activity/audit log to diagnose what changed or what failed.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            limit: { type: "integer", description: "Max entries to return (1-500, default 100)" }
+          }
+        }
       }
     ]
   };
@@ -151,6 +221,31 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         break;
       case "certmate_diagnostics":
         result = await makeRequest("GET", "/api/diagnostics/snapshot");
+        break;
+      case "certmate_get_certificate":
+        result = await makeRequest("GET", `/api/certificates/${encodeURIComponent(args.domain)}`);
+        break;
+      case "certmate_get_job":
+        result = await makeRequest("GET", `/api/certificates/jobs/${encodeURIComponent(args.job_id)}`);
+        break;
+      case "certmate_download_certificate":
+        result = await makeRequest("GET", `/api/certificates/${encodeURIComponent(args.domain)}/download?format=json`);
+        break;
+      case "certmate_set_auto_renew":
+        result = await makeRequest("PUT", `/api/certificates/${encodeURIComponent(args.domain)}/auto-renew`, {
+          enabled: args.enabled
+        });
+        break;
+      case "certmate_list_dns_providers":
+        result = await makeRequest("GET", "/api/settings/dns-providers");
+        break;
+      case "certmate_list_dns_accounts":
+        result = await makeRequest("GET", args.provider
+          ? `/api/dns/${encodeURIComponent(args.provider)}/accounts`
+          : "/api/dns/accounts");
+        break;
+      case "certmate_get_activity":
+        result = await makeRequest("GET", `/api/activity?limit=${encodeURIComponent(args.limit || 100)}`);
         break;
       default:
         throw new Error(`Unknown tool: ${name}`);

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,10 +1,11 @@
 {
   "name": "certmate-mcp-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Model Context Protocol server for CertMate",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node test-smoke.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.1",

--- a/mcp/test-smoke.js
+++ b/mcp/test-smoke.js
@@ -1,0 +1,87 @@
+// Smoke test for the CertMate MCP server — no running CertMate required.
+//
+// 1. Static consistency: every tool declared in ListTools has a switch case
+//    and vice-versa.
+// 2. Live stdio handshake: spawn the server, complete the MCP initialize
+//    handshake, and assert tools/list returns every declared tool.
+//
+// Run with: npm test   (from the mcp/ directory)
+const fs = require("fs");
+const path = require("path");
+const { spawn } = require("child_process");
+
+const INDEX = path.join(__dirname, "index.js");
+const src = fs.readFileSync(INDEX, "utf8");
+
+const declared = [...src.matchAll(/name:\s*"(certmate_[a-z_]+)"/g)].map((m) => m[1]);
+const cases = [...src.matchAll(/case\s*"(certmate_[a-z_]+)"/g)].map((m) => m[1]);
+
+function fail(msg) {
+  console.error("FAIL:", msg);
+  process.exit(1);
+}
+
+// --- 1. static consistency ---
+const declaredSet = new Set(declared);
+const caseSet = new Set(cases);
+const missingCase = declared.filter((n) => !caseSet.has(n));
+const missingDecl = cases.filter((c) => !declaredSet.has(c));
+if (missingCase.length) fail(`tools declared without a switch case: ${missingCase}`);
+if (missingDecl.length) fail(`switch cases without a tool declaration: ${missingDecl}`);
+console.log(`OK: ${declared.length} tools, declarations and switch cases consistent`);
+
+// --- 2. live stdio handshake ---
+const child = spawn("node", [INDEX], {
+  env: { ...process.env, CERTMATE_TOKEN: "dummy" },
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+let buf = "";
+const timeout = setTimeout(() => {
+  child.kill();
+  fail("timed out waiting for tools/list response");
+}, 8000);
+
+child.stdout.on("data", (d) => {
+  buf += d.toString();
+  let idx;
+  while ((idx = buf.indexOf("\n")) >= 0) {
+    const line = buf.slice(0, idx);
+    buf = buf.slice(idx + 1);
+    if (!line.trim()) continue;
+    let msg;
+    try {
+      msg = JSON.parse(line);
+    } catch (e) {
+      continue;
+    }
+    if (msg.id === 2 && msg.result && msg.result.tools) {
+      clearTimeout(timeout);
+      const names = msg.result.tools.map((t) => t.name);
+      child.kill();
+      if (names.length !== declared.length) {
+        fail(`tools/list returned ${names.length}, expected ${declared.length}`);
+      }
+      for (const n of declared) {
+        if (!names.includes(n)) fail(`tools/list missing declared tool ${n}`);
+      }
+      console.log(`OK: stdio handshake -> tools/list returned all ${names.length} tools`);
+      console.log("PASS");
+      process.exit(0);
+    }
+  }
+});
+
+child.stderr.on("data", () => {}); // swallow the "running on stdio" banner
+
+const init = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "smoke", version: "0" } },
+};
+child.stdin.write(JSON.stringify(init) + "\n");
+setTimeout(() => {
+  child.stdin.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n");
+  child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }) + "\n");
+}, 400);


### PR DESCRIPTION
## MCP: cert-lifecycle agent tools + AI scheduling guide

The MCP server exposed 6 tools against a ~62-endpoint API — missing the ones an
autonomous agent needs to run a renew-keeper loop.

### Tools (`mcp/index.js`, 6 -> 13)
Mapped to verified Flask-RESTX routes:
- `certmate_get_certificate` (days_left/status), `certmate_get_job` (poll async issue/renew), `certmate_download_certificate`, `certmate_set_auto_renew`, `certmate_list_dns_providers`, `certmate_list_dns_accounts` (masked), `certmate_get_activity`.
- Destructive/secret-bearing ops (delete, reissue, settings mutation) left out of this pass on purpose.

### Guide (`docs/mcp.md`)
Full tool list + "Operating CertMate with an AI agent (scheduled jobs)": the
*list -> decide (`days_left < N`) -> renew -> poll job -> notify* loop with
example scheduled prompts. Model-agnostic (Claude, Gemini, any MCP client);
notes least-privilege token scoping.

### Testing
- `mcp/test-smoke.js` (`npm test`): tool/switch consistency + a real stdio `initialize` -> `tools/list` handshake (13 tools).
- Docker E2E: live `call_tool` against a running CertMate — `list_certificates`, `list_dns_providers`, `get_activity`, `list_dns_accounts`, `get_settings` all return real data; secrets redacted.

Generated with [Claude Code](https://claude.com/claude-code)
