### PR TITLE
ci: OpenSSF Scorecard hardening (branch-protection token + pin dev tools)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,9 @@ jobs:
 
     - name: Lint with flake8
       run: |
-        pip install flake8
+        # Pinned so the build pulls a known version (OpenSSF Scorecard
+        # Pinned-Dependencies flags bare, unversioned pip installs).
+        pip install flake8==7.3.0
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings
@@ -77,7 +79,7 @@ jobs:
 
     - name: Security check with bandit
       run: |
-        pip install bandit
+        pip install bandit==1.9.4
         bandit -r modules/ app.py --severity-level medium
 
     - name: Run tests with coverage

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # Read-only PAT so Scorecard can evaluate Branch-Protection: the
+          # default GITHUB_TOKEN cannot read branch-protection settings, which
+          # left that high-weight check scored "?". Fine-grained, scoped to
+          # Administration: read + Contents: read.
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           # Publish to scorecard.dev so the README badge renders the
           # live score. Requires the repo to be public (it is).
           publish_results: true


### PR DESCRIPTION
Two low-risk lifts to the OpenSSF Scorecard (currently **7.0**), targeting the most actionable drags.

## Changes
- **Branch-Protection** (high weight, scored `?`): the Scorecard action ran without a `repo_token`, so the default `GITHUB_TOKEN` couldn't read branch-protection settings and the check came back inconclusive. Now passes a fine-grained **read-only** PAT (`SCORECARD_TOKEN`, Administration + Contents: read). The protection is already configured well, so this should score high. (Secret added separately.)
- **Pinned-Dependencies** (was `5/10`): pin the two bare dev-tool installs — `flake8==7.3.0`, `bandit==1.9.4` — so CI no longer installs unversioned packages.

## What this PR deliberately does NOT touch (with reasons)
Investigated the other low scores; these are either structural or carry breakage risk for little gain:
- **Code-Review** (high, `0`): structural for a single-maintainer repo — GitHub doesn't let you approve your own PRs, so there's no enforced reviewer to score. Not fixable without a co-maintainer/bot.
- **Vulnerabilities** (high, `0`): traced with `osv-scanner` (the same tool Scorecard uses). The 52 findings are **transitive `urllib3`/`idna` versions that osv-scanner resolves from the optional cloud-SDK requirement files (`requirements-aws.txt` etc.) in isolation**. The actual product install is safe — `requirements-minimal.txt` already constrains `urllib3>=2.6.0,<3` with CVE annotations, and `pip-audit` on `requirements.txt`/`requirements-test.txt` is clean. Force-pinning `urllib3` into `requirements-aws.txt` risks conflicting with botocore's urllib3 cap, and the `certbot-dns-*` pins are version-matched to certbot — so clearing this safely is a separate, tested dependency-refresh effort, not a quick win.
- **Signed-Releases** (high, `?`), **Fuzzing** (med, `0`), **CII-Best-Practices** (low, `0`): real effort, lower ROI — candidates for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)