### PR TITLE
docs(install): CertMate perimeter hardening (reverse proxy in, forward proxy out)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -230,6 +230,77 @@ proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $scheme;
 ```
 
+#### Example: Zion (Rust TLS gateway + WAF)
+
+[Zion](https://github.com/fabriziosalmi/zion) is a high-performance Rust TLS
+reverse proxy with a built-in WAF — a good fit in front of CertMate when you
+want TLS 1.3 termination and request filtering at the edge. CertMate stays on
+plain HTTP on the internal network; Zion terminates TLS and forwards.
+
+`zion.toml`:
+
+```toml
+[server]
+listen_http  = "0.0.0.0:8080"
+listen_https = "0.0.0.0:8443"
+
+[tls]
+cert_path = "/etc/ssl/zion/tls.crt"   # your cert, or use Zion's ACME (--features acme)
+key_path  = "/etc/ssl/zion/tls.key"
+min_version = "1.3"
+alpn = ["h2", "http/1.1"]
+
+[upstream.backend]
+url = "http://certmate:8000"
+
+# Root + catch-all (a lone /{*rest} can miss the exact "/").
+[[route]]
+path = "/"
+upstream = "backend"
+
+[[route]]
+path = "/{*rest}"
+upstream = "backend"
+```
+
+`docker-compose.yml`:
+
+```yaml
+services:
+  certmate:
+    image: certmate:latest          # the published image, or your local build
+    environment:
+      BEHIND_PROXY: "true"          # trust Zion's X-Forwarded-* headers
+    expose:
+      - "8000"                       # internal only; not published to the host
+    volumes:
+      - ./data:/app/data
+
+  zion:
+    image: zion:latest              # the published image, or your local build
+    depends_on:
+      - certmate
+    environment:
+      ZION_CONFIG: /etc/zion/zion.toml
+    volumes:
+      - ./zion.toml:/etc/zion/zion.toml:ro
+      - ./certs:/etc/ssl/zion:ro
+    ports:
+      - "443:8443"                   # host 443 -> Zion's HTTPS listener
+      - "80:8080"                    # host 80  -> Zion's HTTP listener
+```
+
+Keep `BEHIND_PROXY=true` on the CertMate service: Zion appends
+`X-Forwarded-For`, so this makes per-client rate limiting, audit entries and the
+auth-failure warnings resolve to the real client IP rather than Zion's.
+
+> **`/metrics` is served by Zion, not proxied.** Zion exposes its own Prometheus
+> endpoint at `/metrics` (`zion_*` series for the proxy), which shadows
+> CertMate's `/metrics`. Scrape the two separately: Zion's at the edge, and
+> CertMate's `certmate_*` metrics directly against the internal `certmate:8000`
+> with an admin Bearer token (see [`monitoring/`](../monitoring/) for the
+> dashboard and scrape config).
+
 ### Storage location for the data directory
 
 CertMate uses standard Python blocking file I/O for everything under

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -253,7 +253,8 @@ alpn = ["h2", "http/1.1"]
 [upstream.backend]
 url = "http://certmate:8000"
 
-# Root + catch-all (a lone /{*rest} can miss the exact "/").
+# Catch-all to the backend. The explicit "/" route is harmless and documents
+# intent; recent Zion also auto-registers "/" for a root catch-all.
 [[route]]
 path = "/"
 upstream = "backend"
@@ -296,10 +297,73 @@ auth-failure warnings resolve to the real client IP rather than Zion's.
 
 > **`/metrics` is served by Zion, not proxied.** Zion exposes its own Prometheus
 > endpoint at `/metrics` (`zion_*` series for the proxy), which shadows
-> CertMate's `/metrics`. Scrape the two separately: Zion's at the edge, and
-> CertMate's `certmate_*` metrics directly against the internal `certmate:8000`
-> with an admin Bearer token (see [`monitoring/`](../monitoring/) for the
-> dashboard and scrape config).
+> CertMate's `/metrics`. Scrape them separately: Zion's `/metrics` from inside
+> the host / cluster network (Zion gates it to private source IPs and returns
+> 403 to public clients), and CertMate's `certmate_*` directly against the
+> internal `certmate:8000` with an admin Bearer token (see
+> [`monitoring/`](../monitoring/) for the dashboard and scrape config).
+
+### Confining outbound traffic (egress hardening)
+
+CertMate makes outbound connections to ACME Certificate Authorities, DNS
+provider APIs, object storage, and notification webhooks over HTTP(S), plus
+SMTP for email notifications. You can confine and audit the **HTTP(S)** traffic
+by routing it through a **forward proxy** and denying CertMate any other route
+to the internet.
+
+CertMate's HTTP(S) clients (`requests`, `certbot`, webhook delivery via
+`urllib`, `boto3`) honor the standard `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`
+environment variables, so no code changes are needed. **SMTP is the
+exception:** email notifications use `smtplib`, which opens a direct TCP
+connection and does **not** consult the HTTP-proxy variables. On a locked-down
+egress network, allow your SMTP relay's `host:port` directly (a firewall /
+NetworkPolicy rule), or use a webhook notification channel instead of email.
+
+Example with [Secure Proxy Manager](https://github.com/fabriziosalmi/secure-proxy-manager),
+a self-hosted Squid-based forward proxy with a WAF, a DNS sinkhole, and
+domain / IP / CIDR allow-deny lists:
+
+```yaml
+services:
+  certmate:
+    image: certmate:latest
+    environment:
+      HTTP_PROXY:  "http://proxy:3128"
+      HTTPS_PROXY: "http://proxy:3128"
+      NO_PROXY:    "localhost,127.0.0.1"
+    networks:
+      - egress            # CertMate can reach ONLY the proxy on this network
+  # The Secure Proxy Manager stack provides the `proxy` service on :3128.
+  # Attach that proxy to BOTH the `egress` network (so CertMate can reach it)
+  # AND a second, non-internal network (so the proxy itself reaches the
+  # internet). The proxy is then CertMate's only route out.
+networks:
+  egress:
+    internal: true        # no gateway: CertMate has no direct internet
+```
+
+Putting CertMate on an `internal` network (no gateway) shared with the proxy
+makes the proxy its **only** path out. Outbound becomes a single auditable
+choke point: allow the destinations CertMate actually needs (your CA, DNS
+provider, object storage, notification endpoints), deny the rest; raw-IP-literal
+destinations are blocked at the proxy rather than trusted blindly. If you use
+DNS-alias / CNAME delegation, also allow `cloudflare-dns.com` — CertMate
+resolves those CNAMEs over DoH.
+
+- **Kubernetes:** an egress default-deny `NetworkPolicy` that permits traffic
+  only to the proxy Service, plus the `HTTP(S)_PROXY` env on the Deployment.
+- **systemd:** `Environment=HTTPS_PROXY=...` in the unit, plus host firewall
+  rules that restrict egress to the proxy.
+
+**HTTPS content inspection (optional, advanced).** A forward proxy sees only the
+SNI / host / IP of an HTTPS connection — destination allow-deny works on that
+without decryption. If you additionally enable TLS interception (SSL-bump) on
+the proxy to inspect outbound *content*, CertMate must **trust the proxy's
+interception CA**: point `REQUESTS_CA_BUNDLE` (and `SSL_CERT_FILE`) at a bundle
+that includes it, or add it to the container's system trust store. **Exclude
+(`splice`) the ACME endpoints from interception** — you do not want to MITM the
+connection to your Certificate Authority, and some endpoints pin certificates.
+This is not mutual TLS; it is one-way trust of a private CA.
 
 ### Storage location for the data directory
 


### PR DESCRIPTION
## Docs: CertMate perimeter hardening (reverse proxy in, forward proxy out)

Extends the "Behind a reverse proxy" section of `docs/installation.md` with two
worked, validated examples for running CertMate inside a hardened perimeter.

**Ingress — [Zion](https://github.com/fabriziosalmi/zion)** (Rust TLS gateway + WAF):
a minimal `zion.toml` (TLS 1.3 termination, routes to the internal `certmate:8000`)
and a compose snippet, with `BEHIND_PROXY=true` so `X-Forwarded-*` resolves to the
real client IP. Notes the `/metrics` path collision (Zion serves its own `zion_*`).

**Egress — forward proxy ([Secure Proxy Manager](https://github.com/fabriziosalmi/secure-proxy-manager)):**
route CertMate's HTTP(S) outbound through a forward proxy on an `internal: true`
network so the proxy is its only route to the internet; Kubernetes / systemd
equivalents; the SSL-bump / private-CA-trust caveat (splice ACME, not mTLS).

Both examples were exercised against local builds (TLS termination + proxying for
ingress; an airgapped CertMate reaching the internet only through the forward proxy
for egress). Every factual claim was checked by an adversarial audit against the
CertMate, Zion, and Secure Proxy Manager repos; the wording is deliberately
conservative — notably SMTP is excluded from HTTP-proxy confinement (it uses
`smtplib`), and no destination-geo capability is claimed for the forward proxy.

Docs only; no code changes.

Generated with [Claude Code](https://claude.com/claude-code)
