### PR TITLE
fix(ui): objective UI-audit fixes (i18n dates + semantic colors/icons)

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -184,7 +184,7 @@
 
         statsContainer.innerHTML = [
             statCard('Total', total, 'text-foreground', 'fa-certificate text-blue-500 dark:text-blue-400'),
-            statCard('Valid', valid, 'text-success-fg', 'fa-check-circle text-green-500 dark:text-green-400', null, valid + ' of ' + total),
+            statCard('Valid', valid, valid > 0 ? 'text-success-fg' : 'text-muted', 'fa-check-circle text-green-500 dark:text-green-400', null, valid + ' of ' + total),
             statCard('Expiring', expiring, 'text-warning-fg', 'fa-exclamation-triangle text-yellow-500 dark:text-yellow-400'),
             statCard('Deployed', '<span class="text-gray-300 dark:text-gray-600 animate-pulse">...</span>', 'text-indigo-600 dark:text-indigo-400', 'fa-globe text-indigo-500 dark:text-indigo-400', 'deploymentCount')
         ].join('');
@@ -377,7 +377,10 @@
 
     function deploymentStatusDisplay(role, result) {
         var isBrowser = role === 'browser';
-        var roleLabel = isBrowser ? 'Browser' : 'Backend';
+        // "Server" (the probe ran from CertMate's server) vs "Browser" (from
+        // your browser). Avoids reading "Backend: Unreachable" as "the CertMate
+        // app is down" when it only means the target endpoint failed a probe.
+        var roleLabel = isBrowser ? 'Browser' : 'Server';
         var roleIcon = isBrowser ? 'fa-globe' : 'fa-server';
         var statusClass;
         var statusIcon = roleIcon;
@@ -564,7 +567,7 @@
             }
 
             var expiryDate = new Date(cert.expiry_date);
-            var expiryStr = expiryDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+            var expiryStr = expiryDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
             var daysClass = isExpired ? 'text-danger-fg' : isExpiringSoon ? 'text-warning-fg' : 'text-muted';
 
             // Inline subtle glyph instead of a rounded blue panel — the
@@ -602,10 +605,14 @@
             var mobileDeploymentLine = rowRaw(rowHtml`<div class="flex items-start text-xs text-muted"><i class="fas fa-rocket mr-1.5 mt-0.5 w-3 shrink-0" aria-hidden="true"></i><div class="flex-1 min-w-0">${rowRaw(deploymentBadgesHtml(cert))}</div></div>`);
             var mobileMeta = rowRaw(rowHtml`<div class="md:hidden mt-2 pt-2 border-t border-gray-100 dark:border-gray-700/50 space-y-1">${mobileExpiryLine}${mobileProviderLine}${mobileDeploymentLine}</div>`);
             var lockColor = isExpired ? 'text-red-400' : isExpiringSoon ? 'text-yellow-400' : 'text-green-500';
+            // An expired cert is no longer trusted; a closed padlock (the
+            // "secure connection" glyph) is a visual paradox there. Show an
+            // open padlock for expired so the icon matches the state.
+            var lockIcon = isExpired ? 'fa-lock-open' : 'fa-lock';
             return rowHtml`<tr class="${rowRaw(healthClass)} row-enter hover:bg-blue-50/40 dark:hover:bg-blue-900/10 transition-colors duration-150 cursor-pointer" style="animation-delay:${rowRaw(String(i * 30))}ms" onclick="openCertDetail('${cert.domain}')">
                 <td class="px-6 py-4 max-w-0">
                     <div class="flex items-center min-w-0">
-                        <i class="fas fa-lock ${rowRaw(lockColor)} mr-2 text-sm shrink-0" aria-hidden="true"></i>
+                        <i class="fas ${rowRaw(lockIcon)} ${rowRaw(lockColor)} mr-2 text-sm shrink-0" aria-hidden="true"></i>
                         <div class="min-w-0">
                             <div class="text-sm font-medium text-foreground truncate">${cert.domain}</div>
                             ${aliasHint}
@@ -736,7 +743,7 @@
                 '<dl class="space-y-2">' +
                 '<div class="flex justify-between gap-4 py-2 border-b border-border"><dt class="text-sm text-muted">Domain</dt><dd class="text-sm font-medium text-right text-foreground">' + safeDomain + '</dd></div>' +
                 (sanDomains.length ? '<div class="flex justify-between gap-4 py-2 border-b border-border"><dt class="text-sm text-muted">SANs</dt><dd class="text-sm font-medium text-right text-foreground">' + sanDomainsHtml + '</dd></div>' : '') +
-                '<div class="flex justify-between gap-4 py-2 border-b border-border"><dt class="text-sm text-muted">Expires</dt><dd class="text-sm font-medium text-right text-foreground">' + expiryDate.toLocaleDateString(undefined, { weekday: 'short', month: 'long', day: 'numeric', year: 'numeric' }) + '</dd></div>' +
+                '<div class="flex justify-between gap-4 py-2 border-b border-border"><dt class="text-sm text-muted">Expires</dt><dd class="text-sm font-medium text-right text-foreground">' + expiryDate.toLocaleDateString('en-US', { weekday: 'short', month: 'long', day: 'numeric', year: 'numeric' }) + '</dd></div>' +
                 (providerLabel ? '<div class="flex justify-between gap-4 py-2 border-b border-border"><dt class="text-sm text-muted">DNS Provider</dt><dd class="text-sm font-medium text-right text-foreground">' + providerLabel + '</dd></div>' : '') +
                 (safeDomainAlias ? '<div class="flex justify-between gap-4 py-2 border-b border-border"><dt class="text-sm text-muted">DNS-01 Alias</dt><dd class="text-sm font-medium text-right break-all text-info-fg">' + safeDomainAlias + '</dd></div>' : '') +
                 (safeDomainAlias && aliasProviderLabel ? '<div class="flex justify-between gap-4 py-2 border-b border-border"><dt class="text-sm text-muted">Alias Provider</dt><dd class="text-sm font-medium text-right text-foreground">' + aliasProviderLabel + '</dd></div>' : '') +

--- a/templates/partials/_client_certs.html
+++ b/templates/partials/_client_certs.html
@@ -1,7 +1,7 @@
 <!-- Client Certificates Partial — included in index.html under "Client" tab -->
 
 <!-- Statistics Bar -->
-<div class="grid grid-cols-1 gap-4 md:grid-cols-4 mb-6">
+<div class="grid grid-cols-2 gap-4 md:grid-cols-4 mb-6">
     <div class="bg-surface rounded-lg shadow p-6 border-l-4 border-blue-500">
         <div class="flex items-center">
             <div class="flex-1">


### PR DESCRIPTION
Implements the **objective** subset of the UI audit, verified against the code (subjective IA/layout opinions excluded — those are design decisions, not bugs):

- **i18n date leak** — `toLocaleDateString(undefined, …)` rendered Italian months on an IT-locale browser; pinned to `en-US` (cert table + detail).
- **VALID card green at 0** — hardcoded `text-success-fg`; now neutral when count is 0.
- **Expired = open padlock** — closed padlock on an expired cert was a 'secure' paradox.
- **'Backend:' → 'Server:'** — the deployment badge read as 'the app is down'; relabelled (role id + #324 counter logic untouched).
- **Client stats mobile grid** — `grid-cols-1` → `grid-cols-2` to match the server stats.

No new Tailwind classes (bundle unchanged); JS syntax checked; UI render covered by test_ui.py in CI.

Refuted/excluded from the audit: the 'Create' button is a single disclosure toggle, not a split-button (no change); sort headers already have per-column ids + aria-sort.