### PR TITLE
docs(i18n): add Italian translation of documentation

### DIFF
--- a/docs/it/README.md
+++ b/docs/it/README.md
@@ -1,0 +1,238 @@
+# Documentazione CertMate
+
+Benvenuto nella documentazione di CertMate. Questa cartella contiene guide complete per tutte le funzionalità.
+
+---
+
+## Navigazione rapida
+
+### Per iniziare
+- **[Guida all'installazione](./installation.md)** — Configurazione, dipendenze, deployment in produzione
+- **[Guida Docker](./docker.md)** — Build Docker, multi-piattaforma, Docker Compose
+- **[Note Kubernetes](./kubernetes.md)** — Risorse di produzione, dimensionamento OOM, patching runtime
+
+### Funzionalità principali
+- **[Provider DNS](./dns-providers.md)** — Provider supportati, multi-account, alias di dominio
+- **[Provider CA](./ca-providers.md)** — Let's Encrypt, DigiCert, CA privata
+- **[Certificati client](./guide.md)** — Ciclo di vita dei certificati client, dashboard web, operazioni batch
+- **[Server MCP (Model Context Protocol)](./mcp.md)** — Server Node.js standalone per l'integrazione con agenti IA
+
+### Riferimento
+- **[Riferimento API](./api.md)** — Documentazione completa dell'API REST
+- **[Architettura](./architecture.md)** — Progettazione del sistema, componenti, flusso dei dati
+- **[Guida ai test](./testing.md)** — Framework di test, CI/CD, copertura
+
+---
+
+## Documentazione per pubblico
+
+### Per i nuovi utenti
+
+1. **[Installazione](./installation.md)** — Mettere in funzione CertMate
+2. **[Provider DNS](./dns-providers.md)** — Configurare il proprio provider DNS
+3. **[Guida ai certificati client](./guide.md)** — Creare il primo certificato
+
+### Per gli sviluppatori
+
+1. **[Riferimento API](./api.md)** — Tutti gli endpoint con esempi
+2. **[Architettura](./architecture.md)** — Funzionamento interno e progettazione
+3. **[Guida ai test](./testing.md)** — Come scrivere ed eseguire i test
+
+### Per gli amministratori
+
+1. **[Deployment Docker](./docker.md)** — Configurazione Docker per la produzione
+2. **[Note Kubernetes](./kubernetes.md)** — Dimensionamento dei pod e patching operativo
+3. **[Provider CA](./ca-providers.md)** — Configurare le autorità di certificazione
+4. **[Provider DNS](./dns-providers.md#multi-account-support)** — Configurazione multi-account aziendale
+
+---
+
+## Panoramica delle funzionalità
+
+### Certificati server
+- **Oltre due dozzine di provider DNS** per le sfide Let's Encrypt DNS-01 (vedere [Provider DNS](./dns-providers.md) per l'elenco completo)
+- **Più provider CA**: Let's Encrypt, DigiCert, CA privata
+- **Supporto multi-account** per provider DNS
+- **Storage backend intercambiabili**: locale, Azure Key Vault, AWS, Vault, Infisical
+- **Rinnovo automatico** con soglie configurabili
+- **Supporto Docker** con build multi-piattaforma (ARM64 + AMD64)
+- **Log Sanitizer** — Oscura automaticamente token API, chiavi private e credenziali sensibili dai log di CertMate
+- **Zombie Certificate Scanner** — Scanner multi-thread del filesystem per identificare e rimuovere certificati orfani
+- **Server MCP (Model Context Protocol)** — Server Node.js standalone per l'integrazione con assistenti IA agentici
+
+### Certificati client
+- **CA auto-firmata** con chiavi RSA a 4096 bit
+- **Gestione completa del ciclo di vita** — creazione, rinnovo, revoca, monitoraggio
+- **OCSP & CRL** — stato in tempo reale e liste di revoca
+- **Dashboard web** su `/client-certificates`
+- **Operazioni batch** — importazione di 100-30.000 certificati tramite CSV
+- **Audit logging** e **rate limiting**
+
+---
+
+## Riferimento rapido degli endpoint API
+
+| Metodo | Endpoint                                 | Descrizione                   |
+| ------ | ---------------------------------------- | ----------------------------- |
+| POST   | `/api/client-certs/create`               | Crea un certificato           |
+| GET    | `/api/client-certs`                      | Elenca i certificati          |
+| GET    | `/api/client-certs/<id>`                 | Ottieni i metadati            |
+| GET    | `/api/client-certs/<id>/download/<type>` | Scarica cert/chiave/csr       |
+| POST   | `/api/client-certs/<id>/revoke`          | Revoca un certificato         |
+| POST   | `/api/client-certs/<id>/renew`           | Rinnova un certificato        |
+| GET    | `/api/client-certs/stats`                | Ottieni le statistiche        |
+| POST   | `/api/client-certs/batch`                | Importazione batch CSV        |
+| GET    | `/api/ocsp/status/<serial>`              | Stato OCSP                    |
+| GET    | `/api/crl/download/<format>`             | Scarica la CRL                |
+
+Vedere il [Riferimento API](./api.md#endpoints) per la documentazione completa.
+
+---
+
+## Test
+
+Tutte le funzionalità sono testate in modo approfondito:
+
+```bash
+# Esegui i test
+python -m pytest tests/ -v
+```
+
+La copertura dei test include:
+- Operazioni CA
+- Operazioni CSR
+- Ciclo di vita dei certificati
+- Filtri e ricerca
+- Operazioni batch
+- OCSP & CRL
+- Audit e rate limiting
+
+---
+
+## Funzionalità di sicurezza
+
+- **RSA 4096 bit** per le chiavi CA
+- **Algoritmo di firma** SHA256
+- **Autenticazione** tramite Bearer token
+- **Rate limiting** su tutti gli endpoint
+- **Audit logging** di tutte le operazioni
+- **Permessi sui file** 0600 per le chiavi private
+
+---
+
+## Performance
+
+- Supporta **30.000+ certificati simultanei**
+- Query **multi-filtro** efficienti
+- Pianificazione del **rinnovo automatico**
+- **Operazioni batch** con tracciamento degli errori
+
+---
+
+## Struttura dei file
+
+```
+docs/
+  README.md            ← Sei qui
+  index.md             ← Pagina iniziale dei certificati client
+  installation.md      ← Installazione e configurazione
+  kubernetes.md        ← Note di produzione Kubernetes
+  dns-providers.md     ← Provider DNS e multi-account
+  ca-providers.md      ← Provider delle autorità di certificazione
+  docker.md            ← Build e deployment Docker
+  testing.md           ← Framework di test e CI/CD
+  guide.md             ← Guida utente dei certificati client
+  api.md               ← Riferimento API completo
+  architecture.md      ← Architettura del sistema
+```
+
+---
+
+## Percorso di apprendimento
+
+**Principiante** → [Inizia qui](./index.md) → [Guida introduttiva](./guide.md)
+
+**Sviluppatore** → [Riferimento API](./api.md) → [Architettura](./architecture.md)
+
+**Avanzato** → [Documentazione API completa](./api.md) → [Dettagli architetturali](./architecture.md)
+
+---
+
+## Link importanti
+
+- **Dashboard web**: `http://localhost:8000/client-certificates`
+- **Documentazione API**: `http://localhost:8000/docs/`
+- **Controllo di integrità**: `http://localhost:8000/health`
+- **Log di audit**: `logs/audit/certificate_audit.log`
+
+---
+
+## Dashboard di stato
+
+| Componente          | Stato     | Test      |
+| ------------------- | --------- | --------- |
+| Fondazione CA       | Pronto    | 3/3       |
+| Gestore CSR         | Pronto    | 3/3       |
+| Gestore cert.       | Pronto    | 8/8       |
+| Filtri              | Pronto    | 3/3       |
+| Operazioni batch    | Pronto    | 2/2       |
+| OCSP/CRL            | Pronto    | 5/5       |
+| Audit/Rate Limit    | Pronto    | 3/3       |
+| **Totale**          | **Pronto**| **27/27** |
+
+---
+
+## Esempi rapidi
+
+### Creare un certificato tramite API
+
+```bash
+curl -X POST http://localhost:8000/api/client-certs/create \
+ -H "Authorization: Bearer YOUR_TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "common_name": "user@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "api-mtls",
+ "days_valid": 365
+ }'
+```
+
+### Elencare i certificati
+
+```bash
+curl http://localhost:8000/api/client-certs \
+ -H "Authorization: Bearer YOUR_TOKEN"
+```
+
+### Scaricare un certificato
+
+```bash
+curl http://localhost:8000/api/client-certs/USER_ID/download/crt \
+ -H "Authorization: Bearer YOUR_TOKEN" \
+ -o certificate.crt
+```
+
+Vedere la [Guida API](./api.md) per ulteriori esempi.
+
+---
+
+## Licenza
+
+CertMate è distribuito sotto licenza MIT. Vedere il file LICENSE nel repository.
+
+---
+
+## Domande o problemi?
+
+- Consultare la pagina di documentazione pertinente
+- Esaminare i file di test per esempi di utilizzo
+- Consultare il [Riferimento API](./api.md) per i dettagli degli endpoint
+
+---
+
+<div align="center">
+
+[Home](../README.md) • [Documentation](./) • [GitHub](https://github.com/fabriziosalmi/certmate)
+
+</div>

--- a/docs/it/THEME_MIGRATION.md
+++ b/docs/it/THEME_MIGRATION.md
@@ -1,0 +1,236 @@
+# Migrazione del tema — disaccoppiamento chiaro/scuro tramite token CSS
+
+Stato: **rilasciata** (Fasi 0–5 nella v2.9.0; Fase 6 segue) · Responsabile: Fabrizio · Creato: 2026-05-25
+
+## Obiettivo
+
+Attualmente, cambiare il tema significa modificare i colori in ~19 template e nel
+frontend JS. Questa migrazione fa di un singolo blocco di proprietà personalizzate CSS la
+fonte di verità per l'intera palette, cosicché reimpostare il tema (o aggiungere un nuovo tema)
+significa modificare `:root` / `.dark` in un unico file — non centinaia di punti di chiamata.
+
+## Stato di partenza (rilevato il 2026-05-25)
+
+| Metrica | Valore |
+|---|---|
+| Riferimenti a classi di colore nei template | ~3 197 in 19 file |
+| Coppie `dark:` nei template | ~1 665 |
+| Classi di colore nel JS applicativo (non vendorizzato) | ~789 (dashboard.js 372, settings.js 150, setup-wizard.js 131, certmate.js 60, client-certs.js 57, …) |
+| Hex codificati nel JS applicativo | ~17 (palette toast/grafici); altri 80 in `redoc.standalone.js` sono **vendorizzati, ignorare** |
+| Classi di componenti R-3 adottate | solo `.card` (12×); `.btn-*`, `.badge-*`, `.form-*` = 0 |
+
+File più pesanti: `partials/settings_dns.html` (635 / 395 dark:), `index.html`
+(311 / 150), `partials/settings_deploy.html`, `partials/settings_ca.html`.
+
+## Rischi di processo da correggere prima
+
+1. **Il CSS compilato viene committato a mano.** `package.json` ha solo `css:build` /
+   `css:watch`; nessuna CI ricostruisce `static/css/tailwind.min.css`. Modificare
+   `input.css` senza ricostruire consegna silenziosamente un CSS obsoleto. → aggiungere una build CI + verifica di aggiornamento nella Fase 0.
+2. **~3 200 modifiche manuali = regressioni garantite.** Serve una baseline visiva
+   (screenshot chiaro+scuro di ogni pagina) e un codemod semi-automatico per le
+   coppie `dark:` meccaniche, non un find-replace alla cieca.
+
+## Strategia: proprietà CSS personalizzate come fonte unica
+
+Stile shadcn su Tailwind v3: i colori diventano variabili CSS in `:root` / `.dark`,
+esposte a Tailwind come token semantici (triplette di canali HSL affinché le utility
+`/opacity` continuino a funzionare). Le ~1 665 coppie `dark:` si riducono a classi singole.
+
+### Tabella di corrispondenza dei token proposta
+
+| Token Tailwind | Sostituisce (esempi) | Utilizzo |
+|---|---|---|
+| `bg-background` | `bg-gray-50 dark:bg-surface-dark` | pagina |
+| `bg-surface` | `bg-white dark:bg-surface-card` | card |
+| `bg-surface-2` | `bg-gray-100 dark:bg-gray-800` | elevato |
+| `text-foreground` | `text-gray-900 dark:text-white` | testo principale |
+| `text-muted` | `text-gray-500 dark:text-gray-400` | testo secondario |
+| `border-border` | `border-gray-200 dark:border-gray-700` | bordi |
+| `bg-primary` / `text-primary` | brand (ora basato su var) | brand |
+| `*-success/warning/danger/info` | verde=valido, rosso=scaduto… | **stato, non superfici** |
+
+## Fasi
+
+Ogni fase = un commit atomico (suddividere i partial della Fase 3 nei propri
+commit). Le fasi si raggruppano in uno o più PR di versione `vX.Y.Z`.
+
+### Fase 0 — Fondamenta e guardrail (nessuna modifica visiva)
+- [x] Step CI che esegue `npm run css:build` e fallisce se `tailwind.min.css` è obsoleto (`git diff --exit-code`). → job `frontend-css` in `.github/workflows/ci.yml`. Il bundle committato aveva già deviato; ricostruito e committato.
+- [x] Definire il layer dei token: variabili CSS in `:root` / `.dark` (input.css) + mapping in `tailwind.config.js`, **in parallelo** alla palette esistente — nessun template modificato. Token: `bg-background`, `bg-surface`, `bg-surface-2`, `text-foreground`, `text-muted`, `border-border` (nella safelist).
+- [x] Scrivere il codemod: `scripts/theme_codemod.py` — tabella di corrispondenza delle coppie `dark:` ricorrenti → token, report dry-run + `--apply`. Report sulle ambiguità di seguito.
+- [x] Strumenti per gli screenshot: `scripts/theme_baseline.py` — costruisce Docker con una directory dati effimera, inizializza un admin usa-e-getta, cattura ogni pagina UI reale in chiaro + scuro. Da rieseguire dopo ogni fase e confrontare. **Esecuzione della cattura ancora in sospeso** (richiede `playwright install chromium` + una build Docker locale).
+
+#### Ambito della baseline (solo pagine reali)
+Catturate: `/` (setup, poi index), `/login`, `/settings`, `/help`, `/activity`, `/redoc` — 7 pagine × chiaro/scuro.
+
+> **Rilievo (fuori ambito, segnalato):** le route `/certificates` e `/audit` in `modules/web/ui_routes.py:25-41` rendono `certificates.html` / `audit.html`, che **non esistono** — entrambe restituiscono 500. Route non funzionanti, escluse dalla baseline. Merita una correzione separata (rimuovere le route o ripristinare i template).
+
+#### Utilizzo del codemod
+```
+python scripts/theme_codemod.py                     # report dry-run, tutti i template
+python scripts/theme_codemod.py templates/base.html # report, un file
+python scripts/theme_codemod.py --apply templates/base.html
+```
+Dopo ogni `--apply`: `npm run css:build`, diff rispetto alla baseline, esaminare le varianti `dark:` residue.
+
+#### Panoramica del report (2026-05-25)
+**607 coppie ridotte automaticamente** su ~1 665 varianti `dark:`:
+
+| Token | Coppie |
+|---|---|
+| `text-muted` | 203 |
+| `border-border` | 169 |
+| `text-foreground` | 141 |
+| `bg-surface` | 77 |
+| `bg-surface-2` | 16 |
+| `bg-background` | 1 |
+
+**557 occorrenze / 29 varianti non mappate** — decisioni di design per il pilota della Fase 1, non indovinate automaticamente:
+
+- `dark:bg-gray-700` (137): si accoppia con `bg-white` (card/input) **e** `bg-gray-50` — decidere surface vs surface-2 per contesto.
+- `dark:text-white` (120): quelle accoppiate con `text-gray-900` si mappano già a `text-foreground`; le restanti sono testo sempre bianco su sfondo colorato — probabilmente da lasciare invariate.
+- `dark:text-gray-300` (112): per lo più `text-gray-700 dark:text-gray-300` = il pattern delle label dei form — decidere se adottare un token label dedicato vs `text-muted`/`text-foreground`.
+- `dark:border-gray-600` (41), `dark:text-gray-200` (39), superfici con suffisso opacità (`dark:bg-gray-700/50` ecc.), e `dark:border-white/5`.
+
+Alcuni residui (`dark:text-gray-400{%`, `dark:text-gray-300'`) sono attributi di classe contenenti espressioni Jinja/JS — da migrare a mano.
+
+### Fase 1 — Pilota: shell + primitive
+- [x] Migrare `base.html` (nav/header/footer/barra delle schede) ai token. 19 coppie ridotte; i valori dei token corrispondono esattamente agli originali.
+- [x] Migrare `login.html` ai token. 12 coppie ridotte.
+- [ ] Adottare le classi di componenti `.btn` / `.form-*` (rimandato — il pilota ha usato solo i token; gli input di login differiscono nelle dimensioni da `.form-input`, quindi l'adozione dei componenti è uno step a parte).
+- [x] Validare la parità chiaro/scuro. Verificato in tempo reale in Docker (base.html + login.html, entrambi i temi) — pilota accettato.
+
+#### Decisioni di design aperte (emerse dal pilota)
+1. **Testo delle label dei form** (`text-gray-700 dark:text-gray-300`). **RISOLTO nella Fase 5 → opzione (b):** aggiunto il token `--color-label` con i valori esatti gray-700/gray-300 (fedele, nessuna modifica visiva) e migrate le 137 occorrenze a `text-label`. La fusione in `text-foreground` è stata rifiutata (avrebbe scurito la modalità chiara dal 27% all'11% L).
+2. **Unificazione dei bordi**: `border-gray-300` (input) si mappa ora a `border-border` (= gray-200), quindi i bordi degli input si schiariscono di un livello in modalità chiara. Accettato per il pilota (un singolo token di bordo è l'obiettivo); da riconsiderare con `--color-input-border` solo se la revisione lo ritiene problematico.
+3. **Input glass / `dark:border-white/5` hairline / varianti hover / colori di stato**: intenzionalmente NON tokenizzati — i controlli glass non hanno una controparte chiara, la hairline white/5 è il bordo canonico di `.card`, e hover/stato necessitano di una propria passata di token variante (una fase successiva).
+
+### Fase 2 — Dashboard ✅
+- [x] `index.html` (chrome della dashboard): form di creazione certificato, card lista/statistiche, intestazioni di tabella + divisori, pannello di dettaglio, modali. I ternari Alpine `:class` e `divide-border` gestiti a mano.
+- [x] `static/js/dashboard.js`: righe renderizzate da JS, statistiche, stati vuoti/benvenuto, pannello di dettaglio, output del controllo alias. `node --check` pulito.
+- I colori di stato salute/deployment (verde/ambra/rosso/blu) lasciati intenzionalmente come colori di stato letterali — portano un significato e avranno una passata di token di stato dedicata in seguito, non token di superficie.
+- Input glass (`dark:bg-gray-700`/`dark:text-white`), label dei form e varianti hover lasciati per un trattamento separato (coerente con il pilota).
+
+### Fase 3 — Cluster delle impostazioni ✅
+- [x] `settings.html` + 10 partial + `_modal`: 441 coppie ridotte. Le coppie interne dei ternari Alpine `:class` tokenizzate dal codemod (le virgolette incollano solo le classi di bordo del ramo); struttura ternaria verificata intatta.
+- [x] `settings.js` + `setup-wizard.js`: 49 coppie, `node --check` pulito. Gli altri `settings-*.js` non portano classi di colore.
+- Lasciato invariato (coerente con le fasi precedenti): input glass (`dark:bg-gray-700` ~99), label dei form (`dark:text-gray-300` ~78, rimandato), badge di stato, superfici con opacità, varianti hover, e classi di bordo del ramo ternario.
+
+### Fase 4 — Pagine rimanenti ✅
+- [x] Template: activity, help, setup, `_client_certs` (123 coppie; nessun ternario Alpine qui).
+- [x] JS: client-certs.js, cmd-palette.js, report-issue.js, shortcuts.js (26 coppie, `node --check` pulito). setup-wizard.js era già stato completato nella Fase 3.
+- Stesse esclusioni delle fasi precedenti: input glass, grigi di corpo/label, superfici con opacità, colori di stato, hover, e classi ai limiti di concatenazione di stringhe.
+
+### Fase 5 — Pulizia e consolidamento ✅
+- [x] Decisione sulle label chiusa: token `text-label` + 137 siti migrati (vedi sopra).
+- [x] Punto cieco del codemod rilevato: scansionava solo `class="..."`, tralasciando `className='...'` e la concatenazione di stringhe JS. Aggiunta una **passata letterale consapevole dei limiti** (riduce le sottostringhe `CHIARO SCURO` adiacenti in qualsiasi contesto) + il gate `--check`. La riesecuzione della scansione completa ha ridotto le coppie JS rimanenti (dialoghi confirm/prompt, modali report-issue + shortcuts).
+- [x] Rimossi gli alias legacy inutilizzati `success`/`warning`/`danger` da `tailwind.config.js` (0 siti di chiamata). Mantenuti `primary` (~375) e `secondary` (gradienti).
+- [x] **Guardrail CI**: `python3 scripts/theme_codemod.py --check` nel job `frontend-css` — fa fallire la build se una coppia chiaro+scuro riducibile viene reintrodotta in un template o in un file JS di prima parte.
+- **Hex JS lasciati invariati, per scelta progettuale:** la palette `#60a5fa`/ecc. in `certmate.js` è il **logger della console di debug** su una superficie fissa sempre scura (`bg-black`); `TOAST_COLORS` sono classi di stato letterali. Entrambi sono accenti di stato indipendenti dal tema — per convenzione non fanno parte del theming chiaro/scuro — quindi rimangono letterali anziché diventare token di tema. Una futura **passata di token di stato** (success/warning/danger/info come variabili) è il luogo appropriato per unificarli se mai lo si desiderasse.
+- Aggiornamento della baseline: opzionale; non eseguito (la cattura era rimasta in sospeso — verifica Docker in tempo reale usata ad ogni fase).
+
+### Fase 6 — Passata dei token di stato ✅
+- [x] Ri-aggiunti `success`/`warning`/`danger` (+ nuovo `info`) come **gruppi di token**
+  (`surface`/`line`/`fg`/`strong`), adossati a variabili in `:root`/`.dark` (HSL,
+  fedeli ai valori inline, superfici scure blended sulla card).
+- [x] Esteso il codemod con una tabella generata tonalità×sfumatura (`_expand_status`)
+  che piega le coppie verde/rosso/ambra/blu delle info-box sui token —
+  normalizzando la deriva 50-vs-100 / 700-vs-800 dei callout inline.
+  **300 coppie ridotte** nei template + JS di prima parte.
+- [x] `--check` ora verifica anche le coppie di stato (vivono in `MAPPINGS`), quindi
+  una coppia chiaro+scuro di stato reintrodotta fa fallire la CI come qualsiasi altra.
+- Lasciato letterale per scelta progettuale: i singoli accenti di stato senza coppia chiaro/scuro
+  (icona `text-*-500`), e le tinte solo-scuro (senza controparte chiara).
+
+### Fase 7 — Superficie dei campi form ✅ (v2.9.1)
+- [x] Aggiunto `--color-input` (bianco / gray-700) → `bg-input`; riduzione di 40
+  coppie `bg-white dark:bg-gray-700`. Corrispondenza esatta dei valori.
+
+### Fase 8 — Superfici hover e rientranti ✅ (v2.9.1)
+- [x] Aggiunto `--color-hover` (gray-100/700), `border.strong` (gray-300/500) e
+  `--color-sunken` (gray-50/700); riduzione di 51 coppie hover/rientranti. Le
+  sfumature hover minoritarie lasciate letterali per mantenere la passata strettamente senza modifiche.
+
+### Fase 9 — Tokenizzazione del layer dei componenti + accent ✅
+- [x] Le regole `@apply` dei componenti R-3 (`.card`, `.form-input`/`.form-select`/
+  `.form-label`, `.btn-secondary`, `.btn-ghost`, `.nav-active`, `.nav-inactive`)
+  erano un **punto cieco del codemod** — `--check` scansiona `class="…"`, non `@apply` —
+  e portavano ancora classi raw gray/blue. Migrate sui token.
+- [x] Aggiunto un token `accent` sensibile al tema (blue-600 → blue-400 in modalità scura) affinché
+  `.nav-active` non codifichi più il blu in modo rigido; questo è l'accent on-surface che
+  mancava a #254.
+- Non fatto (per scelta progettuale): adozione di `.btn`/`.form-*` sui siti di chiamata
+  (i siti di chiamata inline sono già tokenizzati; forzare i componenti cambierebbe le
+  dimensioni dei pulsanti a fronte di zero guadagno in termini di disaccoppiamento). `.btn-danger` (rosso d'azione solido) e le
+  varianti `.badge-*` di stato rimangono letterali. Il layer `@apply` resta fuori dal gate
+  `--check` — un futuro miglioramento del codemod potrebbe scansionarlo.
+
+### Fase 10 — Decostruzione delle code di colore (pianificata, progressiva)
+Il disaccoppiamento ha lasciato **565 utility `dark:`** che il codemod non riesce a ridurre: non
+hanno un sibling chiaro con cui accoppiarsi, quindi `--check` non le vede mai. L'audit
+(2026-05-25) mostra che non si tratta di un unico problema ma di tre, con profili di rischio opposti:
+
+| Gruppo | Conteggio | Si risolve in | Nuovi token |
+|---|---|---|---|
+| 1 — Neutri (bianco/grigio) | 388 (69%) | `foreground / surface / surface-2 / sunken / muted / border` | 0 |
+| 2 — Stato (blu/rosso/ambra) | 63 (11%) | `info / success / warning / danger` | 0 |
+| 3 — Arcobaleno (viola/indigo/arancione) | 111 (20%) | **neutro** (decorativo, retrocesso) | 0 |
+
+Rilievo chiave: **zero nuovi token necessari.** Il sistema di token già rilasciato *è*
+il contratto; i 565 sono tutto ciò che vi è sfuggito. La correzione consiste nell'applicazione +
+retrocessione, non in un nuovo vocabolario. (L'arcobaleno è risultato essere una codifica decorativa
+delle sezioni — viola = "configurazione avanzata", indigo = CA/Enterprise, arancione =
+Storage — non stato, e incoerente tra i file.)
+
+Ordine, per rischio UX crescente:
+- **10a — Neutri (388).** Invisibile: `dark:text-white` → `text-foreground`,
+  `dark:bg-gray-700` → `bg-input`/`bg-surface-2`/`bg-sunken` (disambiguato per
+  contesto — stesso grigio scuro, diversa intenzione *chiara*, quindi classificato da un
+  umano per cluster, non sed alla cieca). Estendere `theme_codemod.py` con una
+  passata solo-dark→token. Rischio ~0, pulisce ~70%.
+- **10b — Stato (63).** Mappare i callout blu/rosso/ambra sui gruppi
+  info/success/warning/danger esistenti. Normalizza la deriva 50-vs-100. Basso rischio.
+- **10c — Arcobaleno (111).** La decisione di prodotto (vedi contratto di seguito).
+  Le tonalità decorative di sezione collassano a neutro. Modifica visibile, eseguita per ultima,
+  blocco per blocco con QA screenshot prima/dopo. Deciso: **contratto α**
+  (colore = significato).
+
+## Contratto di colore (lo standard che i 565 hanno eluso)
+Deciso il 2026-05-25. Quattro regole; i token già rilasciati sono l'unica palette.
+
+1. **Il colore si guadagna, non è mai decorativo.** Una tonalità compare solo se porta
+   *stato* (info/success/warning/danger) o *brand* (accent: link, nav attiva, primary, focus).
+   Tutto il resto è neutro
+   (background/surface/surface-2/sunken/border/foreground/muted/label).
+2. **L'identità viene dalla struttura, non dal colore.** Le sezioni si distinguono tramite
+   spaziatura, intestazioni, icone, divisori — non una tonalità di riempimento.
+3. **Una sola primitiva di enfasi.** I blocchi di configurazione/avanzati usano un unico
+   pannello neutro rientrante (`bg-sunken border-border rounded-md`); un bordo sinistro
+   brand opzionale indica "attivo/importante". Nessuna palette per sezione.
+4. **Le icone si tingono solo con brand o stato.** Nessuna tinta viola/indigo/arancione sulle icone.
+
+Applicazione: il gate `--check` acquisisce una regola che fa fallire la CI sul raw
+`purple|indigo|orange` (e su qualsiasi colore non tokenizzato) in `templates/` — un
+contratto con un compilatore alle spalle, che non può regredire.
+
+## Colori di stato — ora tokenizzati (Fase 6)
+Le fasi precedenti hanno deliberatamente rimandato i colori di stato (verde/ambra/rosso/blu con
+le loro varianti `dark:`) come una passata separata e opzionale — portano un significato e sono
+per convenzione invarianti rispetto al tema. **La Fase 6 ha eseguito quella passata:** le
+superfici/bordi/testo delle info-box accoppiate usano ora `bg-success-surface`,
+`text-danger-strong`, ecc. I singoli *accenti* di stato (icona `text-*-500`, senza coppia scura)
+rimangono letterali — sono indipendenti dal tema e non fanno parte del theming chiaro/scuro.
+
+## Allineamento del workflow
+- Zero emoji in commit/PR/note di rilascio.
+- Commit atomici (uno per fase, o per partial nella Fase 3); un PR per versione.
+- Prima del push pubblico: smoke test Docker + emissione certificato reale sul dominio di Fab con sottodomini casuali.
+
+---
+
+<div align="center">
+
+[← Torna alla documentazione](./README.md)
+
+</div>

--- a/docs/it/api.md
+++ b/docs/it/api.md
@@ -1,0 +1,764 @@
+# CertMate Certificati Client - Riferimento API
+
+## Panoramica
+
+L'API CertMate per la gestione dei certificati client fornisce endpoint REST per una gestione completa dei certificati con autenticazione, rate limiting e journalizzazione dell'audit.
+
+**URL di base**: `http://localhost:5000/api`
+**Autenticazione**: Bearer Token (obbligatoria su tutti gli endpoint)
+**Content-Type**: `application/json`
+
+---
+
+## Autenticazione
+
+Tutti gli endpoint API richiedono l'autenticazione tramite Bearer token.
+
+### Formato dell'header
+
+```
+Authorization: Bearer IL_TUO_TOKEN
+```
+
+### Esempio di richiesta
+
+```bash
+curl -X GET http://localhost:5000/api/client-certs \
+ -H "Authorization: Bearer IL_TUO_TOKEN" \
+ -H "Content-Type: application/json"
+```
+
+---
+
+## Rate Limiting
+
+Gli endpoint API hanno limiti di frequenza per prevenire gli abusi:
+
+| Endpoint              | Limite | Per     |
+| --------------------- | ------ | ------- |
+| Generale              | 100    | minuto  |
+| Crea certificato      | 30     | minuto  |
+| Operazioni batch      | 10     | minuto  |
+| Stato OCSP            | 200    | minuto  |
+| Download CRL          | 60     | minuto  |
+
+### Risposta in caso di limite raggiunto
+
+Quando il limite viene superato, si riceve:
+
+```
+HTTP 429 Too Many Requests
+
+{
+ "error": "Rate limit exceeded",
+ "message": "Too many requests. Please try again later.",
+ "retry_after": 60
+}
+```
+
+---
+
+## Endpoint
+
+### Gestione dei certificati
+
+#### 1. Crea certificato
+
+**Endpoint**: `POST /client-certs/create`
+
+Crea un nuovo certificato client.
+
+**Richiesta**:
+```json
+{
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "organizational_unit": "Engineering",
+ "cert_usage": "api-mtls",
+ "days_valid": 365,
+ "generate_key": true,
+ "notes": "Production certificate"
+}
+```
+
+**Parametri**:
+- `common_name` (obbligatorio) — Subject del certificato
+- `email` (opzionale) — Indirizzo e-mail
+- `organization` (opzionale) — Nome dell'organizzazione
+- `organizational_unit` (opzionale) — Nome del reparto
+- `cert_usage` (opzionale) — Tipo di utilizzo: `api-mtls`, `vpn`, o personalizzato
+- `days_valid` (opzionale) — Validita in giorni (predefinito: 365)
+- `generate_key` (opzionale) — Genera chiave privata (predefinito: true)
+- `notes` (opzionale) — Note aggiuntive
+
+**Risposta** (201 Created):
+```json
+{
+ "identifier": "cert-abc123",
+ "common_name": "user@example.com",
+ "serial_number": "12345678901234567890",
+ "created_at": "2024-10-30T18:00:00Z",
+ "expires_at": "2025-10-30T18:00:00Z",
+ "cert_usage": "api-mtls",
+ "status": "active"
+}
+```
+
+**Esempio**:
+```bash
+curl -X POST http://localhost:5000/api/client-certs/create \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "api-mtls",
+ "days_valid": 365
+ }'
+```
+
+---
+
+#### 2. Elenca certificati
+
+**Endpoint**: `GET /client-certs`
+
+Elenca tutti i certificati client con filtro opzionale.
+
+**Parametri di query**:
+- `usage` (opzionale) — Filtra per tipo di utilizzo (es. `api-mtls`)
+- `revoked` (opzionale) — Filtra per stato (`true` o `false`)
+- `search` (opzionale) — Cerca nel common name
+
+**Risposta** (200 OK):
+```json
+{
+ "certificates": [{
+ "identifier": "cert-001",
+ "common_name": "user1@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "api-mtls",
+ "created_at": "2024-10-30T18:00:00Z",
+ "expires_at": "2025-10-30T18:00:00Z",
+ "revoked": false,
+ "status": "active"
+ },
+ {
+ "identifier": "cert-002",
+ "common_name": "user2@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "vpn",
+ "created_at": "2024-10-29T18:00:00Z",
+ "expires_at": "2025-10-29T18:00:00Z",
+ "revoked": true,
+ "status": "revoked"
+ }
+ ],
+ "total": 2
+}
+```
+
+**Esempi**:
+```bash
+# Elenca tutti i certificati
+curl http://localhost:5000/api/client-certs \
+ -H "Authorization: Bearer TOKEN"
+
+# Filtra per tipo di utilizzo
+curl "http://localhost:5000/api/client-certs?usage=api-mtls" \
+ -H "Authorization: Bearer TOKEN"
+
+# Elenca solo i revocati
+curl "http://localhost:5000/api/client-certs?revoked=true" \
+ -H "Authorization: Bearer TOKEN"
+
+# Cerca per common name
+curl "http://localhost:5000/api/client-certs?search=user1" \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+#### 3. Ottieni dettagli certificato
+
+**Endpoint**: `GET /client-certs/<identifier>`
+
+Recupera i metadati completi di un certificato.
+
+**Risposta** (200 OK):
+```json
+{
+ "type": "client_certificate",
+ "identifier": "cert-001",
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "organizational_unit": "Engineering",
+ "serial_number": "12345678901234567890",
+ "created_at": "2024-10-30T18:00:00Z",
+ "expires_at": "2025-10-30T18:00:00Z",
+ "cert_usage": "api-mtls",
+ "notes": "Production certificate",
+ "revocation": {
+ "revoked": false,
+ "revoked_at": null,
+ "reason_revoked": null
+ },
+ "renewal": {
+ "renewal_enabled": true,
+ "renewal_threshold_days": 30
+ }
+}
+```
+
+**Esempio**:
+```bash
+curl http://localhost:5000/api/client-certs/cert-001 \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+#### 4. Scarica file del certificato
+
+**Endpoint**: `GET /client-certs/<identifier>/download/<type>`
+
+Scarica il certificato, la chiave privata o il file CSR.
+
+**Parametri**:
+- `identifier` — ID del certificato
+- `type` — Tipo di file: `crt`, `key`, o `csr`
+
+**Risposta** (200 OK):
+- Content-Type: `application/octet-stream`
+- Allegato con nome appropriato
+
+**Esempi**:
+```bash
+# Scarica il certificato
+curl http://localhost:5000/api/client-certs/cert-001/download/crt \
+ -H "Authorization: Bearer TOKEN" \
+ -o certificate.crt
+
+# Scarica la chiave privata
+curl http://localhost:5000/api/client-certs/cert-001/download/key \
+ -H "Authorization: Bearer TOKEN" \
+ -o private.key
+
+# Scarica il CSR
+curl http://localhost:5000/api/client-certs/cert-001/download/csr \
+ -H "Authorization: Bearer TOKEN" \
+ -o request.csr
+```
+
+---
+
+#### 5. Revoca certificato
+
+**Endpoint**: `POST /client-certs/<identifier>/revoke`
+
+Revoca un certificato con motivo opzionale.
+
+**Richiesta** (opzionale):
+```json
+{
+ "reason": "compromised"
+}
+```
+
+**Risposta** (200 OK):
+```json
+{
+ "message": "Certificate revoked: cert-001",
+ "revoked_at": "2024-10-30T18:15:00Z",
+ "reason": "compromised"
+}
+```
+
+**Esempio**:
+```bash
+curl -X POST http://localhost:5000/api/client-certs/cert-001/revoke \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "reason": "compromised"
+ }'
+```
+
+---
+
+#### 6. Rinnova certificato
+
+**Endpoint**: `POST /client-certs/<identifier>/renew`
+
+Rinnova un certificato (stesso CN, nuovo numero seriale).
+
+**Risposta** (201 Created):
+```json
+{
+ "identifier": "cert-001-renewed",
+ "common_name": "user@example.com",
+ "serial_number": "98765432109876543210",
+ "created_at": "2024-10-30T18:20:00Z",
+ "expires_at": "2025-10-30T18:20:00Z",
+ "status": "active"
+}
+```
+
+**Esempio**:
+```bash
+curl -X POST http://localhost:5000/api/client-certs/cert-001/renew \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+#### 7. Ottieni statistiche
+
+**Endpoint**: `GET /client-certs/stats`
+
+Recupera le statistiche di utilizzo dei certificati.
+
+**Risposta** (200 OK):
+```json
+{
+ "total": 100,
+ "active": 85,
+ "revoked": 15,
+ "expiring_soon": 8,
+ "by_usage": {
+ "api-mtls": 60,
+ "vpn": 35,
+ "other": 5
+ },
+ "created_count": 100,
+ "renewal_enabled": 92
+}
+```
+
+**Esempio**:
+```bash
+curl http://localhost:5000/api/client-certs/stats \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+#### 8. Importazione batch di certificati
+
+**Endpoint**: `POST /client-certs/batch`
+
+Crea piu certificati da dati CSV in un'unica richiesta.
+
+**Richiesta**:
+```json
+{
+ "headers": ["common_name", "email", "organization", "cert_usage", "days_valid"],
+ "rows": [["user1@example.com", "user1@example.com", "ACME Corp", "api-mtls", "365"],
+ ["user2@example.com", "user2@example.com", "ACME Corp", "vpn", "365"],
+ ["user3@example.com", "user3@example.com", "ACME Corp", "api-mtls", "365"]
+ ]
+}
+```
+
+**Risposta** (201 Created):
+```json
+{
+ "total": 3,
+ "successful": 3,
+ "failed": 0,
+ "errors": [],
+ "certificates": [{
+ "identifier": "cert-batch-001",
+ "common_name": "user1@example.com"
+ },
+ {
+ "identifier": "cert-batch-002",
+ "common_name": "user2@example.com"
+ },
+ {
+ "identifier": "cert-batch-003",
+ "common_name": "user3@example.com"
+ }
+ ]
+}
+```
+
+**Esempio**:
+```bash
+curl -X POST http://localhost:5000/api/client-certs/batch \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "headers": ["common_name", "email", "organization"],
+ "rows": [["user1@example.com", "user1@example.com", "ACME Corp"],
+ ["user2@example.com", "user2@example.com", "ACME Corp"]
+ ]
+ }'
+```
+
+---
+
+### OCSP & CRL
+
+#### 9. Query di stato OCSP
+
+**Endpoint**: `GET /ocsp/status/<serial_number>`
+
+Interroga lo stato di un certificato tramite OCSP.
+
+**Risposta** (200 OK):
+```json
+{
+ "response_status": "successful",
+ "certificate_status": "good|revoked|unknown",
+ "certificate_serial": 12345678,
+ "this_update": "2024-10-30T18:00:00Z",
+ "next_update": null,
+ "responder_name": "CertMate OCSP Responder"
+}
+```
+
+**Esempio**:
+```bash
+curl http://localhost:5000/api/ocsp/status/12345678 \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+#### 10. Distribuzione della CRL
+
+**Endpoint**: `GET /crl/download/<format_type>`
+
+Scarica la Certificate Revocation List.
+
+**Parametri**:
+- `format_type` — `pem`, `der`, o `info`
+
+**Risposta**:
+- Per `pem` e `der`: allegato file
+- Per `info`: JSON con metadati CRL
+
+**Esempi**:
+```bash
+# Scarica la CRL in formato PEM
+curl http://localhost:5000/api/crl/download/pem \
+ -H "Authorization: Bearer TOKEN" \
+ -o ca.crl
+
+# Scarica la CRL in formato DER
+curl http://localhost:5000/api/crl/download/der \
+ -H "Authorization: Bearer TOKEN" \
+ -o ca.crl
+
+# Ottieni le informazioni sulla CRL
+curl http://localhost:5000/api/crl/download/info \
+ -H "Authorization: Bearer TOKEN"
+```
+
+**Risposta informazioni CRL**:
+```json
+{
+ "status": "available",
+ "issuer": "CN=CertMate CA, O=CertMate",
+ "last_update": "2024-10-30T18:00:00Z",
+ "next_update": "2024-10-31T18:00:00Z",
+ "revoked_count": 5,
+ "revoked_serials": [12345678,
+ 87654321
+ ]
+}
+```
+
+---
+
+#### 11. Scarica file del certificato di dominio
+
+**Endpoint**: `GET /certificates/<domain>/download`
+
+Scarica i file del certificato per un dominio specifico. Per impostazione predefinita, questo endpoint restituisce un archivio ZIP contenente tutti i componenti del certificato. E possibile richiedere un file specifico tramite il parametro di query `file`. E disponibile anche una modalita JSON per l'automazione che desidera ottenere tutti i PEM in un'unica risposta.
+
+**Parametri**:
+- `domain` (Path) — Il nome di dominio associato al certificato.
+- `file` (Query, opzionale) — Specifica un singolo file da scaricare.
+  - Valori supportati: `fullchain.pem`, `privkey.pem`, `combined.pem`
+- `format` (Query, opzionale) — Impostare a `json` per restituire tutti i file del certificato in un oggetto JSON.
+
+**Risposta** (200 OK):
+- **Predefinito**: `application/zip` (un file ZIP contenente tutti i file PEM)
+- **Con parametro `file`**: `application/x-pem-file` (il contenuto grezzo del file richiesto)
+- **Con `format=json`**: `application/json` con `domain`, `cert_pem`, `chain_pem`, `fullchain_pem` e `private_key_pem`
+
+La forma JSON e il formato di automazione preferito per Ansible, Salt o qualsiasi altro client che desideri scrivere direttamente i file PEM.
+
+**Esempi**:
+
+```bash
+# Scarica tutti i file come archivio ZIP
+curl http://localhost:5000/api/certificates/example.com/download \
+ -H "Authorization: Bearer TOKEN" \
+ -o example_com_bundle.zip
+
+# Scarica solo il file fullchain.pem
+curl "http://localhost:5000/api/certificates/example.com/download?file=fullchain.pem" \
+ -H "Authorization: Bearer TOKEN" \
+ -o fullchain.pem
+
+# Scarica solo la chiave privata
+curl "http://localhost:5000/api/certificates/example.com/download?file=privkey.pem" \
+ -H "Authorization: Bearer TOKEN" \
+ -o privkey.pem
+
+# Scarica il bundle completo in JSON
+curl "http://localhost:5000/api/certificates/example.com/download?format=json" \
+ -H "Authorization: Bearer TOKEN" \
+ -o example_com_bundle.json
+
+```
+
+---
+
+#### 12. Riemetti un certificato di dominio (modifica la configurazione)
+
+**Endpoint**: `POST /certificates/<domain>/reissue`
+
+Modifica la configurazione di un certificato e lo riemette sul posto — estende o rimuove le voci SAN senza cancellare e ricreare. I campi omessi mantengono i valori con cui il certificato e stato emesso (letti dai suoi metadati), evitando cosi di dover reinserire la configurazione DNS/alias/CA. Il certificato attuale continua ad essere servito fino al completamento della riemissione. La forma della chiave e preservata salvo modifica esplicita (nessun flag di chiave viene inviato e certbot mantiene la chiave della lineage).
+
+**Corpo della richiesta** (tutti i campi sono opzionali):
+```json
+{
+  "san_domains": ["www.example.com", "api.example.com"],
+  "domain_alias": "",
+  "async": true
+}
+```
+
+- `san_domains`: set di sostituzione dei SAN — omettere per mantenere, `[]` per rimuovere tutti i SAN
+- `domain_alias`: omettere per mantenere, `""` per cancellare
+- `dns_provider`, `account_id`, `ca_provider`, `challenge_type`: omettere per mantenere
+- `key_type`/`key_size`/`elliptic_curve`: omettere per mantenere la forma di chiave esistente
+- `async`: rinvia l'emissione a un job in background (202 + ID del job, interrogare `GET /certificates/jobs/<job_id>`)
+
+**Risposta** (200 OK, o 202 Accepted con `async`): message, domain, dns_provider, ca_provider, duration.
+
+**Errori**: 404 quando non esiste alcun certificato per il dominio (usare create), 403 scope, 400 validazione, 409 operazione in corso, 422 errore certbot (il certificato precedente e ancora in uso).
+
+**Esempio**:
+```bash
+curl -X POST http://localhost:5000/api/certificates/example.com/reissue \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{"san_domains": ["www.example.com", "api.example.com"]}'
+```
+
+---
+
+## Gestione degli errori
+
+### Formato della risposta di errore
+
+```json
+{
+ "error": "Error message",
+ "code": "ERROR_CODE",
+ "status": 400
+}
+```
+
+### Codici di stato HTTP comuni
+
+| Codice | Significato          | Esempio                          |
+| ------ | -------------------- | -------------------------------- |
+| 200    | Successo             | Certificato elencato             |
+| 201    | Creato               | Certificato creato               |
+| 400    | Richiesta errata     | Campo obbligatorio mancante      |
+| 401    | Non autorizzato      | Token non valido/mancante        |
+| 404    | Non trovato          | Il certificato non esiste        |
+| 429    | Troppe richieste     | Rate limit superato              |
+| 500    | Errore del server    | Errore interno                   |
+| 503    | Servizio non disponibile | OCSP/CRL non disponibile    |
+
+### Esempio di errore
+
+```bash
+curl http://localhost:5000/api/client-certs/invalid-id \
+ -H "Authorization: Bearer TOKEN"
+
+# Risposta
+{
+ "error": "Certificate not found: invalid-id",
+ "code": 404,
+ "status": 404
+}
+```
+
+---
+
+## Journalizzazione dell'audit
+
+Le operazioni del ciclo di vita dei certificati e le modifiche alla configurazione e al controllo degli accessi vengono registrate in un log di audit. Questo include i percorsi critici del ciclo di vita — creazioni, rinnovi, riemissioni, deploy e attivazioni/disattivazioni del rinnovo automatico riusciti e falliti, nonche i **rinnovi non presidiati (pianificati)** — ciascuno attribuito all'attore che lo ha eseguito e al trigger che ne e stata la causa.
+
+### Formato del log
+
+Il log di audit viene scritto in `logs/audit/certificate_audit.log`. Ogni riga e una riga di log Python standard il cui messaggio e la voce di audit JSON:
+
+```
+2026-06-15 18:00:00 - certmate.audit - INFO - {"timestamp": "...", ...}
+```
+
+Per recuperare il JSON, dividere ogni riga sul letterale ` - INFO - ` e analizzare il resto. Si notino le due basi temporali: il prefisso temporale della riga e l'ora **locale** del server, mentre il campo `timestamp` del JSON e in **UTC** (ISO-8601). Leggerlo in tempo reale con:
+
+```bash
+tail -f logs/audit/certificate_audit.log
+```
+
+### Struttura della voce
+
+```json
+{
+  "timestamp": "2026-06-15T18:00:00.000000+00:00",
+  "operation": "renew",
+  "resource_type": "certificate",
+  "resource_id": "api.example.com",
+  "status": "success",
+  "user": "api_key:renew-bot",
+  "ip_address": "10.0.0.9",
+  "details": {"force": false},
+  "error": null,
+  "actor": {
+    "kind": "agent",
+    "id": "9f2c…",
+    "label": "api_key:renew-bot",
+    "token_prefix": "cm_1a2b",
+    "agent_session": "sess-9f2"
+  },
+  "trigger": {"cause": "agent"}
+}
+```
+
+- **`actor.kind`** — `user` (una sessione umana / login OIDC), `api_token` (una chiave API o il token Bearer globale legacy), `agent` (una chiave API esplicitamente contrassegnata come agente IA/MCP — vedi sotto), `scheduler` (un job di rinnovo non presidiato), o `system`. Viene derivato **esclusivamente dall'identita autenticata**.
+- **`actor.id` / `token_prefix`** — l'ID stabile della chiave API e il prefisso del token associato all'azione (assente per il token Bearer globale legacy, che non puo essere distinto per chiamante — preferire le chiavi con scope).
+- **`actor.agent_session` / `agent_id`** — i valori degli header `X-CertMate-Agent-Session` / `X-CertMate-Agent-Id` forniti dal client (il server MCP li invia). Sono una **dichiarazione puramente informativa**: vengono registrati per correlazione ma non modificano mai `actor.kind`, quindi un chiamante non-agent non puo falsificare un'attribuzione `agent`.
+- **`trigger.cause`** — `manual`, `api`, `agent`, `scheduled_renewal`, o `event`; per i rinnovi pianificati, `trigger.job_id` indica il nome del job.
+
+Affinche le azioni di un agent vengano registrate come `actor.kind="agent"`, creare una chiave API con scope e `is_agent: true` (una casella di controllo in Impostazioni → Chiavi API, o `is_agent` in `POST /api/keys`) e puntare il server MCP verso di essa. Vedere la [guida MCP](./mcp.md).
+
+### Lettura del log di audit tramite l'API
+
+`GET /api/activity?limit=N` restituisce le voci piu recenti (admin/viewer, limitato a 500).
+
+### Prova di integrita (hash chain)
+
+Parallelamente al log leggibile dall'utente, ogni voce viene aggiunta a una **hash chain** SHA-256 a prova di manomissione in `data/audit/certificate_audit.chain.jsonl`. Ogni record e `{seq, entry, prev_hash, hash}` dove `hash` si impegna sulla voce e sull'hash del record precedente, e `seq` e un contatore senza lacune — pertanto qualsiasi modifica, cancellazione o riordinamento da parte di chiunque non possa ricalcolare l'intera chain e rilevabile e localizzabile. E attiva per impostazione predefinita; disabilitare con `CERTMATE_AUDIT_CHAIN=0`.
+
+**Verifica tramite API:** `GET /api/audit/verify` (admin) restituisce il risultato del verificatore e HTTP `200` quando integra o `409` quando corrotta:
+
+```json
+{"ok": true, "count": 128, "first_seq": 0, "last_seq": 127, "head_hash": "5ee1…", "reason": "intact"}
+```
+
+**Verifica off-box:** il verificatore autonomo dipende solo dalla libreria standard Python, quindi un revisore puo eseguirlo senza installare ne fidarsi di CertMate:
+
+```bash
+python -m modules.core.audit_verify data/audit/certificate_audit.chain.jsonl
+# OK: audit chain intact (128 entries, seq 0..127)
+# or: FAIL: audit chain broken at seq 42: hash mismatch at seq 42: entry was modified
+```
+
+Codice di uscita `0` integra, `1` corrotta (con il `seq` incriminato e il motivo), `2` file mancante/illeggibile.
+
+### Bundle di esportazione firmato (verificabile da terzi)
+
+L'istanza detiene una chiave di firma Ed25519, persistita in `data/.audit_signing_key` (generata al primo avvio, `0600`; sovrascrivere con `AUDIT_SIGNING_KEY_FILE` per conservarla fuori dalla macchina). La sua identita pubblica e esposta tramite `GET /api/audit/public-key` (admin): `{algorithm, public_key_pem, fingerprint}`. La testa della chain viene firmata in checkpoint periodici (`certificate_audit.checkpoints.jsonl`).
+
+`GET /api/audit/export` (admin, opzionale `?from_seq`/`?to_seq`) restituisce un bundle firmato e auto-verificabile — `{manifest, entries, bundle_signature}`. Il manifest fissa il fingerprint dell'istanza, la chiave pubblica, l'intervallo di `seq` e il `head_hash`; la firma e sul manifest canonico, che (tramite `head_hash`) si impegna transitivamente su ogni voce. Un revisore lo verifica **fuori dalla macchina** senza eseguire ne fidarsi di CertMate, con la possibilita di fissare la chiave esternamente:
+
+```bash
+python -m modules.core.audit_verify --bundle bundle.json --pubkey instance.pem
+# OK: audit bundle intact and signed (128 entries, seq 0..127; signed by 0m2V5lDmnkPWOUHX)
+```
+
+Il verificatore controlla la struttura della chain, che il manifest corrisponda alle voci, la firma Ed25519 e che il fingerprint corrisponda alla chiave pubblica (opzionalmente fissata).
+
+> **Onesta sul modello di minaccia.** La chain e la firma rilevano qualsiasi modifica interna, cancellazione o riordinamento, e collegano un'esportazione alla chiave pubblica di questa istanza — per chiunque non detenga la chiave di firma. Non **vincolano** l'operatore, che detiene la chiave e potrebbe ri-firmare una chain riscritta, e il troncamento finale viene rilevato solo confrontando le esportazioni nel tempo (un'esportazione successiva con meno voci) o rispetto a un checkpoint conservato esternamente. Vincolare completamente l'operatore richiede l'invio dei checkpoint firmati a un sink esterno append-only — un ancoraggio esterno opzionale, una funzionalita pianificata ma non ancora disponibile. Vedere [compliance.md](./compliance.md).
+
+---
+
+## Tipi di certificati
+
+### API mTLS
+
+Per l'autenticazione dei client API tramite TLS mutuale.
+
+```
+cert_usage: "api-mtls"
+```
+
+### VPN
+
+Per l'autenticazione dei client VPN.
+
+```
+cert_usage: "vpn"
+```
+
+### Tipi di utilizzo personalizzati
+
+E possibile utilizzare qualsiasi stringa di tipo di utilizzo personalizzato:
+
+```
+cert_usage: "custom-application"
+```
+
+---
+
+## Buone pratiche
+
+### Sicurezza
+
+1. **Proteggi il tuo token**
+ - Mantieni i token segreti
+ - Ruota i token regolarmente
+ - Usa HTTPS in produzione
+
+2. **Gestione dei certificati**
+ - Abilita il rinnovo automatico
+ - Monitora le date di scadenza
+ - Esamina regolarmente i log di audit
+ - Revoca immediatamente i certificati compromessi
+
+3. **Rate Limiting**
+ - Rispetta i limiti di frequenza
+ - Implementa un backoff esponenziale
+ - Usa le operazioni batch quando possibile
+
+### Performance
+
+1. **Usa le operazioni batch**
+ - Importa piu certificati contemporaneamente
+ - Riduce le chiamate API
+ - Migliore gestione degli errori
+
+2. **Filtra i risultati**
+ - Usa i parametri di query
+ - Filtra per utilizzo o stato
+ - Riduce il trasferimento di dati
+
+3. **Utilizza la cache quando appropriato**
+ - Memorizza in cache i metadati dei certificati
+ - Aggiorna periodicamente
+ - Verifica la scadenza localmente
+
+---
+
+
+---
+
+<div align="center">
+
+[← Torna alla documentazione](./README.md) • [Guida rapida →](./guide.md) • [Architettura →](./architecture.md)
+
+</div>

--- a/docs/it/architecture.md
+++ b/docs/it/architecture.md
@@ -1,0 +1,856 @@
+# Architettura di CertMate
+
+Questo documento descrive l'architettura completa di CertMate — sia il sistema principale per i certificati server che il sottosistema per i certificati client.
+
+---
+
+## Indice
+
+- [Architettura del sistema principale](#architettura-del-sistema-principale)
+- [Diagramma ad alto livello](#diagramma-ad-alto-livello)
+- [Classi di gestione (Manager)](#classi-di-gestione-managers)
+- [Flusso di creazione del certificato](#flusso-di-creazione-del-certificato)
+- [Architettura di archiviazione](#architettura-di-archiviazione)
+- [Struttura di configurazione](#struttura-di-configurazione)
+- [Endpoint API](#endpoint-api)
+- [Stack tecnologico](#stack-tecnologico)
+- [Architettura dei certificati client](#architettura-dei-certificati-client)
+
+---
+
+## Architettura del sistema principale
+
+CertMate è un sistema modulare ed estensibile per la gestione di certificati SSL/TLS costruito con Python/Flask. Supporta molteplici provider CA, oltre due dozzine di provider DNS e backend di archiviazione intercambiabili.
+
+**Informazioni principali:**
+- **Linguaggio**: Python 3.9+ (Flask, Flask-RESTX)
+- **Archiviazione**: filesystem locale come impostazione predefinita + 4 backend cloud (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical)
+- **Provider CA**: Let's Encrypt, DigiCert ACME, CA privata
+- **Provider DNS**: oltre due dozzine supportati (Cloudflare, AWS Route53, Azure, Google e altri — vedere [Provider DNS](./dns-providers.md) per l'elenco completo)
+- **API**: REST con Swagger/OpenAPI tramite Flask-RESTX
+- **Tipi di certificati attuali**: TLS lato server (DV, OV, EV)
+
+---
+
+## Diagramma ad alto livello
+
+```
+┌─────────────────────────────────────────────────────┐
+│              Applicazione CertMate                  │
+│                                                     │
+│  ┌───────────────────────────────────────────────┐  │
+│  │           Livello Web (Flask)                  │  │
+│  │  Dashboard    Impostazioni    Aiuto    Cert. Cl│  │
+│  └────────────────────┬──────────────────────────┘  │
+│                       ↓                             │
+│  ┌──────────────────┐   ┌────────────────────────┐  │
+│  │  API REST         │   │  Route Web             │  │
+│  │  /api/certificates│   │  /api/web/certificates │  │
+│  │  /api/client-certs│   │  /client-certificates  │  │
+│  └────────┬─────────┘   └────────┬───────────────┘  │
+│           └──────────┬───────────┘                   │
+│                      ↓                               │
+│  ┌───────────────────────────────────────────────┐  │
+│  │     Livello Manager (Logica applicativa)       │  │
+│  │                                               │  │
+│  │  CertificateManager    CAManager              │  │
+│  │  DNSManager            StorageManager         │  │
+│  │  AuthManager           SettingsManager        │  │
+│  │  CacheManager          FileOperations         │  │
+│  │  ClientCertManager     OCSPResponder          │  │
+│  │  CRLManager            AuditLogger            │  │
+│  └────────────────────┬──────────────────────────┘  │
+│                       ↓                             │
+│  ┌───────────────────────────────────────────────┐  │
+│  │          Livello di esecuzione                 │  │
+│  │  Certbot (cert server via DNS-01 ACME)        │  │
+│  │  PrivateCA (cert client via firma diretta)    │  │
+│  └────────────────────┬──────────────────────────┘  │
+│                       ↓                             │
+│  ┌───────────────────────────────────────────────┐  │
+│  │     Livello di archiviazione (Backend plug.)  │  │
+│  │  Local FS │ Azure KV │ AWS SM │ Vault │ Infis │  │
+│  └───────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## Classi di gestione (Managers)
+
+```
+CertMateApp (applicazione principale)
+  ├── FileOperations          # I/O file, backup
+  ├── SettingsManager         # Caricamento/salvataggio settings.json
+  ├── AuthManager             # Validazione token
+  ├── CertificateManager      # Crea/rinnova/info (cert server)
+  ├── CAManager               # Configurazione provider CA, costruzione certbot
+  ├── DNSManager              # Account provider DNS
+  ├── CacheManager            # Cache di deployment
+  ├── StorageManager          # Astrazione dei backend
+  ├── ClientCertificateManager # Ciclo di vita dei certificati client
+  ├── PrivateCAGenerator      # Gestione della CA auto-firmata
+  ├── OCSPResponder           # Interrogazioni sullo stato dei certificati
+  ├── CRLManager              # Generazione delle liste di revoca
+  └── AuditLogger             # Tracciamento delle operazioni
+```
+
+---
+
+## Flusso di creazione del certificato
+
+### Certificati server (via Certbot + ACME)
+
+```
+1. L'utente invia: dominio, email, provider DNS, provider CA
+2. Validazione degli input (formato del dominio, email, esistenza del provider)
+3. Recupero della configurazione CA (URL ACME, credenziali EAB se DigiCert)
+4. Recupero della configurazione DNS (credenziali account dalle impostazioni)
+5. Creazione della directory: certificates/{dominio}/
+6. Costruzione del comando certbot:
+   certbot certonly --non-interactive --agree-tos
+     --server {acme_url}
+     --email {email}
+     --{dns_plugin} --{dns_plugin}-credentials {cred_file}
+     --{dns_plugin}-propagation-seconds {timeout}
+     --eab-kid/--eab-hmac-key (se richiesto)
+     -d {dominio}
+7. Creazione del file temporaneo delle credenziali DNS (permessi 600)
+8. Esecuzione di certbot (timeout di 30 minuti)
+9. Risoluzione dei symlink, copia dei file del certificato nella directory radice del dominio
+10. Archiviazione tramite il backend configurato + creazione di metadata.json
+11. Pulizia del file delle credenziali
+```
+
+### Certificati client (via CA privata)
+
+```
+1. L'utente invia: common_name, email, organizzazione, cert_usage
+2. Inizializzazione o caricamento della CA esistente (RSA 4096 bit)
+3. Generazione del CSR (o accettazione di un CSR fornito)
+4. Firma del CSR con la CA privata
+5. Archiviazione dei file cert/chiave/csr + metadata.json
+6. Registrazione nella traccia di audit
+```
+
+---
+
+## Architettura di archiviazione
+
+### Certificati server
+
+```
+certificates/
+  example.com/
+    cert.pem          # Certificato server
+    chain.pem         # Catena CA intermedia
+    fullchain.pem     # cert + catena
+    privkey.pem       # Chiave privata (permessi 600)
+    metadata.json     # Metadati del certificato
+```
+
+### Certificati client
+
+```
+data/certs/
+  ca/
+    ca.crt            # Certificato CA
+    ca.key            # Chiave privata CA (permessi 600)
+    ca_metadata.json  # Metadati CA
+    crl.pem           # Lista di revoca dei certificati
+  client/
+    api-mtls/         # Certificati per tipo di utilizzo
+      cert-001/
+        cert.crt
+        cert.key
+        cert.csr
+        metadata.json
+    vpn/
+      cert-002/
+        ...
+```
+
+### Backend di archiviazione
+
+Tutti i backend implementano `CertificateStorageBackend`:
+
+| Backend | Posizione di archiviazione |
+|---------|---------------------------|
+| **Filesystem locale** | `certificates/{dominio}/` (predefinito) |
+| **Azure Key Vault** | Secret, oggetti Certificate nativi, o entrambi — vedere sotto |
+| **AWS Secrets Manager** | AWS Secrets Manager |
+| **HashiCorp Vault** | Vault KV v1/v2 |
+| **Infisical** | Secret Infisical |
+
+#### Azure Key Vault — modalità di archiviazione
+
+Il backend Azure Key Vault può conservare i certificati come Secret (impostazione predefinita), come oggetti Certificate nativi, o entrambi, controllato da `certificate_storage.azure_keyvault.storage_mode` in `settings.json`.
+
+| Modalità | Scrive Secret | Scrive oggetto Certificate | Quando utilizzarla |
+|---|---|---|---|
+| `secrets` (predefinita) | sì | no | Comportamento retrocompatibile. Ogni `cert.pem` / `chain.pem` / `fullchain.pem` / `privkey.pem` e i metadati sono archiviati come Secret di Key Vault separati. |
+| `certificate` | no | sì | Collegamento diretto da App Service, Application Gateway, Front Door, API Management, AKS Ingress, ecc. Il cert + catena + chiave privata vengono importati come singolo oggetto `Certificate` PKCS12 con `issuer_name="Unknown"` in modo che Key Vault non tenti di rinnovarlo. |
+| `both` | sì | sì | Configurazioni transitorie o con consumatori misti. Le letture preferiscono sempre il percorso dei Secret (meno costoso). |
+
+Un'azione manuale **Backfill Certificate objects** nel pannello delle impostazioni di archiviazione (`POST /api/storage/azure-keyvault/backfill-certificates`) importa un oggetto Certificate per ogni dominio che esiste già nel vault come Secret ma non ne ha ancora uno. Gli oggetti Certificate esistenti vengono ignorati. L'endpoint accetta un parametro di query opzionale `?limit=N` per limitare il numero di domini elaborati per chiamata; i vault di grandi dimensioni possono paginare chiamando ripetutamente fino a quando la risposta segnala `0` rimanenti.
+
+##### Nota di sicurezza — gli oggetti Certificate espongono la chiave privata tramite l'API Secrets
+
+Quando Key Vault importa un oggetto Certificate PKCS12, crea anche un **Secret** associato con lo stesso nome il cui valore è il PFX completo (inclusa la chiave privata). Questo è il comportamento previsto in Azure: è il modo documentato con cui le estensioni VM e App Service consumano il certificato, e qualsiasi principal con `Secrets/Get` sul vault può quindi scaricare la chiave privata — *il permesso `Get` sui Certificate da solo non è sufficiente per estrarre la chiave privata, ma `Secrets/Get` lo è*. Gli operatori che eseguono CertMate in modalità `certificate` o `both` devono limitare `Secrets/Get` con attenzione e preferire Azure RBAC rispetto alle policy di accesso al vault per un controllo più granulare. Vedere [Microsoft Learn — Certificati in Key Vault](https://learn.microsoft.com/azure/key-vault/certificates/about-certificates) per il modello completo.
+
+##### Permessi del Service Principal
+
+| Modalità | Permessi richiesti sul vault |
+|---|---|
+| `secrets` | Secrets `Get/Set/List/Delete` |
+| `certificate` / `both` | Aggiunge Certificates `Get/List/Import/Delete` e mantiene Secrets `Get/List` (Key Vault espone il PFX importato, inclusa la chiave privata, solo tramite il Secret con lo stesso nome dell'oggetto Certificate). |
+
+---
+
+## Struttura di configurazione
+
+Tutte le impostazioni sono archiviate in `data/settings.json`:
+
+```json
+{
+  "email": "admin@example.com",
+  "domains": ["example.com", "*.example.com"],
+  "auto_renew": true,
+  "renewal_threshold_days": 30,
+  "api_bearer_token": "secure-token",
+  "dns_provider": "cloudflare",
+  "dns_providers": {
+    "cloudflare": {
+      "accounts": {
+        "production": {"api_token": "token-prod"},
+        "staging": {"api_token": "token-staging"}
+      }
+    }
+  },
+  "default_accounts": {
+    "cloudflare": "production"
+  },
+  "ca_providers": {
+    "letsencrypt": {
+      "accounts": {
+        "default": {"email": "admin@example.com"}
+      }
+    }
+  },
+  "certificate_storage": {
+    "backend": "local_filesystem",
+    "cert_dir": "certificates"
+  },
+  "default_key_type": "rsa",
+  "default_key_size": 2048,
+  "default_elliptic_curve": "secp256r1"
+}
+```
+
+### Tipo/dimensione della chiave del certificato
+
+Tre chiavi di primo livello controllano la forma della chiave pubblica dei certificati di nuova emissione:
+
+| Chiave | Valori | Si applica quando |
+|---|---|---|
+| `default_key_type` | `rsa` (predefinito) / `ecdsa` | sempre |
+| `default_key_size` | `2048` (predefinito) / `3072` / `4096` | `default_key_type == "rsa"` |
+| `default_elliptic_curve` | `secp256r1` (predefinito) / `secp384r1` | `default_key_type == "ecdsa"` |
+
+È supportato un override per singolo certificato: ogni voce in `domains` può includere un `key_type` opzionale più `key_size` (RSA) o `elliptic_curve` (ECDSA). Quando l'override è presente, ha la precedenza; altrimenti si applica il valore globale predefinito. I valori predefiniti `rsa`/`2048` rispecchiano il default implicito di certbot che CertMate applicava prima dell'introduzione di questa impostazione, pertanto le installazioni aggiornate non subiscono alcuna variazione a meno che l'operatore non scelga qualcos'altro.
+
+I rinnovi preservano sempre la forma in uso al momento della creazione: certbot persiste `--key-type`, `--rsa-key-size` e `--elliptic-curve` nel proprio `renewal/<dominio>.conf` durante la prima emissione, e `certbot renew --cert-name <dominio>` riutilizza automaticamente quei valori.
+
+---
+
+## Endpoint API
+
+### Certificati server
+
+| Metodo | Endpoint | Scopo |
+|--------|----------|-------|
+| GET | `/api/health` | Verifica dello stato |
+| GET | `/api/certificates` | Elenca tutti i certificati |
+| POST | `/api/certificates` | Crea un nuovo certificato |
+| GET | `/api/certificates/{domain}` | Ottieni informazioni sul certificato |
+| POST | `/api/certificates/{domain}/renew` | Rinnova il certificato |
+| GET | `/api/certificates/{domain}/download` | Scarica come ZIP |
+| GET | `/{domain}/tls` | Download diretto della fullchain |
+
+### Certificati client
+
+| Metodo | Endpoint | Scopo |
+|--------|----------|-------|
+| POST | `/api/client-certs/create` | Crea un certificato |
+| GET | `/api/client-certs` | Elenca con filtri |
+| GET | `/api/client-certs/{id}` | Ottieni i metadati |
+| GET | `/api/client-certs/{id}/download/{type}` | Scarica cert/chiave/csr |
+| POST | `/api/client-certs/{id}/revoke` | Revoca il certificato |
+| POST | `/api/client-certs/{id}/renew` | Rinnova il certificato |
+| GET | `/api/client-certs/stats` | Statistiche |
+| POST | `/api/client-certs/batch` | Importazione CSV in batch |
+| GET | `/api/ocsp/status/{serial}` | Stato OCSP |
+| GET | `/api/crl/download/{format}` | Scarica la CRL |
+
+---
+
+## Stack tecnologico
+
+| Livello | Tecnologie |
+|---------|-----------|
+| **Backend** | Python 3.9+, Flask, Flask-RESTX, APScheduler, Certbot |
+| **Frontend** | HTML5, Tailwind CSS, Vanilla JavaScript, Font Awesome |
+| **SDK Cloud** | Azure SDK, boto3, hvac, infisical-python |
+| **Crittografia** | cryptography (OpenSSL), plugin certbot |
+| **Deployment** | Docker, Docker Compose, Gunicorn, systemd |
+
+---
+
+## Limitazioni principali
+
+1. **Solo Certbot per i certificati server**: esclusivamente challenge DNS-01 ACME
+2. **Archiviazione server centrata sul dominio**: un certificato per directory di dominio
+3. **Nessun database**: un singolo file JSON per la configurazione
+4. **Utilizzo delle chiavi nei certificati server**: nessun controllo sulle estensioni keyUsage/extendedKeyUsage
+
+---
+
+# Architettura dei certificati client
+
+## Panoramica del sistema
+
+```
+
+ Livello Interfaccia Web
+ (dashboard web /client-certificates)
+
+ 
+
+ Livello API
+ (/api/client-certs, /api/ocsp, /api/crl)
+ (endpoint REST con Flask-RESTX)
+
+ 
+
+ Livello Manager
+
+ ClientCertificateManager (ciclo di vita + metadati)
+ OCSPResponder (interrogazioni sullo stato dei certificati)
+ CRLManager (generazione delle liste di revoca)
+ AuditLogger (tracciamento delle operazioni)
+ SimpleRateLimiter (limitazione delle richieste)
+
+ 
+
+ Livello Moduli principali
+
+ PrivateCAGenerator (gestione CA)
+ CSRHandler (validazione e creazione CSR)
+ ClientCertificateManager (operazioni sui certificati)
+ OCSPResponder (risposte di stato)
+ CRLManager (liste di revoca)
+ AuditLogger (registrazione)
+ RateLimitConfig/SimpleRateLimiter (limitazione)
+
+ 
+
+ Livello Crittografia e archiviazione
+
+ Cryptography Library (OpenSSL)
+ Archiviazione filesystem (data/certs/)
+ Backend di archiviazione (Azure, AWS, Vault, ecc.)
+
+```
+
+---
+
+## Componenti principali
+
+### 1. PrivateCAGenerator (`modules/core/private_ca.py`)
+
+**Scopo**: Generare e gestire la Certificate Authority auto-firmata
+
+**Funzionalità principali**:
+- Genera chiavi RSA a 4096 bit per la CA
+- Periodo di validità di 10 anni
+- Certificati auto-firmati con estensioni appropriate
+- Funzionalità di backup e ripristino della CA
+- Capacità di firma CRL
+
+**File creati**:
+- `data/certs/ca/ca.crt` — Certificato CA (PEM)
+- `data/certs/ca/ca.key` — Chiave privata CA (PEM, permessi 0600)
+- `data/certs/ca/ca_metadata.json` — Metadati CA
+- `data/certs/ca/crl.pem` — Lista di revoca dei certificati
+
+**Metodi principali**:
+```python
+initialize() # Inizializzare o caricare la CA esistente
+sign_certificate_request() # Firmare un CSR
+generate_crl() # Generare la CRL dai numeri seriali revocati
+get_crl_pem() # Ottenere la CRL in formato PEM
+```
+
+---
+
+### 2. CSRHandler (`modules/core/csr_handler.py`)
+
+**Scopo**: Validare, analizzare e creare Certificate Signing Request
+
+**Funzionalità principali**:
+- Crea nuovi CSR con chiavi private (2048 o 4096 bit)
+- Valida i CSR codificati in PEM
+- Estrae le informazioni dal CSR (CN, Org, Email, SAN, ecc.)
+- Supporto per i Subject Alternative Name (SAN)
+- Salva il CSR e le coppie di chiavi su disco
+
+**Metodi principali**:
+```python
+create_csr() # Creare un nuovo CSR con chiave privata
+validate_csr_pem() # Validare e caricare un CSR da PEM
+get_csr_info() # Estrarre informazioni da un CSR
+save_csr_and_key() # Salvare CSR e chiave in file
+```
+
+---
+
+### 3. ClientCertificateManager (`modules/core/client_certificates.py`)
+
+**Scopo**: Gestione completa del ciclo di vita dei certificati client
+
+**Funzionalità principali**:
+- Crea certificati (firmati dalla CA o tramite CSR)
+- Elenca/filtra i certificati (per utilizzo, stato, ricerca)
+- Revoca certificati con traccia di audit
+- Rinnova certificati (stesso CN, nuovo numero seriale)
+- Pianificazione del rinnovo automatico
+- Archiviazione dei metadati (JSON per certificato)
+- Supporto per 30.000+ certificati simultanei
+
+**Struttura di archiviazione**:
+```
+data/certs/client/
+ api-mtls/ # Certificati per API mTLS
+ cert-001/
+ cert.crt
+ cert.key
+ cert.csr
+ metadata.json
+ vpn/ # Certificati per VPN
+ cert-002/
+ ...
+ other/ # Altri tipi di utilizzo
+ ...
+```
+
+**Struttura dei metadati** (JSON):
+```json
+{
+ "type": "client_certificate",
+ "identifier": "cert-001",
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "organizational_unit": "Engineering",
+ "country": "US",
+ "state": "California",
+ "locality": "San Francisco",
+ "serial_number": "12345678901234567890",
+ "key_usage": ["digitalSignature", "keyEncipherment"],
+ "extended_key_usage": ["serverAuth", "clientAuth"],
+ "created_at": "2024-10-30T18:00:00Z",
+ "expires_at": "2025-10-30T18:00:00Z",
+ "cert_usage": "api-mtls",
+ "notes": "Production certificate",
+ "revocation": {
+ "revoked": false,
+ "revoked_at": null,
+ "reason_revoked": null
+ },
+ "renewal": {
+ "renewal_enabled": true,
+ "renewal_threshold_days": 30,
+ "last_renewed_at": null
+ }
+}
+```
+
+**Metodi principali**:
+```python
+create_client_certificate() # Creare un nuovo certificato
+list_client_certificates() # Elencare con filtri opzionali
+get_certificate_metadata() # Ottenere i metadati del certificato
+get_certificate_file() # Ottenere il file cert/chiave/csr
+revoke_certificate() # Revocare con motivazione
+renew_certificate() # Rinnovare il certificato
+check_renewals() # Verifica dei rinnovi automatici
+get_statistics() # Ottenere le statistiche di utilizzo
+```
+
+---
+
+### 4. OCSPResponder (`modules/core/ocsp_crl.py`)
+
+**Scopo**: Fornire risposte al protocollo Online Certificate Status Protocol (OCSP)
+
+**Funzionalità principali**:
+- Interroga lo stato del certificato (good/revoked/unknown)
+- Genera risposte OCSP
+- Ricerche di stato in tempo reale
+- Supporto per più tipi di stato
+
+**Stati**:
+- `good` — Il certificato è valido
+- `revoked` — Il certificato è stato revocato
+- `unknown` — Certificato non trovato
+
+**Metodi principali**:
+```python
+get_cert_status() # Ottenere lo stato del certificato
+generate_ocsp_response() # Generare la risposta OCSP
+```
+
+**Formato della risposta**:
+```json
+{
+ "response_status": "successful",
+ "certificate_status": "good|revoked|unknown",
+ "certificate_serial": 12345678,
+ "this_update": "2024-10-30T18:00:00Z",
+ "next_update": null,
+ "responder_name": "CertMate OCSP Responder",
+ "revocation_time": null,
+ "revocation_reason": null
+}
+```
+
+---
+
+### 5. CRLManager (`modules/core/ocsp_crl.py`)
+
+**Scopo**: Generare e distribuire le Certificate Revocation List
+
+**Funzionalità principali**:
+- Genera la CRL con tutti i certificati revocati
+- Distribuisce nei formati PEM e DER
+- Archivia i metadati e le informazioni della CRL
+- Aggiornamenti automatici della CRL
+
+**Metodi principali**:
+```python
+get_revoked_serials() # Ottenere i numeri seriali dei certificati revocati
+update_crl() # Generare/aggiornare la CRL
+get_crl_pem() # Ottenere la CRL in formato PEM
+get_crl_der() # Ottenere la CRL in formato DER
+get_crl_info() # Ottenere i metadati della CRL
+```
+
+---
+
+### 6. AuditLogger (`modules/core/audit.py`)
+
+**Scopo**: Tracciare tutte le operazioni sui certificati per la conformità e il debug
+
+**Funzionalità principali**:
+- Registrazione in formato JSON
+- File di audit persistente
+- Tracciamento di operazioni, utenti, indirizzi IP
+- Interrogazione delle voci per risorsa o periodo
+
+**Formato del registro**:
+```json
+{
+ "timestamp": "2024-10-30T18:00:00Z",
+ "operation": "create|revoke|renew|download|batch_import",
+ "resource_type": "certificate|endpoint",
+ "resource_id": "cert-001",
+ "status": "success|failure|denied",
+ "user": "admin@example.com",
+ "ip_address": "192.168.1.1",
+ "details": {},
+ "error": null
+}
+```
+
+**File di registro**: `logs/audit/certificate_audit.log`
+
+**Metodi principali**:
+```python
+log_certificate_created() # Registrare la creazione del certificato
+log_certificate_revoked() # Registrare la revoca
+log_certificate_renewed() # Registrare il rinnovo
+log_certificate_downloaded() # Registrare i download
+log_batch_operation() # Registrare le operazioni in batch
+log_api_request() # Registrare le richieste API
+get_recent_entries() # Ottenere le ultime voci di audit
+get_entries_by_resource() # Ottenere le voci per una risorsa
+```
+
+---
+
+### 7. Rate Limiting (`modules/core/rate_limit.py`)
+
+**Scopo**: Proteggere l'API dagli abusi con la limitazione del tasso di richieste
+
+**Configurazione**:
+- Predefinito: 100 req/min
+- Creazione certificato: 30 req/min (costoso)
+- Operazioni in batch: 10 req/min (molto costoso)
+- Stato OCSP: 200 req/min (economico)
+- Download CRL: 60 req/min
+
+**Classi principali**:
+```python
+RateLimitConfig # Contenitore di configurazione
+SimpleRateLimiter # Limitatore in memoria
+rate_limit_decorator # Decoratore per endpoint Flask
+```
+
+**Risposta al superamento del limite**:
+```json
+{
+ "error": "Rate limit exceeded",
+ "message": "Too many requests. Please try again later.",
+ "retry_after": 60
+}
+```
+
+Stato HTTP: `429 Too Many Requests`
+
+---
+
+## Flusso dei dati
+
+### Flusso di creazione del certificato
+
+```
+Richiesta Utente/API
+ ↓
+ClientCertificateManager.create_client_certificate()
+ Generare il CSR (o accettare un CSR fornito)
+ Firmare il CSR con la CA privata
+ Creare metadata.json
+ Archiviare i file cert/chiave/csr
+ Registrare nella traccia di audit
+ Restituire i dati del certificato
+ ↓
+Risposta all'Utente
+```
+
+### Flusso di revoca del certificato
+
+```
+Richiesta Utente/API (endpoint di revoca)
+ ↓
+ClientCertificateManager.revoke_certificate()
+ Caricare i metadati del certificato
+ Aggiornare lo stato di revoca
+ Salvare i metadati aggiornati
+ Registrare nella traccia di audit
+ Avviare l'aggiornamento della CRL
+ Restituire il successo
+ ↓
+Risposta all'Utente
+```
+
+### Flusso di interrogazione OCSP
+
+```
+Richiesta OCSP del client (numero seriale)
+ ↓
+OCSPResponder.get_cert_status()
+ Ricercare il certificato per numero seriale
+ Verificare lo stato di revoca
+ Restituire lo stato (good/revoked/unknown)
+ ↓
+OCSPResponder.generate_ocsp_response()
+ Formattare la risposta OCSP
+ Aggiungere i timestamp
+ Restituire la risposta
+ ↓
+Risposta al Client
+```
+
+---
+
+## Architettura di archiviazione
+
+### Struttura delle directory
+
+```
+data/certs/
+  ca/                      # Certificate Authority
+    ca.crt                 # Certificato CA (pubblico)
+    ca.key                 # Chiave privata CA (0600)
+    ca_metadata.json       # Metadati CA
+    crl.pem                # Lista di revoca dei certificati
+
+  client/                  # Certificati client
+    api-mtls/              # Certificati API mTLS
+      cert-001/
+        cert.crt
+        cert.key
+        cert.csr
+        metadata.json
+      ...
+    vpn/                   # Certificati VPN
+      ...
+    other/                 # Altri tipi di utilizzo
+      ...
+
+  crl/                     # Archiviazione CRL
+    (CRL generate)
+```
+
+### File di metadati
+
+Ogni certificato ha un file `metadata.json` contenente:
+- Identificazione del certificato (CN, numero seriale, impronta digitale)
+- Informazioni sul soggetto (Org, email, posizione)
+- Date di validità
+- Stato e cronologia di revoca
+- Configurazione del rinnovo
+- Note personalizzate
+
+---
+
+## Modello di sicurezza
+
+### Protezione delle chiavi
+
+- **Permessi dei file**: 0600 (lettura/scrittura solo per il proprietario)
+- **Formato delle chiavi**: PEM nel formato tradizionale OpenSSL
+- **Cifratura delle chiavi**: chiavi archiviate cifrate a riposo se si utilizzano backend di archiviazione
+
+### Firma dei certificati
+
+- **Algoritmo di firma**: SHA256withRSA
+- **Dimensione della chiave**: RSA a 4096 bit per la CA, 2048/4096 bit per i client
+- **Validità**: configurabile (predefinito 1 anno per i certificati client)
+
+### Controllo degli accessi
+
+- **Autenticazione**: Bearer token su tutti gli endpoint API
+- **Autorizzazione**: basata su token (estendibile con ruoli)
+- **Rate Limiting**: protezione per endpoint
+
+### Traccia di audit
+
+- Tutte le operazioni registrate con timestamp
+- Tracciamento di utente e indirizzo IP
+- File di registro di audit immutabile
+- Interrogabile per la conformità
+
+---
+
+## Scalabilità
+
+### Archiviazione dei certificati
+
+- **Scalabilità lineare**: archiviazione basata su directory
+- **Capacità**: testato con oltre 30.000 certificati
+- **Prestazioni**: scansioni delle directory O(n) efficienti
+
+### Prestazioni dell'API
+
+- **Rate Limiting**: previene l'esaurimento delle risorse
+- **Progettazione stateless**: può eseguire più istanze
+- **Operazioni in batch**: gestisce da 100 a 30.000 certificati per richiesta
+
+### Rinnovo automatico
+
+- **Pianificato**: ogni giorno alle ore 3:00 (configurabile)
+- **Soglia**: 30 giorni prima della scadenza (configurabile)
+- **Progressivo**: continua in caso di errori, registra per la revisione
+
+---
+
+## Considerazioni sul deployment
+
+### Requisiti minimi
+
+- Python 3.9+
+- 100 MB di spazio su disco per la CA e i certificati iniziali
+- 50 MB per i registri di audit per milione di operazioni
+- Basso utilizzo di memoria
+
+### Raccomandazioni per la produzione
+
+- Utilizzare un backend di archiviazione (Azure, AWS, Vault) per l'alta disponibilità
+- Abilitare la registrazione di audit per la conformità
+- Configurare il rate limiting in base al carico
+- Aggiornamenti regolari della CRL (giornalieri o alla revoca)
+- Effettuare il backup delle chiavi CA e dei metadati
+- Monitorare i registri di audit per attività sospette
+
+### Alta disponibilità
+
+Per i deployment multi-istanza:
+1. Utilizzare un backend di archiviazione condiviso per i certificati
+2. Sincronizzare i registri di audit in una posizione centrale
+3. Utilizzare un load balancer con sessioni persistenti
+4. Monitorare i contatori di rate limiting tra le istanze
+
+---
+
+## Punti di integrazione
+
+### Con il sistema principale di CertMate
+
+- Utilizza i backend di archiviazione esistenti di CertMate
+- Integrato nei manager di app.py
+- Integrato nella struttura API Flask-RESTX
+- Pianificato con APScheduler
+
+### Sistemi esterni
+
+- Può esportare certificati tramite API
+- Può interrogare lo stato tramite OCSP
+- Può recuperare la CRL per la validazione
+- Supporta l'integrazione webhook/callback (futuro)
+
+---
+
+## Estensibilità futura
+
+### Miglioramenti previsti
+
+1. **Protezione con password della CA** — Cifrare le chiavi CA con password
+2. **Audit avanzato** — Controllo degli accessi basato sui ruoli
+3. **Notifiche webhook** — Per eventi sui certificati
+4. **Firma di certificati** — Accettare CSR da fonti esterne
+5. **Token hardware** — Supporto PKCS#11 per HSM
+
+### Punti di estensione
+
+1. **Backend di archiviazione** — Già supporta più backend
+2. **Destinazioni di audit** — Può inviare i registri di audit a sistemi esterni
+3. **Middleware API** — Aggiungere autenticazione/autorizzazione personalizzata
+4. **Sistema di notifica** — Integrazione con sistemi di alerting
+
+---
+
+## Monitoraggio e osservabilità
+
+### Metriche principali
+
+- Conteggio dei certificati (totali, attivi, revocati, in scadenza)
+- Prestazioni degli endpoint API
+- Violazioni del rate limit
+- Volume dei registri di audit
+- Tasso di successo/fallimento dei rinnovi automatici
+
+### Controlli di stato
+
+- Disponibilità della CA
+- Funzionamento del registro di audit
+- Reattività del limitatore di velocità
+- Stato di generazione della CRL
+
+---
+
+<div align="center">
+
+[← Torna alla documentazione](./README.md) • [Guida rapida →](./guide.md) • [Riferimento API →](./api.md)
+
+</div>

--- a/docs/it/ca-providers.md
+++ b/docs/it/ca-providers.md
@@ -1,0 +1,259 @@
+# Fornitori di Certificate Authority (CA)
+
+CertMate supporta diversi fornitori di Certificate Authority, consentendoti di scegliere la CA più adatta alle tue esigenze.
+
+---
+
+## Fornitori CA supportati
+
+### Let's Encrypt (Predefinito)
+
+- **Tipo**: Certificati SSL gratuiti e automatizzati
+- **Tipi di certificati**: Domain Validation (DV)
+- **Supporto Wildcard**: Si
+- **EAB Richiesto**: No
+- **Ideale per**: Sviluppo, piccole imprese, progetti personali
+
+**Configurazione:**
+- **Email**: Obbligatoria per le notifiche sui certificati
+
+### Let's Encrypt (Staging)
+
+- **Tipo**: Certificati di test dall'ambiente di staging di Let's Encrypt
+- **Tipi di certificati**: Domain Validation (DV) — NON riconosciuti dai browser
+- **Supporto Wildcard**: Si
+- **EAB Richiesto**: No
+- **Ideale per**: Validare la configurazione DNS, il deployment e il rinnovo senza consumare i rate limit di produzione
+
+Lo staging e una voce di Certificate Authority separata (dalla v2.12.0), non un flag per singolo certificato: selezionala come CA durante la creazione di un certificato, oppure impostala come CA predefinita durante i test. L'email utilizza come fallback l'account Let's Encrypt quando lasciata vuota. La conversione di un certificato di staging in produzione richiede una riemissione con la CA di produzione.
+
+### DigiCert ACME
+
+- **Tipo**: Certificati SSL di livello enterprise
+- **Tipi di certificati**: DV, OV, EV
+- **Supporto Wildcard**: Si
+- **EAB Richiesto**: Si
+- **Ideale per**: Ambienti enterprise, applicazioni commerciali
+
+**Requisiti di configurazione:**
+- **URL directory ACME**: `https://acme.digicert.com/v2/acme/directory`
+- **EAB Key ID**: Fornito da DigiCert
+- **EAB HMAC Key**: Fornita da DigiCert
+- **Email**: Obbligatoria per le notifiche sui certificati
+
+### Actalis
+
+- **Tipo**: Certificati DV gratuiti da 90 giorni di una CA europea (italiana)
+- **Tipi di certificati**: Domain Validation (DV)
+- **Supporto Wildcard**: No (non disponibile tramite ACME)
+- **EAB Richiesto**: Si
+- **Ideale per**: Utenti UE che desiderano un'alternativa europea a Let's Encrypt, ambienti eIDAS
+
+**Requisiti di configurazione:**
+- **URL directory ACME**: `https://acme-api.actalis.com/acme/directory` (fisso, preconfigurato)
+- **EAB Key ID**: Dall'area clienti Actalis
+- **EAB HMAC Key**: Dall'area clienti Actalis
+- **Email**: Obbligatoria per le notifiche sui certificati
+
+**Limiti del piano gratuito:**
+- Solo certificati a dominio singolo — una richiesta con voci SAN viene rifiutata con
+  `Your account only grants single-domain 90-days DV certificates`
+- Validita di 90 giorni
+- Nessun certificato wildcard (i piani SAN a pagamento coprono fino a 5 hostname)
+
+### CA Privata
+
+- **Tipo**: Certificate Authority interna/aziendale
+- **Tipi di certificati**: Privati/Interni
+- **Supporto Wildcard**: Si (dipende dall'implementazione della CA)
+- **EAB Richiesto**: Facoltativo
+- **Ideale per**: Reti interne, ambienti aziendali, sistemi isolati
+
+**Software compatibili:**
+- [step-ca](https://smallstep.com/docs/step-ca/)
+- [Boulder](https://github.com/letsencrypt/boulder)
+- [Pebble](https://github.com/letsencrypt/pebble)
+- Altre CA private compatibili con ACME
+
+**Utilizzo di una CA ACME pubblica tramite la voce CA Privata:**
+
+La voce CA Privata e anche la via d'uscita generica per qualsiasi CA ACME priva di una voce dedicata in CertMate: puntala all'URL della directory della CA e, se la CA impone il binding dell'account, compila l'EAB Key ID e la HMAC Key facoltativi. Ad esempio, Actalis funziona sia tramite la sua voce dedicata (consigliato) sia come CA Privata con:
+
+- **URL directory ACME**: `https://acme-api.actalis.com/acme/directory`
+- **EAB Key ID / HMAC Key**: dall'area clienti Actalis
+- **Certificato CA**: lasciare vuoto (root di fiducia pubblici)
+
+---
+
+## Configurazione
+
+### Tramite interfaccia Web
+
+1. Vai su **Impostazioni**
+2. Scorri fino a **Fornitori di Certificate Authority (CA)**
+3. Seleziona il fornitore CA predefinito
+4. Configura i campi obbligatori
+5. Clicca su **Testa connessione CA** per verificare
+6. Salva le impostazioni
+
+### CA predefinita vs. CA per certificato
+
+Imposta una CA predefinita per tutti i nuovi certificati. Puoi sovrascriverla per singolo certificato durante la creazione:
+
+1. Vai alla pagina **Certificati**
+2. Seleziona la CA desiderata dal menu a tendina **Certificate Authority**
+3. Procedi con la creazione del certificato
+
+### Tramite API
+
+```bash
+# Create certificate with specific CA
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "domain": "example.com",
+    "ca_provider": "digicert"
+  }'
+
+# Test CA connection
+curl -X POST http://localhost:8000/api/settings/test-ca-provider \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ca_provider": "digicert",
+    "config": {
+      "acme_url": "https://acme.digicert.com/v2/acme/directory",
+      "eab_kid": "your_key_id",
+      "eab_hmac": "your_hmac_key",
+      "email": "admin@example.com"
+    }
+  }'
+```
+
+---
+
+## External Account Binding (EAB)
+
+Alcuni fornitori CA (come DigiCert e Actalis) richiedono l'External Account Binding per collegare il client ACME al proprio account CA.
+
+### Cos'e l'EAB?
+
+- **Key ID**: Un identificatore univoco per il tuo account
+- **HMAC Key**: Una chiave segreta utilizzata per firmare le richieste
+
+### Ottenere le credenziali EAB
+
+**DigiCert:**
+1. Accedi al tuo account DigiCert
+2. Vai alle impostazioni ACME
+3. Genera o recupera il tuo EAB Key ID e la HMAC Key
+
+**Actalis:**
+1. Registra un account gratuito su [actalis.com](https://www.actalis.com/)
+2. Nell'area clienti, apri **Manage with ACME**
+3. Recupera il KID e la chiave HMAC sotto **ACME Credentials**
+
+**CA Privata:**
+- **step-ca**: L'EAB puo essere abilitato/disabilitato per provisioner
+- **Boulder**: Di norma richiede EAB per la produzione
+- Consulta la documentazione della tua CA privata per i requisiti specifici
+
+---
+
+## Attendibilita dei certificati SSL
+
+### CA pubbliche (Let's Encrypt, DigiCert)
+
+I certificati sono automaticamente riconosciuti dai browser e dai sistemi operativi.
+
+### CA private
+
+Affinche i certificati di una CA privata siano ritenuti attendibili:
+1. Installa il certificato root della CA sui sistemi client
+2. Configura le applicazioni per una trust personalizzata
+3. Importa il certificato root nei trust store dei browser
+
+Puoi facoltativamente fornire il certificato root della CA in CertMate per la verifica della catena di fiducia durante la creazione del certificato.
+
+---
+
+## Risoluzione dei problemi
+
+### Let's Encrypt
+- **Certificato non attendibile dopo l'emissione**: Verifica se il certificato e stato emesso dalla CA di staging — seleziona la voce di produzione "Let's Encrypt" e riemettilo
+- **Rate limit raggiunto**: Passa alla voce CA "Let's Encrypt (Staging)" durante i test
+- **Email valida**: Assicurati che il formato dell'email sia corretto
+
+### DigiCert
+- **Credenziali EAB non valide**: Verifica la Key ID e la HMAC Key
+- **Account non autorizzato**: Assicurati che ACME sia abilitato sul tuo account DigiCert
+- **URL ACME errato**: Verifica l'URL della directory con il supporto DigiCert
+
+### Actalis
+- **`Your account only grants single-domain 90-days DV certificates`**: Il piano gratuito rifiuta le richieste SAN/multi-dominio — emetti un certificato per hostname oppure passa a un piano superiore
+- **Credenziali EAB non valide**: Recupera credenziali aggiornate dall'area clienti sotto Manage with ACME
+- **Wildcard rifiutato**: I certificati wildcard non sono disponibili tramite ACME su Actalis
+
+### CA Privata
+- **URL ACME non raggiungibile**: Verifica la connettivita di rete
+- **Certificato CA non valido**: Verifica il formato PEM e la validita
+- **EAB mismatch**: Controlla se l'EAB e richiesto dalla tua CA
+
+### Generale
+- Assicurati che il provider DNS sia configurato correttamente
+- Verifica la proprieta del dominio e la propagazione DNS
+- Controlla le regole del firewall per la porta ACME (di solito 443)
+
+---
+
+## Migrazione tra CA
+
+1. **I nuovi certificati** utilizzano la nuova CA predefinita
+2. **I certificati esistenti** continuano a usare la CA originale fino al rinnovo
+3. **Migrazione forzata**: Rinnova manualmente per passare alla nuova CA
+
+**Best practice:**
+- Testa la nuova configurazione CA prima di impostarla come predefinita
+- Pianifica la migrazione durante le finestre di manutenzione
+- Conserva backup dei certificati esistenti
+- Monitora la validita dopo la migrazione
+
+---
+
+## Considerazioni sulla sicurezza
+
+- Le chiavi HMAC EAB non vengono visualizzate dopo il salvataggio
+- Le chiavi private vengono generate localmente e non vengono mai trasmesse
+- Utilizza HTTPS per tutte le comunicazioni con le CA
+- Valuta l'uso di una VPN per l'accesso alla CA privata
+
+---
+
+## Risorse
+
+### Let's Encrypt
+- [Documentazione](https://letsencrypt.org/docs/)
+- [Rate Limit](https://letsencrypt.org/docs/rate-limits/)
+- [Ambiente di staging](https://letsencrypt.org/docs/staging-environment/)
+
+### DigiCert
+- [Documentazione ACME](https://docs.digicert.com/certificate-tools/acme-user-guide/)
+- [Configurazione account](https://docs.digicert.com/certificate-tools/acme-user-guide/acme-account-setup/)
+
+### Actalis
+- [Come abilitare ACME](https://guide.actalis.com/ssl/activation/acme)
+- [FAQ ACME](https://guide.actalis.com/faq/SSL/ACME)
+
+### CA Privata
+- [Documentazione step-ca](https://smallstep.com/docs/step-ca/)
+- [Progetto Boulder](https://github.com/letsencrypt/boulder)
+- [Server di test Pebble](https://github.com/letsencrypt/pebble)
+
+---
+
+<div align="center">
+
+[← Torna alla documentazione](./README.md) • [Provider DNS →](./dns-providers.md) • [Docker →](./docker.md)
+
+</div>

--- a/docs/it/compliance.md
+++ b/docs/it/compliance.md
@@ -1,0 +1,53 @@
+# Conformità e traccia di audit
+
+Questa pagina mette in relazione la traccia di audit di CertMate con i regimi che gli operatori chiedono più spesso — l'AI Act dell'UE, NIS2 e ISO/IEC 42001 — quando lasciano che un agente IA/MCP gestisca i certificati su un calendario.
+
+> **Da leggere prima.** CertMate è uno strumento MIT self-hosted a istanza singola. **Non** è un sistema di IA, **non** è un sistema di IA ad alto rischio, **non** è un'entità regolamentata e non "si conforma a" né "certifica" nulla. Gli obblighi di conformità ricadono sull'**operatore** che lo utilizza. Ciò che CertMate fornisce sono **artefatti probatori** che un operatore può usare per i *propri* obblighi. Ogni affermazione di seguito significa "consente all'operatore di dimostrare X", con i limiti esplicitamente indicati.
+
+---
+
+## Cosa fornisce la traccia di audit oggi
+
+- **Attribution.** Ogni azione del ciclo di vita dei certificati — creazione, rinnovo, riemissione, deploy, attivazione/disattivazione del rinnovo automatico e rinnovi pianificati non presidiati — viene registrata con un `actor` strutturato (utente umano vs API token vs agente IA, fino all'ID della chiave API) e un `trigger` (manuale, API, agente o job dello scheduler). Le azioni di un agente IA sono distinguibili da quelle di un umano, a condizione che l'agente utilizzi una chiave con flag `is_agent`. Vedere [API: Audit Logging](./api.md#audit-logging) e la [guida MCP](./mcp.md#audit-attribution).
+- **Prova di integrità.** Le voci vengono scritte in una hash chain SHA-256 in append-only (`data/audit/certificate_audit.chain.jsonl`). Qualsiasi modifica, eliminazione o riordinamento da parte di chi non può ricalcolare la chain è rilevabile e localizzabile.
+- **Verifica indipendente.** Un verificatore autonomo (`python -m modules.core.audit_verify`) ricalcola la chain e restituisce PASS/FAIL senza dover eseguire o fidarsi di CertMate; `GET /api/audit/verify` espone lo stesso controllo tramite API.
+- **Export firmato e verificabile da terze parti.** L'istanza firma la testa della chain (checkpoint periodici) e `GET /api/audit/export` produce un bundle firmato con Ed25519. Un revisore lo verifica al di fuori della macchina, fissando la chiave pubblica dell'istanza (`GET /api/audit/public-key`) fuori banda — dimostrando sia che il record non è stato modificato sia quale istanza lo ha prodotto.
+
+---
+
+## Corrispondenza con i regimi
+
+### NIS2 (Direttiva (UE) 2022/2555) — la corrispondenza più forte
+
+- **A cosa aiuta.** Le operazioni sui certificati modificano la postura di fiducia dei servizi, quindi sono eventi rilevanti per la sicurezza. CertMate produce un record infalsificabile, attribuito e con timestamp di ogni operazione, oltre a una verifica indipendente — utilizzabile come parte delle pratiche di logging (Art. 21) e di documentazione degli incidenti (Art. 23) dell'operatore.
+- **Limite.** NIS2 vincola le **entità** essenziali/importanti, non gli strumenti software. CertMate fornisce log e un verificatore che l'operatore può usare; non valuta, monitora né segnala incidenti, e l'essere un'entità in perimetro (e rispettare NIS2 nella sua totalità) è responsabilità dell'operatore.
+
+### AI Act UE — Articolo 50 trasparenza (solo nello spirito; la corrispondenza più debole)
+
+- **A cosa aiuta.** Quando un agente IA gestisce la PKI in modo autonomo, il record porta un marcatore esplicito `actor.kind="agent"` più la sessione dell'agente, permettendo all'operatore di dimostrare a posteriori quali modifiche sono state effettuate da un agente IA rispetto a un umano, sotto quale identità e con quale trigger — a supporto dello spirito di trasparenza e supervisione umana dell'Atto.
+- **Limite.** Gli obblighi dell'Art. 50 ricadono sui **fornitori/deployer di sistemi di IA** e riguardano la divulgazione alle persone fisiche che interagiscono con l'IA. Un agente che rinnova certificati TLS non è un caso tipico dell'Art. 50, e CertMate è uno strumento, non un sistema di IA. Ci allineiamo solo allo spirito di trasparenza; CertMate **non** soddisfa l'Art. 50 per conto di nessuno.
+
+### ISO/IEC 42001 (Sistema di gestione dell'IA) — registrazioni operative
+
+- **A cosa aiuta.** I record attribuiti e infalsificabili costituiscono prove oggettive che un agente IA ha eseguito specifiche azioni sui certificati — utilizzabili per i controlli di registrazione operativa e tracciabilità del proprio AIMS dell'operatore.
+- **Limite.** ISO 42001 certifica il sistema di gestione di un'organizzazione, non uno strumento. CertMate non è certificato ISO 42001 e non può certificare l'operatore; produce record che l'operatore può presentare come prova per i propri controlli.
+
+---
+
+## Limiti onesti (non interpretare in modo eccessivo)
+
+- **La chiave di firma non vincola l'operatore.** Un bundle di export firmato (e i checkpoint periodici firmati) consentono a una terza parte di verificare, al di fuori della macchina, quale istanza ha prodotto il record e che non è stato modificato — per chiunque **non** detenga la chiave di firma. Ma l'operatore detiene la chiave e potrebbe ri-firmare una chain riscritta. Vincolare completamente l'operatore richiede l'invio dei checkpoint firmati verso un sink esterno in append-only (**ancoraggio esterno opzionale — una funzionalità pianificata, non ancora rilasciata**). Considerare la garanzia attuale come "autenticità, ordinamento e attribuzione all'istanza delle voci registrate", verificabile in modo indipendente da una terza parte che detiene una copia firmata esportata.
+- **Autenticità, non completezza.** Le scritture di audit sono best-effort e non bloccano mai un'operazione sui certificati; la chain prova che le voci registrate sono autentiche e ordinate, e un `seq` mancante all'interno prova un'eliminazione, ma una scrittura che ha fallito prima di essere registrata non lascia alcuna voce da verificare.
+- **Il troncamento in coda richiede un riferimento esterno.** La rimozione di voci dalla **fine** di una singola chain lascia una chain più corta ma internamente coerente che verifica comunque come integra. I checkpoint firmati e i bundle di export sono gli anchor per rilevare questo: un export firmato successivo con meno voci di uno precedente (o di un checkpoint in possesso di un revisore) rivela il troncamento. Un singolo export non può, da solo, provare che nulla è stato rimosso dalla fine — conservare export firmati successivi, oppure attendere l'ancoraggio esterno opzionale, se si necessita di questa garanzia.
+- **L'header di sessione dell'agente è una dichiarazione del client.** Viene registrato per correlazione ma è fornito dal client; l'identità attendibile è la chiave API autenticata.
+- **Limite storico.** La chain inizia quando la funzionalità viene abilitata per la prima volta; la cronologia `.log` precedente non fa parte della chain verificabile.
+
+Gli export firmati che un revisore esterno può fissare a una chiave pubblica sono disponibili oggi. Se i tuoi obblighi richiedono di vincolare l'operatore *stesso* — in modo che nemmeno il detentore della chiave possa riscrivere la cronologia senza essere rilevato — è necessario l'ancoraggio esterno opzionale dei checkpoint firmati verso un sink append-only fuori dalla macchina, che è pianificato ma non ancora rilasciato. Verificarne lo stato prima di farvi affidamento.
+
+---
+
+<div align="center">
+
+[← Torna alla documentazione](./README.md)
+
+</div>

--- a/docs/it/deploy-hooks.md
+++ b/docs/it/deploy-hooks.md
@@ -1,0 +1,293 @@
+# Deploy Hook
+
+Chiude [#117](https://github.com/fabriziosalmi/certmate/issues/117).
+
+I deploy hook sono brevi comandi shell che CertMate esegue **dopo** il rilascio, il rinnovo o la revoca di un certificato. Usali per ricaricare servizi, inviare il nuovo certificato a un load balancer, inviare una notifica, o qualsiasi altra azione necessaria a seguito di una esecuzione riuscita di certbot.
+
+Questa guida illustra:
+
+1. [Cos'è un hook](#cosè-un-hook)
+2. [Configurazione degli hook (UI + JSON)](#configurazione-degli-hook)
+3. [Variabili d'ambiente passate al comando](#variabili-dambiente-passate-al-comando)
+4. [Attivazione manuale](#attivazione-manuale)
+5. [Modello di sicurezza: perché alcuni comandi vengono rifiutati](#modello-di-sicurezza)
+6. [Ricette comuni](#ricette-comuni)
+7. [Audit, cronologia e debug](#audit-cronologia-e-debug)
+
+---
+
+## Cos'è un hook
+
+Un hook è un oggetto JSON con cinque campi:
+
+| Campo | Tipo | Obbligatorio | Note |
+|---|---|---|---|
+| `id` | string | sì | Identificatore stabile (un UUID va bene; l'UI ne genera uno automaticamente). Usato da `/api/deploy/test/<id>`. |
+| `name` | string | sì | Etichetta leggibile mostrata nell'UI e nel log di audit. |
+| `command` | string | sì | Un singolo comando shell (`sh -c`). Max 1024 caratteri. Vedi [sicurezza](#modello-di-sicurezza). |
+| `enabled` | boolean | no | Predefinito `true`. Gli hook disabilitati vengono ignorati durante l'attivazione automatica ma possono ancora essere testati manualmente. |
+| `timeout` | integer | no | Secondi. Predefinito 30, limitato al `MAX_TIMEOUT` di sistema (attualmente 300). |
+| `on_events` | string array | no | Sottoinsieme di `["created", "renewed", "revoked"]`. Se assente, l'hook viene eseguito per tutti e tre. |
+
+Gli hook si trovano sotto due chiavi in `deploy_hooks`:
+
+- **`global_hooks`** — si attivano per ogni dominio. Ideale per "ricaricare nginx dopo qualsiasi modifica al certificato".
+- **`domain_hooks`** — indicizzati per nome di dominio esatto. Ideale per "inviare il certificato LB di `api.example.com` su S3 dopo il rinnovo di quel certificato specifico".
+
+```jsonc
+{
+  "deploy_hooks": {
+    "enabled": true,
+    "global_hooks": [
+      {
+        "id": "5f8...",
+        "name": "Ricarica nginx",
+        "command": "/usr/sbin/nginx -s reload",
+        "enabled": true,
+        "timeout": 30,
+        "on_events": ["created", "renewed"]
+      }
+    ],
+    "domain_hooks": {
+      "api.example.com": [
+        {
+          "id": "9b1...",
+          "name": "Invia al LB",
+          "command": "/opt/scripts/push-cert-to-lb.sh",
+          "enabled": true,
+          "timeout": 120,
+          "on_events": ["renewed"]
+        }
+      ]
+    }
+  }
+}
+```
+
+Se `enabled` al livello superiore è `false`, nessun hook viene eseguito durante gli eventi del certificato. I test manuali (`POST /api/deploy/test/<id>`) continuano a funzionare — utile per iterare su un hook prima di attivare l'interruttore principale.
+
+---
+
+## Configurazione degli hook
+
+### Tramite UI
+
+`Impostazioni → Deploy Hook`. Attiva/disattiva l'interruttore **Abilitato**, quindi aggiungi hook globali o per dominio. Ogni riga ha:
+
+- nome + comando + timeout + caselle di controllo degli eventi
+- un pulsante **Test** (esegue l'hook su un dominio sintetico `test.example.com` con `CERTMATE_EVENT=manual`)
+- interruttore di abilitazione/disabilitazione
+- eliminazione
+
+Salva le impostazioni per rendere le modifiche persistenti.
+
+### Tramite API
+
+```bash
+# Leggere la configurazione attuale
+curl -H "Authorization: Bearer $TOKEN" \
+  https://certmate.local/api/deploy/config
+
+# Sostituire la configurazione (scrittura completa del documento — passa l'intero dizionario deploy_hooks)
+curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d @hooks.json https://certmate.local/api/deploy/config
+```
+
+Il POST sostituisce l'intero blocco `deploy_hooks`; esegui il merge lato client se vuoi preservare le voci esistenti.
+
+---
+
+## Variabili d'ambiente passate al comando
+
+Ogni invocazione imposta queste variabili nell'ambiente del processo dell'hook:
+
+| Variabile | Valore di esempio |
+|---|---|
+| `CERTMATE_DOMAIN` | `api.example.com` |
+| `CERTMATE_CERT_PATH` | `/app/certificates/api.example.com/cert.pem` |
+| `CERTMATE_KEY_PATH` | `/app/certificates/api.example.com/privkey.pem` |
+| `CERTMATE_FULLCHAIN_PATH` | `/app/certificates/api.example.com/fullchain.pem` |
+| `CERTMATE_CHAIN_PATH` | `/app/certificates/api.example.com/chain.pem` (solo intermediari, senza il certificato foglia — per i target che richiedono la chain come file separato) |
+| `CERTMATE_EVENT` | `created` / `renewed` / `revoked` / `manual` |
+| `CERTMATE_DRY_RUN` | Impostato a `1` solo durante il dry-run; assente altrimenti. |
+
+Il tuo comando può fare riferimento a queste variabili come `$CERTMATE_DOMAIN`, `"$CERTMATE_FULLCHAIN_PATH"`, ecc. I valori vengono passati tramite l'ambiente, non per interpolazione di stringa, quindi il quoting funziona come in qualsiasi shell normale.
+
+L'hook viene eseguito come utente del processo CertMate (nell'immagine Docker: `certmate`, UID/GID 1000:1000) all'interno del container. Tutto ciò che esegui con `cp`, `curl`, `ssh`, ecc. deve essere raggiungibile da lì.
+
+---
+
+## Attivazione manuale
+
+Due modi per attivare un hook al di fuori del normale ciclo di vita del certificato:
+
+### Test per singolo hook (admin)
+
+```bash
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  https://certmate.local/api/deploy/test/<hook_id>
+```
+
+Esegue solo l'hook con quell'`id`, sul dominio sintetico `test.example.com`, con `CERTMATE_EVENT=manual`. Bypassa il filtro `on_events` — utile per "questo comando funziona davvero?".
+
+### Eseguire tutti gli hook per un dominio (admin)
+
+```bash
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  https://certmate.local/api/certificates/api.example.com/deploy
+```
+
+Attiva tutti gli hook globali + specifici per il dominio abilitati per `api.example.com` con `CERTMATE_EVENT=manual`, ignorando `on_events`. Restituisce un riepilogo strutturato:
+
+```jsonc
+{
+  "ok": true,
+  "total": 3,
+  "succeeded": 2,
+  "failed": 1,
+  "results": [
+    {"hook_name": "Ricarica nginx", "exit_code": 0, "duration_ms": 142, ...},
+    ...
+  ]
+}
+```
+
+Questo è ciò che il pulsante **Esegui Deploy Hook ora** nel pannello di dettaglio del certificato richiama.
+
+---
+
+## Modello di sicurezza
+
+Gli hook sono esecuzione di codice arbitrario per definizione — questa è la funzionalità. Per limitare il raggio d'azione, il campo command viene validato **al momento del salvataggio e nuovamente a runtime** (difesa in profondità) e rifiutato se contiene:
+
+### Pattern shell bloccati
+
+| Pattern | Motivo |
+|---|---|
+| `` ` `` (backtick) | sostituzione di comando |
+| `$(...)` | sostituzione di comando |
+| `${...}` | espansione di parametro (l'espansione delle variabili d'ambiente è consentita — solo la forma `${...}` è bloccata) |
+| `&&` / `\|\|` | concatenazione logica |
+| `;` | separatore di istruzione |
+| `\|` | pipe |
+| `\r` / `\n` | newline (impedisce a `sh -c` di interpretarli come `;`) |
+| `> /` (redirect verso percorso assoluto) | impedisce la sovrascrittura di file di sistema |
+| `<<` | here-doc |
+| `eval`, `source`, `. /` | builtin shell che caricano codice arbitrario |
+
+Se hai bisogno di uno di questi, inserisci la logica in un file script all'interno del container e richiama lo script direttamente:
+
+```sh
+/opt/scripts/deploy.sh
+```
+
+### Riferimenti a file bloccati
+
+I riferimenti ai file sensibili di CertMate vengono rifiutati (senza distinzione tra maiuscole e minuscole):
+
+`settings.json`, `api_bearer_token`, `client_secret`, `vault_token`, `.env`, `private*key`, `.pem`
+
+Quindi `cat $CERTMATE_FULLCHAIN_PATH` è accettabile (la variabile viene espansa dalla shell, la stringa letterale `.pem` non compare in `command`), ma `cat /app/data/settings.json` verrebbe rifiutato al salvataggio.
+
+### Cosa è consentito
+
+- **Comandi semplici**: `/usr/sbin/nginx -s reload`, `systemctl reload haproxy`
+- **Richieste curl (webhook)**: `curl -X POST -H "Content-Type: application/json" https://hooks.slack.com/...`
+- **Espansione di variabili negli argomenti**: `curl -d "domain=$CERTMATE_DOMAIN" https://...`
+- **Payload JSON con `$VAR` (senza `${}`)**: `curl -d '{"domain":"$CERTMATE_DOMAIN"}' ...`
+- **Invocazione di script singolo**: `/opt/scripts/deploy.sh "$CERTMATE_DOMAIN"`
+
+Se un comando che prima potevi salvare ora genera `Command blocked at runtime: contains dangerous shell metacharacters`, consulta le note di versione — il validatore è stato rafforzato nella v2.4.0 e leggermente allentato nella v2.4.1+.
+
+---
+
+## Ricette comuni
+
+### Ricaricare nginx (globale, tutti gli eventi)
+
+```sh
+/usr/sbin/nginx -t && /usr/sbin/nginx -s reload
+```
+
+(Nota: `&&` è bloccato. Racchiudi questo in uno script: `/opt/scripts/reload-nginx.sh`.)
+
+### Ricaricare haproxy
+
+```sh
+systemctl reload haproxy
+```
+
+### Inviare a un webhook Slack
+
+```sh
+curl -X POST -H 'Content-Type: application/json' -d "{\"text\":\"Cert renewed: $CERTMATE_DOMAIN\"}" https://hooks.slack.com/services/XXX/YYY/ZZZ
+```
+
+### Sincronizzare il certificato su un host remoto
+
+(Da racchiudere in uno script — `;` e `&&` non sono consentiti inline.)
+
+```sh
+/opt/scripts/sync-cert.sh
+```
+
+Dove `sync-cert.sh` è:
+
+```sh
+#!/bin/sh
+set -eu
+scp "$CERTMATE_FULLCHAIN_PATH" "$CERTMATE_KEY_PATH" deploy@lb:/etc/ssl/$CERTMATE_DOMAIN/
+ssh deploy@lb 'systemctl reload haproxy'
+```
+
+### Ignorare gli hook durante il dry-run
+
+Nel tuo script:
+
+```sh
+[ -n "${CERTMATE_DRY_RUN:-}" ] && { echo "dry run, skipping"; exit 0; }
+```
+
+---
+
+## Audit, cronologia e debug
+
+### Feed di attività
+
+`GET /api/deploy/history?limit=50` e la scheda **Attività** nell'UI mostrano le ultime N esecuzioni di hook con: nome dell'hook, dominio, evento, codice di uscita, durata, stdout/stderr (troncati a 4096 byte ciascuno) e timestamp.
+
+### Console di debug
+
+Impostazioni → Deploy Hook dispone di una console di debug (pulsante di attivazione in basso a destra) che trasmette gli eventi `loadConfig` / `saveConfig` / `testHook` lato client. Utile quando si itera sull'UI.
+
+### Log di audit
+
+Ogni esecuzione di hook scrive una voce `operation: deploy_hook` nel log di audit con stato `success`/`failure` più il nome dell'hook, il codice di uscita e la durata. Visibile tramite la scheda Attività e `/api/audit`.
+
+### Errori comuni
+
+| Sintomo | Causa probabile |
+|---|---|
+| `Hook not found` | L'ID dell'hook nella richiesta di test non corrisponde a nessun hook nella configurazione salvata (l'UI era obsoleta o l'hook è stato appena eliminato). Aggiorna la pagina. |
+| `Command blocked at runtime` | Uno dei [pattern bloccati](#pattern-shell-bloccati) ha superato il salvataggio. Sposta la logica problematica in un file script. |
+| `exit code 127` | Comando non trovato all'interno del container (es. `nginx` non è nel `$PATH`). Usa percorsi assoluti o installa il binario nell'immagine. |
+| `timeout after 30s` | L'hook ha superato il suo `timeout`. Aumentalo (max 300s) o sposta il lavoro in uno script in background. |
+| `Deploy hooks disabled` | `deploy_hooks.enabled` è `false`. Attiva l'interruttore principale in Impostazioni. |
+| `No hooks configured for <domain>` | Si tenta di eseguire hook per un dominio senza hook globali E senza voce sotto `domain_hooks[<domain>]`. Aggiungi un hook (o chiama `/api/deploy/test/<id>` per uno specifico). |
+
+---
+
+## Vedi anche
+
+- [`modules/core/deployer.py`](../modules/core/deployer.py) — implementazione
+- [`modules/web/settings_routes.py`](../modules/web/settings_routes.py) — endpoint `/api/deploy/*`
+- [`templates/partials/settings_deploy.html`](../templates/partials/settings_deploy.html) — partial UI
+- [`static/js/settings-deploy.js`](../static/js/settings-deploy.js) — componente Alpine
+
+---
+
+<div align="center">
+
+[← Torna alla documentazione](./README.md)
+
+</div>

--- a/docs/it/dns-providers.md
+++ b/docs/it/dns-providers.md
@@ -1,0 +1,822 @@
+# Provider DNS
+
+CertMate supporta un'ampia gamma di provider DNS per le challenge DNS-01 di Let's Encrypt tramite plugin certbot individuali. La lista completa si trova nella tabella seguente.
+
+---
+
+## Provider supportati
+
+| Provider | Plugin | Credenziali richieste | Categoria |
+|----------|--------|-----------------------|-----------|
+| **Cloudflare** | `certbot-dns-cloudflare` | API Token | Cloud principale |
+| **AWS Route53** | `certbot-dns-route53` | Access Key, Secret Key | Cloud principale |
+| **Azure DNS** | `certbot-dns-azure` | Service Principal | Cloud principale |
+| **Google Cloud DNS** | `certbot-dns-google` | Service Account JSON | Cloud principale |
+| **PowerDNS** | `certbot-dns-powerdns` | URL API, Chiave API | Enterprise |
+| **DNS Made Easy** | `certbot-dns-dnsmadeeasy` | Chiave API, Secret Key | Enterprise |
+| **NS1** | `certbot-dns-nsone` | Chiave API | Enterprise |
+| **DigitalOcean** | `certbot-dns-digitalocean` | API Token | Cloud |
+| **Linode** (Akamai Connected Cloud) | `certbot-dns-linode` | Chiave API | Cloud |
+| **Akamai Edge DNS** | `certbot-plugin-edgedns` | EdgeGrid `.edgerc` (client_token, client_secret, access_token, host) | Enterprise |
+| **Vultr** | `certbot-dns-vultr` | Chiave API | Cloud |
+| **Hetzner (DNS legacy)** | `certbot-dns-hetzner` | API Token | Cloud |
+| **Hetzner Cloud** | `certbot-dns-hetzner-cloud` | API Token | Cloud |
+| **Gandi** | `certbot-dns-gandi` | API Token | Registrar |
+| **Namecheap** | `certbot-dns-namecheap` | Nome utente, Chiave API | Registrar |
+| **Porkbun** | `certbot-dns-porkbun` | Chiave API, Secret Key | Registrar |
+| **GoDaddy** | `certbot-dns-godaddy` | Chiave API, Secret | Registrar |
+| **OVH** | `certbot-dns-ovh` | Credenziali API | Regionale |
+| **Infomaniak** | `certbot-dns-infomaniak` | API Token | Regionale |
+| **ArvanCloud** | `certbot-dns-arvancloud` | Chiave API | Regionale |
+| **RFC2136** | `certbot-dns-rfc2136` | Server DNS, Chiave TSIG | Protocollo standard |
+| **ACME-DNS** | `certbot-acme-dns` | URL API, Nome utente, Password | Specializzato |
+| **Hurricane Electric** | `certbot-dns-he-ddns` | Nome utente, Password | DNS gratuito |
+| **Dynu** | `certbot-dns-dynudns` | API Token | DNS dinamico |
+| **DuckDNS** | `certbot-dns-duckdns` | Token account | DDNS gratuito (senza dominio) |
+| **deSEC** | `certbot-dns-desec` | API Token | Gratuito, UE (DE), DNSSEC — delegare NS a `ns1.desec.io` / `ns2.desec.org` |
+| **Scaleway** | `certbot-dns-scaleway` | Chiave segreta API | Cloud sovrano UE (FR) — plugin della community (alpha), installare separatamente: `pip install certbot-dns-scaleway` |
+| **Script personalizzato** | nessuno (certbot `--manual`) | Percorso script auth (+ script cleanup opzionale) | Porta il tuo |
+
+---
+
+## Configurazione
+
+### Tramite interfaccia Web
+
+1. Vai su **Impostazioni**
+2. Seleziona il provider DNS dall'elenco a discesa
+3. Inserisci le credenziali richieste
+4. Salva le impostazioni
+
+### Tramite API
+
+```bash
+curl -X POST http://localhost:8000/api/settings \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dns_provider": "cloudflare",
+    "dns_providers": {
+      "cloudflare": {
+        "api_token": "your_cloudflare_token"
+      }
+    }
+  }'
+```
+
+---
+
+## Esempi di configurazione per provider
+
+### Cloudflare
+
+```json
+{
+  "dns_provider": "cloudflare",
+  "dns_providers": {
+    "cloudflare": {
+      "api_token": "your_cloudflare_api_token"
+    }
+  }
+}
+```
+
+### AWS Route53
+
+```json
+{
+  "dns_provider": "route53",
+  "dns_providers": {
+    "route53": {
+      "access_key_id": "AKIAIOSFODNN7EXAMPLE",
+      "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      "region": "us-east-1"
+    }
+  }
+}
+```
+
+### Azure DNS
+
+```json
+{
+  "dns_provider": "azure",
+  "dns_providers": {
+    "azure": {
+      "subscription_id": "your_subscription_id",
+      "resource_group": "your_resource_group",
+      "tenant_id": "your_tenant_id",
+      "client_id": "your_client_id",
+      "client_secret": "your_client_secret"
+    }
+  }
+}
+```
+
+### Google Cloud DNS
+
+```json
+{
+  "dns_provider": "google",
+  "dns_providers": {
+    "google": {
+      "project_id": "your_project_id",
+      "service_account_key": "{ ... service account JSON ... }"
+    }
+  }
+}
+```
+
+### PowerDNS
+
+```json
+{
+  "dns_provider": "powerdns",
+  "dns_providers": {
+    "powerdns": {
+      "api_url": "https://your-powerdns-server:8081",
+      "api_key": "your_powerdns_api_key"
+    }
+  }
+}
+```
+
+### Vultr
+
+```json
+{
+  "dns_provider": "vultr",
+  "dns_providers": {
+    "vultr": {
+      "api_key": "your_vultr_api_key"
+    }
+  }
+}
+```
+
+### DNS Made Easy
+
+```json
+{
+  "dns_provider": "dnsmadeeasy",
+  "dns_providers": {
+    "dnsmadeeasy": {
+      "api_key": "your_api_key",
+      "secret_key": "your_secret_key"
+    }
+  }
+}
+```
+
+### NS1
+
+```json
+{
+  "dns_provider": "nsone",
+  "dns_providers": {
+    "nsone": {
+      "api_key": "your_nsone_api_key"
+    }
+  }
+}
+```
+
+### RFC2136
+
+Per server DNS BIND o altri compatibili RFC2136 (incluso **Technitium DNS Server**):
+
+```json
+{
+  "dns_provider": "rfc2136",
+  "dns_providers": {
+    "rfc2136": {
+      "nameserver": "ns.example.com",
+      "tsig_key": "mykey",
+      "tsig_secret": "base64-encoded-secret",
+      "tsig_algorithm": "HMAC-SHA512"
+    }
+  }
+}
+```
+
+> **Technitium DNS**: abilita Dynamic Updates in Zone Options, crea una chiave TSIG (ad es. `certmate-key` con HMAC-SHA512), quindi utilizza il segreto generato nella configurazione sopra.
+
+### Hetzner (API DNS legacy)
+
+> **Avviso di deprecazione:** L'API console DNS Hetzner verrà dismessa a maggio 2025. I nuovi utenti devono utilizzare il provider **Hetzner Cloud** indicato di seguito. Gli utenti esistenti devono migrare a `hetzner-cloud` prima della data di dismissione. Consulta la [pagina di stato Hetzner](https://status.hetzner.com/incident/c2146c42-6dd2-4454-916a-19f07e0e5a44) per i dettagli.
+
+```json
+{
+  "dns_provider": "hetzner",
+  "dns_providers": {
+    "hetzner": {
+      "api_token": "your_hetzner_dns_api_token"
+    }
+  }
+}
+```
+
+### Hetzner Cloud
+
+Utilizza la nuova [API Hetzner Cloud](https://docs.hetzner.cloud/reference/cloud) che sostituisce la console DNS Hetzner deprecata. Questo è il provider consigliato per tutti gli utenti Hetzner.
+
+```json
+{
+  "dns_provider": "hetzner-cloud",
+  "dns_providers": {
+    "hetzner-cloud": {
+      "api_token": "your_hetzner_cloud_api_token"
+    }
+  }
+}
+```
+
+> Genera un API token Hetzner Cloud dalla [Console Hetzner Cloud](https://console.hetzner.cloud/) nella sezione token API del tuo progetto. Il token deve avere i permessi di lettura/scrittura DNS.
+
+### Infomaniak
+
+```json
+{
+  "dns_provider": "infomaniak",
+  "dns_providers": {
+    "infomaniak": {
+      "api_token": "your_infomaniak_api_token"
+    }
+  }
+}
+```
+
+> Ottieni l'API token da Infomaniak Manager (sezione API con scope "Domain").
+
+### Porkbun
+
+```json
+{
+  "dns_provider": "porkbun",
+  "dns_providers": {
+    "porkbun": {
+      "api_key": "your_porkbun_api_key",
+      "secret_key": "your_porkbun_secret_key"
+    }
+  }
+}
+```
+
+### GoDaddy
+
+```json
+{
+  "dns_provider": "godaddy",
+  "dns_providers": {
+    "godaddy": {
+      "api_key": "your_godaddy_api_key",
+      "secret": "your_godaddy_secret"
+    }
+  }
+}
+```
+
+### OVH
+
+```json
+{
+  "dns_provider": "ovh",
+  "dns_providers": {
+    "ovh": {
+      "endpoint": "ovh-eu",
+      "application_key": "your_app_key",
+      "application_secret": "your_app_secret",
+      "consumer_key": "your_consumer_key"
+    }
+  }
+}
+```
+
+### Hurricane Electric
+
+```json
+{
+  "dns_provider": "he-ddns",
+  "dns_providers": {
+    "he-ddns": {
+      "username": "your_he_username",
+      "password": "your_he_password"
+    }
+  }
+}
+```
+
+### Dynu
+
+```json
+{
+  "dns_provider": "dynudns",
+  "dns_providers": {
+    "dynudns": {
+      "token": "your_dynu_api_token"
+    }
+  }
+}
+```
+
+### ArvanCloud
+
+```json
+{
+  "dns_provider": "arvancloud",
+  "dns_providers": {
+    "arvancloud": {
+      "api_key": "your_arvancloud_api_key"
+    }
+  }
+}
+```
+
+### ACME-DNS
+
+```json
+{
+  "dns_provider": "acme-dns",
+  "dns_providers": {
+    "acme-dns": {
+      "api_url": "https://auth.acme-dns.io",
+      "username": "your_acme_username",
+      "password": "your_acme_password",
+      "subdomain": "your_subdomain"
+    }
+  }
+}
+```
+
+### DuckDNS (senza dominio richiesto)
+
+DuckDNS assegna gratuitamente sottodomini `<nome>.duckdns.org` — il modo più semplice per ottenere un certificato di fiducia pubblica quando non si possiede un dominio. Casi d'uso tipici: homelab, servizi self-hosted, dispositivi IoT, dashboard interni precedentemente vincolati a certificati auto-firmati.
+
+1. Accedi su <https://www.duckdns.org/> (SSO Google / GitHub / Twitter / Reddit).
+2. Scegli un sottodominio (ad es. `mybox` → `mybox.duckdns.org`).
+3. Copia il token account visualizzato in cima alla pagina.
+
+```json
+{
+  "dns_provider": "duckdns",
+  "domains": ["mybox.duckdns.org"],
+  "dns_providers": {
+    "duckdns": {
+      "api_token": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    }
+  }
+}
+```
+
+I wildcard come `*.mybox.duckdns.org` sono supportati con lo stesso token. Poiché DuckDNS memorizza un solo record TXT per dominio alla volta, è necessaria una singola esecuzione certbot per sottodominio DuckDNS — i certificati SAN che coprono più sottodomini DuckDNS non sono supportati.
+
+### Script personalizzato (porta il tuo provider)
+
+Per i provider DNS privi di plugin certbot — Oracle Cloud (OCI), DNS interno, API di appliance — punta CertMate ai tuoi script e li gestirà tramite la modalità `--manual` di certbot. Non è richiesta alcuna installazione di plugin.
+
+```json
+{
+  "dns_provider": "custom-script",
+  "dns_providers": {
+    "custom-script": {
+      "auth_hook": "/usr/local/bin/certmate-dns-auth.sh",
+      "cleanup_hook": "/usr/local/bin/certmate-dns-cleanup.sh"
+    }
+  }
+}
+```
+
+certbot invoca l'auth hook una volta per ogni challenge di validazione con l'ambiente standard [manual-hook](https://eff-certbot.readthedocs.io/en/stable/using.html#hooks): `CERTBOT_DOMAIN` (il dominio in fase di validazione) e `CERTBOT_VALIDATION` (il valore TXT). Lo script deve creare il record TXT `_acme-challenge.$CERTBOT_DOMAIN` **e attendere che si propaghi** — certbot valida immediatamente dopo il ritorno dell'hook. Il cleanup hook opzionale viene eseguito dopo la validazione per rimuovere il record.
+
+Esempio per OCI DNS (copre [#285](https://github.com/fabriziosalmi/certmate/issues/285)). Si noti che un certificato che copre sia `example.com` che `*.example.com` produce DUE challenge di validazione sullo stesso nome `_acme-challenge.example.com`, e certbot esegue tutti gli auth hook prima di validare — quindi l'hook deve AGGIUNGERE al rrset TXT, non mai sostituirlo (un semplice `rrset update` sovrascriverebbe il primo token con il secondo):
+
+```bash
+#!/bin/sh
+# /usr/local/bin/certmate-dns-auth.sh
+set -eu
+ZONE="example.com"
+NAME="_acme-challenge.${CERTBOT_DOMAIN}"
+# Unisci il nuovo token di validazione con gli eventuali record già presenti sul nome
+# (i certificati apex + wildcard inseriscono due valori TXT sullo stesso nome).
+EXISTING=$(oci dns record rrset get --zone-name-or-id "$ZONE" \
+  --domain "$NAME" --rtype TXT \
+  --query 'data.items[].rdata' --raw-output 2>/dev/null || echo '[]')
+ITEMS=$(printf '%s' "$EXISTING" | python3 -c "
+import json, os, sys
+name = os.environ['NAME']
+rdata = [r.strip('\"') for r in json.load(sys.stdin)]
+rdata.append(os.environ['CERTBOT_VALIDATION'])
+print(json.dumps([
+    {'domain': name, 'rdata': v, 'rtype': 'TXT', 'ttl': 60} for v in rdata
+]))
+")
+NAME="$NAME" oci dns record rrset update --force \
+  --zone-name-or-id "$ZONE" \
+  --domain "$NAME" \
+  --rtype TXT \
+  --items "$ITEMS"
+sleep "${CERTMATE_DNS_PROPAGATION_SECONDS:-60}"
+```
+
+Requisiti e modello di fiducia:
+
+- I percorsi devono essere **assoluti**, i file devono esistere, essere **eseguibili**, non scrivibili da tutti gli utenti, e non contenere spazi o metacaratteri della shell (certbot esegue gli hook tramite la shell). Validati all'emissione e dall'endpoint API di test (`POST /api/web/certificates/test-provider`)
+- Gli script vengono eseguiti con i privilegi di CertMate — stesso modello di fiducia dei deploy hook: solo gli amministratori possono configurarli, trattali come parte del tuo deployment
+- L'impostazione `dns_propagation_seconds` per provider viene esportata agli script come `CERTMATE_DNS_PROPAGATION_SECONDS` (un campo `propagation_seconds` a livello di account lo sovrascrive)
+- I rinnovi rieseguono i percorsi degli hook dalla configurazione di rinnovo di certbot: mantieni gli script in un percorso stabile (se li sposti, riemetti il certificato)
+- I certificati wildcard funzionano (l'hook riceve ogni record di validazione)
+
+---
+
+## Creazione di certificati
+
+### Utilizzo del provider predefinito
+
+```bash
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"domain": "example.com"}'
+```
+
+### Utilizzo di un provider specifico
+
+```bash
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "domain": "example.com",
+    "dns_provider": "vultr"
+  }'
+```
+
+### Utilizzo di un account specifico
+
+```bash
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "domain": "example.com",
+    "dns_provider": "cloudflare",
+    "account_id": "production"
+  }'
+```
+
+---
+
+## Supporto multi-account
+
+CertMate supporta più account per provider DNS per ambienti enterprise.
+
+### Casi d'uso
+
+- **Separazione degli ambienti**: Account production, staging e DR
+- **Multi-regione**: Account diversi per domini US, UE, APAC
+- **Isolamento dei permessi**: Account admin, limitato e CI/CD
+
+### Aggiunta di più account
+
+```bash
+# Aggiungere un account production
+curl -X POST http://localhost:8000/api/settings/dns-providers/cloudflare/accounts \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "account_id": "production",
+    "config": {
+      "name": "Production Environment",
+      "description": "Main production Cloudflare account",
+      "api_token": "cloudflare_production_token"
+    }
+  }'
+
+# Aggiungere un account staging
+curl -X POST http://localhost:8000/api/settings/dns-providers/cloudflare/accounts \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "account_id": "staging",
+    "config": {
+      "name": "Staging Environment",
+      "description": "Development and testing account",
+      "api_token": "cloudflare_staging_token"
+    }
+  }'
+
+# Impostare production come account predefinito
+curl -X PUT http://localhost:8000/api/settings/dns-providers/cloudflare/default-account \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"account_id": "production"}'
+```
+
+### Gestione degli account
+
+```bash
+# Elencare tutti gli account di un provider
+curl -X GET http://localhost:8000/api/settings/dns-providers/cloudflare/accounts \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+
+# Aggiornare un account
+curl -X PUT http://localhost:8000/api/settings/dns-providers/cloudflare/accounts/staging \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "config": {
+      "name": "Staging & Testing",
+      "api_token": "new_staging_token"
+    }
+  }'
+
+# Eliminare un account
+curl -X DELETE http://localhost:8000/api/settings/dns-providers/cloudflare/accounts/old-account \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+### Struttura di configurazione multi-account
+
+```json
+{
+  "dns_provider": "cloudflare",
+  "default_accounts": {
+    "cloudflare": "production",
+    "route53": "main-aws"
+  },
+  "dns_providers": {
+    "cloudflare": {
+      "production": {
+        "name": "Production Environment",
+        "api_token": "***masked***"
+      },
+      "staging": {
+        "name": "Staging Environment",
+        "api_token": "***masked***"
+      }
+    },
+    "route53": {
+      "main-aws": {
+        "name": "Main AWS Account",
+        "access_key_id": "***masked***",
+        "secret_access_key": "***masked***",
+        "region": "us-east-1"
+      }
+    }
+  }
+}
+```
+
+### Retrocompatibilità
+
+Le configurazioni a singolo account esistenti vengono migrate automaticamente al formato multi-account al primo utilizzo. Non sono richiesti tempi di inattività né migrazioni manuali.
+
+---
+
+## DNS multi-master e alias di dominio (delega CNAME)
+
+Quando il tuo dominio è gestito da più provider DNS contemporaneamente (configurazione multi-master), utilizza la **delega CNAME** standard per centralizzare la validazione ACME DNS su un unico provider.
+
+### Il problema
+
+Con il DNS multi-master (ad es. deSEC + gcore), puoi configurare un solo provider DNS per richiesta di certificato, ma la validazione ACME richiede la creazione di record TXT `_acme-challenge`.
+
+### La soluzione
+
+La validazione tramite alias DNS funziona mediante delega CNAME. Let's Encrypt segue le catene CNAME durante la validazione DNS-01; CertMate scrive il record TXT richiesto sul nome di validazione delegato.
+
+1. **Crea un dominio di validazione** su un provider supportato (ad es. `validation.example.org` su Cloudflare, PowerDNS, Route53 o ACME-DNS)
+2. **Aggiungi record CNAME** in tutti i tuoi provider DNS che puntano al dominio di validazione:
+   ```dns
+   _acme-challenge.example.com. 300 IN CNAME _acme-challenge.validation.example.org.
+   ```
+3. **Richiedi il certificato**, specificando il provider che gestisce il dominio di validazione:
+   ```bash
+   curl -X POST http://localhost:8000/api/certificates/create \
+     -H "Authorization: Bearer YOUR_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "domain": "example.com",
+       "dns_provider": "cloudflare",
+       "domain_alias": "validation.example.org"
+     }'
+   ```
+
+   Quando `domain_alias` è impostato con un provider supportato, CertMate utilizza un hook DNS manuale di certbot per creare il record TXT su `_acme-challenge.validation.example.org`. Il CNAME garantisce che Let's Encrypt trovi quel valore TXT interrogando `_acme-challenge.example.com`.
+
+### Vantaggi
+
+- Funziona indipendentemente dal provider DNS che risponde alla query
+- Non richiede sincronizzazione tra provider
+- Funziona con provider non nativamente supportati da CertMate (deSEC, gcore)
+- Le credenziali DNS sono limitate al solo dominio di validazione
+- Implementato per i provider DNS di prima classe di CertMate; i provider generici vengono rifiutati finché non esistono adapter alias dedicati
+
+### Esempi per provider
+
+Cloudflare, PowerDNS e Route53 utilizzano tutti la stessa forma di richiesta:
+
+```json
+{
+  "domain": "example.com",
+  "dns_provider": "route53",
+  "domain_alias": "validation.example.org"
+}
+```
+
+Per ACME-DNS, `domain_alias` deve corrispondere esattamente al `subdomain`/fulldomain ACME-DNS configurato. CertMate aggiorna direttamente quel record ACME-DNS e non tenta la pulizia perché ACME-DNS memorizza l'ultimo valore di validazione.
+
+### Certificati wildcard con alias di dominio
+
+```bash
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "domain": "*.example.com",
+    "dns_provider": "cloudflare",
+    "domain_alias": "validation.example.org"
+  }'
+```
+
+Assicurati che il CNAME sia in atto prima di richiedere il certificato:
+
+```dns
+_acme-challenge.example.com. 300 IN CNAME _acme-challenge.validation.example.org.
+```
+
+### Risoluzione dei problemi con alias di dominio
+
+```bash
+# Verificare la propagazione del CNAME
+dig @8.8.8.8 _acme-challenge.example.com CNAME +short
+# Atteso: _acme-challenge.validation.example.org.
+
+# Dopo aver richiesto un certificato, verificare il record TXT sul dominio di validazione
+dig _acme-challenge.validation.example.org TXT +short
+# Atteso: un token di challenge ACME codificato in base64
+```
+
+---
+
+## Variabili d'ambiente
+
+Imposta le credenziali del provider DNS tramite variabili d'ambiente per i workflow CI/CD:
+
+```bash
+# Cloudflare
+CLOUDFLARE_API_TOKEN=your_token
+
+# AWS Route53
+AWS_ACCESS_KEY_ID=your_access_key
+AWS_SECRET_ACCESS_KEY=your_secret_key
+AWS_DEFAULT_REGION=us-east-1
+
+# Azure
+AZURE_SUBSCRIPTION_ID=your_subscription_id
+AZURE_RESOURCE_GROUP=your_resource_group
+AZURE_TENANT_ID=your_tenant_id
+AZURE_CLIENT_ID=your_client_id
+AZURE_CLIENT_SECRET=your_client_secret
+
+# Google Cloud
+GOOGLE_PROJECT_ID=your_project_id
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+
+# PowerDNS
+POWERDNS_API_URL=https://your-powerdns-server:8081
+POWERDNS_API_KEY=your_api_key
+```
+
+### Priorità di configurazione (dalla più alta alla più bassa)
+
+1. Variabili d'ambiente
+2. Impostazioni specifiche per dominio
+3. Impostazioni dell'account predefinito
+4. Impostazione globale del provider
+5. Predefinito di sistema (Cloudflare)
+
+---
+
+## Tempi di propagazione DNS
+
+| Velocita | Provider | Secondi |
+|----------|----------|---------|
+| Molto rapida | ACME-DNS | 30 |
+| Rapida | Cloudflare, Route53, PowerDNS, DuckDNS | 60 |
+| Media | DigitalOcean, Linode, Google, ArvanCloud | 120 |
+| Lenta | Azure, Gandi, OVH | 180 |
+| Molto lenta | Namecheap | 300 |
+
+---
+
+## Funzionalita di sicurezza
+
+- **Mascheramento delle credenziali** nell'interfaccia Web e nelle risposte API
+- **Permessi file sicuri** (600) per tutti i file di credenziali
+- **Validazione del token API** prima della creazione del certificato
+- **Supporto variabili d'ambiente** per i workflow CI/CD
+- **Audit logging** per tutte le operazioni sui provider DNS
+- **Isolamento degli account** — le credenziali di ciascun account sono memorizzate separatamente
+
+---
+
+## Architettura e guida per sviluppatori
+
+### Classi principali
+
+| Classe | File | Scopo |
+|--------|------|-------|
+| `DNSManager` | `modules/core/dns_providers.py` | Gestione configurazione multi-account |
+| `CertificateManager` | `modules/core/certificates.py` | Creazione certificati con provider DNS |
+| `SettingsManager` | `modules/core/settings.py` | Persistenza e migrazione delle impostazioni |
+| `Utils` | `modules/core/utils.py` | Generazione e validazione dei file di credenziali |
+
+### Metodi di archiviazione delle credenziali
+
+1. **File delle impostazioni** (`data/settings.json`) — il piu comune
+2. **Variabili d'ambiente** — per CI/CD
+3. **File di configurazione temporanei** (`letsencrypt/config/[provider].ini`) — creati durante le richieste di certificato, eliminati dopo
+
+### Aggiunta di un nuovo provider DNS
+
+1. Aggiungi il plugin a `requirements.txt`: `certbot-dns-newprovider`
+2. Crea una funzione di configurazione in `modules/core/utils.py`
+3. Aggiungi la definizione delle credenziali in `utils.py`
+4. Importa e gestisci in `modules/core/certificates.py`
+5. Aggiungi all'elenco dei provider supportati in `modules/core/settings.py`
+6. Aggiorna la documentazione
+
+Consulta la [Guida all'architettura](./architecture.md) per i dettagli completi di implementazione.
+
+---
+
+## Risoluzione dei problemi
+
+### Problemi comuni
+
+| Errore | Soluzione |
+|--------|-----------|
+| "DNS provider not configured" | Verifica che tutte le credenziali richieste siano fornite |
+| "Certificate creation failed" | Controlla i permessi DNS e la proprieta del dominio |
+| "Plugin not found" | Esegui `pip install -r requirements.txt` o ricostruisci Docker |
+| "Provider detection failing" | Controlla il campo `dns_provider` nelle impostazioni del dominio |
+
+### Modalita di debug
+
+```bash
+export FLASK_DEBUG=1
+python app.py
+```
+
+### Test della configurazione del provider
+
+```bash
+curl -X GET http://localhost:8000/api/settings/dns-providers \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+---
+
+## Guida alla migrazione
+
+### Da un provider singolo a piu provider
+
+Le configurazioni esistenti rimangono invariate. E sufficiente aggiungere i nuovi provider:
+
+```json
+{
+  "dns_providers": {
+    "cloudflare": {
+      "api_token": "existing_token"
+    },
+    "vultr": {
+      "api_key": "new_vultr_api_key"
+    }
+  }
+}
+```
+
+### Utilizzo di provider diversi per certificato
+
+```bash
+# Cloudflare per un dominio
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"domain": "example.com", "dns_provider": "cloudflare"}'
+
+# Route53 per un altro
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"domain": "test.org", "dns_provider": "route53"}'
+```
+
+---
+
+<div align="center">
+
+[← Torna alla documentazione](./README.md) • [Installazione →](./installation.md) • [Provider CA →](./ca-providers.md)
+
+</div>

--- a/docs/it/docker.md
+++ b/docs/it/docker.md
@@ -1,0 +1,326 @@
+# Build e distribuzione con Docker
+
+Questa guida illustra come compilare, distribuire ed eseguire CertMate in Docker — incluso il supporto multi-piattaforma per ARM e AMD64.
+
+---
+
+## Avvio rapido
+
+### Pull ed esecuzione
+
+```bash
+# Docker seleziona automaticamente l'architettura corretta
+docker run -d --name certmate \
+  --env-file .env \
+  -p 8000:8000 \
+  -v certmate_data:/app/data \
+  -v certmate_certificates:/app/certificates \
+  fabriziosalmi/certmate:latest
+```
+
+### Build ed esecuzione locale
+
+```bash
+docker build -t certmate:latest .
+docker run -d --name certmate \
+  --env-file .env \
+  -p 8000:8000 \
+  -v certmate_certificates:/app/certificates \
+  -v certmate_data:/app/data \
+  -v certmate_logs:/app/logs \
+  certmate:latest
+```
+
+---
+
+## Sicurezza
+
+Il processo di build garantisce che nessun segreto venga incluso nell'immagine:
+
+- `.dockerignore` esclude tutti i file `.env` e i dati sensibili
+- Le variabili d'ambiente vengono fornite **in fase di esecuzione**, non durante la build
+- Vengono inclusi solo i file applicativi essenziali
+- Le immagini possono essere pubblicate in sicurezza su registry pubblici
+
+### Verificare l'assenza di segreti nell'immagine
+
+```bash
+docker history certmate:latest
+docker inspect certmate:latest | grep -i env
+docker run --rm certmate:latest find / -name "*.env" 2>/dev/null
+```
+
+---
+
+## Configurazione in fase di esecuzione
+
+### Opzione 1: File d'ambiente
+
+Crea un file `.env` sull'host (non nell'immagine Docker):
+
+```bash
+SECRET_KEY=your-super-secret-key-here
+# SECRET_KEY_FILE=/run/secrets/secret_key  # Alternative: takes precedence over SECRET_KEY
+API_BEARER_TOKEN=your-api-bearer-token-here
+# API_BEARER_TOKEN_FILE=/run/secrets/api_bearer_token  # Alternative: takes precedence over API_BEARER_TOKEN
+CLOUDFLARE_API_TOKEN=your-cloudflare-api-token
+LOG_LEVEL=INFO
+```
+
+```bash
+docker run -d --name certmate \
+  --env-file .env \
+  -p 8000:8000 \
+  -v certmate_certificates:/app/certificates \
+  -v certmate_data:/app/data \
+  -v certmate_logs:/app/logs \
+  certmate:latest
+```
+
+### Opzione 2: Variabili d'ambiente dirette
+
+```bash
+docker run -d --name certmate \
+  -e SECRET_KEY="your-secret-key" \
+  # -e SECRET_KEY_FILE="/run/secrets/secret_key" \  # Alternative: takes precedence over SECRET_KEY
+  -e API_BEARER_TOKEN="your-api-bearer-token" \
+  # -e API_BEARER_TOKEN_FILE="/run/secrets/api_bearer_token" \  # Alternative: takes precedence over API_BEARER_TOKEN
+  -e CLOUDFLARE_API_TOKEN="your-api-token" \
+  -p 8000:8000 \
+  -v certmate_certificates:/app/certificates \
+  -v certmate_data:/app/data \
+  certmate:latest
+```
+
+### Riferimento alle variabili d'ambiente
+
+| Variabile | Richiesta | Descrizione |
+|-----------|-----------|-------------|
+| `SECRET_KEY` | No | Chiave segreta Flask per le sessioni (generata automaticamente se non impostata) |
+| `SECRET_KEY_FILE` | No | Percorso di un file contenente la chiave segreta Flask (ha precedenza su `SECRET_KEY`) |
+| `API_BEARER_TOKEN` | No | Token di autenticazione per l'accesso all'API (generato automaticamente se non impostato) |
+| `API_BEARER_TOKEN_FILE` | No | Percorso di un file contenente il token bearer API (ha precedenza su `API_BEARER_TOKEN`) |
+| `LOG_LEVEL` | No | `INFO` (predefinito), `DEBUG`, `WARNING`, `ERROR` |
+| `CERTMATE_BACKUP_PASSPHRASE` | No | Se impostata, i backup unificati vengono cifrati a riposo (`.zip.enc`, PBKDF2-SHA256 + Fernet). La stessa passphrase è richiesta per il ripristino. Non impostata = backup in chiaro `.zip` (comportamento precedente) |
+| `CLOUDFLARE_API_TOKEN` | No | Token del provider DNS Cloudflare |
+| `AWS_ACCESS_KEY_ID` | No | Chiave di accesso AWS Route53 |
+| `AWS_SECRET_ACCESS_KEY` | No | Chiave segreta AWS Route53 |
+
+Consulta la [Guida all'installazione](./installation.md#environment-variables) per l'elenco completo.
+
+---
+
+## Docker Compose
+
+### Configurazione di base
+
+```yaml
+version: '3.8'
+
+services:
+  certmate:
+    image: fabriziosalmi/certmate:latest
+    container_name: certmate
+    ports:
+      - "8000:8000"
+    environment:
+      - SECRET_KEY=${SECRET_KEY:-}
+      # - SECRET_KEY_FILE=${SECRET_KEY_FILE:-}  # Alternative: path to a file containing the secret key
+      - API_BEARER_TOKEN=${API_BEARER_TOKEN:-}
+      # - API_BEARER_TOKEN_FILE=${API_BEARER_TOKEN_FILE:-}  # Alternative: path to a file containing the bearer token
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+    volumes:
+      - certmate_certificates:/app/certificates
+      - certmate_data:/app/data
+      - certmate_logs:/app/logs
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+volumes:
+  certmate_certificates:
+  certmate_data:
+  certmate_logs:
+```
+
+```bash
+# Avvia con il file .env nella stessa directory
+docker-compose up -d
+
+# Oppure specifica un file .env diverso
+docker-compose --env-file /path/to/.env up -d
+```
+
+---
+
+## Build multi-piattaforma
+
+CertMate supporta immagini Docker multi-piattaforma per le architetture ARM e AMD64.
+
+### Architetture supportate
+
+| Piattaforma | Descrizione | Casi d'uso comuni |
+|-------------|-------------|-------------------|
+| `linux/amd64` | Intel/AMD 64-bit | La maggior parte dei server cloud, desktop |
+| `linux/arm64` | ARM 64-bit | Apple Silicon, istanze cloud ARM |
+| `linux/arm/v7` | ARM 32-bit v7 | Raspberry Pi 3+ |
+| `linux/arm/v6` | ARM 32-bit v6 | Raspberry Pi 1, Zero |
+
+### Script di build
+
+```bash
+# Build per la piattaforma corrente soltanto
+./build-docker.sh
+
+# Build per piattaforme multiple (ARM64 + AMD64)
+./build-docker.sh -m
+
+# Build e push su Docker Hub
+./build-docker.sh -m -p -r YOUR_DOCKERHUB_USERNAME
+
+# Script dedicato multi-piattaforma
+./build-multiplatform.sh -r USERNAME -v v1.0.0 -p
+
+# Build per Raspberry Pi
+./build-multiplatform.sh --platforms linux/arm/v7 -r USERNAME -p
+```
+
+### Docker Buildx manuale
+
+```bash
+# Creare e utilizzare il builder buildx
+docker buildx create --name certmate-builder --use
+
+# Build per piattaforme multiple
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t USERNAME/certmate:latest .
+
+# Build e push
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t USERNAME/certmate:latest --push .
+```
+
+### Prerequisiti per il multi-piattaforma
+
+```bash
+# Verificare il supporto buildx
+docker buildx version
+docker buildx inspect --bootstrap
+
+# Abilitare l'emulazione QEMU (se necessario)
+docker run --privileged --rm tonistiigi/binfmt --install all
+```
+
+### Forzare una piattaforma specifica
+
+```bash
+# Forzare AMD64 (es. su Apple Silicon per i test)
+docker run --platform linux/amd64 --rm \
+  --env-file .env -p 8000:8000 certmate:latest
+
+# Rilevamento automatico (consigliato)
+docker run --rm --env-file .env -p 8000:8000 certmate:latest
+```
+
+---
+
+## Push su Docker Hub
+
+```bash
+# Accesso
+docker login
+
+# Tag e push
+docker build -t USERNAME/certmate:latest .
+docker push USERNAME/certmate:latest
+
+# Con tag di versione
+docker build -t USERNAME/certmate:v1.0.0 .
+docker push USERNAME/certmate:v1.0.0
+```
+
+---
+
+## Integrazione CI/CD
+
+### GitHub Actions
+
+Secret richiesti:
+- `DOCKERHUB_USERNAME`
+- `DOCKERHUB_TOKEN`
+
+```bash
+# Avvio manuale con piattaforme personalizzate
+gh workflow run docker-multiplatform.yml \
+  -f platforms="linux/amd64,linux/arm64,linux/arm/v7" \
+  -f push_to_registry=true
+```
+
+---
+
+## Consigli per la produzione
+
+1. **Usa la gestione dei segreti**: Docker secrets, Kubernetes secrets o un gestore di segreti
+2. **Abilita TLS**: Esegui dietro un reverse proxy con terminazione TLS
+3. **Monitora le risorse**: Imposta limiti di CPU e memoria
+4. **Esegui il backup dei volumi**: Esegui regolarmente il backup dei volumi dei certificati e dei dati
+5. **Aggiorna regolarmente**: Mantieni l'immagine aggiornata con le patch di sicurezza
+6. **Usa la cache dei layer** per build più veloci:
+   ```bash
+   docker buildx build --cache-from type=registry,ref=USERNAME/certmate:cache .
+   ```
+
+---
+
+## Risoluzione dei problemi
+
+### Il container non si avvia
+
+```bash
+docker logs certmate
+docker exec certmate env
+```
+
+### L'health check fallisce
+
+```bash
+docker logs certmate
+docker exec certmate curl -v http://localhost:8000/health
+```
+
+### Problemi di permessi
+
+```bash
+docker exec certmate ls -la /app/certificates
+docker exec certmate ls -la /app/data
+```
+
+### Problemi di build multi-piattaforma
+
+| Errore | Soluzione |
+|--------|-----------|
+| "multiple platforms not supported for docker driver" | `docker buildx create --name multiplatform --use` |
+| "exec format error" | `docker run --privileged --rm tonistiigi/binfmt --install all` |
+| Build non native lente | Normale a causa dell'emulazione; usa GitHub Actions per la produzione |
+| Impossibile caricare il multi-piattaforma in Docker locale | Usa `--load` con una singola piattaforma per i test locali |
+
+---
+
+## Dimensioni delle immagini
+
+Dimensioni tipiche per architettura:
+- **AMD64**: ~200-300 MB
+- **ARM64**: ~200-300 MB
+- **ARM v7**: ~180-250 MB
+
+---
+
+<div align="center">
+
+[← Torna alla documentazione](./README.md) • [Installazione →](./installation.md) • [Architettura →](./architecture.md)
+
+</div>

--- a/docs/it/guide.md
+++ b/docs/it/guide.md
@@ -1,0 +1,532 @@
+# CertMate Certificati Client - Guida all'utilizzo
+
+## Per iniziare
+
+### Installazione
+
+```bash
+# 1. Installa le dipendenze
+pip install -r requirements.txt
+
+# 2. Avvia CertMate
+python app.py
+
+# 3. Apri il dashboard
+# Naviga su: http://localhost:5000/client-certificates
+```
+
+### Primi passi
+
+1. **Genera la CA** — Creata automaticamente al primo avvio
+2. **Accedi al dashboard** — Vai su `/client-certificates`
+3. **Crea un certificato** — Usa il modulo Web o l'API
+4. **Scarica i file** — Ottieni il certificato, la chiave e il CSR
+
+---
+
+## Dashboard Web
+
+### Funzionalità del dashboard
+
+**URL**: `http://localhost:5000/client-certificates`
+
+#### Pannello statistiche
+- Totale certificati
+- Numero attivi
+- Numero revocati
+- Ripartizione per tipo di utilizzo
+
+#### Tabella certificati
+- Elenco di tutti i certificati
+- Ricerca per nome comune
+- Filtro per tipo di utilizzo
+- Filtro per stato
+- Ordinamento per data di creazione
+
+#### Modulo di creazione certificato
+
+**Campi del modulo**:
+- Nome comune (obbligatorio)
+- Indirizzo email
+- Organizzazione
+- Unità organizzativa
+- Tipo di utilizzo (VPN, API-mTLS, ecc.)
+- Giorni di validità (predefinito: 365)
+- Genera chiave (casella di spunta)
+- Note
+
+**Esempio**:
+```
+Common Name: user@example.com
+Email: user@example.com
+Organization: ACME Corp
+Usage Type: api-mtls
+Days Valid: 365
+```
+
+#### Importazione CSV in blocco
+
+1. Clicca sulla scheda "Importazione in blocco"
+2. Prepara un file CSV con le intestazioni:
+ ```
+ common_name,email,organization,cert_usage,days_valid
+ user1@example.com,user1@example.com,ACME Corp,api-mtls,365
+ user2@example.com,user2@example.com,ACME Corp,vpn,365
+ ```
+3. Trascina e rilascia oppure clicca per caricare
+4. Rivedi l'anteprima
+5. Clicca su "Importa"
+
+---
+
+## Operazioni comuni
+
+### Creare un singolo certificato
+
+#### Tramite il dashboard Web
+
+1. Vai su `/client-certificates`
+2. Compila il modulo "Crea certificato"
+3. Clicca su "Crea"
+4. Il certificato appare nella tabella
+
+#### Tramite API
+
+```bash
+curl -X POST http://localhost:5000/api/client-certs/create \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "api-mtls",
+ "days_valid": 365,
+ "generate_key": true
+ }'
+```
+
+---
+
+### Scaricare i file di un certificato
+
+#### Tramite il dashboard Web
+
+1. Trova il certificato nella tabella
+2. Clicca sull'icona "Scarica"
+3. Seleziona il tipo di file:
+   - **CRT** — Certificato (pubblico)
+   - **KEY** — Chiave privata (da tenere segreta)
+   - **CSR** — Richiesta di firma del certificato
+
+#### Tramite API
+
+```bash
+# Scarica il certificato
+curl http://localhost:5000/api/client-certs/CERT_ID/download/crt \
+ -H "Authorization: Bearer TOKEN" \
+ -o my-cert.crt
+
+# Scarica la chiave
+curl http://localhost:5000/api/client-certs/CERT_ID/download/key \
+ -H "Authorization: Bearer TOKEN" \
+ -o my-key.key
+```
+
+---
+
+### Revocare un certificato
+
+#### Tramite il dashboard Web
+
+1. Trova il certificato nella tabella
+2. Clicca sul pulsante "Revoca"
+3. Inserisci il motivo della revoca (facoltativo)
+4. Conferma
+
+#### Tramite API
+
+```bash
+curl -X POST http://localhost:5000/api/client-certs/CERT_ID/revoke \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "reason": "compromised"
+ }'
+```
+
+**Motivi di revoca**:
+- `compromised` — La chiave è stata compromessa
+- `superseded` — Sostituito da un nuovo certificato
+- `unspecified` — Revoca generica
+- Qualsiasi motivo personalizzato
+
+---
+
+### Rinnovare un certificato
+
+#### Tramite il dashboard Web
+
+1. Trova il certificato nella tabella
+2. Clicca sul pulsante "Rinnova"
+3. Conferma il rinnovo
+
+#### Tramite API
+
+```bash
+curl -X POST http://localhost:5000/api/client-certs/CERT_ID/renew \
+ -H "Authorization: Bearer TOKEN"
+```
+
+**Nota**: Il rinnovo crea un nuovo certificato con:
+- Stesso nome comune
+- Nuovo numero seriale
+- Nuova data di scadenza
+- ID originale aggiornato
+
+---
+
+### Elencare e filtrare i certificati
+
+#### Tramite il dashboard Web
+
+1. Vai alla tabella dei certificati
+2. Usa la casella "Cerca" per il nome comune
+3. Usa il menu a tendina "Tipo di utilizzo" per filtrare
+4. Usa il menu a tendina "Stato" (Attivo/Revocato)
+5. Clicca su "Applica filtri"
+
+#### Tramite API
+
+```bash
+# Elenca tutti
+curl http://localhost:5000/api/client-certs \
+ -H "Authorization: Bearer TOKEN"
+
+# Filtra per utilizzo
+curl "http://localhost:5000/api/client-certs?usage=api-mtls" \
+ -H "Authorization: Bearer TOKEN"
+
+# Filtra per stato
+curl "http://localhost:5000/api/client-certs?revoked=false" \
+ -H "Authorization: Bearer TOKEN"
+
+# Cerca
+curl "http://localhost:5000/api/client-certs?search=user@" \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+### Verificare lo stato di un certificato (OCSP)
+
+#### Tramite API
+
+```bash
+curl http://localhost:5000/api/ocsp/status/SERIAL_NUMBER \
+ -H "Authorization: Bearer TOKEN"
+```
+
+**Risposta**:
+```json
+{
+ "certificate_status": "good",
+ "certificate_serial": 12345678,
+ "this_update": "2024-10-30T18:00:00Z"
+}
+```
+
+---
+
+### Ottenere la lista di revoca (CRL)
+
+#### Scarica la CRL
+
+```bash
+# Formato PEM
+curl http://localhost:5000/api/crl/download/pem \
+ -H "Authorization: Bearer TOKEN" \
+ -o ca.crl
+
+# Formato DER
+curl http://localhost:5000/api/crl/download/der \
+ -H "Authorization: Bearer TOKEN" \
+ -o ca.crl
+```
+
+#### Ottieni le informazioni CRL
+
+```bash
+curl http://localhost:5000/api/crl/download/info \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+## Operazioni in blocco
+
+### Formato CSV
+
+```csv
+common_name,email,organization,cert_usage,days_valid
+user1@example.com,user1@example.com,ACME Corp,api-mtls,365
+user2@example.com,user2@example.com,ACME Corp,vpn,365
+user3@example.com,user3@example.com,ACME Corp,api-mtls,730
+```
+
+### Colonne obbligatorie
+
+- `common_name` — Soggetto del certificato (obbligatorio)
+
+### Colonne facoltative
+
+- `email` — Indirizzo email
+- `organization` — Nome dell'organizzazione
+- `organizational_unit` — Nome del reparto
+- `cert_usage` — Tipo di utilizzo
+- `days_valid` — Validità in giorni
+
+### Tramite il dashboard Web
+
+1. Vai alla scheda "Importazione in blocco"
+2. Carica il file CSV
+3. Rivedi l'anteprima
+4. Clicca su "Importa tutto"
+
+### Tramite API
+
+```bash
+curl -X POST http://localhost:5000/api/client-certs/batch \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "headers": ["common_name", "email", "organization"],
+ "rows": [["user1@example.com", "user1@example.com", "ACME Corp"],
+ ["user2@example.com", "user2@example.com", "ACME Corp"],
+ ["user3@example.com", "user3@example.com", "ACME Corp"]
+ ]
+ }'
+```
+
+### Risultati dell'importazione
+
+Restituisce i contatori di successo/fallimento:
+```json
+{
+ "total": 3,
+ "successful": 3,
+ "failed": 0,
+ "errors": [],
+ "certificates": [{"identifier": "cert-batch-001", "common_name": "user1@example.com"},
+ {"identifier": "cert-batch-002", "common_name": "user2@example.com"},
+ {"identifier": "cert-batch-003", "common_name": "user3@example.com"}
+ ]
+}
+```
+
+---
+
+## Tipi di utilizzo dei certificati
+
+### API mTLS
+
+Per l'autenticazione mutual TLS dei client API.
+
+```
+Usage Type: api-mtls
+Typical Validity: 1 year (365 days)
+```
+
+### VPN
+
+Per l'autenticazione dei client VPN.
+
+```
+Usage Type: vpn
+Typical Validity: 1-2 years (365-730 days)
+```
+
+### Tipi personalizzati
+
+Puoi creare certificati per qualsiasi utilizzo personalizzato:
+
+```
+Usage Type: custom-application
+Usage Type: internal-service
+Usage Type: mobile-app
+```
+
+---
+
+## Rinnovo automatico
+
+### Configurazione
+
+- **Orario di verifica**: Ogni giorno alle 3:00
+- **Soglia**: 30 giorni prima della scadenza
+- **Azione**: Rinnovo automatico se abilitato
+
+### Abilitazione del rinnovo automatico
+
+Il rinnovo automatico è abilitato per impostazione predefinita. Per verificare lo stato:
+
+```bash
+curl http://localhost:5000/api/client-certs/CERT_ID \
+ -H "Authorization: Bearer TOKEN"
+```
+
+Cerca:
+```json
+{
+ "renewal": {
+ "renewal_enabled": true,
+ "renewal_threshold_days": 30
+ }
+}
+```
+
+### Comportamento del rinnovo
+
+In caso di rinnovo automatico:
+- Nuovo certificato creato
+- Stesso CN (nome comune)
+- Nuovo numero seriale
+- Nuova data di scadenza
+- L'ID originale rimane invariato
+- Il vecchio certificato viene sostituito
+
+---
+
+## Risoluzione dei problemi
+
+### Problemi comuni
+
+#### Creazione del certificato non riuscita
+
+**Errore**: `Failed to create certificate`
+
+**Soluzioni**:
+1. Verifica che il nome comune sia valido
+2. Controlla che tutti i campi obbligatori siano compilati
+3. Verifica che la CA sia inizializzata
+4. Consulta i log per ulteriori dettagli
+
+#### Download del file non riuscito
+
+**Errore**: `File not found`
+
+**Soluzioni**:
+1. Verifica che l'ID del certificato esista
+2. Controlla il tipo di file (crt, key, csr)
+3. Assicurati che il certificato non sia stato eliminato
+4. Controlla lo spazio su disco
+
+#### Limite di richieste superato
+
+**Errore**: `HTTP 429 Too Many Requests`
+
+**Soluzioni**:
+1. Attendi prima di riprovare
+2. Usa le operazioni in blocco
+3. Implementa un backoff esponenziale
+4. Controlla il limite per il tuo endpoint
+
+### Consultazione dei log
+
+Visualizza i log dell'applicazione:
+```bash
+tail -f logs/certmate.log
+```
+
+Visualizza i log di audit:
+```bash
+tail -f logs/audit/certificate_audit.log
+```
+
+---
+
+## Buone pratiche di sicurezza
+
+### Chiavi private
+
+- **NON** condividere mai le tue chiavi private
+- **NON** includere mai le chiavi in git
+- Conserva le chiavi in modo sicuro
+- Usa i permessi 0600 sui file
+
+### Certificati
+
+- Monitora le date di scadenza
+- Rinnova prima della scadenza
+- Revoca immediatamente i certificati compromessi
+- Conserva i log di audit per la conformità
+
+### Token API
+
+- Ruota i token regolarmente
+- Usa HTTPS in produzione
+- Non includere i token nel codice sorgente
+- Usa le variabili d'ambiente
+
+### Revoca
+
+Revoca sempre quando:
+- La chiave è compromessa
+- Il certificato viene sostituito
+- Un utente lascia l'organizzazione
+- Il servizio viene dismesso
+
+---
+
+## Suggerimenti per le prestazioni
+
+### Per grandi volumi
+
+Usa le operazioni in blocco invece delle creazioni individuali:
+```bash
+# Corretto: una richiesta per 1000 certificati
+POST /api/client-certs/batch
+
+# Scorretto: 1000 richieste per 1000 certificati
+POST /api/client-certs/create × 1000
+```
+
+### Per il filtraggio
+
+Filtra lato server:
+```bash
+# Corretto: il server filtra
+GET /api/client-certs?usage=api-mtls
+
+# Scorretto: il client filtra tutto
+GET /api/client-certs
+```
+
+### Per il monitoraggio
+
+Usa l'endpoint delle statistiche:
+```bash
+GET /api/client-certs/stats
+```
+
+---
+
+## Supporto
+
+### Documentazione
+
+- [Riferimento API](./api.md) — Tutti gli endpoint
+- [Architettura](./architecture.md) — Progettazione del sistema
+- [Note di rilascio](../RELEASE_NOTES.md) — Cronologia delle versioni
+
+### Test
+
+Vedi `test_e2e_complete.py` per esempi di utilizzo.
+
+---
+
+<div align="center">
+
+[← Torna alla documentazione](./README.md) • [Riferimento API →](./api.md) • [Architettura →](./architecture.md)
+
+</div>

--- a/docs/it/index.md
+++ b/docs/it/index.md
@@ -1,0 +1,252 @@
+# CertMate - Certificati Client
+
+<div align="center">
+
+![CertMate](https://img.shields.io/badge/CertMate-Certificati%20Client-blue?style=for-the-badge)
+![Stato](https://img.shields.io/badge/Stato-Pronto%20per%20la%20produzione-green?style=for-the-badge)
+
+**Gestione completa dei certificati client per CertMate**
+
+[Documentazione](#documentazione) • [Avvio rapido](#avvio-rapido) • [Riferimento API](./api.md) • [Architettura](./architecture.md)
+
+</div>
+
+---
+
+## Panoramica
+
+CertMate Certificati Client è una soluzione completa e pronta per la produzione per la gestione dei certificati client con:
+
+- **CA auto-firmata** — Genera e gestisci la tua Certification Authority
+- **Gestione completa del ciclo di vita** — Crea, rinnova, revoca e monitora i certificati client
+- **OCSP & CRL** — Stato dei certificati in tempo reale e liste di revoca
+- **Dashboard Web** — Interfaccia intuitiva per la gestione dei certificati
+- **API REST** — API completa per l'automazione
+- **Operazioni batch** — Importa da 100 a 30.000 certificati tramite CSV
+- **Log di audit** — Traccia tutte le operazioni per la conformità
+- **Rate limiting** — Protezione integrata contro gli abusi
+
+---
+
+## Funzionalità
+
+### Fase 1: Fondamenta CA
+- **PrivateCAGenerator**: CA auto-firmata con chiavi RSA a 4096 bit, validità 10 anni
+- **CSRHandler**: Valida, crea e analizza le Certificate Signing Request
+- **Archiviazione sicura**: Permessi sui file appropriati (0600) per le chiavi private
+
+### Fase 2: Motore dei certificati client
+- **Ciclo di vita completo**: Crea, elenca, filtra, revoca e rinnova i certificati
+- **Query multi-filtro**: Ricerca per tipo di utilizzo, stato di revoca, nome comune
+- **Rinnovo automatico**: Verifiche quotidiane pianificate per i certificati in scadenza
+- **Supporto per 30k+ certificati**: Archiviazione basata su directory per scalabilità lineare
+- **Gestione dei metadati**: Traccia CN, email, organizzazione, utilizzo, date di scadenza
+
+### Fase 3: Interfaccia utente e funzionalità avanzate
+- **Dashboard Web**: Interfaccia di gestione responsive con modalità scura
+- **OCSP Responder**: Interroga lo stato dei certificati in tempo reale
+- **CRL Manager**: Genera e distribuisce le liste di revoca (PEM/DER)
+- **API REST**: 10 endpoint in 3 namespace per un'automazione completa
+- **Operazioni batch**: Importa certificati da file CSV
+
+### Fase 4: Miglioramenti rapidi
+- **Log di audit**: Traccia tutte le operazioni sui certificati con informazioni su utente/IP
+- **Rate limiting**: Limiti configurabili per endpoint con valori predefiniti ragionevoli
+- **Pronto per l'integrazione**: Entrambi i manager disponibili nell'applicazione per un utilizzo immediato
+
+---
+
+## Avvio rapido
+
+### Installazione
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Il server si avvia su `http://localhost:8000`
+
+### Utilizzo di base
+
+#### 1. Accesso alla Dashboard Web
+```
+Naviga verso: http://localhost:8000/client-certificates
+```
+
+#### 2. Creare un certificato tramite API
+```bash
+curl -X POST http://localhost:8000/api/client-certs/create \
+ -H "Authorization: Bearer IL_TUO_TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "api-mtls",
+ "days_valid": 365,
+ "generate_key": true
+ }'
+```
+
+#### 3. Elencare i certificati
+```bash
+curl http://localhost:8000/api/client-certs \
+ -H "Authorization: Bearer IL_TUO_TOKEN"
+```
+
+#### 4. Scaricare i file del certificato
+```bash
+curl http://localhost:8000/api/client-certs/USER_ID/download/crt \
+ -H "Authorization: Bearer IL_TUO_TOKEN" \
+ -o user.crt
+
+curl http://localhost:8000/api/client-certs/USER_ID/download/key \
+ -H "Authorization: Bearer IL_TUO_TOKEN" \
+ -o user.key
+```
+
+---
+
+## Documentazione
+
+### Documentazione principale
+
+- **[Guida all'installazione](./installation.md)** — Configurazione, dipendenze, deployment
+- **[Note Kubernetes](./kubernetes.md)** — Dimensionamento dei pod e risoluzione dei problemi OOM
+- **[Provider DNS](./dns-providers.md)** — Provider supportati, multi-account, alias di dominio
+- **[Provider CA](./ca-providers.md)** — Let's Encrypt, Actalis, DigiCert, CA privata
+- **[Guida Docker](./docker.md)** — Build Docker, multi-piattaforma, Compose
+- **[Guida ai test](./testing.md)** — Framework di test, CI/CD, copertura
+- **[Riferimento API](./api.md)** — Documentazione completa dell'API REST con esempi
+- **[Architettura](./architecture.md)** — Progettazione del sistema, componenti e flusso dei dati
+- **[Guida utente](./guide.md)** — Guida passo-passo per le attività comuni
+
+### Link rapidi
+
+- [Endpoint API](./api.md#endpoints) — Tutti gli endpoint disponibili
+- [Tipi di certificato](./api.md#certificate-types) — VPN, API mTLS, ecc.
+- [Rate limiting](./api.md#rate-limiting) — Limiti predefiniti e configurazione
+- [Log di audit](./api.md#audit-logging) — Comprendere le tracce di audit
+
+---
+
+## Test
+
+Tutte le funzionalità sono state testate in modo approfondito:
+
+```bash
+python -m pytest tests/ -v
+```
+
+### Copertura dei test
+- Operazioni CA (3 test)
+- Operazioni CSR (3 test)
+- Ciclo di vita dei certificati (8 test)
+- Filtraggio e ricerca (3 test)
+- Operazioni batch (2 test)
+- OCSP e CRL (5 test)
+- Audit e rate limiting (3 test)
+
+---
+
+## Riepilogo degli endpoint API
+
+| Metodo | Endpoint                                 | Scopo                               |
+| ------ | ---------------------------------------- | ----------------------------------- |
+| `POST` | `/api/client-certs/create`               | Creare un nuovo certificato         |
+| `GET`  | `/api/client-certs`                      | Elencare i certificati con filtri   |
+| `GET`  | `/api/client-certs/<id>`                 | Ottenere i metadati di un certificato |
+| `GET`  | `/api/client-certs/<id>/download/<type>` | Scaricare cert/key/csr              |
+| `POST` | `/api/client-certs/<id>/revoke`          | Revocare un certificato             |
+| `POST` | `/api/client-certs/<id>/renew`           | Rinnovare un certificato            |
+| `GET`  | `/api/client-certs/stats`                | Ottenere le statistiche             |
+| `POST` | `/api/client-certs/batch`                | Import batch CSV                    |
+| `GET`  | `/api/ocsp/status/<serial>`              | Query di stato OCSP                 |
+| `GET`  | `/api/crl/download/<format>`             | Scaricare la CRL (PEM/DER)          |
+
+---
+
+## Architettura
+
+Il sistema è costruito con un'architettura modulare a livelli:
+
+```
+
+ Interfaccia Web e API REST
+ (/client-certificates, /api/*)
+
+ Risorse API e manager
+ (OCSP, CRL, Audit, Rate Limiting)
+
+ Moduli principali
+ (Gestione certificati, CSR, CA, Archiviazione)
+
+ Crittografia e archiviazione
+ (OpenSSL, File System, Backend)
+
+```
+
+Vedere la [Documentazione sull'architettura](./architecture.md) per informazioni dettagliate.
+
+---
+
+## Sicurezza
+
+### Robustezza crittografica
+- **CA**: Chiavi RSA a 4096 bit, validità 10 anni
+- **Certificati client**: RSA a 2048 o 4096 bit (configurabile)
+- **Firme**: SHA256
+- **Archiviazione delle chiavi**: Permessi 0600 sui sistemi Unix
+
+### Controllo degli accessi
+- **Autenticazione Bearer token** su tutti gli endpoint API
+- **Rate limiting**: Limiti configurabili per endpoint
+- **Log di audit**: Tutte le operazioni tracciate con informazioni su utente/IP
+
+### Conformità
+- Tracciamento dei metadati dei certificati
+- Traccia di audit delle revoche
+- Log delle operazioni persistenti
+- Supporto per le query di conformità
+
+---
+
+## Performance
+
+L'implementazione è ottimizzata per:
+- **Scalabilità**: L'archiviazione basata su directory supporta 30k+ certificati simultanei
+- **Velocità**: Query multi-filtro efficienti
+- **Affidabilità**: Pianificazione automatica del rinnovo
+- **Reattività**: JavaScript asincrono nell'interfaccia Web
+
+---
+
+## Supporto
+
+Per domande o problemi:
+1. Consulta la [Guida utente](./guide.md)
+2. Consulta la [Documentazione API](./api.md)
+3. Consulta la sezione [Architettura](./architecture.md)
+4. Esamina i casi di test in `test_e2e_complete.py`
+
+---
+
+## Licenza
+
+Vedere il file LICENSE nel repository
+
+---
+
+## Versione
+
+**Versione corrente**: 2.3.0
+**Stato**: Pronto per la produzione
+
+---
+
+<div align="center">
+
+[Documentazione](.) • [Licenza](../LICENSE)
+
+</div>

--- a/docs/it/installation.md
+++ b/docs/it/installation.md
@@ -1,0 +1,536 @@
+# Guida all'installazione
+
+Questa guida illustra tutti i metodi di installazione e deploy di CertMate.
+
+---
+
+## Prerequisiti
+
+- Python 3.9 o superiore
+- pip (gestore di pacchetti Python)
+- Docker (opzionale, per il deploy containerizzato)
+
+---
+
+## Metodo 1: Installazione diretta
+
+### 1. Clonare il repository
+
+```bash
+git clone https://github.com/fabriziosalmi/certmate.git
+cd certmate
+```
+
+### 2. Creare l'ambiente virtuale
+
+```bash
+python3 -m venv venv
+source venv/bin/activate  # Linux/Mac
+# oppure
+.\venv\Scripts\activate   # Windows
+```
+
+### 3. Installare le dipendenze
+
+```bash
+pip install -r requirements.txt
+```
+
+### 4. Configurare l'ambiente
+
+Creare un file `.env`:
+
+```bash
+cp .env.example .env
+# Modificare .env con le proprie impostazioni
+```
+
+### 5. Avviare l'applicazione
+
+```bash
+python app.py
+```
+
+---
+
+## Metodo 2: Installazione Docker
+
+### Con Docker Compose (consigliato)
+
+```bash
+git clone https://github.com/fabriziosalmi/certmate.git
+cd certmate
+docker-compose up -d
+```
+
+### Con Docker Build
+
+```bash
+git clone https://github.com/fabriziosalmi/certmate.git
+cd certmate
+docker build -t certmate .
+docker run -p 8000:8000 --env-file .env -v ./certificates:/app/certificates certmate
+```
+
+> Per il deploy Docker avanzato con build multi-piattaforma, consultare la [Guida Docker](./docker.md).
+
+---
+
+## Dipendenze di sistema
+
+### Ubuntu / Debian
+
+```bash
+sudo apt update
+sudo apt install python3-dev python3-venv build-essential libssl-dev libffi-dev
+```
+
+### CentOS / RHEL / Rocky
+
+```bash
+sudo yum install python3-devel gcc openssl-devel libffi-devel
+```
+
+### macOS
+
+```bash
+brew install python3 openssl libffi
+```
+
+---
+
+## Configurazione del provider DNS
+
+Dopo l'installazione, configurare le credenziali del proprio provider DNS. Consultare la [Guida ai provider DNS](./dns-providers.md) per le istruzioni dettagliate.
+
+Configurazione rapida per i provider più comuni:
+
+### Cloudflare
+
+1. Accedere alla [Dashboard Cloudflare](https://dash.cloudflare.com/profile/api-tokens)
+2. Creare un nuovo token API con i permessi `Zone:DNS:Edit`
+3. Aggiungere il token nelle impostazioni di CertMate
+
+### AWS Route53
+
+1. Creare un utente IAM con i permessi Route53
+2. Generare le chiavi di accesso
+3. Aggiungere le credenziali nelle impostazioni di CertMate
+
+### Azure DNS
+
+1. Creare un Service Principal
+2. Assegnare il ruolo DNS Zone Contributor
+3. Configurare i dettagli della sottoscrizione nelle impostazioni di CertMate
+
+### Google Cloud DNS
+
+1. Creare un Service Account con il ruolo DNS Administrator
+2. Scaricare il file di chiave JSON
+3. Importare nelle impostazioni di CertMate
+
+---
+
+## Variabili d'ambiente
+
+```bash
+# Autenticazione API (generata automaticamente se nessuna è impostata)
+# Opzione A: valore diretto
+API_BEARER_TOKEN=your_secure_token_here
+# Opzione B: percorso a un file contenente il token (ha precedenza su API_BEARER_TOKEN)
+API_BEARER_TOKEN_FILE=/run/secrets/api_bearer_token
+
+# Chiave segreta di sessione Flask (generata automaticamente se nessuna è impostata)
+# Opzione A: valore diretto
+SECRET_KEY=your_flask_secret_key
+# Opzione B: percorso a un file contenente la chiave (ha precedenza su SECRET_KEY)
+SECRET_KEY_FILE=/run/secrets/secret_key
+
+# Reverse proxy — impostare a 'true' quando CertMate è dietro Nginx,
+# HAProxy, Traefik, Cloudflare, ecc. Senza questa impostazione, request.remote_addr
+# risolve sull'IP del proxy per ogni richiesta, collassando il rate limiting
+# per client in un unico bucket.
+BEHIND_PROXY=true
+
+# Cifratura dei backup a riposo (opzionale, consigliata).
+# Quando impostata, i backup unificati vengono scritti come file .zip.enc
+# cifrati (derivazione della chiave PBKDF2-SHA256 + Fernet/AES) invece di
+# .zip in chiaro. I backup incorporano ogni chiave privata dei certificati;
+# senza questa opzione un file di backup esfiltrato equivale a una
+# compromissione totale delle chiavi.
+CERTMATE_BACKUP_PASSPHRASE=scegliere-una-lunga-passphrase-casuale
+
+# Provider DNS (scegliere uno o più)
+CLOUDFLARE_TOKEN=your_cloudflare_token
+AWS_ACCESS_KEY_ID=your_aws_access_key
+AWS_SECRET_ACCESS_KEY=your_aws_secret_key
+AZURE_SUBSCRIPTION_ID=your_azure_subscription
+AZURE_TENANT_ID=your_azure_tenant
+AZURE_CLIENT_ID=your_azure_client
+AZURE_CLIENT_SECRET=your_azure_secret
+GOOGLE_PROJECT_ID=your_gcp_project
+POWERDNS_API_URL=https://your-powerdns:8081
+POWERDNS_API_KEY=your_powerdns_key
+```
+
+### Ordine di risoluzione
+
+| Variabile | Priorità |
+|----------|----------|
+| `API_BEARER_TOKEN_FILE` | La più alta — se impostata, `API_BEARER_TOKEN` non viene mai letta |
+| `API_BEARER_TOKEN` | Usata solo quando `API_BEARER_TOKEN_FILE` è assente |
+| *(generata)* | Fallback quando nessuna è impostata o il valore non supera la validazione |
+| `SECRET_KEY_FILE` | La più alta — se impostata, `SECRET_KEY` non viene mai letta |
+| `SECRET_KEY` | Usata solo quando `SECRET_KEY_FILE` è assente |
+| *(generata + persistita)* | Scritta in `data/.secret_key` affinché le sessioni sopravvivano ai riavvii |
+
+> **Suggerimento Docker Secrets**: Usare `API_BEARER_TOKEN_FILE=/run/secrets/api_bearer_token` e `SECRET_KEY_FILE=/run/secrets/secret_key` con Docker Swarm o i secret di Kubernetes per evitare di inserire valori sensibili nelle variabili d'ambiente.
+
+---
+
+## Deploy in produzione
+
+### Dietro un reverse proxy
+
+Se CertMate si trova dietro un reverse proxy (Nginx, HAProxy, Traefik, Cloudflare, Kubernetes Ingress) — che è il modo consigliato per eseguirlo con terminazione TLS — impostare `BEHIND_PROXY=true` nell'ambiente del container. Questo attiva il middleware `ProxyFix` di Werkzeug in modo che i seguenti elementi si fidino degli header `X-Forwarded-*` del proxy:
+
+- `request.remote_addr` risolve sull'IP del client originale invece che su quello del proxy. Il rate limiting, le voci del log di audit e gli avvisi "tentativo con token API non valido da X" diventano per client invece che per proxy.
+- Lo schema / host / prefisso del proxy vengono rispettati, mantenendo corretti gli URL generati e gli scope dei cookie.
+
+```yaml
+# Estratto docker-compose.yml
+services:
+  certmate:
+    image: fabriziosalmi/certmate:latest
+    environment:
+      BEHIND_PROXY: "true"
+    volumes:
+      - ./data:/app/data
+```
+
+**Quando NON abilitarla.** Se si espone CertMate direttamente sulla rete senza un proxy davanti, lasciare `BEHIND_PROXY` non impostato. Con questa opzione attiva, chiunque possa raggiungere il listener potrebbe falsificare `X-Forwarded-For` e aggirare i limiti di rate per client. Il proxy è il confine di fiducia.
+
+Il proxy deve naturalmente inoltrare gli header. Esempio Nginx:
+
+```nginx
+proxy_set_header Host              $host;
+proxy_set_header X-Real-IP         $remote_addr;
+proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+```
+
+#### Esempio: Zion (gateway TLS Rust + WAF)
+
+[Zion](https://github.com/fabriziosalmi/zion) è un reverse proxy Rust ad alte prestazioni con WAF integrato — una scelta ottimale davanti a CertMate quando si desidera la terminazione TLS 1.3 e il filtraggio delle richieste all'edge. CertMate rimane in HTTP semplice sulla rete interna; Zion termina il TLS e inoltra.
+
+`zion.toml`:
+
+```toml
+[server]
+listen_http  = "0.0.0.0:8080"
+listen_https = "0.0.0.0:8443"
+
+[tls]
+cert_path = "/etc/ssl/zion/tls.crt"
+key_path  = "/etc/ssl/zion/tls.key"
+min_version = "1.3"
+alpn = ["h2", "http/1.1"]
+
+[upstream.backend]
+url = "http://certmate:8000"
+
+[[route]]
+path = "/"
+upstream = "backend"
+
+[[route]]
+path = "/{*rest}"
+upstream = "backend"
+```
+
+`docker-compose.yml`:
+
+```yaml
+services:
+  certmate:
+    image: certmate:latest
+    environment:
+      BEHIND_PROXY: "true"
+    expose:
+      - "8000"
+    volumes:
+      - ./data:/app/data
+
+  zion:
+    image: zion:latest
+    depends_on:
+      - certmate
+    environment:
+      ZION_CONFIG: /etc/zion/zion.toml
+    volumes:
+      - ./zion.toml:/etc/zion/zion.toml:ro
+      - ./certs:/etc/ssl/zion:ro
+    ports:
+      - "443:8443"
+      - "80:8080"
+```
+
+Mantenere `BEHIND_PROXY=true` sul servizio CertMate: Zion aggiunge `X-Forwarded-For`, quindi il rate limiting per client, le voci di audit e gli avvisi di autenticazione fallita risolveranno sul vero IP del client anziché su quello di Zion.
+
+### Usare Gunicorn
+
+```bash
+pip install gunicorn
+gunicorn --bind 0.0.0.0:8000 --workers 4 --threads 8 app:app
+```
+
+### Usare systemd
+
+Creare `/etc/systemd/system/certmate.service`:
+
+```ini
+[Unit]
+Description=CertMate SSL Certificate Manager
+After=network.target
+
+[Service]
+Type=simple
+User=certmate
+WorkingDirectory=/opt/certmate
+Environment=PATH=/opt/certmate/venv/bin
+ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 4 app:app
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Backup e ripristino
+
+```bash
+# Creare un backup
+curl -X POST http://localhost:8000/api/backups/create \
+  -H "Authorization: Bearer IL_PROPRIO_TOKEN_API"
+
+# Elencare i backup
+curl http://localhost:8000/api/backups \
+  -H "Authorization: Bearer IL_PROPRIO_TOKEN_API"
+
+# Ripristinare un backup
+curl -X POST http://localhost:8000/api/backups/restore \
+  -H "Authorization: Bearer IL_PROPRIO_TOKEN_API" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "backup_20240101_120000.zip"}'
+```
+
+---
+
+## Risoluzione dei problemi
+
+### Conflitti di versioni dei plugin DNS
+
+In caso di conflitti di versioni, utilizzare queste versioni specifiche:
+
+```txt
+certbot==4.1.1
+certbot-dns-cloudflare==4.1.1
+certbot-dns-route53==4.1.1
+certbot-dns-azure==2.6.1
+certbot-dns-google==4.1.1
+certbot-dns-powerdns==0.2.1
+```
+
+### Comandi di verifica
+
+```bash
+# Verificare i plugin certbot
+certbot plugins --text
+
+# Verificare che il servizio sia in esecuzione
+curl -X GET http://localhost:8000/api/health
+```
+
+### Errori comuni
+
+| Errore | Soluzione |
+|--------|-----------|
+| `ModuleNotFoundError` | Eseguire `pip install -r requirements.txt` |
+| `Port already in use` | Cambiare la porta nelle variabili d'ambiente |
+| `certbot not found` | Installare certbot: `pip install certbot` |
+| `Permission denied` | Verificare i permessi su `/app/data` e `/app/certificates` |
+| `Token API non valido` | Verificare `API_BEARER_TOKEN` nel file `.env` |
+
+### Modalità debug
+
+```bash
+export FLASK_DEBUG=1
+python app.py
+```
+
+### Confinamento del traffico in uscita (hardening dell'egress)
+
+CertMate stabilisce connessioni in uscita verso le autorità di certificazione ACME, le API dei provider DNS, lo storage a oggetti e i webhook di notifica via HTTP(S), nonché SMTP per le notifiche email. È possibile confinare e verificare il traffico **HTTP(S)** instradandolo attraverso un **forward proxy** e negando a CertMate qualsiasi altra route verso internet.
+
+I client HTTP(S) di CertMate (`requests`, `certbot`, consegna webhook via `urllib`, `boto3`) rispettano le variabili d'ambiente standard `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`, quindi non è necessaria alcuna modifica al codice. **SMTP è l'eccezione:** le notifiche email usano `smtplib`, che apre una connessione TCP diretta e **non** consulta le variabili del proxy HTTP. Su una rete egress chiusa, consentire direttamente l'`host:port` del proprio relay SMTP (regola firewall / NetworkPolicy), oppure usare un canale di notifica webhook al posto dell'email.
+
+Esempio con [Secure Proxy Manager](https://github.com/fabriziosalmi/secure-proxy-manager), un forward proxy self-hosted basato su Squid con WAF, DNS sinkhole e — dalla v3.9.0 — una **allowlist egress default-deny** nativa (solo le destinazioni esplicitamente approvate sono raggiungibili; tutto il resto viene rifiutato):
+
+```yaml
+services:
+  certmate:
+    image: certmate:latest
+    environment:
+      HTTP_PROXY:  "http://proxy:3128"
+      HTTPS_PROXY: "http://proxy:3128"
+      NO_PROXY:    "localhost,127.0.0.1"
+    networks:
+      - egress            # CertMate può raggiungere SOLO il proxy su questa rete
+networks:
+  egress:
+    internal: true        # nessun gateway: CertMate non ha accesso diretto a internet
+```
+
+Collocare CertMate su una rete `internal` (senza gateway) condivisa con il proxy fa del proxy il suo **unico** percorso in uscita. Il traffico in uscita diventa un unico punto di controllo verificabile: consentire le destinazioni di cui CertMate ha effettivamente bisogno (la propria CA, provider DNS, storage a oggetti, endpoint di notifica) e rifiutare il resto.
+
+**Kubernetes:** una `NetworkPolicy` egress default-deny che consente il traffico solo verso il Service del proxy, più le variabili d'ambiente `HTTP(S)_PROXY` sul Deployment.
+
+**systemd:** `Environment=HTTPS_PROXY=...` nell'unità, più regole firewall dell'host che limitano l'egress al proxy.
+
+### Posizione di archiviazione per la directory dei dati
+
+CertMate usa le I/O su file bloccanti standard di Python per tutto ciò che si trova sotto `data/` (impostazioni, certificati, log di audit, store SQLite dello scheduler). Il disco locale è fortemente raccomandato.
+
+Se si monta `data/` su un filesystem di rete (NFS, SMB), tenere presente che:
+
+- Un server NFS bloccato può sospendere indefinitamente le letture di file Python senza timeout integrato. Il worker di rinnovo, il writer del log di audit e la sonda /health si bloccheranno tutti sullo stesso punto di mount.
+- La modalità journal WAL di SQLite richiede semantiche di lock che NFS non fornisce sempre. CertMate registra un avviso se ha dovuto ricorrere a una modalità journal più debole; la correttezza è preservata, ma la concorrenza diminuisce.
+
+Se NFS è inevitabile, montare con `soft,timeo=30,retrans=3` (o l'equivalente della propria distribuzione) affinché le I/O falliscano rapidamente invece di bloccarsi su un server fermo.
+
+### Usare Gunicorn
+
+```bash
+gunicorn --bind 0.0.0.0:8000 --workers 4 app:app
+```
+
+### Usare systemd
+
+Creare `/etc/systemd/system/certmate.service`:
+
+```ini
+[Unit]
+Description=CertMate SSL Certificate Manager
+After=network.target
+
+[Service]
+Type=simple
+User=certmate
+WorkingDirectory=/opt/certmate
+Environment=PATH=/opt/certmate/venv/bin
+ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 4 app:app
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Abilitare e avviare:
+
+```bash
+sudo systemctl enable certmate
+sudo systemctl start certmate
+```
+
+### Usare Docker in produzione
+
+```yaml
+version: '3.8'
+services:
+  certmate:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - API_BEARER_TOKEN=${API_BEARER_TOKEN}
+      - CLOUDFLARE_TOKEN=${CLOUDFLARE_TOKEN}
+    volumes:
+      - ./certificates:/app/certificates
+      - ./data:/app/data
+    restart: unless-stopped
+```
+
+---
+
+## Risoluzione dei problemi
+
+### Installazione manuale delle dipendenze
+
+Se l'installazione automatica non va a buon fine, installare i provider DNS singolarmente:
+
+```bash
+# Core certbot
+pip install certbot==4.1.1
+
+# Cloudflare
+pip install certbot-dns-cloudflare==4.1.1
+
+# AWS Route53
+pip install certbot-dns-route53==4.1.1 boto3==1.35.76
+
+# Azure DNS
+pip install certbot-dns-azure==2.6.1 azure-identity==1.19.0 azure-mgmt-dns==8.1.0
+
+# Google Cloud DNS
+pip install certbot-dns-google==4.1.1 google-cloud-dns==0.35.0
+
+# PowerDNS
+pip install certbot-dns-powerdns==0.2.1
+```
+
+> La maggior parte dei plugin DNS richiede Certbot 4.1.1. Il plugin Azure ha un versioning indipendente (2.6.1) e PowerDNS è un plugin più recente (0.2.1).
+
+### Comandi di verifica
+
+```bash
+# Verificare i plugin certbot
+certbot plugins --text
+
+# Verificare che il servizio sia in esecuzione
+curl -X GET http://localhost:8000/api/health
+```
+
+### Errori comuni
+
+| Errore | Soluzione |
+|--------|-----------|
+| `ModuleNotFoundError` | Eseguire `pip install -r requirements.txt` |
+| `Port already in use` | Cambiare la porta nelle variabili d'ambiente |
+| `certbot not found` | Installare certbot: `pip install certbot` |
+| `Permission denied` | Verificare i permessi su `/app/data` e `/app/certificates` |
+| `Token API non valido` | Verificare `API_BEARER_TOKEN` nel file `.env` |
+
+### Modalità debug
+
+```bash
+export FLASK_DEBUG=1
+python app.py
+```
+
+---
+
+## Supporto
+
+In caso di problemi:
+
+1. Controllare i log per gli errori specifici
+2. Verificare le credenziali del proprio provider DNS
+3. Consultare la [Guida ai provider DNS](./dns-providers.md) per la risoluzione dei problemi specifici per provider
+4. Consultare la [Guida ai test](./testing.md) per eseguire la diagnostica
+
+---
+
+<div align="center">
+
+[← Torna alla documentazione](./README.md) • [Provider DNS →](./dns-providers.md) • [Docker →](./docker.md)
+
+</div>

--- a/docs/it/kubernetes.md
+++ b/docs/it/kubernetes.md
@@ -1,0 +1,96 @@
+# Note di produzione Kubernetes
+
+Questa guida raccoglie la configurazione di dimensionamento di base per CertMate quando viene eseguito dietro un Ingress/HTTPRoute Kubernetes e utilizza un backend di certificati remoto come Azure Key Vault.
+
+## Risorse consigliate
+
+CertMate esegue gunicorn insieme ai sottoprocessi certbot nello stesso container. Durante la creazione o il rinnovo dei certificati, certbot e i plugin DNS possono generare temporaneamente un picco di memoria elevato. Con Azure Key Vault in modalità `both`, elencare i certificati comporta anche chiamate remote, quindi limiti molto ridotti possono trasformare operazioni di routine in riavvii OOM.
+
+Utilizza questa configurazione di base per i pod di produzione che gestiscono decine di certificati:
+
+```yaml
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1536Mi
+env:
+  - name: CERTMATE_CERT_INFO_CACHE_TTL
+    value: "60"
+  - name: GUNICORN_TIMEOUT
+    value: "300"
+```
+
+Per il caso di errore specifico in cui un pod con `memory: 512Mi` si riavvia durante la creazione di un certificato, aumenta prima il limite di memoria. Il percorso del codice evita ora i sottoprocessi `openssl` della precedente vista elenco, utilizza letture leggere delle informazioni sui certificati tramite Azure Key Vault, ed esclude le directory temporanee/storiche di certbot dai backup di routine, ma certbot ha comunque bisogno di margine durante l'emissione dei certificati.
+
+## Esempio di applicazione del patch
+
+```bash
+kubectl -n certificate-management patch deployment certmate --type='strategic' -p '
+spec:
+  template:
+    spec:
+      containers:
+        - name: certmate
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1536Mi
+          env:
+            - name: CERTMATE_CERT_INFO_CACHE_TTL
+              value: "60"
+            - name: GUNICORN_TIMEOUT
+              value: "300"
+'
+```
+
+Verifica il motivo del successivo riavvio dopo l'applicazione:
+
+```bash
+kubectl -n certificate-management describe pod -l app=certmate | grep -A6 "Last State"
+kubectl -n certificate-management top pod -l app=certmate
+```
+
+## Numero di repliche
+
+Esegui `replicas: 1` a meno che tutti i percorsi mutabili (`/app/data`, `/app/certificates`, `/app/backups`, `/app/logs`) non siano supportati da uno storage sicuro per scritture concorrenti e tu abbia validato il comportamento dello scheduler e del rinnovo per pod multipli. Azure Key Vault può archiviare i certificati in remoto, ma CertMate mantiene comunque localmente le impostazioni, i metadati, i backup e lo stato di esecuzione.
+
+## Il badge di stato del deployment mostra "Backend: Unreachable"
+
+*Aggiornato il 2026-05-25 (vedi [#263](https://github.com/fabriziosalmi/certmate/issues/263)).*
+
+Il badge di stato del deployment nella dashboard è un indicatore di salute facoltativo e **non influisce** sull'emissione, il rinnovo o il download. Il processo di CertMate apre una connessione TLS diretta verso `<domain>:443` e confronta l'impronta digitale del certificato servito con quella memorizzata:
+
+- **Deployed** — l'handshake ha avuto successo e l'impronta digitale corrisponde.
+- **Wrong Cert** — l'handshake ha avuto successo ma viene servito un certificato diverso.
+- **Unreachable** — il pod non ha potuto aprire una connessione TLS verso il dominio.
+
+Su Kubernetes, **Unreachable per ogni certificato è previsto** ogni volta che il pod CertMate non riesce a raggiungere direttamente il tuo IP pubblico/Ingress. Cause comuni:
+
+- Il dominio risolve un IP pubblico/Ingress non raggiungibile dall'interno del pod (hairpin/NAT o DNS split-horizon).
+- Una `NetworkPolicy` di uscita blocca il traffico in uscita sulla porta 443.
+- TLS viene terminato dal controller Ingress o da un load balancer esterno, quindi non esiste un endpoint che CertMate possa raggiungere direttamente.
+- La probe è semplicemente lenta e supera il budget predefinito di 3 secondi.
+
+Se la destinazione è raggiungibile ma lenta, aumenta il budget della probe:
+
+```yaml
+env:
+  - name: CERTMATE_TLS_PROBE_TIMEOUT_SECONDS
+    value: "10"   # accepts 1–30 seconds; default is 3
+```
+
+In caso contrario, il badge può essere ignorato in tutta sicurezza in una topologia Ingress/Kubernetes — i certificati vengono emessi e serviti correttamente anche quando CertMate non riesce a verificarli autonomamente.
+
+---
+
+<div align="center">
+
+[← Torna alla documentazione](./README.md) • [Guida Docker →](./docker.md)
+
+</div>

--- a/docs/it/mcp.md
+++ b/docs/it/mcp.md
@@ -1,0 +1,117 @@
+# Server MCP (Model Context Protocol) CertMate
+
+CertMate include un server MCP (Model Context Protocol) integrato scritto in Node.js. Questo consente agli assistenti IA agentici (come Claude o Gemini) di ispezionare in modo sicuro lo stato dei certificati, attivare rinnovi, richiedere diagnostiche e interagire direttamente con l'API CertMate.
+
+## Funzionalità e strumenti
+
+Il server MCP CertMate espone i seguenti strumenti agli assistenti IA:
+
+**Inventario e stato**
+1. **`certmate_list_certificates`** — Elenca tutti i certificati gestiti dall'istanza CertMate attiva (con scadenza, stato, domini).
+2. **`certmate_get_certificate`** — Dettaglio completo per un dominio: stato, giorni alla scadenza, SAN, provider DNS/CA, flag di rinnovo automatico. Usalo per decidere se un certificato deve essere rinnovato.
+3. **`certmate_get_activity`** — Attività recente/registro di audit, per diagnosticare cosa è cambiato o ha fallito.
+4. **`certmate_diagnostics`** — Istantanea diagnostica completa e sanificata.
+5. **`certmate_get_settings`** — Impostazioni globali e configurazione.
+
+**Operazioni sul ciclo di vita**
+6. **`certmate_create_certificate`** — Richiede un nuovo certificato TLS per un dominio (provider DNS, account, CA opzionali). Può restituire un `job_id` (HTTP 202) per l'emissione asincrona.
+7. **`certmate_renew_certificate`** — Forza il rinnovo di un certificato esistente (può restituire anch'esso un `job_id`).
+8. **`certmate_get_job`** — Interroga un job asincrono di creazione/rinnovo tramite `job_id` finché non segnala completato o fallito.
+9. **`certmate_set_auto_renew`** — Abilita o disabilita il rinnovo automatico per un singolo dominio.
+10. **`certmate_deploy_certificate`** — Esegue manualmente tutti i deploy hook configurati per un dominio.
+11. **`certmate_download_certificate`** — Restituisce il materiale del certificato di un dominio come JSON (fullchain, key, chain) affinché un agente possa distribuirlo altrove.
+
+**Provider**
+12. **`certmate_list_dns_providers`** — Provider DNS supportati e configurati su questa istanza.
+13. **`certmate_list_dns_accounts`** — Account provider DNS configurati (credenziali mascherate); usa un id account restituito come `account_id` durante la creazione di un certificato.
+
+## Configurazione
+
+### Prerequisiti
+- Node.js (v18 o superiore)
+- npm
+
+### Installazione
+Naviga nella directory `mcp/` del repository CertMate e installa le dipendenze:
+```bash
+cd mcp
+npm install
+```
+
+### Variabili d'ambiente
+Il server MCP comunica con l'API REST CertMate e richiede due variabili d'ambiente:
+- `CERTMATE_URL` — L'URL della tua istanza CertMate (predefinito: `http://localhost:8000`).
+- `CERTMATE_TOKEN` — Un token Bearer API valido con le opportune autorizzazioni di ruolo (solitamente `operator` o `admin`). Per un agente verificabile, usa una chiave contrassegnata come chiave agente (vedi [Attribuzione audit](#attribuzione-audit)).
+
+Opzionale:
+- `CERTMATE_AGENT_SESSION` — Sovrascrive l'id di sessione per processo che il server invia a ogni chiamata (`X-CertMate-Agent-Session`), in modo che un'esecuzione possa essere correlata con l'id di un orchestratore esterno. Se non impostato, viene generato un UUID nuovo per ogni processo.
+- `CERTMATE_AGENT_ID` — Un'etichetta per questo deployment dell'agente (`X-CertMate-Agent-Id`, predefinito `certmate-mcp-server`).
+
+### Esempio di integrazione (configurazione Claude Desktop)
+Per aggiungere il server MCP CertMate a Claude Desktop, aggiungi quanto segue al tuo file di configurazione (solitamente in `~/Library/Application Support/Claude/claude_desktop_config.json` su macOS o `%APPDATA%\Claude\claude_desktop_config.json` su Windows):
+
+```json
+{
+  "mcpServers": {
+    "certmate": {
+      "command": "node",
+      "args": ["/percorso/assoluto/verso/certmate/mcp/index.js"],
+      "env": {
+        "CERTMATE_URL": "http://localhost:8000",
+        "CERTMATE_TOKEN": "your_secure_bearer_token"
+      }
+    }
+  }
+}
+```
+
+### Altri client MCP (Gemini, ecc.)
+
+Il server comunica tramite MCP standard su stdio, quindi qualsiasi client che supporta MCP funziona allo stesso modo: puntalo su `node /percorso/assoluto/verso/certmate/mcp/index.js` e imposta le due variabili d'ambiente. Nulla nel server è specifico per Claude.
+
+## Utilizzo di CertMate con un agente IA (job pianificati)
+
+La maggior parte degli assistenti di punta supporta ora i **task pianificati** (Claude, Gemini e altri). Combinando questo con il server MCP si ottiene un "custode dei certificati" autonomo: descrivi la policy in linguaggio naturale con condizioni esplicite, il modello si pianifica da solo e a ogni esecuzione usa gli strumenti sopra per applicare la policy. Il pattern è agnostico rispetto al modello — qualsiasi sistema in grado di eseguire un prompt salvato su un calendario e chiamare strumenti MCP funzionerà.
+
+### Il ciclo eseguito dall'agente
+
+1. `certmate_list_certificates` (o `certmate_get_certificate` per dominio) per leggere `days_left` / stato.
+2. Decisione in base alla tua condizione, ad es. *rinnova quando `days_left < 14`*.
+3. `certmate_renew_certificate` per ogni dominio interessato.
+4. Se un rinnovo restituisce un `job_id`, `certmate_get_job` finché non segnala `completed` / `failed`.
+5. In caso di fallimento, segnalalo — e i canali di notifica di CertMate (email, Slack, Discord, Telegram, ntfy, Gotify) si attiveranno anch'essi su `certificate_failed`, così ricevi una notifica in ogni caso.
+
+### Esempi di prompt pianificati
+
+> **Giornaliero, 08:00** — "Usando gli strumenti MCP CertMate, elenca tutti i certificati. Per quelli con `days_left < 14`, chiama `certmate_renew_certificate`, poi interroga `certmate_get_job` fino al termine. Rispondi con un riepilogo di una riga per dominio e segnala eventuali fallimenti."
+
+> **Settimanale** — "Chiama `certmate_get_activity` e `certmate_diagnostics`. Riassumi eventuali anomalie (rinnovi falliti, certificati scaduti, scheduler non in esecuzione) in tre punti. Se non c'è nulla di anomalo, indicalo."
+
+> **Su richiesta** — "Emetti un certificato per `shop.example.com` usando `certmate_list_dns_providers` per scegliere un provider configurato e `certmate_list_dns_accounts` per l'id dell'account, poi monitora il job fino al completamento."
+
+Poiché le condizioni vivono nel prompt, puoi modificare la policy (soglia, domini, azione in caso di fallimento) senza toccare alcun codice. Assegna all'agente un token con scope limitato esattamente a ciò che deve fare — `operator` per rinnovo/deploy, `admin` solo se deve modificare impostazioni o leggere diagnostiche.
+
+## Sicurezza
+
+1. **Protezione del token** — Il server MCP richiede un `CERTMATE_TOKEN` valido. Trasmette questo token in modo sicuro nell'header `Authorization` per tutte le richieste all'API CertMate.
+2. **Privilegio minimo** — Limita il token a ciò di cui l'agente ha bisogno. Un custode di rinnovi pianificato ha bisogno di `operator`; riserva i token `admin` agli agenti che devono modificare impostazioni o estrarre diagnostiche. Revoca il token per disconnettere immediatamente l'agente.
+3. **Compatibilità con la sanificazione dei log** — Strumenti come `certmate_diagnostics` recuperano i dati dopo che il Log Sanitizer ha rimosso le credenziali sensibili, proteggendo chiavi e token da fughe nei contesti LLM.
+
+## Attribuzione audit
+
+Affinché la traccia di audit possa distinguere le azioni di un agente da quelle di un operatore umano, assegna al server MCP una **chiave API dedicata contrassegnata come agente** anziché il token Bearer globale legacy:
+
+1. In CertMate, vai in **Impostazioni → Chiavi API**, crea una chiave e spunta **Chiave agente IA** (oppure invia `"is_agent": true` a `POST /api/keys`). Limitala con `allowed_domains` e il ruolo minimo necessario.
+2. Imposta quella chiave come `CERTMATE_TOKEN` per il server MCP.
+
+Ogni azione sui certificati eseguita dall'agente viene registrata con `actor.kind="agent"`, l'id stabile della chiave e il `X-CertMate-Agent-Session` per processo inviato dal server — così puoi mostrare esattamente quali modifiche ai certificati ha effettuato un agente IA, sotto quale identità e raggruppate per esecuzione. Il token Bearer globale legacy riduce ogni chiamante a `api_user` senza id di chiave ed è registrato come `api_token`, non `agent`. L'header di sessione agente è un'informazione dichiarativa e non promuove mai autonomamente un chiamante a `agent`.
+
+I record risultanti fanno parte della catena di audit a prova di manomissione; vedi [Registro audit](./api.md#audit-logging) e [compliance.md](./compliance.md).
+
+---
+
+<div align="center">
+
+[← Torna alla documentazione](./README.md)
+
+</div>

--- a/docs/it/probes.md
+++ b/docs/it/probes.md
@@ -1,0 +1,76 @@
+# Probe di Deployment
+
+Le probe verificano che i tuoi certificati siano raggiungibili sulla rete eseguendo un TLS handshake in tempo reale con il server deployato.
+
+## Configurazione
+
+Configura le probe per dominio in **Impostazioni → Probe di deployment**.
+
+| Campo | Descrizione |
+|---|---|
+| Dominio | Il dominio del certificato da sondare |
+| Porta | Porta TCP (default: 443 per HTTPS/TLS, 587 per SMTP STARTTLS) |
+| Protocollo | `HTTPS/TLS` — handshake HTTPS standard, `TLS` — TLS grezzo senza HTTP, `SMTP STARTTLS` — SMTP semplice con upgrade a TLS |
+
+Il protocollo e la porta sono memorizzati nel `metadata.json` del certificato sotto le chiavi `deployment_protocol` e `deployment_port`.
+
+## Funzionamento
+
+### Probe backend
+
+1. Il backend legge la porta e il protocollo configurati nei metadati del certificato.
+2. Viene aperta una connessione socket ed eseguito un TLS handshake.
+3. L'impronta digitale del certificato servito viene confrontata con quella del certificato locale.
+4. Il risultato (raggiungibile, deployato, corrispondenza certificato) viene messo in cache per 5 minuti (configurabile).
+
+### Probe browser (fallback)
+
+Quando la probe backend indica che il server non è raggiungibile **e** il protocollo è `HTTPS/TLS`, viene attivata una probe di riserva lato browser tramite `fetch(..., { mode: 'no-cors' })`. Questo permette di verificare la raggiungibilità anche quando il backend non riesce a connettersi (es. segmentazione di rete).
+
+Per i protocolli `TLS` e `SMTP STARTTLS`, la probe browser viene **ignorata** perché i browser non sono in grado di eseguire connessioni TLS grezze o SMTP. Lo stato browser mostra "Non verificato".
+
+### Cache
+
+| Livello | Durata | Bypass |
+|---|---|---|
+| Backend (memoria) | 300 s (default) | Parametro `?refresh=1` |
+| Frontend (memoria) | 300 s | `forceRefresh=true` (pulsante Verifica probe) |
+
+## API
+
+### Verificare lo stato di deployment
+
+```
+GET /api/certificates/<domain>/deployment-status
+GET /api/certificates/<domain>/deployment-status?refresh=1
+```
+
+Restituisce:
+
+| Campo | Tipo | Descrizione |
+|---|---|---|
+| domain | string | Il dominio sondato |
+| deployed | boolean | Se un certificato è stato servito |
+| reachable | boolean | Se il server ha risposto |
+| certificate_match | boolean/null | Se il certificato servito corrisponde a quello locale |
+| method | string | Protocollo utilizzato (`https-tls`, `tls`, `smtp-starttls`) |
+| port | integer | Porta TCP sondara |
+| protocol | string | Uguale a method |
+| error | string | Messaggio di errore se la probe ha fallito |
+| browser | object | Risultato della probe browser (solo HTTPS) |
+
+### Configurare una probe
+
+```
+PATCH /api/certificates/<domain>
+```
+
+```json
+{ "deployment_port": 444, "deployment_protocol": "https-tls" }
+```
+
+Impostare a `null` per rimuovere la configurazione:
+
+```json
+{ "deployment_port": null, "deployment_protocol": null }
+```

--- a/docs/it/testing.md
+++ b/docs/it/testing.md
@@ -1,0 +1,351 @@
+# Guida ai test
+
+Questa guida descrive il framework di test di CertMate, inclusi unit test, test di integrazione e la validazione degli endpoint API.
+
+---
+
+## Avvio rapido
+
+```bash
+# Attivare l'ambiente virtuale
+source .venv/bin/activate
+
+# Installare le dipendenze di test
+pip install -r requirements-test.txt
+
+# Eseguire tutti i test
+pytest
+
+# Eseguire i test con la copertura
+pytest --cov=. --cov-report=html
+```
+
+---
+
+## Struttura dei test
+
+```
+Directory radice:
+  conftest.py                              # Configurazione della raccolta e fixture condivise
+  pytest.ini                               # Configurazione e marcatori di test
+  test_certificate_creation.py             # Test di creazione dei certificati
+  test_certificate_listing.py              # Test di elenco dei certificati
+  test_client_certificates_comprehensive.py # Test del ciclo di vita dei certificati client
+  test_dns_accounts.py                     # Operazioni multi-account
+  test_dns_provider.py                     # Funzionalità di base dei provider
+  test_dns_provider_inheritance.py         # Ereditarietà della configurazione
+  test_domain_alias.py                     # Test degli alias di dominio
+  test_infisical_backend.py               # Backend di archiviazione Infisical
+  test_shell_executor.py                   # Test di esecuzione shell
+  test_e2e_complete.py                     # Suite di test end-to-end
+```
+
+---
+
+## Esecuzione dei test
+
+### Comandi comuni
+
+```bash
+# Eseguire tutti i test
+pytest
+
+# Eseguire con output dettagliato
+pytest -v
+
+# Eseguire un file di test specifico
+pytest test_certificate_creation.py
+
+# Eseguire una funzione di test specifica
+pytest test_certificate_creation.py::test_specific_function -v -s
+
+# Eseguire i test corrispondenti a un pattern
+pytest -k "dns_provider"
+
+# Eseguire con rapporto di copertura
+pytest --cov=. --cov-report=html
+open htmlcov/index.html
+```
+
+### Con Make
+
+```bash
+make test              # Eseguire tutti i test
+make test-unit         # Solo unit test
+make test-integration  # Solo test di integrazione
+make test-coverage     # Test con copertura
+make check             # Tutte le verifiche qualità
+```
+
+---
+
+## Categorie di test
+
+I test sono organizzati con i marcatori pytest:
+
+```bash
+# Unit test (veloci, senza servizi esterni)
+pytest -m "not integration and not slow"
+
+# Test di integrazione
+pytest -m integration
+
+# Test API
+pytest -m api
+
+# Test dei provider DNS
+pytest -m dns
+
+# Test end-to-end (richiedono un server in esecuzione)
+pytest -m e2e
+```
+
+### E2E senza Docker
+
+Per impostazione predefinita, le fixture e2e costruiscono l'immagine Docker e gestiscono un container
+per tutta la sessione. Quando Docker non è disponibile (sandbox CI,
+reti con restrizioni), puntare la suite su un'istanza già in esecuzione:
+
+```bash
+# Terminale 1: avviare CertMate come si preferisce
+gunicorn --bind 127.0.0.1:18888 --workers 1 --threads 8 app:app
+
+# Terminale 2: puntare all'istanza (ignora tutta la gestione del ciclo di vita Docker)
+CERTMATE_E2E_BASE_URL=http://localhost:18888 pytest -m "e2e and not ui"
+```
+
+I test di emissione reale richiedono inoltre `CLOUDFLARE_API_TOKEN` e un
+`CERTMATE_TEST_DOMAIN` sotto il proprio controllo, e consumano certificati
+Let's Encrypt reali — vengono ignorati automaticamente quando il token è assente.
+L'istanza di destinazione deve avviarsi da una directory dati pulita: i test e2e
+presuppongono uno stato di primo avvio, quindi il riutilizzo tra esecuzioni provoca
+errori legati all'autenticazione.
+
+---
+
+## Test degli endpoint API
+
+### Script di test rapido
+
+Usare `quick_test.sh` per una validazione rapida degli endpoint prima di ogni commit:
+
+```bash
+# Eseguire prima di ogni commit
+./quick_test.sh
+
+# Testare solo gli endpoint pubblici
+./quick_test.sh --public-only
+```
+
+Questo script:
+- Verifica se il server è in esecuzione
+- Carica automaticamente il token API da `data/settings.json`
+- Testa tutte le categorie di endpoint
+- Fornisce un output chiaro di successo/fallimento
+
+### Suite di test API completa
+
+```bash
+# Caricamento automatico del token dalle impostazioni
+python3 test_all_endpoints.py --auto-token
+
+# Con URL del server personalizzato
+python3 test_all_endpoints.py --url http://192.168.1.100:8000
+
+# Con token API manuale
+python3 test_all_endpoints.py --token your-api-bearer-token
+
+# Test rapido degli elementi essenziali soltanto
+python3 test_all_endpoints.py --quick --auto-token
+
+# Solo endpoint pubblici (nessuna autenticazione richiesta)
+python3 test_all_endpoints.py --public-only
+```
+
+### Endpoint testati
+
+| Categoria | Endpoint |
+|-----------|----------|
+| **Salute** | `GET /api/health`, `GET /health` |
+| **Impostazioni** | `GET /api/settings`, `GET /api/settings/dns-providers`, `POST /api/settings` |
+| **Certificati** | `GET /api/certificates`, `POST /api/certificates/create`, download, renew |
+| **Cache** | `GET /api/cache/stats`, `POST /api/cache/clear` |
+| **Backup** | `GET /api/backups`, `POST /api/backups/create`, `POST /api/backups/cleanup` |
+| **Interfaccia Web** | `/`, `/settings`, `/help`, `/docs/`, `/api/swagger.json` |
+
+### Codici di stato attesi
+
+- **200/201**: Successo
+- **400/422**: Errori di validazione attesi (normali per i payload di test)
+- **404**: Atteso per risorse inesistenti
+- **401**: Token API non valido o assente
+- **500**: Bug dell'applicazione (da investigare)
+
+---
+
+## Scrittura dei test
+
+### Struttura di un test
+
+```python
+import pytest
+from unittest.mock import patch, MagicMock
+
+def test_function_name(client, sample_settings):
+    """Test description."""
+    # Arrange
+    setup_data = {...}
+
+    # Act
+    response = client.get('/api/endpoint')
+
+    # Assert
+    assert response.status_code == 200
+    assert 'expected_key' in response.json()
+```
+
+### Utilizzo delle fixture
+
+```python
+def test_with_app_context(app):
+    """Test that requires app context."""
+    with app.app_context():
+        pass
+
+def test_api_endpoint(client):
+    """Test API endpoint."""
+    response = client.get('/api/test')
+    assert response.status_code == 200
+
+def test_with_mock_data(mock_certificate_data):
+    """Test with mock data."""
+    assert mock_certificate_data['domain'] == 'test.example.com'
+```
+
+### Simulazione di servizi esterni
+
+```python
+@patch('app.requests.get')
+def test_external_api(mock_get, client):
+    """Test external API call."""
+    mock_get.return_value.json.return_value = {'status': 'success'}
+    response = client.post('/api/certificate/request')
+    assert response.status_code == 200
+```
+
+---
+
+## Integrazione continua
+
+### GitHub Actions
+
+La pipeline CI viene eseguita ad ogni push e pull request:
+
+1. **Versioni Python multiple**: Test su Python 3.9, 3.11, 3.12
+2. **Qualita del codice**: Linting con flake8
+3. **Sicurezza**: Scansione con bandit
+4. **Test**: Suite completa con copertura
+5. **Docker**: Test della build Docker
+6. **Copertura**: Caricamento su Codecov
+
+### Hook Pre-Commit
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Gli hook includono: formattazione del codice (black, isort), linting (flake8), verifiche di sicurezza (bandit).
+
+### Test API CI/CD
+
+```yaml
+# Esempio GitHub Actions
+- name: Test API Endpoints
+  run: |
+    python app.py &
+    sleep 5
+    python3 test_all_endpoints.py --auto-token
+```
+
+---
+
+## Requisiti di copertura
+
+- Minimo **80%** di copertura del codice complessiva
+- I percorsi critici devono avere una copertura **95%+**
+- Tutte le nuove funzionalita devono includere test
+
+---
+
+## Buone pratiche
+
+### Da fare
+
+- Scrivere test per tutte le nuove funzionalita
+- Usare nomi di test descrittivi
+- Testare sia i casi di successo che quelli di fallimento
+- Simulare le dipendenze esterne
+- Usare i marcatori di test appropriati
+- Mantenere i test isolati e indipendenti
+
+### Da non fare
+
+- Non testare i dettagli di implementazione
+- Non usare chiavi API reali nei test
+- Non rendere i test dipendenti gli uni dagli altri
+- Non ignorare i fallimenti dei test
+- Non saltare la scrittura di test per il codice "semplice"
+
+---
+
+## Debug dei test
+
+```bash
+# Output dettagliato con istruzioni print
+pytest -v -s
+
+# Debug di un test specifico
+pytest test_api.py::test_specific -v -s
+
+# Utilizzo di pdb
+def test_debug_example():
+    import pdb; pdb.set_trace()
+    # Test code here
+```
+
+---
+
+## Test di prestazioni
+
+```python
+import pytest
+import concurrent.futures
+
+@pytest.mark.slow
+def test_api_load(client):
+    """Test API under load."""
+    def make_request():
+        return client.get('/api/certificates')
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [executor.submit(make_request) for _ in range(100)]
+        responses = [f.result() for f in futures]
+
+    assert all(r.status_code == 200 for r in responses)
+```
+
+---
+
+## Codici di uscita
+
+- **0**: Tutti i test superati
+- **1**: Alcuni test falliti
+
+---
+
+<div align="center">
+
+[← Torna alla documentazione](./README.md) • [Architettura →](./architecture.md) • [Riferimento API →](./api.md)
+
+</div>


### PR DESCRIPTION
Italian documentation tree under `docs/it/` (16 files, ~5.7k lines), mirroring the French tree from #327.

- Translated from the canonical English sources, French versions used as structural reference.
- Code/commands/links/section structure preserved verbatim; only prose translated.
- Heading parity verified vs English (no sections dropped); no stray emoji beyond what the English sources already carry (the ✅ in THEME_MIGRATION match EN + the merged FR).

Native-speaker review welcome — @fabriziosalmi can verify the Italian directly.