### PR TITLE
feat(deployment-status): tunnel TLS probe through HTTP proxy

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -3,12 +3,16 @@ API endpoints module for CertMate
 Defines Flask-RESTX Resource classes for REST API endpoints
 """
 
+import base64
+import http.client
 import logging
 import re
 import socket
 import ssl
 import tempfile
 import time
+import urllib.parse
+import urllib.request
 import zipfile
 import os
 import io
@@ -115,6 +119,29 @@ def _tls_probe_timeout_seconds():
 _PROBE_PROTOCOLS = ('https-tls', 'tls', 'smtp-starttls')
 
 
+def _https_proxy_for(host):
+    """Return (proxy_host, proxy_port, auth_headers) for tunneling to *host*.
+
+    Honours the standard HTTPS_PROXY/https_proxy env vars and the NO_PROXY
+    bypass list (via urllib). Returns None when no proxy applies, so the probe
+    falls back to a direct connection. A raw socket ignores these env vars, so
+    without this CertMate cannot reach external targets on a machine that
+    requires an outbound HTTP proxy (#326).
+    """
+    proxy = urllib.request.getproxies().get('https')
+    if not proxy or urllib.request.proxy_bypass(host):
+        return None
+    parts = urllib.parse.urlsplit(proxy if '://' in proxy else 'http://' + proxy)
+    if not parts.hostname:
+        return None
+    headers = {}
+    if parts.username:
+        raw = f"{urllib.parse.unquote(parts.username)}:{urllib.parse.unquote(parts.password or '')}"
+        token = base64.b64encode(raw.encode()).decode()
+        headers['Proxy-Authorization'] = f'Basic {token}'
+    return parts.hostname, parts.port or 8080, headers
+
+
 def _probe_tls_certificate(domain, port=443, protocol='https-tls', timeout=None):
     """Return the live TLS certificate for a domain, if reachable.
 
@@ -154,10 +181,25 @@ def _probe_tls_certificate(domain, port=443, protocol='https-tls', timeout=None)
         if protocol == 'smtp-starttls':
             cert_bytes = _probe_smtp_starttls(host, port, context, timeout)
         else:
-            # Direct TLS (https-tls, tls)
-            with socket.create_connection((host, port), timeout=timeout) as raw_sock:
-                with context.wrap_socket(raw_sock, server_hostname=host) as tls_sock:
-                    cert_bytes = tls_sock.getpeercert(binary_form=True)
+            # Direct TLS (https-tls, tls). When an HTTPS_PROXY applies (and the
+            # host isn't in NO_PROXY) tunnel the TCP leg through the proxy with
+            # HTTP CONNECT, then run the TLS handshake over that tunnel so we
+            # still read the real peer certificate (#326).
+            proxy = _https_proxy_for(host)
+            if proxy:
+                proxy_host, proxy_port, proxy_headers = proxy
+                conn = http.client.HTTPConnection(proxy_host, proxy_port, timeout=timeout)
+                try:
+                    conn.set_tunnel(host, port, headers=proxy_headers)
+                    conn.connect()
+                    with context.wrap_socket(conn.sock, server_hostname=host) as tls_sock:
+                        cert_bytes = tls_sock.getpeercert(binary_form=True)
+                finally:
+                    conn.close()
+            else:
+                with socket.create_connection((host, port), timeout=timeout) as raw_sock:
+                    with context.wrap_socket(raw_sock, server_hostname=host) as tls_sock:
+                        cert_bytes = tls_sock.getpeercert(binary_form=True)
 
         return {
             'reachable': True,

--- a/tests/test_tls_probe_proxy.py
+++ b/tests/test_tls_probe_proxy.py
@@ -1,0 +1,159 @@
+"""
+Tests for tunnelling the TLS deployment probe through an HTTP proxy.
+
+The dashboard's "is this cert actually deployed?" probe opens a raw TCP socket
+to <domain>:<port>. A raw socket ignores HTTPS_PROXY, so on a host that can
+only reach the outside internet via an outbound HTTP proxy the server-side
+probe always reports "Unreachable" even though the target is up. The fix: when
+HTTPS_PROXY is set (and the host isn't in NO_PROXY) tunnel the TCP leg through
+the proxy with HTTP CONNECT, then run the TLS handshake over that tunnel (#326).
+
+These tests pin: proxy discovery (env + NO_PROXY + auth) and that the probe
+actually uses CONNECT — to the configured port — when a proxy applies.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from modules.api.resources import _https_proxy_for, _probe_tls_certificate
+
+
+# ---- _https_proxy_for -----------------------------------------------------
+
+
+def test_no_proxy_env_returns_none(monkeypatch):
+    monkeypatch.delenv('HTTPS_PROXY', raising=False)
+    monkeypatch.delenv('https_proxy', raising=False)
+    assert _https_proxy_for('example.com') is None
+
+
+def test_parses_host_and_port(monkeypatch):
+    monkeypatch.delenv('NO_PROXY', raising=False)
+    monkeypatch.delenv('no_proxy', raising=False)
+    monkeypatch.setenv('https_proxy', 'http://proxy.internal:3128')
+    assert _https_proxy_for('example.com') == ('proxy.internal', 3128, {})
+
+
+def test_default_port_when_omitted(monkeypatch):
+    monkeypatch.delenv('NO_PROXY', raising=False)
+    monkeypatch.delenv('no_proxy', raising=False)
+    monkeypatch.setenv('https_proxy', 'http://proxy.internal')
+    host, port, headers = _https_proxy_for('example.com')
+    assert (host, port) == ('proxy.internal', 8080)
+
+
+def test_scheme_optional(monkeypatch):
+    monkeypatch.delenv('NO_PROXY', raising=False)
+    monkeypatch.delenv('no_proxy', raising=False)
+    monkeypatch.setenv('https_proxy', 'proxy.internal:3128')
+    assert _https_proxy_for('example.com') == ('proxy.internal', 3128, {})
+
+
+def test_basic_auth_header_from_credentials(monkeypatch):
+    monkeypatch.delenv('NO_PROXY', raising=False)
+    monkeypatch.delenv('no_proxy', raising=False)
+    monkeypatch.setenv('https_proxy', 'http://user:p%40ss@proxy.internal:3128')
+    host, port, headers = _https_proxy_for('example.com')
+    assert (host, port) == ('proxy.internal', 3128)
+    # base64("user:p@ss") — note the password is URL-decoded first.
+    assert headers == {'Proxy-Authorization': 'Basic dXNlcjpwQHNz'}
+
+
+def test_no_proxy_bypass(monkeypatch):
+    monkeypatch.setenv('https_proxy', 'http://proxy.internal:3128')
+    monkeypatch.setenv('no_proxy', 'example.com')
+    assert _https_proxy_for('example.com') is None
+
+
+# ---- _probe_tls_certificate proxy path ------------------------------------
+
+
+def _mock_tls_context(cert_bytes):
+    tls_sock = MagicMock()
+    tls_sock.__enter__ = MagicMock(return_value=tls_sock)
+    tls_sock.__exit__ = MagicMock(return_value=False)
+    tls_sock.getpeercert.return_value = cert_bytes
+    context = MagicMock()
+    context.wrap_socket.return_value = tls_sock
+    return context
+
+
+def test_probe_tunnels_via_connect_when_proxy_set(monkeypatch):
+    """With a proxy configured the probe must use HTTP CONNECT, not a direct
+    socket, and still return the peer certificate from the tunnelled TLS."""
+    monkeypatch.delenv('NO_PROXY', raising=False)
+    monkeypatch.delenv('no_proxy', raising=False)
+    monkeypatch.setenv('https_proxy', 'http://proxy.internal:3128')
+
+    mock_conn = MagicMock()
+    mock_conn.sock = MagicMock()
+
+    with patch('modules.api.resources.http.client.HTTPConnection',
+               return_value=mock_conn) as mock_http, \
+            patch('modules.api.resources.ssl.create_default_context',
+                  return_value=_mock_tls_context(b'tunnelled-cert')), \
+            patch('modules.api.resources.socket.create_connection') as mock_direct:
+        result = _probe_tls_certificate('example.com', timeout=2)
+
+    mock_http.assert_called_once_with('proxy.internal', 3128, timeout=2)
+    mock_conn.set_tunnel.assert_called_once_with('example.com', 443, headers={})
+    mock_conn.connect.assert_called_once()
+    mock_conn.close.assert_called_once()
+    mock_direct.assert_not_called()  # never a direct connection when proxied
+    assert result == {
+        'reachable': True,
+        'certificate_bytes': b'tunnelled-cert',
+        'port': 443,
+        'protocol': 'https-tls',
+    }
+
+
+def test_proxy_tunnel_uses_configured_port(monkeypatch):
+    """The CONNECT target must be the per-cert probe port, not a hardcoded 443."""
+    monkeypatch.delenv('NO_PROXY', raising=False)
+    monkeypatch.delenv('no_proxy', raising=False)
+    monkeypatch.setenv('https_proxy', 'http://proxy.internal:3128')
+
+    mock_conn = MagicMock()
+    mock_conn.sock = MagicMock()
+
+    with patch('modules.api.resources.http.client.HTTPConnection',
+               return_value=mock_conn), \
+            patch('modules.api.resources.ssl.create_default_context',
+                  return_value=_mock_tls_context(b'cert')):
+        result = _probe_tls_certificate('example.com', port=8443, protocol='tls', timeout=2)
+
+    mock_conn.set_tunnel.assert_called_once_with('example.com', 8443, headers={})
+    assert result['port'] == 8443
+    assert result['protocol'] == 'tls'
+
+
+def test_probe_direct_when_no_proxy(monkeypatch):
+    """Without a proxy the probe keeps its original direct-socket behaviour."""
+    monkeypatch.delenv('HTTPS_PROXY', raising=False)
+    monkeypatch.delenv('https_proxy', raising=False)
+
+    mock_sock = MagicMock()
+    mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+    mock_sock.__exit__ = MagicMock(return_value=False)
+
+    with patch('modules.api.resources.socket.create_connection',
+               return_value=mock_sock), \
+            patch('modules.api.resources.ssl.create_default_context',
+                  return_value=_mock_tls_context(b'direct-cert')), \
+            patch('modules.api.resources.http.client.HTTPConnection') as mock_http:
+        result = _probe_tls_certificate('example.com', timeout=2)
+
+    mock_http.assert_not_called()
+    assert result == {
+        'reachable': True,
+        'certificate_bytes': b'direct-cert',
+        'port': 443,
+        'protocol': 'https-tls',
+    }
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/test_tls_probe_timeout.py
+++ b/tests/test_tls_probe_timeout.py
@@ -27,6 +27,16 @@ import pytest
 from modules.api.resources import _tls_probe_timeout_seconds, _probe_tls_certificate
 
 
+@pytest.fixture(autouse=True)
+def _no_proxy_env(monkeypatch):
+    """These tests exercise the direct-socket probe path. Clear proxy env so a
+    runner that happens to have HTTPS_PROXY set doesn't route the probe through
+    the CONNECT tunnel instead (proxy tunnelling is covered in
+    test_tls_probe_proxy.py)."""
+    for var in ('HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy'):
+        monkeypatch.delenv(var, raising=False)
+
+
 # ---- _tls_probe_timeout_seconds -------------------------------------------
 
 


### PR DESCRIPTION
The dashboard deployment-status probe opened a raw socket to <domain>:443, which ignores HTTPS_PROXY. On a host that can only reach the internet via an outbound HTTP proxy this always reported "Backend: Unreachable" even when the target was up (the browser fallback, which uses the system proxy, succeeded).

Honour HTTPS_PROXY/https_proxy and NO_PROXY: when a proxy applies, tunnel the TCP leg with HTTP CONNECT and run the TLS handshake over the tunnel, so the real peer certificate is still compared. Falls back to the original direct connection when no proxy applies. Supports basic proxy auth from the proxy URL. Pure stdlib, no new dependency.