### PR TITLE
ci: fix Codecov uploads (token + scope coverage to the app package)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         # the badge silently freezes at a stale value. fail_ci_if_error stays
         # false so a transient Codecov outage never blocks a release.
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,15 +85,24 @@ jobs:
         FLASK_ENV: testing
         TESTING: true
       run: |
-        pytest -v --tb=short --cov=. --cov-report=xml --cov-report=html -m "not ui"
+        # Measure the application package (modules/), not the whole repo: a
+        # bare --cov=. folds the tests/ and scripts/ trees (which run at ~100%)
+        # into the number, inflating it and hiding the real app coverage.
+        pytest -v --tb=short --cov=modules --cov-report=xml --cov-report=html -m "not ui"
 
     - name: Upload coverage reports
       if: matrix.python-version == '3.12'
       uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5 (was v3)
       with:
+        # Required since main is a protected branch — without a token Codecov
+        # rejects the upload ("Token required because branch is protected") and
+        # the badge silently freezes at a stale value. fail_ci_if_error stays
+        # false so a transient Codecov outage never blocks a release.
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         flags: unittests
         name: codecov-umbrella
+        fail_ci_if_error: false
 
     - name: Test Docker build
       if: matrix.python-version == '3.12'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,34 @@
+# Codecov configuration.
+#
+# Coverage is measured over the application package (modules/) only — the CI
+# job runs `pytest --cov=modules` (see .github/workflows/ci.yml). A bare
+# --cov=. would fold the tests/ and scripts/ trees, which run at ~100%, into
+# the number and hide the real application coverage.
+#
+# Statuses are informational: a small coverage change never blocks a PR on this
+# single-maintainer project; the number is a signal, not a gate.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+    patch:
+      default:
+        informational: true
+
+# Belt-and-suspenders: even if a future run uploads a wider report, never count
+# these toward the application coverage number.
+ignore:
+  - "tests"
+  - "scripts"
+  - "venv"
+  - ".venv"
+  - "docs"
+  - "mcp/node_modules"
+
+comment:
+  layout: "reach, diff, flags"
+  require_changes: true


### PR DESCRIPTION
The README coverage badge was stuck at a stale ~38% that matched no real measurement. Root cause: Codecov **rejected every upload from the protected `main` branch** —

```
-> Token length: 0
error -- Upload queued for processing failed: {"message":"Token required because branch is protected"}
```

The `codecov-action` ran without a token, and with no `fail_ci_if_error` the upload step failed **silently** while the job stayed green, so the badge froze at the last successful upload (months old).

**Real coverage today:** ~**70%** over `modules/` (84% if you count the `tests/` tree, which `--cov=.` was folding in). So this is a broken-badge problem, not a low-coverage problem.

## Changes
- **`token: ${{ secrets.CODECOV_TOKEN }}`** on the codecov-action so uploads from `main` succeed again. (`CODECOV_TOKEN` repo secret added separately.) `fail_ci_if_error` stays `false` so a transient Codecov outage never blocks a release.
- **`--cov=modules`** instead of `--cov=.` — measure the application package, not the whole repo (the `tests/` tree runs at ~100% and was inflating the number). The badge will report the honest ~70%.
- **`codecov.yml`** (new): informational statuses (no PR gating on a single-maintainer project) + an ignore list for `tests/scripts/docs`.

After this merges, the next CI run on `main` uploads successfully and the badge updates to the real number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)