### PR TITLE
fix(deploy-hooks): fire hooks on scheduled renewal (#329) + fix Deployed counter (#324)

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -91,10 +91,37 @@ class CertificateManager:
         # standalone/unit contexts, where emission is simply skipped.
         self._audit_logger = None
         self._renewal_job_id = 'certificate_renewal_check'
+        # Optional event bus, injected by the factory. The manual/API renewal
+        # path publishes 'certificate_renewed' via the IssuanceExecutor; the
+        # scheduler calls renew_certificate() directly, so without this the
+        # deploy hooks never fire after a background renewal (#329). None in
+        # standalone/unit contexts, where publishing is simply skipped.
+        self._event_bus = None
 
     def set_audit_logger(self, audit_logger):
         """Wire an AuditLogger so scheduled renewals are recorded. Optional."""
         self._audit_logger = audit_logger
+
+    def set_event_bus(self, event_bus):
+        """Wire an EventBus so scheduled renewals notify the deploy pipeline
+        (#329). Optional — publishing is skipped when unset."""
+        self._event_bus = event_bus
+
+    def _publish_renewed_event(self, domain):
+        """Publish the same 'certificate_renewed' event the manual/API path
+        emits, so deploy hooks fire after an unattended renewal too (#329).
+
+        No-op when no event bus is wired; never raises — a notification
+        failure must not turn a successful renewal into a reported failure.
+        The payload mirrors IssuanceExecutor's: {'domain': domain}."""
+        if self._event_bus is None:
+            return
+        try:
+            self._event_bus.publish('certificate_renewed', {'domain': domain})
+        except Exception:  # pragma: no cover - defensive
+            logger.exception(
+                "Failed to publish certificate_renewed for %s", domain
+            )
 
     def _audit_scheduled_renew(self, domain, status, error=None):
         """Emit an attributed audit record for an unattended renewal. No-op
@@ -1609,6 +1636,10 @@ class CertificateManager:
                         summary['renewed'] += 1
                         logger.info(f"Successfully renewed certificate for {domain}")
                         self._audit_scheduled_renew(domain, 'success')
+                        # Fire deploy hooks for background renewals too (#329):
+                        # the manual path publishes this via the executor, the
+                        # scheduler must publish it itself.
+                        self._publish_renewed_event(domain)
                     except Exception as e:
                         summary['failed'] += 1
                         logger.error(f"Failed to renew certificate for {domain}: {e}")

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -476,6 +476,11 @@ def initialize_managers(container: AppContainer, app):
         data_dir=str(container.data_dir),
     )
     event_bus.add_listener(deploy_manager.on_certificate_event)
+    # Let unattended (scheduler-driven) renewals publish 'certificate_renewed'
+    # so deploy hooks fire for background renewals, not just manual/API ones
+    # (#329). The manual path publishes via the IssuanceExecutor; the scheduler
+    # calls certificate_manager.renew_certificate() directly.
+    certificate_manager.set_event_bus(event_bus)
     app.config['EVENT_BUS'] = event_bus
     # DATA_DIR is the partition the DiagnosticsSnapshot endpoint queries
     # for disk_free / disk_total. Stored on the Flask app config so the

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -912,7 +912,13 @@
 
         var deployedCount = allCertificates.filter(function (cert) {
             if (!cert.exists) return false;
-            var statusElement = document.getElementById('deployment-status-' + cert.domain.replace(/\./g, '-'));
+            // Must match deploymentBadgeHtml's id exactly: it builds
+            // 'deployment-status-<domainId>-<role>' where domainId is the
+            // escaped, dot-stripped domain. The backend badge carries the
+            // authoritative verdict; without the '-backend' suffix this lookup
+            // matched nothing and the counter was stuck at 0 (#324).
+            var domainId = escapeHtml(cert.domain).replace(/\./g, '-');
+            var statusElement = document.getElementById('deployment-status-' + domainId + '-backend');
             var isDeployed = statusElement && statusElement.textContent.indexOf('Deployed') !== -1;
             return isDeployed;
         }).length;

--- a/tests/test_check_renewals_summary.py
+++ b/tests/test_check_renewals_summary.py
@@ -80,3 +80,70 @@ def test_global_auto_renew_disabled_short_circuits(tmp_path):
 
     assert summary['auto_renew_disabled'] is True
     mgr.get_certificate_info.assert_not_called()
+
+
+# --- #329: scheduled renewals must fire deploy hooks ----------------------
+# The deployer listens for 'certificate_renewed' on the event bus. The
+# manual/API path publishes it via the IssuanceExecutor; the scheduler calls
+# renew_certificate() directly, so check_renewals has to publish it itself or
+# background renewals silently skip every deploy hook.
+
+def test_successful_scheduled_renewal_publishes_certificate_renewed(tmp_path):
+    settings = {'auto_renew': True, 'domains': ['good.com', 'fresh.com']}
+    mgr = _manager(tmp_path, settings)
+    mgr.get_certificate_info = MagicMock(
+        side_effect=lambda domain, **kw: {'needs_renewal': domain == 'good.com'}
+    )
+    mgr.renew_certificate = MagicMock()
+    bus = MagicMock()
+    mgr.set_event_bus(bus)
+
+    mgr.check_renewals()
+
+    # Exactly the renewed domain, with the same payload the executor emits —
+    # not fresh.com (no renewal) and not a duplicate.
+    bus.publish.assert_called_once_with(
+        'certificate_renewed', {'domain': 'good.com'}
+    )
+
+
+def test_failed_scheduled_renewal_does_not_publish(tmp_path):
+    settings = {'auto_renew': True, 'domains': ['boom.com']}
+    mgr = _manager(tmp_path, settings)
+    mgr.get_certificate_info = MagicMock(return_value={'needs_renewal': True})
+    mgr.renew_certificate = MagicMock(side_effect=RuntimeError("certbot failed"))
+    bus = MagicMock()
+    mgr.set_event_bus(bus)
+
+    summary = mgr.check_renewals()
+
+    assert summary['failed'] == 1
+    bus.publish.assert_not_called()
+
+
+def test_scheduled_renewal_without_event_bus_does_not_crash(tmp_path):
+    settings = {'auto_renew': True, 'domains': ['good.com']}
+    mgr = _manager(tmp_path, settings)
+    mgr.get_certificate_info = MagicMock(return_value={'needs_renewal': True})
+    mgr.renew_certificate = MagicMock()
+    # No set_event_bus() call — standalone/unit default.
+
+    summary = mgr.check_renewals()
+
+    assert summary['renewed'] == 1
+
+
+def test_publish_failure_does_not_fail_the_renewal(tmp_path):
+    settings = {'auto_renew': True, 'domains': ['good.com']}
+    mgr = _manager(tmp_path, settings)
+    mgr.get_certificate_info = MagicMock(return_value={'needs_renewal': True})
+    mgr.renew_certificate = MagicMock()
+    bus = MagicMock()
+    bus.publish.side_effect = RuntimeError("event bus down")
+    mgr.set_event_bus(bus)
+
+    summary = mgr.check_renewals()
+
+    # A notification failure must not turn a successful renewal into a failure.
+    assert summary['renewed'] == 1
+    assert summary['failed'] == 0


### PR DESCRIPTION
Two orphan bugs from the deploy-hook cluster that had no PR.

### #329 — scheduled auto-renewal doesn't fire deploy hooks
The manual/API path publishes `certificate_renewed` via the IssuanceExecutor, but the scheduler calls `CertificateManager.renew_certificate()` directly and the manager had no event bus — so background renewals updated the cert on disk but never notified the deployer, and the live endpoint kept serving the old cert. Inject the event bus (`set_event_bus`, mirroring `set_audit_logger`) and publish `certificate_renewed`/`{domain}` from `check_renewals` after a successful renew. Publishing stays out of `renew_certificate` to avoid double-firing on the manual path; a publish failure never demotes a successful renewal. 4 new tests + a real-EventBus round-trip.

### #324 — "Deployed" counter always 0
`updateDeploymentStats` looked up `deployment-status-<domain>` but the badges render as `deployment-status-<domainId>-<role>`. Mirror the badge id derivation and target the authoritative `-backend` role.

Closes #329, closes #324.