### PR TITLE
docs(i18n): add German and Spanish documentation (needs native review)

### DIFF
--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -1,0 +1,238 @@
+# CertMate Dokumentation
+
+Willkommen in der CertMate-Dokumentation. Dieser Ordner enthält umfassende Anleitungen zu allen Funktionen.
+
+---
+
+## Schnellnavigation
+
+### Erste Schritte
+- **[Installationsanleitung](./installation.md)** — Einrichtung, Abhängigkeiten, Produktions-Deployment
+- **[Docker-Anleitung](./docker.md)** — Docker-Builds, Multi-Plattform, Docker Compose
+- **[Kubernetes-Hinweise](./kubernetes.md)** — Produktionsressourcen, OOM-Dimensionierung, Runtime-Patching
+
+### Kernfunktionen
+- **[DNS-Provider](./dns-providers.md)** — Unterstützte Provider, Multi-Account, Domain-Alias
+- **[CA-Provider](./ca-providers.md)** — Let's Encrypt, DigiCert, Private CA
+- **[Client-Zertifikate](./guide.md)** — Lebenszyklus von Client-Zertifikaten, Web-Dashboard, Batch-Operationen
+- **[Model Context Protocol (MCP) Server](./mcp.md)** — Eigenständiger Node.js-Server für KI-Agenten-Integrationen
+
+### Referenz
+- **[API-Referenz](./api.md)** — Vollständige REST-API-Dokumentation
+- **[Architektur](./architecture.md)** — Systemdesign, Komponenten, Datenfluss
+- **[Test-Anleitung](./testing.md)** — Test-Framework, CI/CD, Abdeckung
+
+---
+
+## Dokumentation nach Zielgruppe
+
+### Für neue Benutzer
+
+1. **[Installation](./installation.md)** — CertMate in Betrieb nehmen
+2. **[DNS-Provider](./dns-providers.md)** — Ihren DNS-Provider konfigurieren
+3. **[Anleitung zu Client-Zertifikaten](./guide.md)** — Ihr erstes Zertifikat erstellen
+
+### Für Entwickler
+
+1. **[API-Referenz](./api.md)** — Alle Endpoints mit Beispielen
+2. **[Architektur](./architecture.md)** — Interne Systemstruktur und Design
+3. **[Test-Anleitung](./testing.md)** — Wie man Tests schreibt und ausführt
+
+### Für Administratoren
+
+1. **[Docker-Deployment](./docker.md)** — Docker-Einrichtung für die Produktion
+2. **[Kubernetes-Hinweise](./kubernetes.md)** — Pod-Dimensionierung und operatives Patching in der Produktion
+3. **[CA-Provider](./ca-providers.md)** — Zertifizierungsstellen konfigurieren
+4. **[DNS-Provider](./dns-providers.md#multi-account-support)** — Unternehmensweite Multi-Account-Einrichtung
+
+---
+
+## Funktionsübersicht
+
+### Server-Zertifikate
+- **Über zwei Dutzend DNS-Provider** für Let's Encrypt DNS-01-Challenges (vollständige Liste unter [DNS-Provider](./dns-providers.md))
+- **Mehrere CA-Provider**: Let's Encrypt, DigiCert, Private CA
+- **Multi-Account-Unterstützung** pro DNS-Provider
+- **Austauschbare Storage-Backends**: Lokal, Azure Key Vault, AWS, Vault, Infisical
+- **Auto-Renewal** mit konfigurierbaren Schwellenwerten
+- **Docker-Unterstützung** mit Multi-Plattform-Builds (ARM64 + AMD64)
+- **Log Sanitizer** — Bereinigt automatisch API-Tokens, private Schlüssel und sensible Zugangsdaten aus den CertMate-Logs
+- **Zombie Certificate Scanner** — Multi-Threaded-Dateisystem-Scanner zur Identifikation und Bereinigung verwaister Zertifikate
+- **Model Context Protocol (MCP) Server** — Eigenständiger Node.js-Server zur Integration mit agentischen KI-Assistenten
+
+### Client-Zertifikate
+- **Self-signed CA** mit 4096-Bit-RSA-Schlüsseln
+- **Vollständiges Lifecycle-Management** — erstellen, erneuern, widerrufen, überwachen
+- **OCSP & CRL** — Echtzeit-Status und Sperrlisten
+- **Web-Dashboard** unter `/client-certificates`
+- **Batch-Operationen** — Import von 100 bis 30.000 Zertifikaten per CSV
+- **Audit-Logging** und **Rate Limiting**
+
+---
+
+## API-Endpoints Kurzreferenz
+
+| Methode | Endpoint                                 | Beschreibung              |
+| ------- | ---------------------------------------- | ------------------------- |
+| POST    | `/api/client-certs/create`               | Zertifikat erstellen      |
+| GET     | `/api/client-certs`                      | Zertifikate auflisten     |
+| GET     | `/api/client-certs/<id>`                 | Metadaten abrufen         |
+| GET     | `/api/client-certs/<id>/download/<type>` | Zert/Schlüssel/CSR laden  |
+| POST    | `/api/client-certs/<id>/revoke`          | Zertifikat widerrufen     |
+| POST    | `/api/client-certs/<id>/renew`           | Zertifikat erneuern       |
+| GET     | `/api/client-certs/stats`                | Statistiken abrufen       |
+| POST    | `/api/client-certs/batch`                | CSV-Batch-Import          |
+| GET     | `/api/ocsp/status/<serial>`              | OCSP-Status               |
+| GET     | `/api/crl/download/<format>`             | CRL herunterladen         |
+
+Vollständige Dokumentation unter [API-Referenz](./api.md#endpoints).
+
+---
+
+## Tests
+
+Alle Funktionen sind umfassend getestet:
+
+```bash
+# Tests ausführen
+python -m pytest tests/ -v
+```
+
+Die Testabdeckung umfasst:
+- CA-Operationen
+- CSR-Operationen
+- Zertifikat-Lebenszyklus
+- Filterung & Suche
+- Batch-Operationen
+- OCSP & CRL
+- Audit & Rate Limiting
+
+---
+
+## Sicherheitsfunktionen
+
+- **4096-Bit RSA** für CA-Schlüssel
+- **SHA256**-Signaturalgorithmus
+- **Bearer-Token**-Authentifizierung
+- **Rate Limiting** auf allen Endpoints
+- **Audit-Logging** aller Operationen
+- **Dateiberechtigungen** 0600 für private Schlüssel
+
+---
+
+## Performance
+
+- Unterstützt **30.000+ gleichzeitige Zertifikate**
+- Effiziente **Multi-Filter-Abfragen**
+- **Auto-Renewal**-Planung
+- **Batch-Operationen** mit Fehlerverfolgung
+
+---
+
+## Dateistruktur
+
+```
+docs/
+  README.md            ← Sie sind hier
+  index.md             ← Einstiegsseite für Client-Zertifikate
+  installation.md      ← Installation & Einrichtung
+  kubernetes.md        ← Kubernetes-Produktionshinweise
+  dns-providers.md     ← DNS-Provider & Multi-Account
+  ca-providers.md      ← Zertifizierungsstellen-Provider
+  docker.md            ← Docker-Build & Deployment
+  testing.md           ← Test-Framework & CI/CD
+  guide.md             ← Benutzeranleitung Client-Zertifikate
+  api.md               ← Vollständige API-Referenz
+  architecture.md      ← Systemarchitektur
+```
+
+---
+
+## Lernpfad
+
+**Einsteiger** → [Hier starten](./index.md) → [Erste Schritte](./guide.md)
+
+**Entwickler** → [API-Referenz](./api.md) → [Architektur](./architecture.md)
+
+**Fortgeschritten** → [Vollständige API-Dokumentation](./api.md) → [Architekturdetails](./architecture.md)
+
+---
+
+## Wichtige Links
+
+- **Web-Dashboard**: `http://localhost:8000/client-certificates`
+- **API-Dokumentation**: `http://localhost:8000/docs/`
+- **Statusprüfung**: `http://localhost:8000/health`
+- **Audit-Logs**: `logs/audit/certificate_audit.log`
+
+---
+
+## Status-Dashboard
+
+| Komponente       | Status    | Tests     |
+| ---------------- | --------- | --------- |
+| CA-Grundlage     | Bereit    | 3/3       |
+| CSR-Handler      | Bereit    | 3/3       |
+| Zert.-Manager    | Bereit    | 8/8       |
+| Filterung        | Bereit    | 3/3       |
+| Batch-Operationen| Bereit    | 2/2       |
+| OCSP/CRL         | Bereit    | 5/5       |
+| Audit/Rate Limit | Bereit    | 3/3       |
+| **Gesamt**       | **Bereit**| **27/27** |
+
+---
+
+## Schnellbeispiele
+
+### Zertifikat per API erstellen
+
+```bash
+curl -X POST http://localhost:8000/api/client-certs/create \
+ -H "Authorization: Bearer YOUR_TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "common_name": "user@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "api-mtls",
+ "days_valid": 365
+ }'
+```
+
+### Zertifikate auflisten
+
+```bash
+curl http://localhost:8000/api/client-certs \
+ -H "Authorization: Bearer YOUR_TOKEN"
+```
+
+### Zertifikat herunterladen
+
+```bash
+curl http://localhost:8000/api/client-certs/USER_ID/download/crt \
+ -H "Authorization: Bearer YOUR_TOKEN" \
+ -o certificate.crt
+```
+
+Weitere Beispiele im [API-Leitfaden](./api.md).
+
+---
+
+## Lizenz
+
+CertMate steht unter der MIT-Lizenz. Siehe die LICENSE-Datei im Repository.
+
+---
+
+## Fragen oder Probleme?
+
+- Konsultieren Sie die entsprechende Dokumentationsseite
+- Schauen Sie in die Testdateien für Verwendungsbeispiele
+- Prüfen Sie die [API-Referenz](./api.md) für Details zu den Endpoints
+
+---
+
+<div align="center">
+
+[Startseite](../README.md) • [Dokumentation](./) • [GitHub](https://github.com/fabriziosalmi/certmate)
+
+</div>

--- a/docs/de/THEME_MIGRATION.md
+++ b/docs/de/THEME_MIGRATION.md
@@ -1,0 +1,225 @@
+# Theme-Migration — Entkopplung von Hell/Dunkel über CSS-Variable-Tokens
+
+Status: **ausgeliefert** (Phasen 0–5 in v2.9.0; Phase 6 folgt) · Verantwortlicher: Fabrizio · Erstellt: 2026-05-25
+
+## Ziel
+
+Bisher bedeutet ein Themenwechsel, Farben in ~19 Templates und im Frontend-JS zu bearbeiten. Diese Migration macht einen einzigen Block von CSS Custom Properties zur einzigen Quelle der Wahrheit für die gesamte Palette — ein Retheming (oder das Hinzufügen eines neuen Themes) erfordert danach nur noch die Bearbeitung von `:root` / `.dark` in einer einzigen Datei, nicht an Hunderten von Verwendungsstellen.
+
+## Ausgangszustand (gemessen am 2026-05-25)
+
+| Metrik | Wert |
+|---|---|
+| Farbklassen-Referenzen in Templates | ~3.197 in 19 Dateien |
+| `dark:`-Paare in Templates | ~1.665 |
+| Farbklassen im Anwendungs-JS (nicht vendored) | ~789 (dashboard.js 372, settings.js 150, setup-wizard.js 131, certmate.js 60, client-certs.js 57, …) |
+| Hartcodierte Hex-Werte im Anwendungs-JS | ~17 (Toast-/Diagramm-Paletten); 80 weitere in `redoc.standalone.js` sind **vendored, ignorieren** |
+| Übernommene R-3-Komponentenklassen | nur `.card` (12×); `.btn-*`, `.badge-*`, `.form-*` = 0 |
+
+Schwerste Dateien: `partials/settings_dns.html` (635 / 395 dark:), `index.html`
+(311 / 150), `partials/settings_deploy.html`, `partials/settings_ca.html`.
+
+## Prozessrisiken, die zuerst behoben werden müssen
+
+1. **Das kompilierte CSS wird manuell eingecheckt.** `package.json` hat nur `css:build` /
+   `css:watch`; kein CI baut `static/css/tailwind.min.css` neu. Eine Bearbeitung von
+   `input.css` ohne anschließenden Build liefert stillschweigend veraltetes CSS aus. → CI-Build + Aktualitätsprüfung in Phase 0 hinzufügen.
+2. **~3.200 manuelle Bearbeitungen = garantierte Regressionen.** Es wird eine visuelle Baseline
+   (Hell+Dunkel-Screenshots jeder Seite) und ein halbautomatischer Codemod für die
+   mechanischen `dark:`-Paare benötigt — kein blindes Suchen und Ersetzen.
+
+## Strategie: CSS Custom Properties als einzige Quelle
+
+shadcn-Stil auf Tailwind v3: Farben werden zu CSS-Variablen in `:root` / `.dark`,
+die Tailwind als semantische Tokens zur Verfügung gestellt werden (HSL-Kanal-Triplets, damit
+die `/opacity`-Utilities weiterhin funktionieren). Die ~1.665 `dark:`-Paare reduzieren sich auf einzelne Klassen.
+
+### Vorgeschlagene Token-Zuordnungstabelle
+
+| Tailwind-Token | Ersetzt (Beispiele) | Verwendung |
+|---|---|---|
+| `bg-background` | `bg-gray-50 dark:bg-surface-dark` | Seite |
+| `bg-surface` | `bg-white dark:bg-surface-card` | Karte |
+| `bg-surface-2` | `bg-gray-100 dark:bg-gray-800` | erhöht |
+| `text-foreground` | `text-gray-900 dark:text-white` | Haupttext |
+| `text-muted` | `text-gray-500 dark:text-gray-400` | Sekundärtext |
+| `border-border` | `border-gray-200 dark:border-gray-700` | Rahmen |
+| `bg-primary` / `text-primary` | Marke (jetzt variablenbasiert) | Marke |
+| `*-success/warning/danger/info` | grün=gültig, rot=abgelaufen… | **Status, keine Oberflächen** |
+
+## Phasen
+
+Jede Phase = ein atomarer Commit (Partials in Phase 3 in eigene Commits aufteilen). Phasen werden in einem oder mehreren `vX.Y.Z`-Release-PRs zusammengefasst.
+
+### Phase 0 — Grundlagen und Absicherungen (keine visuelle Änderung)
+- [x] CI-Schritt führt `npm run css:build` aus und schlägt fehl, wenn `tailwind.min.css` veraltet ist (`git diff --exit-code`). → `frontend-css`-Job in `.github/workflows/ci.yml`. Das eingecheckte Bundle war bereits abgewichen; neu gebaut und eingecheckt.
+- [x] Token-Schicht definieren: CSS-Variablen in `:root` / `.dark` (input.css) + Zuordnung in `tailwind.config.js`, **neben** der bestehenden Palette — noch keine Templates geändert. Tokens: `bg-background`, `bg-surface`, `bg-surface-2`, `text-foreground`, `text-muted`, `border-border` (safelisted).
+- [x] Den Codemod schreiben: `scripts/theme_codemod.py` — Zuordnungstabelle häufig auftretender `dark:`-Paare → Tokens, Dry-run-Report + `--apply`. Mehrdeutigkeitsbericht unten.
+- [x] Screenshot-Baseline-Tooling: `scripts/theme_baseline.py` — baut Docker mit einem frischen, kurzlebigen Datenverzeichnis, initialisiert einen Wegwerf-Admin, erfasst jede echte UI-Seite in Hell + Dunkel. Nach jeder Phase erneut ausführen und Diff erstellen. **Erfassungslauf noch ausstehend** (erfordert `playwright install chromium` + einen lokalen Docker-Build).
+
+#### Baseline-Umfang (nur echte Seiten)
+Erfasst: `/` (Setup, dann Index), `/login`, `/settings`, `/help`, `/activity`, `/redoc` — 7 Seiten × Hell/Dunkel.
+
+> **Befund (außerhalb des Umfangs, markiert):** Die Routen `/certificates` und `/audit` in `modules/web/ui_routes.py:25-41` rendern `certificates.html` / `audit.html`, die **nicht existieren** — beide liefern 500. Tote Routen, von der Baseline ausgeschlossen. Eine separate Korrektur wäre sinnvoll (Routen entfernen oder Templates wiederherstellen).
+
+#### Codemod-Verwendung
+```
+python scripts/theme_codemod.py                     # dry-run report, all templates
+python scripts/theme_codemod.py templates/base.html # report, one file
+python scripts/theme_codemod.py --apply templates/base.html
+```
+Nach jedem `--apply`: `npm run css:build`, Diff gegen Baseline, verbleibende `dark:`-Varianten prüfen.
+
+#### Report-Snapshot (2026-05-25)
+**607 Paare werden automatisch zusammengefasst** von ~1.665 `dark:`-Varianten:
+
+| Token | Paare |
+|---|---|
+| `text-muted` | 203 |
+| `border-border` | 169 |
+| `text-foreground` | 141 |
+| `bg-surface` | 77 |
+| `bg-surface-2` | 16 |
+| `bg-background` | 1 |
+
+**557 Vorkommen / 29 Varianten sind nicht zugeordnet** — Designentscheidungen für den Phase-1-Piloten, nicht automatisch erraten:
+
+- `dark:bg-gray-700` (137): wird mit `bg-white` (Karten/Inputs) **und** `bg-gray-50` kombiniert — je nach Kontext surface vs. surface-2 entscheiden.
+- `dark:text-white` (120): die mit `text-gray-900` kombinierten werden bereits auf `text-foreground` abgebildet; der Rest ist immer weißer Text auf farbigem Hintergrund — wahrscheinlich so belassen.
+- `dark:text-gray-300` (112): meist `text-gray-700 dark:text-gray-300` = das Formularlabel-Muster — einen dedizierten Label-Token vs. `text-muted`/`text-foreground` entscheiden.
+- `dark:border-gray-600` (41), `dark:text-gray-200` (39), Oberflächen mit Opacity-Suffix (`dark:bg-gray-700/50` etc.) und `dark:border-white/5`.
+
+Einige Überreste (`dark:text-gray-400{%`, `dark:text-gray-300'`) sind Klassenattribute mit Jinja/JS-Ausdrücken — manuell migrieren.
+
+### Phase 1 — Pilot: Shell + Primitive
+- [x] `base.html` (Nav/Header/Footer/Tab-Leiste) auf Tokens migrieren. 19 Paare zusammengefasst; Token-Werte stimmen exakt mit den Originalen überein.
+- [x] `login.html` auf Tokens migrieren. 12 Paare zusammengefasst.
+- [ ] `.btn` / `.form-*`-Komponentenklassen übernehmen (zurückgestellt — der Pilot verwendete nur Tokens; die Login-Inputs unterscheiden sich in der Größe von `.form-input`, daher ist die Komponentenübernahme ein eigener Schritt).
+- [x] Hell/Dunkel-Parität validieren. Live in Docker verifiziert (base.html + login.html, beide Themes) — Pilot akzeptiert.
+
+#### Offene Designentscheidungen (durch den Pilot aufgedeckt)
+1. **Formularlabel-Text** (`text-gray-700 dark:text-gray-300`). **In Phase 5 gelöst → Option (b):** `--color-label`-Token mit den genauen gray-700/gray-300-Werten hinzugefügt (treu, keine visuelle Änderung) und alle 137 Vorkommen auf `text-label` migriert. Das Zusammenführen mit `text-foreground` wurde abgelehnt (würde den Hellmodus von 27 %→11 % L abdunkeln).
+2. **Rahmenvereinheitlichung**: `border-gray-300` (Inputs) wird jetzt auf `border-border` (= gray-200) abgebildet, sodass Input-Rahmen im Hellmodus eine Stufe heller werden. Für den Piloten akzeptiert (ein einziger Rahmen-Token ist das Ziel); mit `--color-input-border` nochmals überdenken, falls die Review es ablehnt.
+3. **Glass-Inputs / `dark:border-white/5`-Haarlinie / hover:-Varianten / Statusfarben**: absichtlich NICHT tokenisiert — Glass-Steuerelemente haben kein Hell-Gegenstück, die white/5-Haarlinie ist der kanonische `.card`-Rand, und Hover/Status benötigen ihren eigenen Varianten-Token-Durchlauf (eine spätere Phase).
+
+### Phase 2 — Dashboard ✅
+- [x] `index.html` (Dashboard-Chrome): Zertifikat-Erstellungsformular, Listen-/Statistikkarten, Tabellenköpfe + Trennlinien, Detailbereich, Modale. Alpine `:class`-Ternaries und `divide-border` manuell behandelt.
+- [x] `static/js/dashboard.js`: JS-gerenderte Zeilen, Statistiken, Leer-/Willkommenszustände, Detailbereich, Alias-Prüfausgabe. `node --check` sauber.
+- Gesundheits-/Deployment-Statusfarben (grün/amber/rot/blau) wurden absichtlich als buchstäbliche Statusfarben belassen — sie tragen Bedeutung und erhalten später einen dedizierten Status-Token-Durchlauf, keine Oberflächen-Tokens.
+- Glass-Formular-Inputs (`dark:bg-gray-700`/`dark:text-white`), Formularlabels und hover:-Varianten für ihre eigene Behandlung zurückgestellt (konsistent mit dem Piloten).
+
+### Phase 3 — Einstellungscluster ✅
+- [x] `settings.html` + 10 Partials + `_modal`: 441 Paare zusammengefasst. Innere Alpine-`:class`-Ternary-Paare vom Codemod tokenisiert (Anführungszeichen verbinden nur die Branch-Edge-Klassen); Ternary-Struktur als intakt verifiziert.
+- [x] `settings.js` + `setup-wizard.js`: 49 Paare, `node --check` sauber. Die anderen `settings-*.js` enthalten keine Farbklassen.
+- Unverändert belassen (konsistent mit den vorangegangenen Phasen): Glass-Inputs (`dark:bg-gray-700` ~99), Formularlabels (`dark:text-gray-300` ~78, zurückgestellt), Status-Badges, Opacity-Oberflächen, hover:-Varianten und Ternary-Branch-Edge-Klassen.
+
+### Phase 4 — Verbleibende Seiten ✅
+- [x] Templates: activity, help, setup, `_client_certs` (123 Paare; keine Alpine-Ternaries hier).
+- [x] JS: client-certs.js, cmd-palette.js, report-issue.js, shortcuts.js (26 Paare, `node --check` sauber). setup-wizard.js wurde bereits in Phase 3 erledigt.
+- Dieselben Ausnahmen wie zuvor: Glass-Inputs, Body-/Label-Grautöne, Opacity-Oberflächen, Statusfarben, hover: und Klassen an String-Verkettungsgrenzen.
+
+### Phase 5 — Bereinigung und Festschreibung ✅
+- [x] Label-Entscheidung abgeschlossen: `text-label`-Token + 137 Stellen migriert (siehe oben).
+- [x] Blinden Fleck des Codemods entdeckt: Er scannte nur `class="..."` und übersah `className='...'`-Zuweisungen sowie JS-String-Verkettung. Ein **grenzenbewusster Literal-Durchlauf** hinzugefügt (fasst benachbarte `HELL DUNKEL`-Teilstrings in beliebigem Kontext zusammen) + das `--check`-Gate. Das erneute Ausführen des vollständigen Durchlaufs fasste die verbleibenden JS-Paare zusammen (confirm/prompt-Dialog, report-issue + shortcuts-Modale).
+- [x] Ungenutzte Legacy-Aliasse `success`/`warning`/`danger` aus `tailwind.config.js` entfernt (0 Verwendungsstellen). `primary` (~375) und `secondary` (Verläufe) beibehalten.
+- [x] **CI-Absicherung**: `python3 scripts/theme_codemod.py --check` im `frontend-css`-Job — schlägt den Build fehl, wenn ein zusammenfassbares Hell+Dunkel-Paar in einem Template oder einer First-Party-JS-Datei wieder eingeführt wird.
+- **JS-Hex unverändert belassen, by design:** Die `#60a5fa`/etc.-Palette in `certmate.js` ist der **Debug-Konsolen-Logger** auf einer festen, immer dunklen Oberfläche (`bg-black`); `TOAST_COLORS` sind buchstäbliche Statusklassen. Beides sind themenunabhängige Statusakzente — konventionell kein Bestandteil von Hell/Dunkel-Theming — und bleiben daher buchstäblich statt zu Theme-Tokens zu werden. Ein künftiger **Status-Token-Durchlauf** (success/warning/danger/info als Variablen) ist der richtige Ort, um sie zu vereinheitlichen, falls je gewünscht.
+- Baseline-Aktualisierung: optional; nicht ausgeführt (Erfassung wurde zurückgestellt — stattdessen wurde in jeder Phase eine Live-Docker-Verifizierung verwendet).
+
+### Phase 6 — Status-Token-Durchlauf ✅
+- [x] `success`/`warning`/`danger` (+ neues `info`) als **Token-Gruppen** neu hinzugefügt
+  (`surface`/`line`/`fg`/`strong`), variablenbasiert in `:root`/`.dark` (HSL,
+  treu zu den Inline-Werten, dunkle Oberflächen über die Karte geblendet).
+- [x] Den Codemod um eine generierte Farbton×Abstufungstabelle (`_expand_status`) erweitert,
+  die die grün/rot/amber/blau-Info-Box-Paare auf die Tokens faltet —
+  und den 50-vs-100 / 700-vs-800-Drift der Inline-Callouts normalisiert.
+  **300 Paare zusammengefasst** in Templates + First-Party-JS.
+- [x] `--check` bewacht jetzt auch Status-Paare (sie leben in `MAPPINGS`), sodass ein
+  wieder eingeführtes Hell+Dunkel-Status-Paar den CI wie jedes andere fehlschlagen lässt.
+- Buchstäblich belassen by design: einzelne Statusakzente ohne Hell/Dunkel-Paar
+  (Icon `text-*-500`) und eigenständige Nur-Dunkel-Töne (ohne Hell-Gegenstück).
+
+### Phase 7 — Formularfeld-Oberfläche ✅ (v2.9.1)
+- [x] `--color-input` (weiß / gray-700) → `bg-input` hinzugefügt; 40
+  `bg-white dark:bg-gray-700`-Feldpaare zusammengefasst. Exakte Wertübereinstimmung.
+
+### Phase 8 — Hover- und eingesenkte Oberflächen ✅ (v2.9.1)
+- [x] `--color-hover` (gray-100/700), `border.strong` (gray-300/500) und
+  `--color-sunken` (gray-50/700) hinzugefügt; 51 Hover-/eingesenkte Paare zusammengefasst. Minderheit
+  der Hover-Abstufungen buchstäblich belassen, damit der Durchlauf strikt nullverändernd bleibt.
+
+### Phase 9 — Komponentenschicht-Tokenisierung + Akzent ✅
+- [x] Die `@apply`-Regeln der R-3-Komponenten (`.card`, `.form-input`/`.form-select`/
+  `.form-label`, `.btn-secondary`, `.btn-ghost`, `.nav-active`, `.nav-inactive`)
+  waren ein **blinder Fleck des Codemods** — `--check` scannt `class="…"`, nicht `@apply` —
+  und enthielten noch rohe gray/blue-Klassen. Auf die Tokens migriert.
+- [x] Einen thema-bewussten `accent`-Token hinzugefügt (blue-600 → blue-400 im Dunkelmodus), sodass
+  `.nav-active` die Blaufarbe nicht mehr fest kodiert; das ist der On-Surface-Akzent, den #254
+  vermisste.
+- Nicht erledigt (by design): Übernahme von `.btn`/`.form-*` an den Verwendungsstellen (die Inline-
+  Verwendungsstellen sind bereits tokenisiert; das Erzwingen der Komponenten würde die Button-Größe
+  ohne Entkopplungsgewinn ändern). `.btn-danger` (solide Aktionsrot) und die
+  `.badge-*`-Statusvarianten bleiben buchstäblich. Die `@apply`-Schicht bleibt außerhalb
+  des `--check`-Gates — eine künftige Codemod-Erweiterung könnte sie scannen.
+
+### Phase 10 — Farb-Tail-Zerlegung (geplant, schrittweise)
+Die Entkopplung hinterließ **565 `dark:`-Utilities**, die der Codemod nicht zusammenfassen kann: Sie
+haben kein helles Geschwisterelement zum Paaren, sodass `--check` sie nie sieht. Die Prüfung
+(2026-05-25) zeigt, dass es sich nicht um ein Problem, sondern um drei handelt, mit gegensätzlichen Risikoprofilen:
+
+| Gruppe | Anzahl | Wird aufgelöst zu | Neue Tokens |
+|---|---|---|---|
+| 1 — Neutraltöne (weiß/grau) | 388 (69%) | `foreground / surface / surface-2 / sunken / muted / border` | 0 |
+| 2 — Status (blau/rot/amber) | 63 (11%) | `info / success / warning / danger` | 0 |
+| 3 — Regenbogen (lila/indigo/orange) | 111 (20%) | **neutral** (dekorativ, herabgestuft) | 0 |
+
+Wichtigste Erkenntnis: **null neue Tokens nötig.** Das bereits ausgelieferte Token-System *ist*
+der Vertrag; die 565 sind alles, was ihm entkommen ist. Die Korrektur ist Durchsetzung +
+Herabstufung, kein neues Vokabular. (Die Regenbogenfarben wurden als dekorative
+Abschnittscodierung gemessen — lila = "erweiterte Konfiguration", indigo = CA/Enterprise, orange =
+Speicher — kein Status, und über Dateien hinweg inkonsistent.)
+
+Reihenfolge, nach steigendem UX-Risiko:
+- **10a — Neutraltöne (388).** Unsichtbar: `dark:text-white` → `text-foreground`,
+  `dark:bg-gray-700` → `bg-input`/`bg-surface-2`/`bg-sunken` (nach Kontext disambiguiert —
+  dasselbe Dunkelgrau, unterschiedliche *helle* Bedeutung, daher menschlich klassifiziert pro
+  Cluster, kein blindes sed). `theme_codemod.py` um einen Solo-Dark→Token-Durchlauf erweitern. Risiko ~0, bereinigt ~70%.
+- **10b — Status (63).** Die blau/rot/amber-Callouts den vorhandenen
+  info/success/warning/danger-Gruppen zuordnen. Normalisiert den 50-vs-100-Drift. Geringes Risiko.
+- **10c — Regenbogen (111).** Die Produktentscheidung (siehe Vertrag unten).
+  Dekorative Abschnittsfarbtöne werden auf Neutral reduziert. Sichtbare Änderung, zuletzt erledigt,
+  Block für Block mit Vorher/Nachher-Screenshot-QA. Entschieden: **Vertrag α**
+  (Farbe = Bedeutung).
+
+## Farbvertrag (der Standard, dem die 565 entkamen)
+Entschieden am 2026-05-25. Vier Regeln; die bereits ausgelieferten Tokens sind die einzige Palette.
+
+1. **Farbe wird verdient, nie dekorativ eingesetzt.** Ein Farbton erscheint nur, wenn er
+   *Status* (info/success/warning/danger) oder *Marke* (Akzent: Links, aktive Nav, Primary, Fokus) trägt. Alles andere ist neutral
+   (background/surface/surface-2/sunken/border/foreground/muted/label).
+2. **Identität kommt aus der Struktur, nicht aus der Farbe.** Abschnitte werden durch
+   Abstände, Überschriften, Icons, Trennlinien unterschieden — nicht durch einen Füllton.
+3. **Eine einzige Betonungsprimitiv.** Konfigurations-/erweiterte Blöcke verwenden ein einzelnes neutrales
+   eingesenktes Panel (`bg-sunken border-border rounded-md`); ein optionaler linker Markenrand markiert "aktiv/wichtig". Keine abschnittsspezifische Palette.
+4. **Icons erhalten nur Marken- oder Statusfarbe.** Keine lila/indigo/orange-Icon-Töne.
+
+Durchsetzung: Das `--check`-Gate erhält eine Regel, die den CI bei rohem
+`purple|indigo|orange` (und jeder nicht-tokenisierten Farbe) unter `templates/` fehlschlagen lässt — ein Vertrag mit einem Compiler dahinter, sodass er nicht wieder verfallen kann.
+
+## Statusfarben — jetzt tokenisiert (Phase 6)
+Frühere Phasen haben Statusfarben (grün/amber/rot/blau mit ihren `dark:`-Varianten) bewusst als
+separaten, optionalen Durchlauf zurückgestellt — sie tragen Bedeutung und sind konventionell thema-invariant. **Phase 6 hat diesen Durchlauf vorgenommen:** Die kombinierten Info-Box-Oberflächen/Rahmen/Texte verwenden jetzt `bg-success-surface`,
+`text-danger-strong` usw. Einzelne Status-*Akzente* (Icon `text-*-500`, kein dunkles Paar) bleiben buchstäblich — diese sind themenunabhängig und kein Bestandteil von Hell/Dunkel-Theming.
+
+## Workflow-Abstimmung
+- Kein Emoji in Commits/PRs/Release-Notes.
+- Atomare Commits (einer pro Phase, oder pro Partial in Phase 3); ein PR pro Release.
+- Vor dem öffentlichen Push: Docker-Smoke-Test + echte Zertifikatsausstellung gegen Fabs Domain mit zufälligen Subdomains.
+
+---
+
+<div align="center">
+
+[← Zurück zur Dokumentation](./README.md)
+
+</div>

--- a/docs/de/api.md
+++ b/docs/de/api.md
@@ -1,0 +1,764 @@
+# CertMate Client-Zertifikate - API-Referenz
+
+## Übersicht
+
+Die CertMate-API für Client-Zertifikate stellt REST-Endpoints für eine vollständige Zertifikatsverwaltung mit Authentifizierung, Rate Limiting und Audit-Protokollierung bereit.
+
+**Basis-URL**: `http://localhost:5000/api`
+**Authentifizierung**: Bearer Token (auf allen Endpoints erforderlich)
+**Content-Type**: `application/json`
+
+---
+
+## Authentifizierung
+
+Alle API-Endpoints erfordern eine Authentifizierung per Bearer Token.
+
+### Header-Format
+
+```
+Authorization: Bearer IHR_TOKEN
+```
+
+### Beispielanfrage
+
+```bash
+curl -X GET http://localhost:5000/api/client-certs \
+ -H "Authorization: Bearer IHR_TOKEN" \
+ -H "Content-Type: application/json"
+```
+
+---
+
+## Rate Limiting
+
+API-Endpoints unterliegen Rate Limits, um Missbrauch zu verhindern:
+
+| Endpoint              | Limit | Pro    |
+| --------------------- | ----- | ------ |
+| Allgemein             | 100   | Minute |
+| Zertifikat erstellen  | 30    | Minute |
+| Batch-Operationen     | 10    | Minute |
+| OCSP-Status           | 200   | Minute |
+| CRL-Download          | 60    | Minute |
+
+### Antwort bei überschrittenem Limit
+
+Wird das Limit überschritten, erhalten Sie:
+
+```
+HTTP 429 Too Many Requests
+
+{
+ "error": "Rate limit exceeded",
+ "message": "Too many requests. Please try again later.",
+ "retry_after": 60
+}
+```
+
+---
+
+## Endpoints
+
+### Zertifikatsverwaltung
+
+#### 1. Zertifikat erstellen
+
+**Endpoint**: `POST /client-certs/create`
+
+Erstellt ein neues Client-Zertifikat.
+
+**Anfrage**:
+```json
+{
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "organizational_unit": "Engineering",
+ "cert_usage": "api-mtls",
+ "days_valid": 365,
+ "generate_key": true,
+ "notes": "Production certificate"
+}
+```
+
+**Parameter**:
+- `common_name` (erforderlich) — Subject des Zertifikats
+- `email` (optional) — E-Mail-Adresse
+- `organization` (optional) — Name der Organisation
+- `organizational_unit` (optional) — Abteilungsname
+- `cert_usage` (optional) — Verwendungstyp: `api-mtls`, `vpn` oder benutzerdefiniert
+- `days_valid` (optional) — Gültigkeitsdauer in Tagen (Standard: 365)
+- `generate_key` (optional) — Privaten Schlüssel erzeugen (Standard: true)
+- `notes` (optional) — Zusätzliche Anmerkungen
+
+**Antwort** (201 Created):
+```json
+{
+ "identifier": "cert-abc123",
+ "common_name": "user@example.com",
+ "serial_number": "12345678901234567890",
+ "created_at": "2024-10-30T18:00:00Z",
+ "expires_at": "2025-10-30T18:00:00Z",
+ "cert_usage": "api-mtls",
+ "status": "active"
+}
+```
+
+**Beispiel**:
+```bash
+curl -X POST http://localhost:5000/api/client-certs/create \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "api-mtls",
+ "days_valid": 365
+ }'
+```
+
+---
+
+#### 2. Zertifikate auflisten
+
+**Endpoint**: `GET /client-certs`
+
+Listet alle Client-Zertifikate mit optionaler Filterung auf.
+
+**Query-Parameter**:
+- `usage` (optional) — Nach Verwendungstyp filtern (z. B. `api-mtls`)
+- `revoked` (optional) — Nach Status filtern (`true` oder `false`)
+- `search` (optional) — Im Common Name suchen
+
+**Antwort** (200 OK):
+```json
+{
+ "certificates": [{
+ "identifier": "cert-001",
+ "common_name": "user1@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "api-mtls",
+ "created_at": "2024-10-30T18:00:00Z",
+ "expires_at": "2025-10-30T18:00:00Z",
+ "revoked": false,
+ "status": "active"
+ },
+ {
+ "identifier": "cert-002",
+ "common_name": "user2@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "vpn",
+ "created_at": "2024-10-29T18:00:00Z",
+ "expires_at": "2025-10-29T18:00:00Z",
+ "revoked": true,
+ "status": "revoked"
+ }
+ ],
+ "total": 2
+}
+```
+
+**Beispiele**:
+```bash
+# Alle Zertifikate auflisten
+curl http://localhost:5000/api/client-certs \
+ -H "Authorization: Bearer TOKEN"
+
+# Nach Verwendungstyp filtern
+curl "http://localhost:5000/api/client-certs?usage=api-mtls" \
+ -H "Authorization: Bearer TOKEN"
+
+# Nur widerrufene auflisten
+curl "http://localhost:5000/api/client-certs?revoked=true" \
+ -H "Authorization: Bearer TOKEN"
+
+# Nach Common Name suchen
+curl "http://localhost:5000/api/client-certs?search=user1" \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+#### 3. Zertifikatsdetails abrufen
+
+**Endpoint**: `GET /client-certs/<identifier>`
+
+Ruft die vollständigen Metadaten eines Zertifikats ab.
+
+**Antwort** (200 OK):
+```json
+{
+ "type": "client_certificate",
+ "identifier": "cert-001",
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "organizational_unit": "Engineering",
+ "serial_number": "12345678901234567890",
+ "created_at": "2024-10-30T18:00:00Z",
+ "expires_at": "2025-10-30T18:00:00Z",
+ "cert_usage": "api-mtls",
+ "notes": "Production certificate",
+ "revocation": {
+ "revoked": false,
+ "revoked_at": null,
+ "reason_revoked": null
+ },
+ "renewal": {
+ "renewal_enabled": true,
+ "renewal_threshold_days": 30
+ }
+}
+```
+
+**Beispiel**:
+```bash
+curl http://localhost:5000/api/client-certs/cert-001 \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+#### 4. Zertifikatsdateien herunterladen
+
+**Endpoint**: `GET /client-certs/<identifier>/download/<type>`
+
+Lädt das Zertifikat, den privaten Schlüssel oder die CSR-Datei herunter.
+
+**Parameter**:
+- `identifier` — Zertifikats-ID
+- `type` — Dateityp: `crt`, `key` oder `csr`
+
+**Antwort** (200 OK):
+- Content-Type: `application/octet-stream`
+- Dateianhang mit korrekter Benennung
+
+**Beispiele**:
+```bash
+# Zertifikat herunterladen
+curl http://localhost:5000/api/client-certs/cert-001/download/crt \
+ -H "Authorization: Bearer TOKEN" \
+ -o certificate.crt
+
+# Privaten Schlüssel herunterladen
+curl http://localhost:5000/api/client-certs/cert-001/download/key \
+ -H "Authorization: Bearer TOKEN" \
+ -o private.key
+
+# CSR herunterladen
+curl http://localhost:5000/api/client-certs/cert-001/download/csr \
+ -H "Authorization: Bearer TOKEN" \
+ -o request.csr
+```
+
+---
+
+#### 5. Zertifikat widerrufen
+
+**Endpoint**: `POST /client-certs/<identifier>/revoke`
+
+Widerruft ein Zertifikat mit optionalem Grund.
+
+**Anfrage** (optional):
+```json
+{
+ "reason": "compromised"
+}
+```
+
+**Antwort** (200 OK):
+```json
+{
+ "message": "Certificate revoked: cert-001",
+ "revoked_at": "2024-10-30T18:15:00Z",
+ "reason": "compromised"
+}
+```
+
+**Beispiel**:
+```bash
+curl -X POST http://localhost:5000/api/client-certs/cert-001/revoke \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "reason": "compromised"
+ }'
+```
+
+---
+
+#### 6. Zertifikat erneuern
+
+**Endpoint**: `POST /client-certs/<identifier>/renew`
+
+Erneuert ein Zertifikat (gleicher CN, neue Seriennummer).
+
+**Antwort** (201 Created):
+```json
+{
+ "identifier": "cert-001-renewed",
+ "common_name": "user@example.com",
+ "serial_number": "98765432109876543210",
+ "created_at": "2024-10-30T18:20:00Z",
+ "expires_at": "2025-10-30T18:20:00Z",
+ "status": "active"
+}
+```
+
+**Beispiel**:
+```bash
+curl -X POST http://localhost:5000/api/client-certs/cert-001/renew \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+#### 7. Statistiken abrufen
+
+**Endpoint**: `GET /client-certs/stats`
+
+Ruft Nutzungsstatistiken zu Zertifikaten ab.
+
+**Antwort** (200 OK):
+```json
+{
+ "total": 100,
+ "active": 85,
+ "revoked": 15,
+ "expiring_soon": 8,
+ "by_usage": {
+ "api-mtls": 60,
+ "vpn": 35,
+ "other": 5
+ },
+ "created_count": 100,
+ "renewal_enabled": 92
+}
+```
+
+**Beispiel**:
+```bash
+curl http://localhost:5000/api/client-certs/stats \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+#### 8. Zertifikate im Batch importieren
+
+**Endpoint**: `POST /client-certs/batch`
+
+Erstellt mehrere Zertifikate aus CSV-Daten in einer einzigen Anfrage.
+
+**Anfrage**:
+```json
+{
+ "headers": ["common_name", "email", "organization", "cert_usage", "days_valid"],
+ "rows": [["user1@example.com", "user1@example.com", "ACME Corp", "api-mtls", "365"],
+ ["user2@example.com", "user2@example.com", "ACME Corp", "vpn", "365"],
+ ["user3@example.com", "user3@example.com", "ACME Corp", "api-mtls", "365"]
+ ]
+}
+```
+
+**Antwort** (201 Created):
+```json
+{
+ "total": 3,
+ "successful": 3,
+ "failed": 0,
+ "errors": [],
+ "certificates": [{
+ "identifier": "cert-batch-001",
+ "common_name": "user1@example.com"
+ },
+ {
+ "identifier": "cert-batch-002",
+ "common_name": "user2@example.com"
+ },
+ {
+ "identifier": "cert-batch-003",
+ "common_name": "user3@example.com"
+ }
+ ]
+}
+```
+
+**Beispiel**:
+```bash
+curl -X POST http://localhost:5000/api/client-certs/batch \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "headers": ["common_name", "email", "organization"],
+ "rows": [["user1@example.com", "user1@example.com", "ACME Corp"],
+ ["user2@example.com", "user2@example.com", "ACME Corp"]
+ ]
+ }'
+```
+
+---
+
+### OCSP & CRL
+
+#### 9. OCSP-Statusabfrage
+
+**Endpoint**: `GET /ocsp/status/<serial_number>`
+
+Fragt den Zertifikatsstatus per OCSP ab.
+
+**Antwort** (200 OK):
+```json
+{
+ "response_status": "successful",
+ "certificate_status": "good|revoked|unknown",
+ "certificate_serial": 12345678,
+ "this_update": "2024-10-30T18:00:00Z",
+ "next_update": null,
+ "responder_name": "CertMate OCSP Responder"
+}
+```
+
+**Beispiel**:
+```bash
+curl http://localhost:5000/api/ocsp/status/12345678 \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+#### 10. CRL-Distribution
+
+**Endpoint**: `GET /crl/download/<format_type>`
+
+Lädt die Zertifikatssperrliste (CRL) herunter.
+
+**Parameter**:
+- `format_type` — `pem`, `der` oder `info`
+
+**Antwort**:
+- Für `pem` und `der`: Dateianhang
+- Für `info`: JSON mit CRL-Metadaten
+
+**Beispiele**:
+```bash
+# CRL im PEM-Format herunterladen
+curl http://localhost:5000/api/crl/download/pem \
+ -H "Authorization: Bearer TOKEN" \
+ -o ca.crl
+
+# CRL im DER-Format herunterladen
+curl http://localhost:5000/api/crl/download/der \
+ -H "Authorization: Bearer TOKEN" \
+ -o ca.crl
+
+# CRL-Informationen abrufen
+curl http://localhost:5000/api/crl/download/info \
+ -H "Authorization: Bearer TOKEN"
+```
+
+**CRL-Info-Antwort**:
+```json
+{
+ "status": "available",
+ "issuer": "CN=CertMate CA, O=CertMate",
+ "last_update": "2024-10-30T18:00:00Z",
+ "next_update": "2024-10-31T18:00:00Z",
+ "revoked_count": 5,
+ "revoked_serials": [12345678,
+ 87654321
+ ]
+}
+```
+
+---
+
+#### 11. Domain-Zertifikatsdateien herunterladen
+
+**Endpoint**: `GET /certificates/<domain>/download`
+
+Lädt Zertifikatsdateien für eine bestimmte Domain herunter. Standardmäßig gibt dieser Endpoint ein ZIP-Archiv zurück, das alle Zertifikatskomponenten enthält. Eine einzelne Datei kann über den Query-Parameter `file` angefordert werden. Ein JSON-Modus ist ebenfalls verfügbar für Automatisierung, die alle PEMs in einer einzigen Antwort erhalten möchte.
+
+**Parameter**:
+- `domain` (Pfad) — Der mit dem Zertifikat verknüpfte Domainname.
+- `file` (Query, optional) — Gibt eine einzelne herunterzuladende Datei an.
+  - Unterstützte Werte: `fullchain.pem`, `privkey.pem`, `combined.pem`
+- `format` (Query, optional) — Auf `json` setzen, um alle Zertifikatsdateien in einem JSON-Objekt zurückzugeben.
+
+**Antwort** (200 OK):
+- **Standard**: `application/zip` (ein ZIP-Archiv mit allen PEM-Dateien)
+- **Mit `file`-Parameter**: `application/x-pem-file` (der rohe Inhalt der angeforderten Datei)
+- **Mit `format=json`**: `application/json` mit `domain`, `cert_pem`, `chain_pem`, `fullchain_pem` und `private_key_pem`
+
+Die JSON-Form ist das bevorzugte Automatisierungsformat für Ansible, Salt oder jeden anderen Client, der PEM-Dateien direkt schreiben möchte.
+
+**Beispiele**:
+
+```bash
+# Alle Dateien als ZIP-Archiv herunterladen
+curl http://localhost:5000/api/certificates/example.com/download \
+ -H "Authorization: Bearer TOKEN" \
+ -o example_com_bundle.zip
+
+# Nur die Datei fullchain.pem herunterladen
+curl "http://localhost:5000/api/certificates/example.com/download?file=fullchain.pem" \
+ -H "Authorization: Bearer TOKEN" \
+ -o fullchain.pem
+
+# Nur den privaten Schlüssel herunterladen
+curl "http://localhost:5000/api/certificates/example.com/download?file=privkey.pem" \
+ -H "Authorization: Bearer TOKEN" \
+ -o privkey.pem
+
+# Das vollständige Zertifikats-Bundle als JSON herunterladen
+curl "http://localhost:5000/api/certificates/example.com/download?format=json" \
+ -H "Authorization: Bearer TOKEN" \
+ -o example_com_bundle.json
+
+```
+
+---
+
+#### 12. Domain-Zertifikat neu ausstellen (Konfiguration bearbeiten)
+
+**Endpoint**: `POST /certificates/<domain>/reissue`
+
+Bearbeitet die Konfiguration eines Zertifikats und stellt es an Ort und Stelle neu aus — SAN-Einträge erweitern oder entfernen, ohne löschen + neu erstellen zu müssen. Ausgelassene Felder behalten die Werte, mit denen das Zertifikat ausgestellt wurde (aus den Metadaten gelesen), sodass die DNS/Alias/CA-Konfiguration nie erneut eingegeben werden muss. Das aktuelle Zertifikat wird weiterhin ausgeliefert, bis die Neuausstellung erfolgreich ist. Die Schlüsselform bleibt erhalten, sofern nicht explizit geändert (es werden keine Schlüssel-Flags gesendet und certbot behält den Lineage-Schlüssel).
+
+**Request Body** (alle Felder optional):
+```json
+{
+  "san_domains": ["www.example.com", "api.example.com"],
+  "domain_alias": "",
+  "async": true
+}
+```
+
+- `san_domains`: Ersatz-SAN-Menge — weglassen zum Beibehalten, `[]` um alle SANs zu entfernen
+- `domain_alias`: weglassen zum Beibehalten, `""` zum Löschen
+- `dns_provider`, `account_id`, `ca_provider`, `challenge_type`: weglassen zum Beibehalten
+- `key_type`/`key_size`/`elliptic_curve`: weglassen, um die vorhandene Schlüsselform beizubehalten
+- `async`: Ausstellung an einen Hintergrund-Job verschieben (202 + Job-ID, `GET /certificates/jobs/<job_id>` abfragen)
+
+**Antwort** (200 OK oder 202 Accepted mit `async`): message, domain, dns_provider, ca_provider, duration.
+
+**Fehler**: 404 wenn kein Zertifikat für die Domain vorhanden ist (create verwenden), 403 Scope, 400 Validierung, 409 Operation läuft bereits, 422 certbot-Fehler (das vorherige Zertifikat ist weiterhin aktiv).
+
+**Beispiel**:
+```bash
+curl -X POST http://localhost:5000/api/certificates/example.com/reissue \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{"san_domains": ["www.example.com", "api.example.com"]}'
+```
+
+---
+
+## Fehlerbehandlung
+
+### Format der Fehlerantwort
+
+```json
+{
+ "error": "Error message",
+ "code": "ERROR_CODE",
+ "status": 400
+}
+```
+
+### Häufige HTTP-Statuscodes
+
+| Code | Bedeutung           | Beispiel                          |
+| ---- | ------------------- | --------------------------------- |
+| 200  | Erfolg              | Zertifikat aufgelistet            |
+| 201  | Erstellt            | Zertifikat erstellt               |
+| 400  | Ungültige Anfrage   | Pflichtfeld fehlt                 |
+| 401  | Nicht autorisiert   | Token ungültig/fehlend            |
+| 404  | Nicht gefunden      | Zertifikat existiert nicht        |
+| 429  | Zu viele Anfragen   | Rate Limit überschritten          |
+| 500  | Serverfehler        | Interner Fehler                   |
+| 503  | Dienst nicht verfügbar | OCSP/CRL nicht verfügbar       |
+
+### Fehlerbeispiel
+
+```bash
+curl http://localhost:5000/api/client-certs/invalid-id \
+ -H "Authorization: Bearer TOKEN"
+
+# Antwort
+{
+ "error": "Certificate not found: invalid-id",
+ "code": 404,
+ "status": 404
+}
+```
+
+---
+
+## Audit-Protokollierung
+
+Zertifikats-Lebenszyklusoperationen sowie Konfigurationsänderungen und Zugangskontrolländerungen werden in einem Audit-Log aufgezeichnet. Dies umfasst die sicherheitsrelevanten Lebenszykluspfade — erfolgreiche und fehlgeschlagene Erstellungen, Erneuerungen, Neuausstellungen, Deployments und Auto-Erneuerungs-Umschalter sowie **unbeaufsichtigte (scheduler-gesteuerte) Erneuerungen** — jeweils dem Akteur zugeordnet, der die Aktion durchgeführt hat, und dem Auslöser, der sie verursacht hat.
+
+### Protokollformat
+
+Das Audit-Log wird in `logs/audit/certificate_audit.log` geschrieben. Jede Zeile ist eine Standard-Python-Logzeile, deren Nachricht der JSON-Audit-Eintrag ist:
+
+```
+2026-06-15 18:00:00 - certmate.audit - INFO - {"timestamp": "...", ...}
+```
+
+Um das JSON zu extrahieren, teilen Sie jede Zeile am Literal ` - INFO - ` auf und parsen den Rest. Beachten Sie die zwei Zeitbasen: der Zeilenpräfix-Zeitstempel ist die **lokale** Serverzeit, während das Feld `timestamp` im JSON **UTC** (ISO-8601) ist. Live lesen mit:
+
+```bash
+tail -f logs/audit/certificate_audit.log
+```
+
+### Eintragsstruktur
+
+```json
+{
+  "timestamp": "2026-06-15T18:00:00.000000+00:00",
+  "operation": "renew",
+  "resource_type": "certificate",
+  "resource_id": "api.example.com",
+  "status": "success",
+  "user": "api_key:renew-bot",
+  "ip_address": "10.0.0.9",
+  "details": {"force": false},
+  "error": null,
+  "actor": {
+    "kind": "agent",
+    "id": "9f2c…",
+    "label": "api_key:renew-bot",
+    "token_prefix": "cm_1a2b",
+    "agent_session": "sess-9f2"
+  },
+  "trigger": {"cause": "agent"}
+}
+```
+
+- **`actor.kind`** — `user` (eine menschliche Sitzung / OIDC-Login), `api_token` (ein API-Schlüssel oder der veraltete globale Bearer Token), `agent` (ein API-Schlüssel, der explizit als KI/MCP-Agent markiert ist — siehe unten), `scheduler` (ein unbeaufsichtigter Erneuerungsjob) oder `system`. Wird **ausschließlich aus der authentifizierten Identität** abgeleitet.
+- **`actor.id` / `token_prefix`** — die stabile API-Schlüssel-ID und das Token-Präfix hinter der Aktion (fehlt beim veralteten globalen Bearer Token, der nicht pro Aufrufer unterschieden werden kann — bevorzugen Sie Scoped Keys).
+- **`actor.agent_session` / `agent_id`** — die Werte der vom Client gelieferten Header `X-CertMate-Agent-Session` / `X-CertMate-Agent-Id` (der MCP-Server sendet sie). Dies sind **rein informative Angaben**: Sie werden zur Korrelation aufgezeichnet, ändern aber niemals `actor.kind`, sodass ein Nicht-Agent-Aufrufer keine `agent`-Attribution fälschen kann.
+- **`trigger.cause`** — `manual`, `api`, `agent`, `scheduled_renewal` oder `event`; bei geplanten Erneuerungen benennt `trigger.job_id` den Job.
+
+Damit die Aktionen eines Agents als `actor.kind="agent"` aufgezeichnet werden, erstellen Sie einen Scoped API-Schlüssel mit `is_agent: true` (ein Kontrollkästchen unter Einstellungen → API-Schlüssel oder `is_agent` in `POST /api/keys`) und verweisen Sie den MCP-Server darauf. Siehe den [MCP-Leitfaden](./mcp.md).
+
+### Audit-Log über die API lesen
+
+`GET /api/activity?limit=N` gibt die neuesten Einträge zurück (Admin/Betrachter, begrenzt auf 500).
+
+### Manipulationssicherheit (Hash-Kette)
+
+Neben dem menschenlesbaren Log wird jeder Eintrag an eine manipulationssichere SHA-256-**Hash-Kette** in `data/audit/certificate_audit.chain.jsonl` angehängt. Jeder Datensatz hat die Form `{seq, entry, prev_hash, hash}`, wobei `hash` sich auf den Eintrag und den Hash des vorherigen Datensatzes festlegt und `seq` ein lückenloser Zähler ist — jede Änderung, Löschung oder Neuordnung durch jemanden, der die gesamte Kette nicht neu berechnen kann, ist erkennbar und lokalisierbar. Standardmäßig aktiviert; deaktivieren mit `CERTMATE_AUDIT_CHAIN=0`.
+
+**Verifikation über die API:** `GET /api/audit/verify` (Admin) gibt das Verifikationsergebnis zurück und liefert HTTP `200` bei Integrität oder `409` bei Beschädigung:
+
+```json
+{"ok": true, "count": 128, "first_seq": 0, "last_seq": 127, "head_hash": "5ee1…", "reason": "intact"}
+```
+
+**Offline-Verifikation:** Der eigenständige Verifizierer hängt nur von der Python-Standardbibliothek ab, sodass ein Prüfer ihn ohne Installation oder Vertrauen in CertMate ausführen kann:
+
+```bash
+python -m modules.core.audit_verify data/audit/certificate_audit.chain.jsonl
+# OK: audit chain intact (128 entries, seq 0..127)
+# or: FAIL: audit chain broken at seq 42: hash mismatch at seq 42: entry was modified
+```
+
+Exit-Code `0` intakt, `1` beschädigt (mit dem betroffenen `seq` und Grund), `2` fehlend/nicht lesbar.
+
+### Signiertes Export-Bundle (durch Dritte verifizierbar)
+
+Die Instanz hält einen Ed25519-Signaturschlüssel, gespeichert unter `data/.audit_signing_key` (beim ersten Start generiert, `0600`; mit `AUDIT_SIGNING_KEY_FILE` überschreiben, um ihn extern vorzuhalten). Die öffentliche Identität ist über `GET /api/audit/public-key` (Admin) zugänglich: `{algorithm, public_key_pem, fingerprint}`. Der Kettenstand wird in periodische Checkpoints signiert (`certificate_audit.checkpoints.jsonl`).
+
+`GET /api/audit/export` (Admin, optional `?from_seq`/`?to_seq`) gibt ein signiertes, selbst-verifizierendes Bundle zurück — `{manifest, entries, bundle_signature}`. Das Manifest pinnt den Instanz-Fingerprint, den öffentlichen Schlüssel, den seq-Bereich und den `head_hash`; die Signatur gilt für das kanonische Manifest, das (über `head_hash`) transitiv jeden Eintrag einschließt. Ein Prüfer verifiziert es **außerhalb der Instanz**, ohne CertMate zu installieren oder ihm zu vertrauen, und kann den Schlüssel optional extern pinnen:
+
+```bash
+python -m modules.core.audit_verify --bundle bundle.json --pubkey instance.pem
+# OK: audit bundle intact and signed (128 entries, seq 0..127; signed by 0m2V5lDmnkPWOUHX)
+```
+
+Der Verifizierer prüft die Kettenstruktur, die Übereinstimmung des Manifests mit den Einträgen, die Ed25519-Signatur und ob der Fingerprint mit dem (optional gepinnten) öffentlichen Schlüssel übereinstimmt.
+
+> **Ehrlichkeit zum Bedrohungsmodell.** Die Kette + Signatur erkennen jede interne Änderung, Löschung oder Neuordnung und binden einen Export an den öffentlichen Schlüssel dieser Instanz — für jeden, der nicht im Besitz des Signaturschlüssels ist. Sie **binden nicht** den Betreiber, der den Schlüssel hält und eine umgeschriebene Kette neu signieren könnte, und eine Kürzung am Ende wird nur durch Vergleich von Exporten über die Zeit (ein späterer Export mit weniger Einträgen) oder gegen einen extern gehaltenen Checkpoint erkannt. Eine vollständige Einschränkung des Betreibers erfordert das Versenden signierter Checkpoints an eine externe Append-Only-Senke — optionales externes Anchoring, eine geplante Folgefunktion, die noch nicht ausgeliefert wurde. Siehe [compliance.md](./compliance.md).
+
+---
+
+## Zertifikatstypen
+
+### API mTLS
+
+Für die API-Client-Authentifizierung via mutual TLS.
+
+```
+cert_usage: "api-mtls"
+```
+
+### VPN
+
+Für die VPN-Client-Authentifizierung.
+
+```
+cert_usage: "vpn"
+```
+
+### Benutzerdefinierte Verwendungstypen
+
+Sie können eine beliebige benutzerdefinierte Verwendungstyp-Zeichenkette verwenden:
+
+```
+cert_usage: "custom-application"
+```
+
+---
+
+## Best Practices
+
+### Sicherheit
+
+1. **Token schützen**
+ - Tokens geheim halten
+ - Tokens regelmäßig rotieren
+ - HTTPS in der Produktion verwenden
+
+2. **Zertifikatsverwaltung**
+ - Auto-Erneuerung aktivieren
+ - Ablaufdaten überwachen
+ - Audit-Logs regelmäßig prüfen
+ - Kompromittierte Zertifikate sofort widerrufen
+
+3. **Rate Limiting**
+ - Rate Limits einhalten
+ - Exponentielles Backoff implementieren
+ - Batch-Operationen wenn möglich nutzen
+
+### Performance
+
+1. **Batch-Operationen nutzen**
+ - Mehrere Zertifikate auf einmal importieren
+ - Reduziert API-Aufrufe
+ - Bessere Fehlerberichterstattung
+
+2. **Ergebnisse filtern**
+ - Query-Parameter verwenden
+ - Nach Verwendungstyp oder Status filtern
+ - Reduziert den Datentransfer
+
+3. **Caching wo sinnvoll**
+ - Zertifikats-Metadaten cachen
+ - Regelmäßig aktualisieren
+ - Ablauf lokal prüfen
+
+---
+
+
+---
+
+<div align="center">
+
+[← Zurück zur Dokumentation](./README.md) • [Schnellstart →](./guide.md) • [Architektur →](./architecture.md)
+
+</div>

--- a/docs/de/architecture.md
+++ b/docs/de/architecture.md
@@ -1,0 +1,855 @@
+# CertMate Architektur
+
+Dieses Dokument beschreibt die vollständige Architektur von CertMate — sowohl das Hauptsystem für Server-Zertifikate als auch das Teilsystem für Client-Zertifikate.
+
+---
+
+## Inhaltsverzeichnis
+
+- [Architektur des Hauptsystems](#architektur-des-hauptsystems)
+- [Überblick-Diagramm](#überblick-diagramm)
+- [Manager-Klassen](#manager-klassen)
+- [Ablauf der Zertifikatserstellung](#ablauf-der-zertifikatserstellung)
+- [Speicherarchitektur](#speicherarchitektur)
+- [Konfigurationsstruktur](#konfigurationsstruktur)
+- [API-Endpoints](#api-endpoints)
+- [Technologie-Stack](#technologie-stack)
+- [Architektur der Client-Zertifikate](#architektur-der-client-zertifikate)
+
+---
+
+## Architektur des Hauptsystems
+
+CertMate ist ein modulares, erweiterbares SSL/TLS-Zertifikatsverwaltungssystem, das mit Python/Flask gebaut wurde. Es unterstützt mehrere CA-Anbieter, mehr als zwei Dutzend DNS-Anbieter sowie austauschbare Storage-Backends.
+
+**Wichtige Fakten:**
+- **Sprache**: Python 3.9+ (Flask, Flask-RESTX)
+- **Speicher**: Lokales Dateisystem als Standard + 4 Cloud-Backends (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical)
+- **CA-Anbieter**: Let's Encrypt, DigiCert ACME, Private CA
+- **DNS-Anbieter**: mehr als zwei Dutzend unterstützt (Cloudflare, AWS Route53, Azure, Google und weitere — siehe [DNS-Anbieter](./dns-providers.md) für die vollständige Liste)
+- **API**: REST mit Swagger/OpenAPI via Flask-RESTX
+- **Aktuelle Zertifikatstypen**: Server-seitiges TLS (DV, OV, EV)
+
+---
+
+## Überblick-Diagramm
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  CertMate Application               │
+│                                                     │
+│  ┌───────────────────────────────────────────────┐  │
+│  │             Web Layer (Flask)                  │  │
+│  │  Dashboard    Settings    Help    Client Certs │  │
+│  └────────────────────┬──────────────────────────┘  │
+│                       ↓                             │
+│  ┌──────────────────┐   ┌────────────────────────┐  │
+│  │  REST API         │   │  Web Routes            │  │
+│  │  /api/certificates│   │  /api/web/certificates │  │
+│  │  /api/client-certs│   │  /client-certificates  │  │
+│  └────────┬─────────┘   └────────┬───────────────┘  │
+│           └──────────┬───────────┘                   │
+│                      ↓                               │
+│  ┌───────────────────────────────────────────────┐  │
+│  │          Manager Layer (Business Logic)        │  │
+│  │                                               │  │
+│  │  CertificateManager    CAManager              │  │
+│  │  DNSManager            StorageManager         │  │
+│  │  AuthManager           SettingsManager        │  │
+│  │  CacheManager          FileOperations         │  │
+│  │  ClientCertManager     OCSPResponder          │  │
+│  │  CRLManager            AuditLogger            │  │
+│  └────────────────────┬──────────────────────────┘  │
+│                       ↓                             │
+│  ┌───────────────────────────────────────────────┐  │
+│  │          Execution Layer                       │  │
+│  │  Certbot (server certs via DNS-01 ACME)       │  │
+│  │  PrivateCA (client certs via direct signing)  │  │
+│  └────────────────────┬──────────────────────────┘  │
+│                       ↓                             │
+│  ┌───────────────────────────────────────────────┐  │
+│  │          Storage Layer (Pluggable Backends)    │  │
+│  │  Local FS │ Azure KV │ AWS SM │ Vault │ Infis │  │
+│  └───────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## Manager-Klassen
+
+```
+CertMateApp (Hauptanwendung)
+  ├── FileOperations          # Datei-Ein-/Ausgabe, Sicherungen
+  ├── SettingsManager         # Laden/Speichern von settings.json
+  ├── AuthManager             # Token-Validierung
+  ├── CertificateManager      # Erstellen/Erneuern/Infos (Server-Zertifikate)
+  ├── CAManager               # CA-Anbieter-Konfiguration, Certbot-Aufbau
+  ├── DNSManager              # DNS-Anbieter-Konten
+  ├── CacheManager            # Deployment-Cache
+  ├── StorageManager          # Backend-Abstraktion
+  ├── ClientCertificateManager # Lebenszyklus der Client-Zertifikate
+  ├── PrivateCAGenerator      # Verwaltung der selbst-signierten CA
+  ├── OCSPResponder           # Abfragen des Zertifikatsstatus
+  ├── CRLManager              # Erzeugung von Sperrlisten
+  └── AuditLogger             # Verfolgung von Operationen
+```
+
+---
+
+## Ablauf der Zertifikatserstellung
+
+### Server-Zertifikate (via Certbot + ACME)
+
+```
+1. User submits: domain, email, DNS provider, CA provider
+2. Validate inputs (domain format, email, provider existence)
+3. Get CA config (ACME URL, EAB credentials if DigiCert)
+4. Get DNS config (account credentials from settings)
+5. Create directory: certificates/{domain}/
+6. Build certbot command:
+   certbot certonly --non-interactive --agree-tos
+     --server {acme_url}
+     --email {email}
+     --{dns_plugin} --{dns_plugin}-credentials {cred_file}
+     --{dns_plugin}-propagation-seconds {timeout}
+     --eab-kid/--eab-hmac-key (if required)
+     -d {domain}
+7. Create temporary DNS credentials file (600 permissions)
+8. Execute certbot (30-minute timeout)
+9. Resolve symlinks, copy cert files to domain root
+10. Store via configured backend + create metadata.json
+11. Clean up credentials file
+```
+
+### Client-Zertifikate (via Private CA)
+
+```
+1. User submits: common_name, email, organization, cert_usage
+2. Initialize or load existing CA (4096-bit RSA)
+3. Generate CSR (or accept provided CSR)
+4. Sign CSR with private CA
+5. Store cert/key/csr files + metadata.json
+6. Log in audit trail
+```
+
+---
+
+## Speicherarchitektur
+
+### Server-Zertifikate
+
+```
+certificates/
+  example.com/
+    cert.pem          # Server certificate
+    chain.pem         # Intermediate CA chain
+    fullchain.pem     # cert + chain
+    privkey.pem       # Private key (600 permissions)
+    metadata.json     # Certificate metadata
+```
+
+### Client-Zertifikate
+
+```
+data/certs/
+  ca/
+    ca.crt            # CA certificate
+    ca.key            # CA private key (600 permissions)
+    ca_metadata.json  # CA metadata
+    crl.pem           # Certificate Revocation List
+  client/
+    api-mtls/         # Certificates by usage type
+      cert-001/
+        cert.crt
+        cert.key
+        cert.csr
+        metadata.json
+    vpn/
+      cert-002/
+        ...
+```
+
+### Storage-Backends
+
+Alle Backends implementieren `CertificateStorageBackend`:
+
+| Backend | Speicherort |
+|---------|-----------------|
+| **Lokales Dateisystem** | `certificates/{domain}/` (Standard) |
+| **Azure Key Vault** | Secrets, native Certificate-Objekte oder beides — siehe unten |
+| **AWS Secrets Manager** | AWS Secrets Manager |
+| **HashiCorp Vault** | Vault KV v1/v2 |
+| **Infisical** | Infisical-Secrets |
+
+#### Azure Key Vault — Speichermodi
+
+Das Azure Key Vault-Backend kann Zertifikate als Secrets (Standard), als native Certificate-Objekte oder als beides persistieren; gesteuert wird dies über `certificate_storage.azure_keyvault.storage_mode` in `settings.json`.
+
+| Modus | Schreibt Secrets | Schreibt Certificate-Objekt | Wann verwenden |
+|---|---|---|---|
+| `secrets` (Standard) | ja | nein | Rückwärtskompatibles Verhalten. Jedes `cert.pem` / `chain.pem` / `fullchain.pem` / `privkey.pem` sowie die Metadaten werden als separate Key Vault-Secrets gespeichert. |
+| `certificate` | nein | ja | Direkte Einbindung über App Service, Application Gateway, Front Door, API Management, AKS Ingress usw. Das Zertifikat + Kette + privater Schlüssel werden als einzelnes PKCS12-`Certificate`-Objekt mit `issuer_name="Unknown"` importiert, damit Key Vault keine Erneuerung versucht. |
+| `both` | ja | ja | Übergangs- oder Mischkonsumenten-Setups. Lesezugriffe bevorzugen weiterhin den Secrets-Pfad (kostengünstiger). |
+
+Eine manuelle Aktion **Backfill Certificate objects** im Einstellungsbereich für den Speicher (`POST /api/storage/azure-keyvault/backfill-certificates`) importiert ein Certificate-Objekt für jede Domain, die im Vault bereits als Secret vorhanden ist, aber noch kein solches Objekt besitzt. Bereits vorhandene Certificate-Objekte werden übersprungen. Der Endpoint akzeptiert einen optionalen Abfrageparameter `?limit=N`, um die Anzahl der pro Aufruf verarbeiteten Domains zu begrenzen; bei großen Vaults kann durch wiederholte Aufrufe paginiert werden, bis die Antwort `0` verbleibende Domains meldet.
+
+##### Sicherheitshinweis — Certificate-Objekte legen den privaten Schlüssel über die Secrets-API offen
+
+Wenn Key Vault ein PKCS12-Certificate-Objekt importiert, erstellt es gleichzeitig ein begleitendes **Secret** mit demselben Namen, dessen Wert das vollständige PFX (einschließlich des privaten Schlüssels) enthält. Dies ist in Azure by design: Es ist der dokumentierte Weg, über den VM-Extensions und App Service das Zertifikat abrufen; jeder Principal mit `Secrets/Get` auf dem Vault kann daher den privaten Schlüssel herunterladen — *die Berechtigung `Get` auf Certificates allein reicht nicht aus, um den privaten Schlüssel zu extrahieren, `Secrets/Get` hingegen schon*. Betreiber, die CertMate im Modus `certificate` oder `both` betreiben, sollten `Secrets/Get` sorgfältig einschränken und Azure RBAC gegenüber Vault-Zugriffsrichtlinien für eine feinere Steuerung bevorzugen. Siehe [Microsoft Learn — Zertifikate in Key Vault](https://learn.microsoft.com/azure/key-vault/certificates/about-certificates) für das vollständige Modell.
+
+##### Service-Principal-Berechtigungen
+
+| Modus | Erforderliche Berechtigungen auf dem Vault |
+|---|---|
+| `secrets` | Secrets `Get/Set/List/Delete` |
+| `certificate` / `both` | Fügt Certificates `Get/List/Import/Delete` hinzu und behält Secrets `Get/List` (Key Vault stellt das importierte PFX, einschließlich des privaten Schlüssels, ausschließlich über das Secret mit demselben Namen wie das Certificate-Objekt bereit). |
+
+---
+
+## Konfigurationsstruktur
+
+Alle Einstellungen werden in `data/settings.json` gespeichert:
+
+```json
+{
+  "email": "admin@example.com",
+  "domains": ["example.com", "*.example.com"],
+  "auto_renew": true,
+  "renewal_threshold_days": 30,
+  "api_bearer_token": "secure-token",
+  "dns_provider": "cloudflare",
+  "dns_providers": {
+    "cloudflare": {
+      "accounts": {
+        "production": {"api_token": "token-prod"},
+        "staging": {"api_token": "token-staging"}
+      }
+    }
+  },
+  "default_accounts": {
+    "cloudflare": "production"
+  },
+  "ca_providers": {
+    "letsencrypt": {
+      "accounts": {
+        "default": {"email": "admin@example.com"}
+      }
+    }
+  },
+  "certificate_storage": {
+    "backend": "local_filesystem",
+    "cert_dir": "certificates"
+  },
+  "default_key_type": "rsa",
+  "default_key_size": 2048,
+  "default_elliptic_curve": "secp256r1"
+}
+```
+
+### Zertifikat-Schlüsseltyp/-größe
+
+Drei Schlüssel auf der obersten Ebene steuern die Form des öffentlichen Schlüssels neu ausgestellter Zertifikate:
+
+| Schlüssel | Werte | Gilt wenn |
+|---|---|---|
+| `default_key_type` | `rsa` (Standard) / `ecdsa` | immer |
+| `default_key_size` | `2048` (Standard) / `3072` / `4096` | `default_key_type == "rsa"` |
+| `default_elliptic_curve` | `secp256r1` (Standard) / `secp384r1` | `default_key_type == "ecdsa"` |
+
+Eine pro-Zertifikat-Überschreibung wird unterstützt: Jeder Eintrag in `domains` kann optional einen `key_type` sowie entweder `key_size` (RSA) oder `elliptic_curve` (ECDSA) tragen. Ist die Überschreibung vorhanden, hat sie Vorrang; andernfalls gilt der globale Standardwert. Die Standardwerte `rsa`/`2048` spiegeln den impliziten certbot-Standard wider, den CertMate vor der Einführung dieser Einstellung verwendete; aktualisierte Installationen sehen daher keine Änderung, sofern der Betreiber nichts anderes wählt.
+
+Erneuerungen behalten stets die Form bei, die zum Zeitpunkt der Erstellung gültig war: certbot schreibt `--key-type`, `--rsa-key-size` und `--elliptic-curve` beim ersten Ausstellen in seine eigene `renewal/<domain>.conf`, und `certbot renew --cert-name <domain>` verwendet diese Werte automatisch wieder.
+
+---
+
+## API-Endpoints
+
+### Server-Zertifikate
+
+| Methode | Endpoint | Zweck |
+|--------|----------|---------|
+| GET | `/api/health` | Statusprüfung |
+| GET | `/api/certificates` | Alle Zertifikate auflisten |
+| POST | `/api/certificates` | Neues Zertifikat erstellen |
+| GET | `/api/certificates/{domain}` | Zertifikatsinformationen abrufen |
+| POST | `/api/certificates/{domain}/renew` | Zertifikat erneuern |
+| GET | `/api/certificates/{domain}/download` | Als ZIP herunterladen |
+| GET | `/{domain}/tls` | Direkter Fullchain-Download |
+
+### Client-Zertifikate
+
+| Methode | Endpoint | Zweck |
+|--------|----------|---------|
+| POST | `/api/client-certs/create` | Zertifikat erstellen |
+| GET | `/api/client-certs` | Mit Filtern auflisten |
+| GET | `/api/client-certs/{id}` | Metadaten abrufen |
+| GET | `/api/client-certs/{id}/download/{type}` | Zertifikat/Schlüssel/CSR herunterladen |
+| POST | `/api/client-certs/{id}/revoke` | Zertifikat sperren |
+| POST | `/api/client-certs/{id}/renew` | Zertifikat erneuern |
+| GET | `/api/client-certs/stats` | Statistiken |
+| POST | `/api/client-certs/batch` | CSV-Massenimport |
+| GET | `/api/ocsp/status/{serial}` | OCSP-Status |
+| GET | `/api/crl/download/{format}` | CRL herunterladen |
+
+---
+
+## Technologie-Stack
+
+| Schicht | Technologien |
+|-------|-------------|
+| **Backend** | Python 3.9+, Flask, Flask-RESTX, APScheduler, Certbot |
+| **Frontend** | HTML5, Tailwind CSS, Vanilla JavaScript, Font Awesome |
+| **Cloud-SDKs** | Azure SDK, boto3, hvac, infisical-python |
+| **Kryptografie** | cryptography (OpenSSL), certbot-Plugins |
+| **Deployment** | Docker, Docker Compose, Gunicorn, systemd |
+
+---
+
+## Bekannte Einschränkungen
+
+1. **Nur Certbot für Server-Zertifikate**: Ausschließlich DNS-01-ACME-Challenges
+2. **Domain-zentrierter Server-Speicher**: Ein Zertifikat pro Domain-Verzeichnis
+3. **Keine Datenbank**: Einzelne JSON-Datei für die Konfiguration
+4. **Schlüsselverwendung bei Server-Zertifikaten**: Keine Kontrolle über keyUsage/extendedKeyUsage-Erweiterungen
+
+---
+
+# Architektur der Client-Zertifikate
+
+## Systemüberblick
+
+```
+
+ Web UI Layer 
+ (/client-certificates web dashboard) 
+
+ 
+ API Layer 
+ (/api/client-certs, /api/ocsp, /api/crl) 
+ (REST endpoints with Flask-RESTX) 
+
+ 
+ Managers Layer 
+ 
+ ClientCertificateManager (lifecycle + metadata) 
+ OCSPResponder (certificate status queries) 
+ CRLManager (revocation list generation) 
+ AuditLogger (operation tracking) 
+ SimpleRateLimiter (request throttling) 
+ 
+
+ 
+ Core Modules Layer 
+ 
+ PrivateCAGenerator (CA management) 
+ CSRHandler (CSR validation & creation) 
+ ClientCertificateManager (cert operations) 
+ OCSPResponder (status responses) 
+ CRLManager (revocation lists) 
+ AuditLogger (logging) 
+ RateLimitConfig/SimpleRateLimiter (limiting) 
+ 
+
+ 
+ Cryptography & Storage Layer 
+ 
+ Cryptography Library (OpenSSL) 
+ File System Storage (data/certs/) 
+ Storage Backends (Azure, AWS, Vault, etc) 
+ 
+
+```
+
+---
+
+## Kernkomponenten
+
+### 1. PrivateCAGenerator (`modules/core/private_ca.py`)
+
+**Zweck**: Die selbst-signierte Zertifizierungsstelle erzeugen und verwalten
+
+**Hauptfunktionen**:
+- Erzeugt 4096-Bit-RSA-Schlüssel für die CA
+- Gültigkeitsdauer von 10 Jahren
+- Selbst-signierte Zertifikate mit korrekten Erweiterungen
+- Sicherungs- und Wiederherstellungsfunktion der CA
+- CRL-Signierfähigkeit
+
+**Erstellte Dateien**:
+- `data/certs/ca/ca.crt` — CA-Zertifikat (PEM)
+- `data/certs/ca/ca.key` — Privater CA-Schlüssel (PEM, Berechtigungen 0600)
+- `data/certs/ca/ca_metadata.json` — CA-Metadaten
+- `data/certs/ca/crl.pem` — Zertifikats-Sperrliste
+
+**Hauptmethoden**:
+```python
+initialize() # Initialize or load existing CA
+sign_certificate_request() # Sign a CSR
+generate_crl() # Generate CRL from revoked serials
+get_crl_pem() # Get CRL in PEM format
+```
+
+---
+
+### 2. CSRHandler (`modules/core/csr_handler.py`)
+
+**Zweck**: Certificate Signing Requests validieren, analysieren und erstellen
+
+**Hauptfunktionen**:
+- Neue CSRs mit privaten Schlüsseln erstellen (2048 oder 4096 Bit)
+- PEM-kodierte CSRs validieren
+- CSR-Informationen extrahieren (CN, Org, E-Mail, SAN usw.)
+- Unterstützung für Subject Alternative Names (SANs)
+- CSR- und Schlüsselpaare auf Disk speichern
+
+**Hauptmethoden**:
+```python
+create_csr() # Create new CSR with private key
+validate_csr_pem() # Validate and load CSR from PEM
+get_csr_info() # Extract information from CSR
+save_csr_and_key() # Save CSR and key to files
+```
+
+---
+
+### 3. ClientCertificateManager (`modules/core/client_certificates.py`)
+
+**Zweck**: Vollständiges Lebenszyklusmanagement von Client-Zertifikaten
+
+**Hauptfunktionen**:
+- Zertifikate erstellen (CA-signiert oder per CSR)
+- Zertifikate auflisten/filtern (nach Verwendungszweck, Status, Suche)
+- Zertifikate mit Audit-Trail sperren
+- Zertifikate erneuern (gleicher CN, neue Seriennummer)
+- Automatische Erneuerungsplanung
+- Metadatenspeicherung (JSON pro Zertifikat)
+- Unterstützung von 30.000+ gleichzeitigen Zertifikaten
+
+**Speicherstruktur**:
+```
+data/certs/client/
+ api-mtls/ # Certificates for API mTLS
+ cert-001/
+ cert.crt
+ cert.key
+ cert.csr
+ metadata.json
+ vpn/ # Certificates for VPN
+ cert-002/
+ ...
+ other/ # Other usage types
+ ...
+```
+
+**Metadatenstruktur** (JSON):
+```json
+{
+ "type": "client_certificate",
+ "identifier": "cert-001",
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "organizational_unit": "Engineering",
+ "country": "US",
+ "state": "California",
+ "locality": "San Francisco",
+ "serial_number": "12345678901234567890",
+ "key_usage": ["digitalSignature", "keyEncipherment"],
+ "extended_key_usage": ["serverAuth", "clientAuth"],
+ "created_at": "2024-10-30T18:00:00Z",
+ "expires_at": "2025-10-30T18:00:00Z",
+ "cert_usage": "api-mtls",
+ "notes": "Production certificate",
+ "revocation": {
+ "revoked": false,
+ "revoked_at": null,
+ "reason_revoked": null
+ },
+ "renewal": {
+ "renewal_enabled": true,
+ "renewal_threshold_days": 30,
+ "last_renewed_at": null
+ }
+}
+```
+
+**Hauptmethoden**:
+```python
+create_client_certificate() # Create new certificate
+list_client_certificates() # List with optional filters
+get_certificate_metadata() # Get cert metadata
+get_certificate_file() # Get cert/key/csr file
+revoke_certificate() # Revoke with reason
+renew_certificate() # Renew certificate
+check_renewals() # Auto-renewal check
+get_statistics() # Get usage statistics
+```
+
+---
+
+### 4. OCSPResponder (`modules/core/ocsp_crl.py`)
+
+**Zweck**: Antworten gemäß dem Online Certificate Status Protocol (OCSP) bereitstellen
+
+**Hauptfunktionen**:
+- Zertifikatsstatus abfragen (good/revoked/unknown)
+- OCSP-Antworten erzeugen
+- Statusabfragen in Echtzeit
+- Unterstützung mehrerer Statustypen
+
+**Status-Werte**:
+- `good` — Zertifikat ist gültig
+- `revoked` — Zertifikat wurde gesperrt
+- `unknown` — Zertifikat nicht gefunden
+
+**Hauptmethoden**:
+```python
+get_cert_status() # Get certificate status
+generate_ocsp_response() # Generate OCSP response
+```
+
+**Antwortformat**:
+```json
+{
+ "response_status": "successful",
+ "certificate_status": "good|revoked|unknown",
+ "certificate_serial": 12345678,
+ "this_update": "2024-10-30T18:00:00Z",
+ "next_update": null,
+ "responder_name": "CertMate OCSP Responder",
+ "revocation_time": null,
+ "revocation_reason": null
+}
+```
+
+---
+
+### 5. CRLManager (`modules/core/ocsp_crl.py`)
+
+**Zweck**: Zertifikats-Sperrlisten erzeugen und verteilen
+
+**Hauptfunktionen**:
+- CRL mit allen gesperrten Zertifikaten erzeugen
+- Verteilung in PEM- und DER-Format
+- CRL-Metadaten und -Informationen speichern
+- Automatische CRL-Aktualisierungen
+
+**Hauptmethoden**:
+```python
+get_revoked_serials() # Get revoked certificate serials
+update_crl() # Generate/update CRL
+get_crl_pem() # Get CRL in PEM format
+get_crl_der() # Get CRL in DER format
+get_crl_info() # Get CRL metadata
+```
+
+---
+
+### 6. AuditLogger (`modules/core/audit.py`)
+
+**Zweck**: Alle Zertifikatsoperationen zur Compliance und zur Fehleranalyse protokollieren
+
+**Hauptfunktionen**:
+- Protokollierung im JSON-Format
+- Persistente Audit-Datei
+- Verfolgung von Operationen, Benutzern und IP-Adressen
+- Abfrage von Einträgen nach Ressource oder Zeitraum
+
+**Protokollformat**:
+```json
+{
+ "timestamp": "2024-10-30T18:00:00Z",
+ "operation": "create|revoke|renew|download|batch_import",
+ "resource_type": "certificate|endpoint",
+ "resource_id": "cert-001",
+ "status": "success|failure|denied",
+ "user": "admin@example.com",
+ "ip_address": "192.168.1.1",
+ "details": {},
+ "error": null
+}
+```
+
+**Protokolldatei**: `logs/audit/certificate_audit.log`
+
+**Hauptmethoden**:
+```python
+log_certificate_created() # Log cert creation
+log_certificate_revoked() # Log revocation
+log_certificate_renewed() # Log renewal
+log_certificate_downloaded() # Log downloads
+log_batch_operation() # Log batch operations
+log_api_request() # Log API requests
+get_recent_entries() # Get latest audit entries
+get_entries_by_resource() # Get entries for a resource
+```
+
+---
+
+### 7. Rate Limiting (`modules/core/rate_limit.py`)
+
+**Zweck**: API durch Request-Rate-Limiting vor Missbrauch schützen
+
+**Konfiguration**:
+- Standard: 100 Req/min
+- Zertifikatserstellung: 30 Req/min (aufwendig)
+- Batch-Operationen: 10 Req/min (sehr aufwendig)
+- OCSP-Status: 200 Req/min (kostengünstig)
+- CRL-Download: 60 Req/min
+
+**Hauptklassen**:
+```python
+RateLimitConfig # Configuration holder
+SimpleRateLimiter # In-memory limiter
+rate_limit_decorator # Flask endpoint decorator
+```
+
+**Antwort bei überschrittenem Limit**:
+```json
+{
+ "error": "Rate limit exceeded",
+ "message": "Too many requests. Please try again later.",
+ "retry_after": 60
+}
+```
+
+HTTP-Status: `429 Too Many Requests`
+
+---
+
+## Datenfluss
+
+### Ablauf der Zertifikatserstellung
+
+```
+User/API Request
+ ↓
+ClientCertificateManager.create_client_certificate()
+ Generate CSR (or accept provided CSR)
+ Sign CSR with private CA
+ Create metadata.json
+ Store cert/key/csr files
+ Log in audit trail
+ Return cert data
+ ↓
+Response to User
+```
+
+### Ablauf der Zertifikatssperrung
+
+```
+User/API Request (revoke endpoint)
+ ↓
+ClientCertificateManager.revoke_certificate()
+ Load certificate metadata
+ Update revocation status
+ Save updated metadata
+ Log in audit trail
+ Trigger CRL update
+ Return success
+ ↓
+Response to User
+```
+
+### OCSP-Abfrageablauf
+
+```
+Client OCSP Request (serial number)
+ ↓
+OCSPResponder.get_cert_status()
+ Search certificate by serial
+ Check revocation status
+ Return status (good/revoked/unknown)
+ ↓
+OCSPResponder.generate_ocsp_response()
+ Format OCSP response
+ Add timestamps
+ Return response
+ ↓
+Response to Client
+```
+
+---
+
+## Speicherarchitektur
+
+### Verzeichnisstruktur
+
+```
+data/certs/
+ ca/ # Certificate Authority
+ ca.crt # CA certificate (public)
+ ca.key # CA private key (0600)
+ ca_metadata.json # CA metadata
+ crl.pem # Certificate Revocation List
+
+ client/ # Client certificates
+ api-mtls/ # API mTLS certificates
+ cert-001/
+ cert.crt
+ cert.key
+ cert.csr
+ metadata.json
+ ...
+ vpn/ # VPN certificates
+ ...
+ other/ # Other usage types
+ ...
+
+ crl/ # CRL storage
+ (generated CRLs)
+```
+
+### Metadaten-Dateien
+
+Jedes Zertifikat besitzt eine `metadata.json`-Datei mit folgenden Inhalten:
+- Zertifikatsidentifikation (CN, Seriennummer, Fingerabdruck)
+- Inhaberinformationen (Organisation, E-Mail, Standort)
+- Gültigkeitszeiträume
+- Sperrstatus und -verlauf
+- Erneuerungskonfiguration
+- Benutzerdefinierte Notizen
+
+---
+
+## Sicherheitsmodell
+
+### Schlüsselschutz
+
+- **Dateiberechtigungen**: 0600 (nur Lesen/Schreiben für den Eigentümer)
+- **Schlüsselformat**: PEM im traditionellen OpenSSL-Format
+- **Keine Schlüsselverschlüsselung**: Schlüssel werden verschlüsselt im Ruhezustand gespeichert, wenn Storage-Backends verwendet werden
+
+### Zertifikatssignierung
+
+- **Signaturalgorithmus**: SHA256withRSA
+- **Schlüsselgröße**: 4096-Bit RSA für die CA, 2048/4096 Bit für Clients
+- **Gültigkeit**: Konfigurierbar (Standard 1 Jahr für Client-Zertifikate)
+
+### Zugangskontrolle
+
+- **Authentifizierung**: Bearer-Token auf allen API-Endpoints
+- **Autorisierung**: Token-basiert (erweiterbar mit Rollen)
+- **Rate Limiting**: Schutz pro Endpoint
+
+### Audit-Trail
+
+- Alle Operationen mit Zeitstempel protokolliert
+- Benutzer- und IP-Adress-Verfolgung
+- Unveränderliche Audit-Protokolldatei
+- Für Compliance abfragbar
+
+---
+
+## Skalierbarkeit
+
+### Zertifikatsspeicherung
+
+- **Lineare Skalierbarkeit**: Verzeichnisbasierter Speicher
+- **Kapazität**: Getestet mit 30.000+ Zertifikaten
+- **Performance**: Effiziente O(n)-Verzeichnis-Scans
+
+### API-Performance
+
+- **Rate Limiting**: Verhindert Ressourcenerschöpfung
+- **Zustandsloses Design**: Kann in mehreren Instanzen betrieben werden
+- **Batch-Operationen**: Verarbeitet 100–30.000 Zertifikate pro Anfrage
+
+### Automatische Erneuerung
+
+- **Geplant**: Täglich um 3 Uhr (konfigurierbar)
+- **Schwellenwert**: 30 Tage vor Ablauf (konfigurierbar)
+- **Fehlertolerant**: Setzt bei Fehlern fort und protokolliert zur Überprüfung
+
+---
+
+## Deployment-Überlegungen
+
+### Mindestanforderungen
+
+- Python 3.9+
+- 100 MB Speicherplatz für CA und initiale Zertifikate
+- 50 MB für Audit-Protokolle pro 1 Mio. Operationen
+- Geringer Speicherbedarf
+
+### Empfehlungen für den Produktionsbetrieb
+
+- Storage-Backend (Azure, AWS, Vault) für Hochverfügbarkeit verwenden
+- Audit-Protokollierung zur Compliance aktivieren
+- Rate Limiting entsprechend der Last konfigurieren
+- Regelmäßige CRL-Aktualisierungen (täglich oder bei Sperrungen)
+- CA-Schlüssel und Metadaten sichern
+- Audit-Protokolle auf verdächtige Aktivitäten überwachen
+
+### Hochverfügbarkeit
+
+Für Multi-Instanz-Deployments:
+1. Gemeinsames Storage-Backend für Zertifikate verwenden
+2. Audit-Protokolle an einen zentralen Speicherort synchronisieren
+3. Load Balancer mit Sticky Sessions einsetzen
+4. Rate-Limiting-Zähler instanzübergreifend überwachen
+
+---
+
+## Integrationspunkte
+
+### Mit dem CertMate-Hauptsystem
+
+- Verwendet bestehende CertMate-Storage-Backends
+- In die Manager von app.py integriert
+- Teil der Flask-RESTX-API-Struktur
+- Mit APScheduler geplant
+
+### Externe Systeme
+
+- Kann Zertifikate über die API exportieren
+- Kann den Status über OCSP abfragen
+- Kann die CRL zur Validierung abrufen
+- Unterstützt Webhook/Callback-Integration (zukünftig)
+
+---
+
+## Zukünftige Erweiterbarkeit
+
+### Geplante Verbesserungen
+
+1. **CA-Passwortschutz** — CA-Schlüssel mit Passwort verschlüsseln
+2. **Erweitertes Audit** — Rollenbasierte Zugriffskontrolle
+3. **Webhook-Benachrichtigungen** — Bei Zertifikatsereignissen
+4. **Zertifikatssignierung** — CSRs von externen Quellen akzeptieren
+5. **Hardware-Token** — PKCS#11-Unterstützung für HSMs
+
+### Erweiterungspunkte
+
+1. **Storage-Backends** — Unterstützt bereits mehrere Backends
+2. **Audit-Ziele** — Kann Audit-Protokolle an externe Systeme senden
+3. **API-Middleware** — Benutzerdefinierte Authentifizierung/Autorisierung hinzufügen
+4. **Benachrichtigungssystem** — Integration mit Alarmsystemen
+
+---
+
+## Überwachung und Beobachtbarkeit
+
+### Wichtige Metriken
+
+- Zertifikatsanzahl (gesamt, aktiv, gesperrt, demnächst ablaufend)
+- Performance der API-Endpoints
+- Rate-Limiting-Verstöße
+- Volumen der Audit-Protokolle
+- Erfolgs-/Fehlerquote bei automatischen Erneuerungen
+
+### Statusprüfungen
+
+- Verfügbarkeit der CA
+- Funktionsfähigkeit des Audit-Loggers
+- Reaktionsfähigkeit des Rate Limiters
+- Status der CRL-Erzeugung
+
+---
+
+<div align="center">
+
+[← Zurück zur Dokumentation](./README.md) • [Schnellstart →](./guide.md) • [API-Referenz →](./api.md)
+
+</div>

--- a/docs/de/ca-providers.md
+++ b/docs/de/ca-providers.md
@@ -1,0 +1,259 @@
+# Zertifizierungsstellen (CA) Anbieter
+
+CertMate unterstützt mehrere Zertifizierungsstellen-Anbieter, sodass Sie die für Ihre Anforderungen am besten geeignete CA auswählen können.
+
+---
+
+## Unterstützte CA-Anbieter
+
+### Let's Encrypt (Standard)
+
+- **Typ**: Kostenlose, automatisierte SSL-Zertifikate
+- **Zertifikattypen**: Domain Validation (DV)
+- **Wildcard-Unterstützung**: Ja
+- **EAB Erforderlich**: Nein
+- **Am besten geeignet für**: Entwicklung, kleine Unternehmen, private Projekte
+
+**Konfiguration:**
+- **E-Mail**: Erforderlich für Zertifikatsbenachrichtigungen
+
+### Let's Encrypt (Staging)
+
+- **Typ**: Testzertifikate aus der Let's Encrypt Staging-Umgebung
+- **Zertifikattypen**: Domain Validation (DV) — von Browsern NICHT vertraut
+- **Wildcard-Unterstützung**: Ja
+- **EAB Erforderlich**: Nein
+- **Am besten geeignet für**: DNS-Konfiguration, Deployment und Erneuerungsablauf validieren, ohne Produktions-Rate-Limits zu verbrauchen
+
+Staging ist ein eigenständiger Zertifizierungsstellen-Eintrag (seit v2.12.0), kein Kennzeichen pro Zertifikat: Wählen Sie ihn beim Erstellen eines Zertifikats als CA aus oder legen Sie ihn während des Testens als Standard-CA fest. Die E-Mail-Adresse fällt auf das Let's Encrypt-Konto zurück, wenn sie leer gelassen wird. Die Umwandlung eines Staging-Zertifikats in ein Produktionszertifikat erfordert eine Neuausstellung mit der Produktions-CA.
+
+### DigiCert ACME
+
+- **Typ**: SSL-Zertifikate für Unternehmensumgebungen
+- **Zertifikattypen**: DV, OV, EV
+- **Wildcard-Unterstützung**: Ja
+- **EAB Erforderlich**: Ja
+- **Am besten geeignet für**: Unternehmensumgebungen, kommerzielle Anwendungen
+
+**Konfigurationsanforderungen:**
+- **ACME Directory URL**: `https://acme.digicert.com/v2/acme/directory`
+- **EAB Key ID**: Von DigiCert bereitgestellt
+- **EAB HMAC Key**: Von DigiCert bereitgestellt
+- **E-Mail**: Erforderlich für Zertifikatsbenachrichtigungen
+
+### Actalis
+
+- **Typ**: Kostenlose 90-tägige DV-Zertifikate einer europäischen (italienischen) CA
+- **Zertifikattypen**: Domain Validation (DV)
+- **Wildcard-Unterstützung**: Nein (nicht per ACME angeboten)
+- **EAB Erforderlich**: Ja
+- **Am besten geeignet für**: EU-Nutzer, die eine europäische Alternative zu Let's Encrypt suchen, eIDAS-Ökosystem-Umgebungen
+
+**Konfigurationsanforderungen:**
+- **ACME Directory URL**: `https://acme-api.actalis.com/acme/directory` (fest vorkonfiguriert)
+- **EAB Key ID**: Aus Ihrem Actalis-Kundenbereich
+- **EAB HMAC Key**: Aus Ihrem Actalis-Kundenbereich
+- **E-Mail**: Erforderlich für Zertifikatsbenachrichtigungen
+
+**Limits des kostenlosen Tarifs:**
+- Nur Einzeldomain-Zertifikate — eine Anfrage mit SAN-Einträgen wird mit
+  `Your account only grants single-domain 90-days DV certificates` abgelehnt
+- 90 Tage Gültigkeit
+- Keine Wildcard-Zertifikate (kostenpflichtige SAN-Tarife decken bis zu 5 Hostnamen ab)
+
+### Private CA
+
+- **Typ**: Interne/Unternehmenseigene Zertifizierungsstelle
+- **Zertifikattypen**: Privat/Intern
+- **Wildcard-Unterstützung**: Ja (abhängig von der CA-Implementierung)
+- **EAB Erforderlich**: Optional
+- **Am besten geeignet für**: Interne Netzwerke, Unternehmensumgebungen, abgeschottete Systeme
+
+**Kompatible Software:**
+- [step-ca](https://smallstep.com/docs/step-ca/)
+- [Boulder](https://github.com/letsencrypt/boulder)
+- [Pebble](https://github.com/letsencrypt/pebble)
+- Andere ACME-kompatible private CAs
+
+**Öffentliche ACME-CA über Private CA nutzen:**
+
+Der Private-CA-Eintrag ist auch der generische Ausweg für jede ACME-CA ohne dedizierten CertMate-Eintrag: Richten Sie ihn auf die Directory-URL der CA aus und füllen Sie, falls die CA eine Kontobindung erzwingt, die optionale EAB Key ID und den HMAC Key aus. Actalis funktioniert beispielsweise sowohl über seinen dedizierten Eintrag (empfohlen) als auch als Private CA mit:
+
+- **ACME Directory URL**: `https://acme-api.actalis.com/acme/directory`
+- **EAB Key ID / HMAC Key**: aus dem Actalis-Kundenbereich
+- **CA-Zertifikat**: leer lassen (öffentlich vertrauenswürdige Stammzertifikate)
+
+---
+
+## Konfiguration
+
+### Über die Weboberfläche
+
+1. Navigieren Sie zu **Einstellungen**
+2. Scrollen Sie zu **Zertifizierungsstellen (CA) Anbieter**
+3. Wählen Sie Ihren Standard-CA-Anbieter aus
+4. Konfigurieren Sie die erforderlichen Felder
+5. Klicken Sie auf **CA-Verbindung testen**, um die Verbindung zu prüfen
+6. Einstellungen speichern
+
+### Standard-CA vs. CA pro Zertifikat
+
+Legen Sie eine Standard-CA für alle neuen Zertifikate fest. Überschreiben Sie diese pro Zertifikat während der Erstellung:
+
+1. Gehen Sie zur Seite **Zertifikate**
+2. Wählen Sie die gewünschte CA aus dem Dropdown-Menü **Zertifizierungsstelle**
+3. Fahren Sie mit der Zertifikatserstellung fort
+
+### Über die API
+
+```bash
+# Create certificate with specific CA
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "domain": "example.com",
+    "ca_provider": "digicert"
+  }'
+
+# Test CA connection
+curl -X POST http://localhost:8000/api/settings/test-ca-provider \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ca_provider": "digicert",
+    "config": {
+      "acme_url": "https://acme.digicert.com/v2/acme/directory",
+      "eab_kid": "your_key_id",
+      "eab_hmac": "your_hmac_key",
+      "email": "admin@example.com"
+    }
+  }'
+```
+
+---
+
+## External Account Binding (EAB)
+
+Einige CA-Anbieter (wie DigiCert und Actalis) erfordern External Account Binding, um Ihren ACME-Client mit Ihrem CA-Konto zu verknüpfen.
+
+### Was ist EAB?
+
+- **Key ID**: Ein eindeutiger Bezeichner für Ihr Konto
+- **HMAC Key**: Ein geheimer Schlüssel zum Signieren von Anfragen
+
+### EAB-Zugangsdaten beziehen
+
+**DigiCert:**
+1. Melden Sie sich in Ihrem DigiCert-Konto an
+2. Navigieren Sie zu den ACME-Einstellungen
+3. Generieren oder rufen Sie Ihre EAB Key ID und den HMAC Key ab
+
+**Actalis:**
+1. Registrieren Sie ein kostenloses Konto auf [actalis.com](https://www.actalis.com/)
+2. Öffnen Sie im Kundenbereich **Manage with ACME**
+3. Rufen Sie die KID und den HMAC Key unter **ACME Credentials** ab
+
+**Private CA:**
+- **step-ca**: EAB kann pro Provisioner aktiviert/deaktiviert werden
+- **Boulder**: Erfordert in der Regel EAB für den Produktionsbetrieb
+- Entnehmen Sie die spezifischen Anforderungen der Dokumentation Ihrer privaten CA
+
+---
+
+## SSL-Zertifikatsvertrauen
+
+### Öffentliche CAs (Let's Encrypt, DigiCert)
+
+Zertifikate werden von Browsern und Betriebssystemen automatisch als vertrauenswürdig eingestuft.
+
+### Private CAs
+
+Damit Zertifikate einer privaten CA als vertrauenswürdig gelten:
+1. Installieren Sie das Stamm-CA-Zertifikat auf den Client-Systemen
+2. Konfigurieren Sie Anwendungen für benutzerdefiniertes Vertrauen
+3. Importieren Sie das Stammzertifikat in die Vertrauensspeicher der Browser
+
+Sie können in CertMate optional das Stamm-CA-Zertifikat angeben, um bei der Zertifikatserstellung die Vertrauenskette zu prüfen.
+
+---
+
+## Fehlerbehebung
+
+### Let's Encrypt
+- **Zertifikat nach Ausstellung nicht vertrauenswürdig**: Prüfen Sie, ob das Zertifikat von der Staging-CA ausgestellt wurde — wählen Sie den Produktionseintrag "Let's Encrypt" und stellen Sie es neu aus
+- **Rate-Limit erreicht**: Wechseln Sie während des Testens zum CA-Eintrag "Let's Encrypt (Staging)"
+- **Gültige E-Mail**: Stellen Sie sicher, dass das E-Mail-Format korrekt ist
+
+### DigiCert
+- **Ungültige EAB-Zugangsdaten**: Überprüfen Sie Key ID und HMAC Key
+- **Konto nicht autorisiert**: Stellen Sie sicher, dass ACME in Ihrem DigiCert-Konto aktiviert ist
+- **Falsche ACME-URL**: Überprüfen Sie die Directory-URL beim DigiCert-Support
+
+### Actalis
+- **`Your account only grants single-domain 90-days DV certificates`**: Der kostenlose Tarif lehnt SAN/Multi-Domain-Anfragen ab — stellen Sie je ein Zertifikat pro Hostname aus oder upgraden Sie den Tarif
+- **Ungültige EAB-Zugangsdaten**: Rufen Sie neue Zugangsdaten aus dem Kundenbereich unter Manage with ACME ab
+- **Wildcard abgelehnt**: Wildcard-Zertifikate sind bei Actalis über ACME nicht verfügbar
+
+### Private CA
+- **ACME-URL nicht erreichbar**: Überprüfen Sie die Netzwerkkonnektivität
+- **CA-Zertifikat ungültig**: Überprüfen Sie das PEM-Format und die Gültigkeit
+- **EAB mismatch**: Prüfen Sie, ob EAB von Ihrer CA verlangt wird
+
+### Allgemein
+- Stellen Sie sicher, dass der DNS-Anbieter korrekt konfiguriert ist
+- Überprüfen Sie die Domain-Inhaberschaft und die DNS-Propagation
+- Prüfen Sie die Firewall-Regeln für den ACME-Port (in der Regel 443)
+
+---
+
+## Migration zwischen CAs
+
+1. **Neue Zertifikate** verwenden die neue Standard-CA
+2. **Bestehende Zertifikate** nutzen weiterhin ihre ursprüngliche CA bis zur Erneuerung
+3. **Erzwungene Migration**: Manuell erneuern, um zur neuen CA zu wechseln
+
+**Best Practices:**
+- Testen Sie die neue CA-Konfiguration, bevor Sie sie als Standard festlegen
+- Planen Sie die Migration in Wartungsfenstern
+- Sichern Sie vorhandene Zertifikate
+- Überwachen Sie die Gültigkeit nach der Migration
+
+---
+
+## Sicherheitshinweise
+
+- EAB-HMAC-Schlüssel werden nach dem Speichern nicht mehr angezeigt
+- Private Schlüssel werden lokal generiert und niemals übertragen
+- Verwenden Sie HTTPS für alle CA-Kommunikationen
+- Erwägen Sie einen VPN für den Zugriff auf private CAs
+
+---
+
+## Ressourcen
+
+### Let's Encrypt
+- [Dokumentation](https://letsencrypt.org/docs/)
+- [Rate Limits](https://letsencrypt.org/docs/rate-limits/)
+- [Staging-Umgebung](https://letsencrypt.org/docs/staging-environment/)
+
+### DigiCert
+- [ACME-Dokumentation](https://docs.digicert.com/certificate-tools/acme-user-guide/)
+- [Konto-Einrichtung](https://docs.digicert.com/certificate-tools/acme-user-guide/acme-account-setup/)
+
+### Actalis
+- [ACME aktivieren](https://guide.actalis.com/ssl/activation/acme)
+- [ACME FAQ](https://guide.actalis.com/faq/SSL/ACME)
+
+### Private CA
+- [step-ca Dokumentation](https://smallstep.com/docs/step-ca/)
+- [Boulder-Projekt](https://github.com/letsencrypt/boulder)
+- [Pebble-Testserver](https://github.com/letsencrypt/pebble)
+
+---
+
+<div align="center">
+
+[← Zurück zur Dokumentation](./README.md) • [DNS-Anbieter →](./dns-providers.md) • [Docker →](./docker.md)
+
+</div>

--- a/docs/de/compliance.md
+++ b/docs/de/compliance.md
@@ -1,0 +1,53 @@
+# Compliance und Audit-Trail
+
+Diese Seite ordnet den Audit-Trail von CertMate den Regelwerken zu, nach denen Betreiber am häufigsten fragen — dem EU AI Act, NIS2 und ISO/IEC 42001 — wenn sie einen KI/MCP-Agenten Zertifikate nach einem Zeitplan verwalten lassen.
+
+> **Zuerst lesen.** CertMate ist ein selbst gehostetes MIT-Tool für Einzelinstanzen. Es ist **kein** KI-System, **kein** KI-System mit hohem Risiko und **keine** regulierte Einheit, und es „erfüllt" oder „zertifiziert" nichts. Die Compliance-Pflichten liegen beim **Betreiber**, der es einsetzt. Was CertMate bereitstellt, sind **Nachweisartefakte**, die ein Betreiber für *seine eigenen* Verpflichtungen nutzen kann. Jede Aussage unten bedeutet „versetzt den Betreiber in die Lage, X nachzuweisen", mit den ausdrücklich genannten Einschränkungen.
+
+---
+
+## Was der Audit-Trail heute bietet
+
+- **Attribution.** Jede Aktion im Zertifikatslebenszyklus — Erstellen, Erneuern, Neuausstellen, Deploy, Umschalten der automatischen Erneuerung und unbeaufsichtigte geplante Erneuerungen — wird mit einem strukturierten `actor` (Mensch vs. API-Token vs. KI-Agent, bis zur API-Key-ID) und einem `trigger` (manuell, API, Agent oder Scheduler-Job) aufgezeichnet. Die Aktionen eines KI-Agenten sind von denen eines Menschen unterscheidbar, sofern der Agent einen mit `is_agent` gekennzeichneten Schlüssel verwendet. Siehe [API: Audit Logging](./api.md#audit-logging) und den [MCP-Leitfaden](./mcp.md#audit-attribution).
+- **Manipulationsnachweis.** Einträge werden in eine append-only SHA-256-Hash-Kette geschrieben (`data/audit/certificate_audit.chain.jsonl`). Jede Änderung, Löschung oder Umordnung durch jemanden, der die Kette nicht neu berechnen kann, ist erkennbar und lokalisierbar.
+- **Unabhängige Verifizierung.** Ein eigenständiger Verifier (`python -m modules.core.audit_verify`) berechnet die Kette neu und liefert PASS/FAIL, ohne CertMate ausführen oder ihm vertrauen zu müssen; `GET /api/audit/verify` stellt dieselbe Prüfung über die API bereit.
+- **Signierter, durch Dritte verifizierbarer Export.** Die Instanz signiert den Kettenanfang (periodische Checkpoints), und `GET /api/audit/export` erzeugt ein Ed25519-signiertes Bundle. Ein Auditor verifiziert es außerhalb der Maschine und pinnt dabei den öffentlichen Schlüssel der Instanz (`GET /api/audit/public-key`) out-of-band — was beweist, dass der Eintrag nicht bearbeitet wurde und welche Instanz ihn erzeugt hat.
+
+---
+
+## Zuordnung zu Regelwerken
+
+### NIS2 (Richtlinie (EU) 2022/2555) — die stärkste Übereinstimmung
+
+- **Wobei es hilft.** Zertifikatsoperationen verändern die Vertrauensposition von Diensten und sind daher sicherheitsrelevante Ereignisse. CertMate erzeugt einen manipulationssicheren, attribuierten, zeitgestempelten Nachweis jeder solchen Operation sowie eine unabhängig verifizierbare Prüfung — nutzbar als Teil der Protokollierungs- (Art. 21) und Vorfallsnachweispraktiken (Art. 23) des Betreibers.
+- **Einschränkung.** NIS2 verpflichtet wesentliche/wichtige **Einrichtungen**, nicht Software-Tools. CertMate liefert Protokolle und einen Verifier, den der Betreiber nutzen kann; es bewertet, überwacht oder meldet keine Vorfälle, und die Eigenschaft, eine einbezogene Einrichtung zu sein (und NIS2 vollständig zu erfüllen), liegt in der Verantwortung des Betreibers.
+
+### EU AI Act — Artikel 50 Transparenz (nur im Geiste; die schwächste Übereinstimmung)
+
+- **Wobei es hilft.** Wenn ein KI-Agent autonom PKI-Aufgaben übernimmt, trägt der Eintrag einen expliziten `actor.kind="agent"`-Marker sowie die Agent-Session, sodass der Betreiber im Nachhinein nachweisen kann, welche Änderungen von einem KI-Agenten gegenüber einem Menschen vorgenommen wurden, unter welcher Identität und was sie ausgelöst hat — was den Transparenz- und Menschenaufsichtsgeist des Gesetzes unterstützt.
+- **Einschränkung.** Die Pflichten aus Art. 50 liegen bei **Anbietern/Betreibern von KI-Systemen** und betreffen die Offenlegung gegenüber natürlichen Personen, die mit KI interagieren. Ein Agent, der TLS-Zertifikate erneuert, ist kein Lehrbuchfall von Art. 50, und CertMate ist ein Tool, kein KI-System. Wir beziehen uns nur auf den Transparenzgeist; CertMate erfüllt Art. 50 **nicht** für irgendjemanden.
+
+### ISO/IEC 42001 (KI-Managementsystem) — operative Aufzeichnungen
+
+- **Wobei es hilft.** Die attribuierten, manipulationssicheren Aufzeichnungen sind objektive Nachweise, dass ein KI-Agent bestimmte Zertifikatsaktionen durchgeführt hat — nutzbar für die operativen Aufzeichnungs- und Rückverfolgbarkeitskontrollen des eigenen AIMS des Betreibers.
+- **Einschränkung.** ISO 42001 zertifiziert das Managementsystem einer Organisation, nicht ein Tool. CertMate ist nicht nach ISO 42001 zertifiziert und kann den Betreiber nicht zertifizieren; es erzeugt Aufzeichnungen, die der Betreiber als Nachweis für seine eigenen Kontrollen vorlegen kann.
+
+---
+
+## Ehrliche Einschränkungen (nicht überinterpretieren)
+
+- **Der Signierschlüssel bindet den Betreiber nicht.** Ein signiertes Export-Bundle (und die periodischen signierten Checkpoints) ermöglichen es einem Dritten, außerhalb der Maschine zu verifizieren, welche Instanz den Eintrag erzeugt hat und dass er nicht bearbeitet wurde — für jeden, der den Signierschlüssel **nicht** besitzt. Aber der Betreiber besitzt den Schlüssel und könnte eine neu geschriebene Kette erneut signieren. Die vollständige Bindung des Betreibers erfordert das Versenden der signierten Checkpoints an eine externe append-only-Senke (**opt-in-externes Anchoring — eine geplante Folgefunktion, noch nicht ausgeliefert**). Betrachten Sie die aktuelle Garantie als „Authentizität, Reihenfolge und Instanzattribution der aufgezeichneten Einträge", unabhängig verifizierbar durch einen Dritten, der eine exportierte, signierte Kopie besitzt.
+- **Authentizität, nicht Vollständigkeit.** Audit-Schreibvorgänge erfolgen nach bestem Bemühen und blockieren niemals eine Zertifikatsoperation; die Kette beweist, dass die aufgezeichneten Einträge authentisch und geordnet sind, und ein fehlendes inneres `seq` beweist eine Löschung, aber ein Schreibvorgang, der fehlgeschlagen ist, bevor er aufgezeichnet wurde, hinterlässt keinen Eintrag zur Verifizierung.
+- **Tail-Trunkierung erfordert eine externe Referenz.** Das Entfernen von Einträgen am **Ende** einer einzelnen Kette hinterlässt eine kürzere, aber intern konsistente Kette, die weiterhin als intakt verifiziert wird. Die signierten Checkpoints und Export-Bundles sind die Ankerpunkte, um dies zu erkennen: ein späterer signierter Export mit weniger Einträgen als ein früherer (oder als ein Checkpoint, den ein Auditor besitzt) enthüllt die Trunkierung. Ein einzelner In-place-Export kann allein nicht beweisen, dass am Ende nichts entfernt wurde — bewahren Sie aufeinanderfolgende signierte Exporte auf, oder warten Sie auf das opt-in externe Anchoring, wenn Sie diese Garantie benötigen.
+- **Der Agent-Session-Header ist eine Angabe des Clients.** Er wird zur Korrelation aufgezeichnet, wird aber vom Client geliefert; die vertrauenswürdige Identität ist der authentifizierte API-Schlüssel.
+- **Historische Grenze.** Die Kette beginnt, wenn die Funktion erstmals aktiviert wird; älterer `.log`-Verlauf ist nicht Teil der verifizierbaren Kette.
+
+Signierte Exporte, die ein externer Auditor an einen veröffentlichten Schlüssel pinnen kann, sind heute verfügbar. Wenn Ihre Verpflichtungen erfordern, den Betreiber *selbst* zu binden — sodass auch der Schlüsselinhaber die Geschichte nicht unentdeckt umschreiben kann — ist dafür das opt-in externe Anchoring der signierten Checkpoints an eine append-only-Senke außerhalb der Maschine erforderlich, das geplant, aber noch nicht ausgeliefert ist. Verfolgen Sie dessen Entwicklung, bevor Sie sich darauf verlassen.
+
+---
+
+<div align="center">
+
+[← Zurück zur Dokumentation](./README.md)
+
+</div>

--- a/docs/de/deploy-hooks.md
+++ b/docs/de/deploy-hooks.md
@@ -1,0 +1,293 @@
+# Deploy Hooks
+
+Schliesst [#117](https://github.com/fabriziosalmi/certmate/issues/117).
+
+Deploy Hooks sind kurze Shell-Befehle, die CertMate **nach** der Ausstellung, Erneuerung oder dem Widerruf eines Zertifikats ausführt. Verwenden Sie sie, um Dienste neu zu laden, das neue Zertifikat an einen Load Balancer zu übermitteln, eine Benachrichtigung zu versenden oder alles andere, was nach einem erfolgreichen certbot-Lauf erledigt werden muss.
+
+Diese Anleitung behandelt:
+
+1. [Was ein Hook ist](#was-ein-hook-ist)
+2. [Hooks konfigurieren (UI + JSON)](#hooks-konfigurieren)
+3. [Umgebungsvariablen, die an Ihren Befehl übergeben werden](#umgebungsvariablen-die-an-ihren-befehl-übergeben-werden)
+4. [Manuelles Auslösen](#manuelles-auslösen)
+5. [Sicherheitsmodell: warum bestimmte Befehle abgelehnt werden](#sicherheitsmodell)
+6. [Häufige Rezepte](#häufige-rezepte)
+7. [Audit, Verlauf und Debugging](#audit-verlauf-und-debugging)
+
+---
+
+## Was ein Hook ist
+
+Ein Hook ist ein JSON-Objekt mit fünf Feldern:
+
+| Feld | Typ | Erforderlich | Hinweise |
+|---|---|---|---|
+| `id` | string | ja | Stabiler Bezeichner (eine UUID ist geeignet; die UI generiert automatisch eine). Wird von `/api/deploy/test/<id>` verwendet. |
+| `name` | string | ja | Lesbares Label, das in der UI und im Audit-Log angezeigt wird. |
+| `command` | string | ja | Ein einzelner Shell-Befehl (`sh -c`). Max. 1024 Zeichen. Siehe [Sicherheitsmodell](#sicherheitsmodell). |
+| `enabled` | boolean | nein | Standard: `true`. Deaktivierte Hooks werden beim automatischen Auslösen übersprungen, können aber weiterhin manuell getestet werden. |
+| `timeout` | integer | nein | Sekunden. Standard 30, begrenzt auf den systemweiten `MAX_TIMEOUT` (aktuell 300). |
+| `on_events` | string array | nein | Teilmenge von `["created", "renewed", "revoked"]`. Fehlt dieses Feld, läuft der Hook bei allen drei Ereignissen. |
+
+Hooks werden unter zwei Schlüsseln in `deploy_hooks` gespeichert:
+
+- **`global_hooks`** — werden für jede Domain ausgeführt. Gut geeignet für „nginx nach jeder Zertifikatsänderung neu laden".
+- **`domain_hooks`** — nach exaktem Domainnamen indiziert. Gut geeignet für „das LB-Zertifikat für `api.example.com` nach der Erneuerung dieses spezifischen Zertifikats zu S3 übertragen".
+
+```jsonc
+{
+  "deploy_hooks": {
+    "enabled": true,
+    "global_hooks": [
+      {
+        "id": "5f8...",
+        "name": "Reload nginx",
+        "command": "/usr/sbin/nginx -s reload",
+        "enabled": true,
+        "timeout": 30,
+        "on_events": ["created", "renewed"]
+      }
+    ],
+    "domain_hooks": {
+      "api.example.com": [
+        {
+          "id": "9b1...",
+          "name": "Push to LB",
+          "command": "/opt/scripts/push-cert-to-lb.sh",
+          "enabled": true,
+          "timeout": 120,
+          "on_events": ["renewed"]
+        }
+      ]
+    }
+  }
+}
+```
+
+Wenn `enabled` auf der obersten Ebene `false` ist, werden bei Zertifikatsereignissen keine Hooks ausgeführt. Manuelle Testläufe (`POST /api/deploy/test/<id>`) funktionieren weiterhin — nützlich, wenn Sie einen Hook iterativ entwickeln, bevor Sie den Hauptschalter umlegen.
+
+---
+
+## Hooks konfigurieren
+
+### Über die UI
+
+`Einstellungen → Deploy Hooks`. Schalten Sie den **Aktiviert**-Schalter um, und fügen Sie dann globale oder domainspezifische Hooks hinzu. Jede Zeile enthält:
+
+- Name + Befehl + Timeout + Ereignis-Checkboxen
+- eine **Test**-Schaltfläche (führt den Hook gegen die synthetische Domain `test.example.com` mit `CERTMATE_EVENT=manual` aus)
+- Aktivieren/Deaktivieren-Schalter
+- Löschen
+
+Einstellungen speichern, um die Änderungen beizubehalten.
+
+### Über die API
+
+```bash
+# Aktuelle Konfiguration lesen
+curl -H "Authorization: Bearer $TOKEN" \
+  https://certmate.local/api/deploy/config
+
+# Konfiguration ersetzen (vollständiges Dokument schreiben — gesamtes deploy_hooks-Dict übergeben)
+curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d @hooks.json https://certmate.local/api/deploy/config
+```
+
+Der POST ersetzt den gesamten `deploy_hooks`-Block; führen Sie die Zusammenführung clientseitig durch, wenn Sie bestehende Einträge beibehalten möchten.
+
+---
+
+## Umgebungsvariablen, die an Ihren Befehl übergeben werden
+
+Jeder Aufruf setzt diese Variablen in der Prozessumgebung des Hooks:
+
+| Variable | Beispielwert |
+|---|---|
+| `CERTMATE_DOMAIN` | `api.example.com` |
+| `CERTMATE_CERT_PATH` | `/app/certificates/api.example.com/cert.pem` |
+| `CERTMATE_KEY_PATH` | `/app/certificates/api.example.com/privkey.pem` |
+| `CERTMATE_FULLCHAIN_PATH` | `/app/certificates/api.example.com/fullchain.pem` |
+| `CERTMATE_CHAIN_PATH` | `/app/certificates/api.example.com/chain.pem` (nur Zwischenzertifikate, kein Blattzertifikat — für Ziele, die die Chain als separate Datei benötigen) |
+| `CERTMATE_EVENT` | `created` / `renewed` / `revoked` / `manual` |
+| `CERTMATE_DRY_RUN` | Nur während eines Dry-Run auf `1` gesetzt; andernfalls nicht vorhanden. |
+
+Ihr Befehl kann diese Variablen als `$CERTMATE_DOMAIN`, `"$CERTMATE_FULLCHAIN_PATH"` usw. referenzieren. Die Werte werden über die Umgebung übergeben, nicht durch String-Interpolation, sodass das Quoting wie in jeder normalen Shell funktioniert.
+
+Der Hook wird als Prozessbenutzer von CertMate ausgeführt (im Docker-Image: `certmate`, UID/GID 1000:1000), innerhalb des Containers. Alles, was Sie per `cp`, `curl`, `ssh` usw. ausführen, muss von dort erreichbar sein.
+
+---
+
+## Manuelles Auslösen
+
+Zwei Möglichkeiten, einen Hook ausserhalb des normalen Zertifikatslebenszyklus auszuführen:
+
+### Hook-Test pro Hook (Admin)
+
+```bash
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  https://certmate.local/api/deploy/test/<hook_id>
+```
+
+Führt nur den Hook mit dieser `id` gegen die synthetische Domain `test.example.com` aus, mit `CERTMATE_EVENT=manual`. Umgeht den `on_events`-Filter — nützlich für „funktioniert dieser Befehl tatsächlich?".
+
+### Alle Hooks für eine Domain ausführen (Admin)
+
+```bash
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  https://certmate.local/api/certificates/api.example.com/deploy
+```
+
+Löst alle aktivierten globalen und domainspezifischen Hooks für `api.example.com` mit `CERTMATE_EVENT=manual` aus und ignoriert dabei `on_events`. Gibt eine strukturierte Zusammenfassung zurück:
+
+```jsonc
+{
+  "ok": true,
+  "total": 3,
+  "succeeded": 2,
+  "failed": 1,
+  "results": [
+    {"hook_name": "Reload nginx", "exit_code": 0, "duration_ms": 142, ...},
+    ...
+  ]
+}
+```
+
+Dies ist das, was die Schaltfläche **Deploy Hooks jetzt ausführen** im Zertifikat-Detailbereich aufruft.
+
+---
+
+## Sicherheitsmodell
+
+Hooks sind konzeptbedingt beliebige Code-Ausführung — das ist das Feature. Um den möglichen Schaden zu begrenzen, wird das Befehlsfeld **beim Speichern und erneut zur Laufzeit** validiert (Defense in Depth) und abgelehnt, wenn es Folgendes enthält:
+
+### Blockierte Shell-Muster
+
+| Muster | Grund |
+|---|---|
+| `` ` `` (Backticks) | Befehlssubstitution |
+| `$(...)` | Befehlssubstitution |
+| `${...}` | Parameterexpansion (Env-Variablen-Expansion ist erlaubt — nur die `${...}`-Form ist blockiert) |
+| `&&` / `\|\|` | Logische Verknüpfung |
+| `;` | Anweisungstrenner |
+| `\|` | Pipe |
+| `\r` / `\n` | Zeilenumbrüche (damit `sh -c` sie nicht als `;` interpretiert) |
+| `> /` (Umleitung auf absoluten Pfad) | Verhindert das Überschreiben von Systemdateien |
+| `<<` | Here-Doc |
+| `eval`, `source`, `. /` | Shell-Builtins, die beliebigen Code laden |
+
+Wenn Sie eines dieser Muster benötigen, legen Sie die Logik in eine Skriptdatei innerhalb des Containers und rufen Sie das Skript direkt auf:
+
+```sh
+/opt/scripts/deploy.sh
+```
+
+### Blockierte Dateireferenzen
+
+Referenzen auf CertMates eigene sensible Dateien werden grundsätzlich abgelehnt (Gross-/Kleinschreibung wird ignoriert):
+
+`settings.json`, `api_bearer_token`, `client_secret`, `vault_token`, `.env`, `private*key`, `.pem`
+
+`cat $CERTMATE_FULLCHAIN_PATH` ist also zulässig (die Variable wird von der Shell aufgelöst, die literale Zeichenkette `.pem` erscheint nicht in `command`), aber `cat /app/data/settings.json` würde beim Speichern abgelehnt.
+
+### Was erlaubt ist
+
+- **Einfache Befehle**: `/usr/sbin/nginx -s reload`, `systemctl reload haproxy`
+- **Curl-POSTs (Webhooks)**: `curl -X POST -H "Content-Type: application/json" https://hooks.slack.com/...`
+- **Variablenexpansion in Argumenten**: `curl -d "domain=$CERTMATE_DOMAIN" https://...`
+- **JSON-Payloads mit `$VAR` (kein `${}`)**: `curl -d '{"domain":"$CERTMATE_DOMAIN"}' ...`
+- **Einzelne Skriptaufrufe**: `/opt/scripts/deploy.sh "$CERTMATE_DOMAIN"`
+
+Wenn ein Befehl, den Sie früher speichern konnten, jetzt `Command blocked at runtime: contains dangerous shell metacharacters` auslöst, lesen Sie die Versionshinweise — der Validator wurde in v2.4.0 verschärft und in v2.4.1+ leicht gelockert.
+
+---
+
+## Häufige Rezepte
+
+### nginx neu laden (global, alle Ereignisse)
+
+```sh
+/usr/sbin/nginx -t && /usr/sbin/nginx -s reload
+```
+
+(Hinweis: `&&` ist blockiert. Verpacken Sie dies in ein Skript: `/opt/scripts/reload-nginx.sh`.)
+
+### haproxy neu laden
+
+```sh
+systemctl reload haproxy
+```
+
+### An einen Slack-Webhook senden
+
+```sh
+curl -X POST -H 'Content-Type: application/json' -d "{\"text\":\"Cert renewed: $CERTMATE_DOMAIN\"}" https://hooks.slack.com/services/XXX/YYY/ZZZ
+```
+
+### Zertifikat auf einen Remote-Host synchronisieren
+
+(In ein Skript verpacken — kein `;`, `&&` inline erlaubt.)
+
+```sh
+/opt/scripts/sync-cert.sh
+```
+
+Wobei `sync-cert.sh` folgenden Inhalt hat:
+
+```sh
+#!/bin/sh
+set -eu
+scp "$CERTMATE_FULLCHAIN_PATH" "$CERTMATE_KEY_PATH" deploy@lb:/etc/ssl/$CERTMATE_DOMAIN/
+ssh deploy@lb 'systemctl reload haproxy'
+```
+
+### Hooks während eines Dry-Run überspringen
+
+In Ihrem Skript:
+
+```sh
+[ -n "${CERTMATE_DRY_RUN:-}" ] && { echo "dry run, skipping"; exit 0; }
+```
+
+---
+
+## Audit, Verlauf und Debugging
+
+### Aktivitätsfeed
+
+`GET /api/deploy/history?limit=50` und der **Aktivität**-Tab der UI zeigen die letzten N Hook-Ausführungen mit: Hook-Name, Domain, Ereignis, Exit-Code, Dauer, stdout/stderr (jeweils auf 4096 Byte gekürzt) und Zeitstempel.
+
+### Debug-Konsole
+
+Einstellungen → Deploy Hooks verfügt über eine Debug-Konsole (Umschalter-Schaltfläche unten rechts), die `loadConfig` / `saveConfig` / `testHook`-Ereignisse clientseitig streamt. Nützlich, wenn Sie iterativ an der UI arbeiten.
+
+### Audit-Log
+
+Jede Hook-Ausführung schreibt einen `operation: deploy_hook`-Eintrag in das Audit-Log mit dem Status `success`/`failure` sowie Hook-Name, Exit-Code und Dauer. Sichtbar über den Aktivität-Tab und `/api/audit`.
+
+### Häufige Fehler
+
+| Symptom | Wahrscheinliche Ursache |
+|---|---|
+| `Hook not found` | Die Hook-ID in der Testanfrage stimmt mit keinem Hook in der gespeicherten Konfiguration überein (UI war veraltet oder der Hook wurde gerade gelöscht). Seite neu laden. |
+| `Command blocked at runtime` | Eines der [blockierten Muster](#blockierte-shell-muster) hat die Speicherprüfung umgangen. Verschieben Sie die problematische Logik in eine Skriptdatei. |
+| `exit code 127` | Befehl im Container nicht gefunden (z. B. `nginx` ist nicht in `$PATH`). Absolute Pfade verwenden oder die Binärdatei im Image installieren. |
+| `timeout after 30s` | Der Hook hat seinen `timeout` überschritten. Erhöhen Sie ihn (max. 300s) oder verlagern Sie die Arbeit in ein im Hintergrund laufendes Skript. |
+| `Deploy hooks disabled` | `deploy_hooks.enabled` ist `false`. Den Hauptschalter in den Einstellungen aktivieren. |
+| `No hooks configured for <domain>` | Versuch, Hooks für eine Domain ohne globale Hooks UND ohne Eintrag unter `domain_hooks[<domain>]` auszuführen. Einen Hook hinzufügen (oder `/api/deploy/test/<id>` für einen bestimmten Hook aufrufen). |
+
+---
+
+## Siehe auch
+
+- [`modules/core/deployer.py`](../modules/core/deployer.py) — Implementierung
+- [`modules/web/settings_routes.py`](../modules/web/settings_routes.py) — `/api/deploy/*`-Endpoints
+- [`templates/partials/settings_deploy.html`](../templates/partials/settings_deploy.html) — UI-Partial
+- [`static/js/settings-deploy.js`](../static/js/settings-deploy.js) — Alpine-Komponente
+
+---
+
+<div align="center">
+
+[← Zurück zur Dokumentation](./README.md)
+
+</div>

--- a/docs/de/dns-providers.md
+++ b/docs/de/dns-providers.md
@@ -1,0 +1,822 @@
+# DNS-Anbieter
+
+CertMate unterstützt eine breite Palette von DNS-Anbietern für Let's Encrypt DNS-01-Challenges über individuelle certbot-Plugins. Die vollständige Liste befindet sich in der nachstehenden Tabelle.
+
+---
+
+## Unterstützte Anbieter
+
+| Anbieter | Plugin | Erforderliche Zugangsdaten | Kategorie |
+|---|---|---|---|
+| **Cloudflare** | `certbot-dns-cloudflare` | API-Token | Großer Cloud-Anbieter |
+| **AWS Route53** | `certbot-dns-route53` | Access Key, Secret Key | Großer Cloud-Anbieter |
+| **Azure DNS** | `certbot-dns-azure` | Service Principal | Großer Cloud-Anbieter |
+| **Google Cloud DNS** | `certbot-dns-google` | Service Account JSON | Großer Cloud-Anbieter |
+| **PowerDNS** | `certbot-dns-powerdns` | API-URL, API-Schlüssel | Enterprise |
+| **DNS Made Easy** | `certbot-dns-dnsmadeeasy` | API-Schlüssel, Secret Key | Enterprise |
+| **NS1** | `certbot-dns-nsone` | API-Schlüssel | Enterprise |
+| **DigitalOcean** | `certbot-dns-digitalocean` | API-Token | Cloud |
+| **Linode (Akamai Connected Cloud)** | `certbot-dns-linode` | API-Schlüssel | Cloud |
+| **Akamai Edge DNS** | `certbot-plugin-edgedns` | EdgeGrid `.edgerc` (client_token, client_secret, access_token, host) | Enterprise |
+| **Vultr** | `certbot-dns-vultr` | API-Schlüssel | Cloud |
+| **Hetzner (DNS legacy)** | `certbot-dns-hetzner` | API-Token | Cloud |
+| **Hetzner Cloud** | `certbot-dns-hetzner-cloud` | API-Token | Cloud |
+| **Gandi** | `certbot-dns-gandi` | API-Token | Registrar |
+| **Namecheap** | `certbot-dns-namecheap` | Benutzername, API-Schlüssel | Registrar |
+| **Porkbun** | `certbot-dns-porkbun` | API-Schlüssel, Secret Key | Registrar |
+| **GoDaddy** | `certbot-dns-godaddy` | API-Schlüssel, Secret | Registrar |
+| **OVH** | `certbot-dns-ovh` | API-Zugangsdaten | Regional |
+| **Infomaniak** | `certbot-dns-infomaniak` | API-Token | Regional |
+| **ArvanCloud** | `certbot-dns-arvancloud` | API-Schlüssel | Regional |
+| **RFC2136** | `certbot-dns-rfc2136` | Nameserver, TSIG-Schlüssel | Standardprotokoll |
+| **ACME-DNS** | `certbot-acme-dns` | API-URL, Benutzername, Passwort | Spezialisiert |
+| **Hurricane Electric** | `certbot-dns-he-ddns` | Benutzername, Passwort | Kostenloses DNS |
+| **Dynu** | `certbot-dns-dynudns` | API-Token | Dynamisches DNS |
+| **DuckDNS** | `certbot-dns-duckdns` | Konto-Token | Kostenloses DDNS (ohne eigene Domain) |
+| **deSEC** | `certbot-dns-desec` | API-Token | Kostenlos, EU (DE), DNSSEC — NS an `ns1.desec.io` / `ns2.desec.org` delegieren |
+| **Scaleway** | `certbot-dns-scaleway` | Geheimer API-Schlüssel | Souveräne EU-Cloud (FR) — Community-Plugin (Alpha), separat installieren: `pip install certbot-dns-scaleway` |
+| **Custom Script** | keines (certbot `--manual`) | Pfad zum Auth-Hook-Skript (+ optionaler Cleanup-Hook) | Eigene Lösung |
+
+---
+
+## Konfiguration
+
+### Über die Weboberfläche
+
+1. Navigieren Sie zu **Einstellungen**
+2. Wählen Sie Ihren DNS-Anbieter aus dem Dropdown-Menü
+3. Tragen Sie die erforderlichen Zugangsdaten ein
+4. Einstellungen speichern
+
+### Über die API
+
+```bash
+curl -X POST http://localhost:8000/api/settings \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dns_provider": "cloudflare",
+    "dns_providers": {
+      "cloudflare": {
+        "api_token": "your_cloudflare_token"
+      }
+    }
+  }'
+```
+
+---
+
+## Konfigurationsbeispiele je Anbieter
+
+### Cloudflare
+
+```json
+{
+  "dns_provider": "cloudflare",
+  "dns_providers": {
+    "cloudflare": {
+      "api_token": "your_cloudflare_api_token"
+    }
+  }
+}
+```
+
+### AWS Route53
+
+```json
+{
+  "dns_provider": "route53",
+  "dns_providers": {
+    "route53": {
+      "access_key_id": "AKIAIOSFODNN7EXAMPLE",
+      "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      "region": "us-east-1"
+    }
+  }
+}
+```
+
+### Azure DNS
+
+```json
+{
+  "dns_provider": "azure",
+  "dns_providers": {
+    "azure": {
+      "subscription_id": "your_subscription_id",
+      "resource_group": "your_resource_group",
+      "tenant_id": "your_tenant_id",
+      "client_id": "your_client_id",
+      "client_secret": "your_client_secret"
+    }
+  }
+}
+```
+
+### Google Cloud DNS
+
+```json
+{
+  "dns_provider": "google",
+  "dns_providers": {
+    "google": {
+      "project_id": "your_project_id",
+      "service_account_key": "{ ... service account JSON ... }"
+    }
+  }
+}
+```
+
+### PowerDNS
+
+```json
+{
+  "dns_provider": "powerdns",
+  "dns_providers": {
+    "powerdns": {
+      "api_url": "https://your-powerdns-server:8081",
+      "api_key": "your_powerdns_api_key"
+    }
+  }
+}
+```
+
+### Vultr
+
+```json
+{
+  "dns_provider": "vultr",
+  "dns_providers": {
+    "vultr": {
+      "api_key": "your_vultr_api_key"
+    }
+  }
+}
+```
+
+### DNS Made Easy
+
+```json
+{
+  "dns_provider": "dnsmadeeasy",
+  "dns_providers": {
+    "dnsmadeeasy": {
+      "api_key": "your_api_key",
+      "secret_key": "your_secret_key"
+    }
+  }
+}
+```
+
+### NS1
+
+```json
+{
+  "dns_provider": "nsone",
+  "dns_providers": {
+    "nsone": {
+      "api_key": "your_nsone_api_key"
+    }
+  }
+}
+```
+
+### RFC2136
+
+Für BIND oder andere RFC2136-kompatible DNS-Server (einschließlich **Technitium DNS Server**):
+
+```json
+{
+  "dns_provider": "rfc2136",
+  "dns_providers": {
+    "rfc2136": {
+      "nameserver": "ns.example.com",
+      "tsig_key": "mykey",
+      "tsig_secret": "base64-encoded-secret",
+      "tsig_algorithm": "HMAC-SHA512"
+    }
+  }
+}
+```
+
+> **Technitium DNS**: Aktivieren Sie Dynamic Updates in den Zone-Optionen, legen Sie einen TSIG-Schlüssel an (z. B. `certmate-key` mit HMAC-SHA512) und verwenden Sie das generierte Secret in der obigen Konfiguration.
+
+### Hetzner (legacy DNS API)
+
+> **Abkündigungshinweis:** Die Hetzner-DNS-Konsolen-API wird im Mai 2025 abgeschaltet. Neue Nutzer sollten den **Hetzner Cloud**-Anbieter weiter unten verwenden. Bestehende Nutzer müssen vor dem Abschalttermin zu `hetzner-cloud` migrieren. Einzelheiten finden Sie auf der [Hetzner-Statusseite](https://status.hetzner.com/incident/c2146c42-6dd2-4454-916a-19f07e0e5a44).
+
+```json
+{
+  "dns_provider": "hetzner",
+  "dns_providers": {
+    "hetzner": {
+      "api_token": "your_hetzner_dns_api_token"
+    }
+  }
+}
+```
+
+### Hetzner Cloud
+
+Verwendet die neue [Hetzner Cloud API](https://docs.hetzner.cloud/reference/cloud), die die veraltete Hetzner-DNS-Konsole ersetzt. Dies ist der empfohlene Anbieter für alle Hetzner-Nutzer.
+
+```json
+{
+  "dns_provider": "hetzner-cloud",
+  "dns_providers": {
+    "hetzner-cloud": {
+      "api_token": "your_hetzner_cloud_api_token"
+    }
+  }
+}
+```
+
+> Erzeugen Sie einen Hetzner Cloud API-Token in der [Hetzner Cloud Console](https://console.hetzner.cloud/) im Bereich API-Token Ihres Projekts. Der Token benötigt Lese- und Schreibrechte für DNS.
+
+### Infomaniak
+
+```json
+{
+  "dns_provider": "infomaniak",
+  "dns_providers": {
+    "infomaniak": {
+      "api_token": "your_infomaniak_api_token"
+    }
+  }
+}
+```
+
+> Den API-Token erhalten Sie im Infomaniak Manager (Bereich API mit dem Scope „Domain").
+
+### Porkbun
+
+```json
+{
+  "dns_provider": "porkbun",
+  "dns_providers": {
+    "porkbun": {
+      "api_key": "your_porkbun_api_key",
+      "secret_key": "your_porkbun_secret_key"
+    }
+  }
+}
+```
+
+### GoDaddy
+
+```json
+{
+  "dns_provider": "godaddy",
+  "dns_providers": {
+    "godaddy": {
+      "api_key": "your_godaddy_api_key",
+      "secret": "your_godaddy_secret"
+    }
+  }
+}
+```
+
+### OVH
+
+```json
+{
+  "dns_provider": "ovh",
+  "dns_providers": {
+    "ovh": {
+      "endpoint": "ovh-eu",
+      "application_key": "your_app_key",
+      "application_secret": "your_app_secret",
+      "consumer_key": "your_consumer_key"
+    }
+  }
+}
+```
+
+### Hurricane Electric
+
+```json
+{
+  "dns_provider": "he-ddns",
+  "dns_providers": {
+    "he-ddns": {
+      "username": "your_he_username",
+      "password": "your_he_password"
+    }
+  }
+}
+```
+
+### Dynu
+
+```json
+{
+  "dns_provider": "dynudns",
+  "dns_providers": {
+    "dynudns": {
+      "token": "your_dynu_api_token"
+    }
+  }
+}
+```
+
+### ArvanCloud
+
+```json
+{
+  "dns_provider": "arvancloud",
+  "dns_providers": {
+    "arvancloud": {
+      "api_key": "your_arvancloud_api_key"
+    }
+  }
+}
+```
+
+### ACME-DNS
+
+```json
+{
+  "dns_provider": "acme-dns",
+  "dns_providers": {
+    "acme-dns": {
+      "api_url": "https://auth.acme-dns.io",
+      "username": "your_acme_username",
+      "password": "your_acme_password",
+      "subdomain": "your_subdomain"
+    }
+  }
+}
+```
+
+### DuckDNS (ohne eigene Domain)
+
+DuckDNS stellt kostenlose `<name>.duckdns.org`-Subdomains bereit — der einfachste Weg, ein öffentlich vertrauenswürdiges Zertifikat zu erhalten, wenn Sie keine eigene Domain besitzen. Typische Anwendungsfälle: Homelabs, selbst gehostete Dienste, IoT-Geräte, interne Dashboards, die bisher auf selbstsignierten Zertifikaten feststeckten.
+
+1. Melden Sie sich auf <https://www.duckdns.org/> an (Google / GitHub / Twitter / Reddit SSO).
+2. Wählen Sie eine Subdomain (z. B. `mybox` → `mybox.duckdns.org`).
+3. Kopieren Sie den Konto-Token, der oben auf der Seite angezeigt wird.
+
+```json
+{
+  "dns_provider": "duckdns",
+  "domains": ["mybox.duckdns.org"],
+  "dns_providers": {
+    "duckdns": {
+      "api_token": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    }
+  }
+}
+```
+
+Wildcards wie `*.mybox.duckdns.org` werden mit demselben Token unterstützt. Da DuckDNS pro Domain jeweils nur einen TXT-Eintrag speichert, ist pro DuckDNS-Subdomain genau ein certbot-Lauf erforderlich — SAN-Zertifikate, die mehrere DuckDNS-Subdomains umfassen, werden nicht unterstützt.
+
+### Custom Script (eigene Lösung)
+
+Für DNS-Anbieter ohne certbot-Plugin — Oracle Cloud (OCI), unternehmensinternes DNS, Appliance-APIs — verweisen Sie CertMate auf Ihre eigenen Skripte; CertMate steuert diese dann über certbots `--manual`-Modus. Eine Plugin-Installation ist nicht erforderlich.
+
+```json
+{
+  "dns_provider": "custom-script",
+  "dns_providers": {
+    "custom-script": {
+      "auth_hook": "/usr/local/bin/certmate-dns-auth.sh",
+      "cleanup_hook": "/usr/local/bin/certmate-dns-cleanup.sh"
+    }
+  }
+}
+```
+
+certbot ruft den Auth-Hook einmal pro Validierungs-Challenge mit der standardmäßigen [manual-hook-Umgebung](https://eff-certbot.readthedocs.io/en/stable/using.html#hooks) auf: `CERTBOT_DOMAIN` (die zu validierende Domain) und `CERTBOT_VALIDATION` (der TXT-Wert). Das Skript muss den TXT-Eintrag `_acme-challenge.$CERTBOT_DOMAIN` anlegen **und warten, bis dieser propagiert ist** — certbot validiert unmittelbar nach Rückkehr des Hooks. Der optionale Cleanup-Hook wird nach der Validierung ausgeführt, um den Eintrag zu entfernen.
+
+Praxisbeispiel für OCI DNS (behandelt [#285](https://github.com/fabriziosalmi/certmate/issues/285)). Beachten Sie: Ein Zertifikat, das sowohl `example.com` als auch `*.example.com` abdeckt, erzeugt ZWEI Validierungs-Challenges auf demselben Namen `_acme-challenge.example.com`; certbot führt alle Auth-Hooks aus, bevor es validiert — der Hook muss daher zum TXT-Rrset HINZUFÜGEN und es niemals ersetzen (ein einfaches `rrset update` würde den ersten Token mit dem zweiten überschreiben):
+
+```bash
+#!/bin/sh
+# /usr/local/bin/certmate-dns-auth.sh
+set -eu
+ZONE="example.com"
+NAME="_acme-challenge.${CERTBOT_DOMAIN}"
+# Merge the new validation token with any records already on the name
+# (apex + wildcard certs place two TXT values on the same name).
+EXISTING=$(oci dns record rrset get --zone-name-or-id "$ZONE" \
+  --domain "$NAME" --rtype TXT \
+  --query 'data.items[].rdata' --raw-output 2>/dev/null || echo '[]')
+ITEMS=$(printf '%s' "$EXISTING" | python3 -c "
+import json, os, sys
+name = os.environ['NAME']
+rdata = [r.strip('\"') for r in json.load(sys.stdin)]
+rdata.append(os.environ['CERTBOT_VALIDATION'])
+print(json.dumps([
+    {'domain': name, 'rdata': v, 'rtype': 'TXT', 'ttl': 60} for v in rdata
+]))
+")
+NAME="$NAME" oci dns record rrset update --force \
+  --zone-name-or-id "$ZONE" \
+  --domain "$NAME" \
+  --rtype TXT \
+  --items "$ITEMS"
+sleep "${CERTMATE_DNS_PROPAGATION_SECONDS:-60}"
+```
+
+Voraussetzungen und Vertrauensmodell:
+
+- Pfade müssen **absolut** sein, die Dateien müssen vorhanden und **ausführbar** sein, dürfen nicht world-writable sein und dürfen keine Leerzeichen oder Shell-Metazeichen enthalten (certbot führt Hooks über die Shell aus). Die Prüfung erfolgt bei der Ausstellung und über den Test-Provider-API-Endpoint (`POST /api/web/certificates/test-provider`)
+- Skripte laufen mit den Berechtigungen von CertMate — dasselbe Vertrauensmodell wie bei deploy hooks: nur Administratoren können sie konfigurieren; behandeln Sie sie als Teil Ihres Deployments
+- Die anbieterspezifische Einstellung `dns_propagation_seconds` wird den Skripten als `CERTMATE_DNS_PROPAGATION_SECONDS` exportiert (ein `propagation_seconds`-Feld auf Kontoebene überschreibt diesen Wert)
+- Verlängerungen spielen die Hook-Pfade aus der certbot-Verlängerungskonfiguration erneut ab: halten Sie die Skripte unter einem stabilen Pfad (wenn Sie sie verschieben, stellen Sie das Zertifikat neu aus)
+- Wildcard-Zertifikate funktionieren (der Hook erhält jeden Validierungseintrag)
+
+---
+
+## Zertifikate erstellen
+
+### Mit dem Standard-Anbieter
+
+```bash
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"domain": "example.com"}'
+```
+
+### Mit einem bestimmten Anbieter
+
+```bash
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "domain": "example.com",
+    "dns_provider": "vultr"
+  }'
+```
+
+### Mit einem bestimmten Konto
+
+```bash
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "domain": "example.com",
+    "dns_provider": "cloudflare",
+    "account_id": "production"
+  }'
+```
+
+---
+
+## Multi-Konto-Unterstützung
+
+CertMate unterstützt mehrere Konten pro DNS-Anbieter für Enterprise-Umgebungen.
+
+### Anwendungsfälle
+
+- **Umgebungstrennung**: Produktions-, Staging- und DR-Konten
+- **Multi-Region**: Unterschiedliche Konten für US-, EU- und APAC-Domains
+- **Berechtigungsisolierung**: Admin-, eingeschränkte und CI/CD-Konten
+
+### Mehrere Konten hinzufügen
+
+```bash
+# Produktionskonto hinzufügen
+curl -X POST http://localhost:8000/api/settings/dns-providers/cloudflare/accounts \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "account_id": "production",
+    "config": {
+      "name": "Production Environment",
+      "description": "Main production Cloudflare account",
+      "api_token": "cloudflare_production_token"
+    }
+  }'
+
+# Staging-Konto hinzufügen
+curl -X POST http://localhost:8000/api/settings/dns-providers/cloudflare/accounts \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "account_id": "staging",
+    "config": {
+      "name": "Staging Environment",
+      "description": "Development and testing account",
+      "api_token": "cloudflare_staging_token"
+    }
+  }'
+
+# Produktion als Standardkonto festlegen
+curl -X PUT http://localhost:8000/api/settings/dns-providers/cloudflare/default-account \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"account_id": "production"}'
+```
+
+### Konten verwalten
+
+```bash
+# Alle Konten eines Anbieters auflisten
+curl -X GET http://localhost:8000/api/settings/dns-providers/cloudflare/accounts \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+
+# Ein Konto aktualisieren
+curl -X PUT http://localhost:8000/api/settings/dns-providers/cloudflare/accounts/staging \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "config": {
+      "name": "Staging & Testing",
+      "api_token": "new_staging_token"
+    }
+  }'
+
+# Ein Konto löschen
+curl -X DELETE http://localhost:8000/api/settings/dns-providers/cloudflare/accounts/old-account \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+### Struktur der Multi-Konto-Konfiguration
+
+```json
+{
+  "dns_provider": "cloudflare",
+  "default_accounts": {
+    "cloudflare": "production",
+    "route53": "main-aws"
+  },
+  "dns_providers": {
+    "cloudflare": {
+      "production": {
+        "name": "Production Environment",
+        "api_token": "***masked***"
+      },
+      "staging": {
+        "name": "Staging Environment",
+        "api_token": "***masked***"
+      }
+    },
+    "route53": {
+      "main-aws": {
+        "name": "Main AWS Account",
+        "access_key_id": "***masked***",
+        "secret_access_key": "***masked***",
+        "region": "us-east-1"
+      }
+    }
+  }
+}
+```
+
+### Abwärtskompatibilität
+
+Bestehende Einzelkonto-Konfigurationen werden bei der ersten Verwendung automatisch in das Multi-Konto-Format migriert. Kein Ausfall und keine manuelle Migration erforderlich.
+
+---
+
+## Multi-Master-DNS und Domain-Alias (CNAME-Delegation)
+
+Wenn Ihre Domain gleichzeitig von mehreren DNS-Anbietern verwaltet wird (Multi-Master-Setup), verwenden Sie die standardmäßige **CNAME-Delegation**, um die ACME-DNS-Validierung bei einem einzigen Anbieter zu zentralisieren.
+
+### Das Problem
+
+Bei Multi-Master-DNS (z. B. deSEC + gcore) kann pro Zertifikatsanfrage nur ein DNS-Anbieter konfiguriert werden, die ACME-Validierung erfordert jedoch das Anlegen von `_acme-challenge`-TXT-Einträgen.
+
+### Die Lösung
+
+Die DNS-Alias-Validierung funktioniert über CNAME-Delegation. Let's Encrypt folgt CNAME-Ketten während der DNS-01-Validierung; CertMate schreibt den erforderlichen TXT-Eintrag auf den delegierten Validierungsnamen.
+
+1. **Erstellen Sie eine Validierungsdomain** bei einem unterstützten erstklassigen Anbieter (z. B. `validation.example.org` bei Cloudflare, PowerDNS, Route53 oder ACME-DNS)
+2. **Fügen Sie CNAME-Einträge** in allen Ihren DNS-Anbietern hinzu, die auf die Validierungsdomain zeigen:
+   ```dns
+   _acme-challenge.example.com. 300 IN CNAME _acme-challenge.validation.example.org.
+   ```
+3. **Fordern Sie das Zertifikat an** und geben Sie dabei den Anbieter an, der die Validierungsdomain verwaltet:
+   ```bash
+   curl -X POST http://localhost:8000/api/certificates/create \
+     -H "Authorization: Bearer YOUR_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "domain": "example.com",
+       "dns_provider": "cloudflare",
+       "domain_alias": "validation.example.org"
+     }'
+   ```
+
+   Wenn `domain_alias` mit einem unterstützten Anbieter gesetzt ist, verwendet CertMate einen manuellen certbot-DNS-Hook, um den TXT-Eintrag unter `_acme-challenge.validation.example.org` zu erstellen. Der CNAME stellt sicher, dass Let's Encrypt diesen TXT-Wert findet, wenn es `_acme-challenge.example.com` abfragt.
+
+### Vorteile
+
+- Funktioniert unabhängig davon, welcher DNS-Anbieter die Abfrage bedient
+- Keine Synchronisation zwischen Anbietern erforderlich
+- Funktioniert mit Anbietern, die von CertMate nicht nativ unterstützt werden (deSEC, gcore)
+- DNS-API-Zugangsdaten sind auf die Validierungsdomain beschränkt
+- Implementiert für CertMate's erstklassige DNS-Anbieter; generische Fallback-Anbieter werden abgelehnt, bis dedizierte Alias-Adapter vorhanden sind
+
+### Anbieterbeispiele
+
+Cloudflare, PowerDNS und Route53 verwenden alle dieselbe Anfragestruktur:
+
+```json
+{
+  "domain": "example.com",
+  "dns_provider": "route53",
+  "domain_alias": "validation.example.org"
+}
+```
+
+Bei ACME-DNS muss `domain_alias` exakt mit der konfigurierten ACME-DNS-`subdomain`/Fulldomain übereinstimmen. CertMate aktualisiert diesen ACME-DNS-Eintrag direkt und versucht keine Bereinigung, da ACME-DNS immer den letzten Validierungswert speichert.
+
+### Wildcard-Zertifikate mit Domain-Alias
+
+```bash
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "domain": "*.example.com",
+    "dns_provider": "cloudflare",
+    "domain_alias": "validation.example.org"
+  }'
+```
+
+Stellen Sie sicher, dass der CNAME vorhanden ist, bevor Sie das Zertifikat anfordern:
+
+```dns
+_acme-challenge.example.com. 300 IN CNAME _acme-challenge.validation.example.org.
+```
+
+### Fehlerbehebung beim Domain-Alias
+
+```bash
+# CNAME-Propagation prüfen
+dig @8.8.8.8 _acme-challenge.example.com CNAME +short
+# Erwartet: _acme-challenge.validation.example.org.
+
+# Nach der Zertifikatsanfrage den TXT-Eintrag auf der Validierungsdomain prüfen
+dig _acme-challenge.validation.example.org TXT +short
+# Erwartet: ein base64-kodierter ACME-Challenge-Token
+```
+
+---
+
+## Umgebungsvariablen
+
+Setzen Sie DNS-Anbieter-Zugangsdaten über Umgebungsvariablen für CI/CD-Workflows:
+
+```bash
+# Cloudflare
+CLOUDFLARE_API_TOKEN=your_token
+
+# AWS Route53
+AWS_ACCESS_KEY_ID=your_access_key
+AWS_SECRET_ACCESS_KEY=your_secret_key
+AWS_DEFAULT_REGION=us-east-1
+
+# Azure
+AZURE_SUBSCRIPTION_ID=your_subscription_id
+AZURE_RESOURCE_GROUP=your_resource_group
+AZURE_TENANT_ID=your_tenant_id
+AZURE_CLIENT_ID=your_client_id
+AZURE_CLIENT_SECRET=your_client_secret
+
+# Google Cloud
+GOOGLE_PROJECT_ID=your_project_id
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+
+# PowerDNS
+POWERDNS_API_URL=https://your-powerdns-server:8081
+POWERDNS_API_KEY=your_api_key
+```
+
+### Konfigurationspriorität (höchste bis niedrigste)
+
+1. Umgebungsvariablen
+2. Domainspezifische Einstellungen
+3. Standard-Konto-Einstellungen
+4. Globale Anbietereinstellung
+5. Systemstandard (Cloudflare)
+
+---
+
+## DNS-Propagationszeiten
+
+| Geschwindigkeit | Anbieter | Sekunden |
+|----------------|----------|----------|
+| Sehr schnell | ACME-DNS | 30 |
+| Schnell | Cloudflare, Route53, PowerDNS, DuckDNS | 60 |
+| Mittel | DigitalOcean, Linode, Google, ArvanCloud | 120 |
+| Langsam | Azure, Gandi, OVH | 180 |
+| Sehr langsam | Namecheap | 300 |
+
+---
+
+## Sicherheitsfunktionen
+
+- **Maskierung von Zugangsdaten** in der Weboberfläche und in API-Antworten
+- **Sichere Dateiberechtigungen** (600) für alle Zugangsdaten-Dateien
+- **API-Token-Validierung** vor der Zertifikatserstellung
+- **Unterstützung von Umgebungsvariablen** für CI/CD-Workflows
+- **Audit-Logging** für alle DNS-Anbieter-Operationen
+- **Kontoisolierung** — die Zugangsdaten jedes Kontos werden separat gespeichert
+
+---
+
+## Architektur und Entwicklerhandbuch
+
+### Wichtige Klassen
+
+| Klasse | Datei | Zweck |
+|--------|-------|-------|
+| `DNSManager` | `modules/core/dns_providers.py` | Verwaltung der Multi-Konto-Konfiguration |
+| `CertificateManager` | `modules/core/certificates.py` | Zertifikatserstellung mit DNS-Anbietern |
+| `SettingsManager` | `modules/core/settings.py` | Persistenz und Migration von Einstellungen |
+| `Utils` | `modules/core/utils.py` | Generierung und Validierung von Zugangsdaten-Dateien |
+
+### Methoden zur Speicherung von Zugangsdaten
+
+1. **Einstellungsdatei** (`data/settings.json`) — am häufigsten verwendet
+2. **Umgebungsvariablen** — für CI/CD
+3. **Temporäre Konfigurationsdateien** (`letsencrypt/config/[provider].ini`) — werden während Zertifikatsanfragen erstellt und danach gelöscht
+
+### Einen neuen DNS-Anbieter hinzufügen
+
+1. Plugin zu `requirements.txt` hinzufügen: `certbot-dns-newprovider`
+2. Konfigurationsfunktion in `modules/core/utils.py` erstellen
+3. Zugangsdaten-Definition in `utils.py` hinzufügen
+4. Importieren und verarbeiten in `modules/core/certificates.py`
+5. Zur Liste der unterstützten Anbieter in `modules/core/settings.py` hinzufügen
+6. Dokumentation aktualisieren
+
+Vollständige Implementierungsdetails finden Sie im [Architekturhandbuch](./architecture.md).
+
+---
+
+## Fehlerbehebung
+
+### Häufige Probleme
+
+| Fehler | Lösung |
+|--------|--------|
+| "DNS provider not configured" | Stellen Sie sicher, dass alle erforderlichen Zugangsdaten angegeben sind |
+| "Certificate creation failed" | DNS-Berechtigungen und Domain-Inhaberschaft prüfen |
+| "Plugin not found" | `pip install -r requirements.txt` ausführen oder Docker neu erstellen |
+| "Provider detection failing" | Das Feld `dns_provider` in den Domain-Einstellungen prüfen |
+
+### Debug-Modus
+
+```bash
+export FLASK_DEBUG=1
+python app.py
+```
+
+### Anbieterkonfiguration testen
+
+```bash
+curl -X GET http://localhost:8000/api/settings/dns-providers \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+---
+
+## Migrationshandbuch
+
+### Von einem einzelnen Anbieter zu mehreren Anbietern
+
+Bestehende Konfigurationen bleiben unverändert. Fügen Sie einfach neue Anbieter hinzu:
+
+```json
+{
+  "dns_providers": {
+    "cloudflare": {
+      "api_token": "existing_token"
+    },
+    "vultr": {
+      "api_key": "new_vultr_api_key"
+    }
+  }
+}
+```
+
+### Verschiedene Anbieter je Zertifikat verwenden
+
+```bash
+# Cloudflare für eine Domain
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"domain": "example.com", "dns_provider": "cloudflare"}'
+
+# Route53 für eine andere
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"domain": "test.org", "dns_provider": "route53"}'
+```
+
+---
+
+<div align="center">
+
+[← Zurück zur Dokumentation](./README.md) • [Installation →](./installation.md) • [CA-Anbieter →](./ca-providers.md)
+
+</div>

--- a/docs/de/docker.md
+++ b/docs/de/docker.md
@@ -1,0 +1,326 @@
+# Docker Build & Deployment
+
+Diese Anleitung beschreibt das Erstellen, Deployen und Ausführen von CertMate in Docker — einschließlich Multi-Plattform-Unterstützung für ARM und AMD64.
+
+---
+
+## Schnellstart
+
+### Pull und Ausführen
+
+```bash
+# Docker wählt automatisch die richtige Architektur
+docker run -d --name certmate \
+  --env-file .env \
+  -p 8000:8000 \
+  -v certmate_data:/app/data \
+  -v certmate_certificates:/app/certificates \
+  fabriziosalmi/certmate:latest
+```
+
+### Lokal bauen und ausführen
+
+```bash
+docker build -t certmate:latest .
+docker run -d --name certmate \
+  --env-file .env \
+  -p 8000:8000 \
+  -v certmate_certificates:/app/certificates \
+  -v certmate_data:/app/data \
+  -v certmate_logs:/app/logs \
+  certmate:latest
+```
+
+---
+
+## Sicherheit
+
+Der Build-Prozess stellt sicher, dass keine Secrets im Image enthalten sind:
+
+- `.dockerignore` schließt alle `.env`-Dateien und sensible Daten aus
+- Umgebungsvariablen werden **zur Laufzeit** bereitgestellt, nicht beim Build
+- Es werden nur die wesentlichen Anwendungsdateien eingebunden
+- Images können sicher in öffentliche Registries gepusht werden
+
+### Keine Secrets im Image prüfen
+
+```bash
+docker history certmate:latest
+docker inspect certmate:latest | grep -i env
+docker run --rm certmate:latest find / -name "*.env" 2>/dev/null
+```
+
+---
+
+## Laufzeitkonfiguration
+
+### Option 1: Environment-Datei
+
+Erstellen Sie eine `.env`-Datei auf Ihrem Host (nicht im Docker-Image):
+
+```bash
+SECRET_KEY=your-super-secret-key-here
+# SECRET_KEY_FILE=/run/secrets/secret_key  # Alternative: takes precedence over SECRET_KEY
+API_BEARER_TOKEN=your-api-bearer-token-here
+# API_BEARER_TOKEN_FILE=/run/secrets/api_bearer_token  # Alternative: takes precedence over API_BEARER_TOKEN
+CLOUDFLARE_API_TOKEN=your-cloudflare-api-token
+LOG_LEVEL=INFO
+```
+
+```bash
+docker run -d --name certmate \
+  --env-file .env \
+  -p 8000:8000 \
+  -v certmate_certificates:/app/certificates \
+  -v certmate_data:/app/data \
+  -v certmate_logs:/app/logs \
+  certmate:latest
+```
+
+### Option 2: Direkte Umgebungsvariablen
+
+```bash
+docker run -d --name certmate \
+  -e SECRET_KEY="your-secret-key" \
+  # -e SECRET_KEY_FILE="/run/secrets/secret_key" \  # Alternative: takes precedence over SECRET_KEY
+  -e API_BEARER_TOKEN="your-api-bearer-token" \
+  # -e API_BEARER_TOKEN_FILE="/run/secrets/api_bearer_token" \  # Alternative: takes precedence over API_BEARER_TOKEN
+  -e CLOUDFLARE_API_TOKEN="your-api-token" \
+  -p 8000:8000 \
+  -v certmate_certificates:/app/certificates \
+  -v certmate_data:/app/data \
+  certmate:latest
+```
+
+### Referenz der Umgebungsvariablen
+
+| Variable | Erforderlich | Beschreibung |
+|----------|--------------|--------------|
+| `SECRET_KEY` | Nein | Flask-Secret-Key für Sessions (wird automatisch generiert, wenn nicht gesetzt) |
+| `SECRET_KEY_FILE` | Nein | Pfad zu einer Datei mit dem Flask-Secret-Key (hat Vorrang vor `SECRET_KEY`) |
+| `API_BEARER_TOKEN` | Nein | Authentifizierungs-Token für den API-Zugriff (wird automatisch generiert, wenn nicht gesetzt) |
+| `API_BEARER_TOKEN_FILE` | Nein | Pfad zu einer Datei mit dem API-Bearer-Token (hat Vorrang vor `API_BEARER_TOKEN`) |
+| `LOG_LEVEL` | Nein | `INFO` (Standard), `DEBUG`, `WARNING`, `ERROR` |
+| `CERTMATE_BACKUP_PASSPHRASE` | Nein | Wenn gesetzt, werden einheitliche Backups im Ruhezustand verschlüsselt (`.zip.enc`, PBKDF2-SHA256 + Fernet). Dieselbe Passphrase wird zur Wiederherstellung benötigt. Nicht gesetzt = ältere unverschlüsselte `.zip`-Backups |
+| `CLOUDFLARE_API_TOKEN` | Nein | Cloudflare-DNS-Provider-Token |
+| `AWS_ACCESS_KEY_ID` | Nein | AWS-Route53-Zugriffsschlüssel |
+| `AWS_SECRET_ACCESS_KEY` | Nein | AWS-Route53-Secret-Key |
+
+Siehe den [Installationsleitfaden](./installation.md#environment-variables) für die vollständige Liste.
+
+---
+
+## Docker Compose
+
+### Grundkonfiguration
+
+```yaml
+version: '3.8'
+
+services:
+  certmate:
+    image: fabriziosalmi/certmate:latest
+    container_name: certmate
+    ports:
+      - "8000:8000"
+    environment:
+      - SECRET_KEY=${SECRET_KEY:-}
+      # - SECRET_KEY_FILE=${SECRET_KEY_FILE:-}  # Alternative: path to a file containing the secret key
+      - API_BEARER_TOKEN=${API_BEARER_TOKEN:-}
+      # - API_BEARER_TOKEN_FILE=${API_BEARER_TOKEN_FILE:-}  # Alternative: path to a file containing the bearer token
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+    volumes:
+      - certmate_certificates:/app/certificates
+      - certmate_data:/app/data
+      - certmate_logs:/app/logs
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+volumes:
+  certmate_certificates:
+  certmate_data:
+  certmate_logs:
+```
+
+```bash
+# Mit .env-Datei im selben Verzeichnis starten
+docker-compose up -d
+
+# Oder eine andere .env-Datei angeben
+docker-compose --env-file /path/to/.env up -d
+```
+
+---
+
+## Multi-Plattform-Builds
+
+CertMate unterstützt Multi-Plattform-Docker-Images für ARM- und AMD64-Architekturen.
+
+### Unterstützte Architekturen
+
+| Plattform | Beschreibung | Typische Anwendungsfälle |
+|-----------|--------------|--------------------------|
+| `linux/amd64` | Intel/AMD 64-Bit | Die meisten Cloud-Server, Desktops |
+| `linux/arm64` | ARM 64-Bit | Apple Silicon, ARM-Cloud-Instanzen |
+| `linux/arm/v7` | ARM 32-Bit v7 | Raspberry Pi 3+ |
+| `linux/arm/v6` | ARM 32-Bit v6 | Raspberry Pi 1, Zero |
+
+### Build-Skripte
+
+```bash
+# Nur für die aktuelle Plattform bauen
+./build-docker.sh
+
+# Für mehrere Plattformen bauen (ARM64 + AMD64)
+./build-docker.sh -m
+
+# Bauen und zu Docker Hub pushen
+./build-docker.sh -m -p -r YOUR_DOCKERHUB_USERNAME
+
+# Dediziertes Multi-Plattform-Skript
+./build-multiplatform.sh -r USERNAME -v v1.0.0 -p
+
+# Für Raspberry Pi bauen
+./build-multiplatform.sh --platforms linux/arm/v7 -r USERNAME -p
+```
+
+### Manuelles Docker Buildx
+
+```bash
+# Buildx-Builder erstellen und verwenden
+docker buildx create --name certmate-builder --use
+
+# Für mehrere Plattformen bauen
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t USERNAME/certmate:latest .
+
+# Bauen und pushen
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t USERNAME/certmate:latest --push .
+```
+
+### Voraussetzungen für Multi-Plattform
+
+```bash
+# Buildx-Unterstützung prüfen
+docker buildx version
+docker buildx inspect --bootstrap
+
+# QEMU-Emulation aktivieren (falls erforderlich)
+docker run --privileged --rm tonistiigi/binfmt --install all
+```
+
+### Bestimmte Plattform erzwingen
+
+```bash
+# AMD64 erzwingen (z. B. auf Apple Silicon zum Testen)
+docker run --platform linux/amd64 --rm \
+  --env-file .env -p 8000:8000 certmate:latest
+
+# Automatische Erkennung (empfohlen)
+docker run --rm --env-file .env -p 8000:8000 certmate:latest
+```
+
+---
+
+## Zu Docker Hub pushen
+
+```bash
+# Anmelden
+docker login
+
+# Taggen und pushen
+docker build -t USERNAME/certmate:latest .
+docker push USERNAME/certmate:latest
+
+# Mit Versions-Tag
+docker build -t USERNAME/certmate:v1.0.0 .
+docker push USERNAME/certmate:v1.0.0
+```
+
+---
+
+## CI/CD-Integration
+
+### GitHub Actions
+
+Erforderliche Secrets:
+- `DOCKERHUB_USERNAME`
+- `DOCKERHUB_TOKEN`
+
+```bash
+# Manueller Trigger mit benutzerdefinierten Plattformen
+gh workflow run docker-multiplatform.yml \
+  -f platforms="linux/amd64,linux/arm64,linux/arm/v7" \
+  -f push_to_registry=true
+```
+
+---
+
+## Tipps für den Produktionsbetrieb
+
+1. **Secrets-Verwaltung nutzen**: Docker Secrets, Kubernetes Secrets oder einen Secrets Manager
+2. **TLS aktivieren**: Hinter einem Reverse Proxy mit TLS-Terminierung betreiben
+3. **Ressourcen überwachen**: CPU- und Speicherlimits setzen
+4. **Volumes sichern**: Zertifikats- und Daten-Volumes regelmäßig sichern
+5. **Regelmäßig aktualisieren**: Image mit Sicherheits-Patches aktuell halten
+6. **Layer-Caching verwenden** für schnellere Builds:
+   ```bash
+   docker buildx build --cache-from type=registry,ref=USERNAME/certmate:cache .
+   ```
+
+---
+
+## Fehlerbehebung
+
+### Container startet nicht
+
+```bash
+docker logs certmate
+docker exec certmate env
+```
+
+### Health Check schlägt fehl
+
+```bash
+docker logs certmate
+docker exec certmate curl -v http://localhost:8000/health
+```
+
+### Berechtigungsprobleme
+
+```bash
+docker exec certmate ls -la /app/certificates
+docker exec certmate ls -la /app/data
+```
+
+### Probleme bei Multi-Plattform-Builds
+
+| Fehler | Lösung |
+|--------|--------|
+| "multiple platforms not supported for docker driver" | `docker buildx create --name multiplatform --use` |
+| "exec format error" | `docker run --privileged --rm tonistiigi/binfmt --install all` |
+| Langsame nicht-native Builds | Normal aufgrund der Emulation; GitHub Actions für den Produktionsbetrieb verwenden |
+| Multi-Plattform-Image kann nicht in lokales Docker geladen werden | `--load` mit einer einzelnen Plattform für lokale Tests verwenden |
+
+---
+
+## Image-Größen
+
+Typische Größen je Architektur:
+- **AMD64**: ~200-300 MB
+- **ARM64**: ~200-300 MB
+- **ARM v7**: ~180-250 MB
+
+---
+
+<div align="center">
+
+[← Zurück zur Dokumentation](./README.md) • [Installation →](./installation.md) • [Architektur →](./architecture.md)
+
+</div>

--- a/docs/de/guide.md
+++ b/docs/de/guide.md
@@ -1,0 +1,532 @@
+# CertMate Client-Zertifikate - Benutzerhandbuch
+
+## Erste Schritte
+
+### Installation
+
+```bash
+# 1. Install dependencies
+pip install -r requirements.txt
+
+# 2. Run CertMate
+python app.py
+
+# 3. Open dashboard
+# Navigate to: http://localhost:5000/client-certificates
+```
+
+### Erste Schritte
+
+1. **CA generieren** — Wird beim ersten Start automatisch erstellt
+2. **Dashboard aufrufen** — Gehen Sie zu `/client-certificates`
+3. **Zertifikat erstellen** — Verwenden Sie das Webformular oder die API
+4. **Dateien herunterladen** — Laden Sie Zertifikat, Schlüssel und CSR herunter
+
+---
+
+## Web-Dashboard
+
+### Dashboard-Funktionen
+
+**URL**: `http://localhost:5000/client-certificates`
+
+#### Statistikbereich
+- Gesamtanzahl der Zertifikate
+- Anzahl aktiver Zertifikate
+- Anzahl widerrufener Zertifikate
+- Aufschlüsselung nach Verwendungstyp
+
+#### Zertifikattabelle
+- Alle Zertifikate auflisten
+- Suche nach Common Name
+- Filter nach Verwendungstyp
+- Filter nach Status
+- Sortierung nach Erstellungsdatum
+
+#### Formular zum Erstellen von Zertifikaten
+
+**Formularfelder**:
+- Common Name (erforderlich)
+- E-Mail-Adresse
+- Organisation
+- Organisationseinheit
+- Verwendungstyp (VPN, API-mTLS usw.)
+- Gültigkeitsdauer in Tagen (Standard: 365)
+- Schlüssel generieren (Kontrollkästchen)
+- Notizen
+
+**Beispiel**:
+```
+Common Name: user@example.com
+Email: user@example.com
+Organization: ACME Corp
+Usage Type: api-mtls
+Days Valid: 365
+```
+
+#### CSV-Massenimport
+
+1. Klicken Sie auf den Tab "Bulk Import"
+2. Bereiten Sie eine CSV-Datei mit folgenden Spaltenköpfen vor:
+ ```
+ common_name,email,organization,cert_usage,days_valid
+ user1@example.com,user1@example.com,ACME Corp,api-mtls,365
+ user2@example.com,user2@example.com,ACME Corp,vpn,365
+ ```
+3. Drag-and-drop oder klicken zum Hochladen
+4. Vorschau prüfen
+5. Auf "Import" klicken
+
+---
+
+## Häufige Aufgaben
+
+### Ein einzelnes Zertifikat erstellen
+
+#### Über das Web-Dashboard
+
+1. Gehen Sie zu `/client-certificates`
+2. Füllen Sie das Formular "Zertifikat erstellen" aus
+3. Klicken Sie auf "Erstellen"
+4. Das Zertifikat erscheint in der Tabelle
+
+#### Über die API
+
+```bash
+curl -X POST http://localhost:5000/api/client-certs/create \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "api-mtls",
+ "days_valid": 365,
+ "generate_key": true
+ }'
+```
+
+---
+
+### Zertifikatdateien herunterladen
+
+#### Über das Web-Dashboard
+
+1. Zertifikat in der Tabelle suchen
+2. Auf das Download-Symbol klicken ()
+3. Dateityp auswählen:
+ - **CRT** — Zertifikat (öffentlich)
+ - **KEY** — Privater Schlüssel (geheim halten)
+ - **CSR** — Certificate Signing Request
+
+#### Über die API
+
+```bash
+# Download certificate
+curl http://localhost:5000/api/client-certs/CERT_ID/download/crt \
+ -H "Authorization: Bearer TOKEN" \
+ -o my-cert.crt
+
+# Download key
+curl http://localhost:5000/api/client-certs/CERT_ID/download/key \
+ -H "Authorization: Bearer TOKEN" \
+ -o my-key.key
+```
+
+---
+
+### Ein Zertifikat widerrufen
+
+#### Über das Web-Dashboard
+
+1. Zertifikat in der Tabelle suchen
+2. Auf die Schaltfläche "Widerrufen" klicken ()
+3. Widerrufsgrund eingeben (optional)
+4. Bestätigen
+
+#### Über die API
+
+```bash
+curl -X POST http://localhost:5000/api/client-certs/CERT_ID/revoke \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "reason": "compromised"
+ }'
+```
+
+**Widerrufsgründe**:
+- `compromised` — Schlüssel wurde kompromittiert
+- `superseded` — Durch ein neues Zertifikat ersetzt
+- `unspecified` — Allgemeiner Widerruf
+- Beliebiger benutzerdefinierter Grund
+
+---
+
+### Ein Zertifikat erneuern
+
+#### Über das Web-Dashboard
+
+1. Zertifikat in der Tabelle suchen
+2. Auf die Schaltfläche "Erneuern" klicken ()
+3. Erneuerung bestätigen
+
+#### Über die API
+
+```bash
+curl -X POST http://localhost:5000/api/client-certs/CERT_ID/renew \
+ -H "Authorization: Bearer TOKEN"
+```
+
+**Hinweis**: Bei der Erneuerung wird ein neues Zertifikat erstellt mit:
+- Demselben Common Name
+- Neuer Seriennummer
+- Neuem Ablaufdatum
+- Aktualisierter ursprünglicher ID
+
+---
+
+### Zertifikate auflisten und filtern
+
+#### Über das Web-Dashboard
+
+1. Zur Zertifikattabelle wechseln
+2. Suchfeld für den Common Name verwenden
+3. Dropdown "Verwendungstyp" zum Filtern verwenden
+4. Dropdown "Status" verwenden (Aktiv/Widerrufen)
+5. Auf "Filter anwenden" klicken
+
+#### Über die API
+
+```bash
+# List all
+curl http://localhost:5000/api/client-certs \
+ -H "Authorization: Bearer TOKEN"
+
+# Filter by usage
+curl "http://localhost:5000/api/client-certs?usage=api-mtls" \
+ -H "Authorization: Bearer TOKEN"
+
+# Filter by status
+curl "http://localhost:5000/api/client-certs?revoked=false" \
+ -H "Authorization: Bearer TOKEN"
+
+# Search
+curl "http://localhost:5000/api/client-certs?search=user@" \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+### Zertifikatstatus prüfen (OCSP)
+
+#### Über die API
+
+```bash
+curl http://localhost:5000/api/ocsp/status/SERIAL_NUMBER \
+ -H "Authorization: Bearer TOKEN"
+```
+
+**Antwort**:
+```json
+{
+ "certificate_status": "good",
+ "certificate_serial": 12345678,
+ "this_update": "2024-10-30T18:00:00Z"
+}
+```
+
+---
+
+### Sperrliste abrufen (CRL)
+
+#### CRL herunterladen
+
+```bash
+# PEM format
+curl http://localhost:5000/api/crl/download/pem \
+ -H "Authorization: Bearer TOKEN" \
+ -o ca.crl
+
+# DER format
+curl http://localhost:5000/api/crl/download/der \
+ -H "Authorization: Bearer TOKEN" \
+ -o ca.crl
+```
+
+#### CRL-Informationen abrufen
+
+```bash
+curl http://localhost:5000/api/crl/download/info \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+## Massenoperationen
+
+### CSV-Format
+
+```csv
+common_name,email,organization,cert_usage,days_valid
+user1@example.com,user1@example.com,ACME Corp,api-mtls,365
+user2@example.com,user2@example.com,ACME Corp,vpn,365
+user3@example.com,user3@example.com,ACME Corp,api-mtls,730
+```
+
+### Erforderliche Spalten
+
+- `common_name` — Subject des Zertifikats (erforderlich)
+
+### Optionale Spalten
+
+- `email` — E-Mail-Adresse
+- `organization` — Organisationsname
+- `organizational_unit` — Abteilungsname
+- `cert_usage` — Verwendungstyp
+- `days_valid` — Gültigkeitsdauer in Tagen
+
+### Über das Web-Dashboard
+
+1. Tab "Bulk Import" aufrufen
+2. CSV-Datei hochladen
+3. Vorschau prüfen
+4. Auf "Alle importieren" klicken
+
+### Über die API
+
+```bash
+curl -X POST http://localhost:5000/api/client-certs/batch \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "headers": ["common_name", "email", "organization"],
+ "rows": [["user1@example.com", "user1@example.com", "ACME Corp"],
+ ["user2@example.com", "user2@example.com", "ACME Corp"],
+ ["user3@example.com", "user3@example.com", "ACME Corp"]
+ ]
+ }'
+```
+
+### Importergebnisse
+
+Gibt Erfolgs- und Fehlerzähler zurück:
+```json
+{
+ "total": 3,
+ "successful": 3,
+ "failed": 0,
+ "errors": [],
+ "certificates": [{"identifier": "cert-batch-001", "common_name": "user1@example.com"},
+ {"identifier": "cert-batch-002", "common_name": "user2@example.com"},
+ {"identifier": "cert-batch-003", "common_name": "user3@example.com"}
+ ]
+}
+```
+
+---
+
+## Zertifikat-Verwendungstypen
+
+### API mTLS
+
+Für die gegenseitige TLS-Authentifizierung von API-Clients.
+
+```
+Usage Type: api-mtls
+Typical Validity: 1 year (365 days)
+```
+
+### VPN
+
+Für die Authentifizierung von VPN-Clients.
+
+```
+Usage Type: vpn
+Typical Validity: 1-2 years (365-730 days)
+```
+
+### Benutzerdefinierte Typen
+
+Sie können Zertifikate für jeden benutzerdefinierten Verwendungszweck erstellen:
+
+```
+Usage Type: custom-application
+Usage Type: internal-service
+Usage Type: mobile-app
+```
+
+---
+
+## Automatische Erneuerung
+
+### Konfiguration
+
+- **Prüfzeitpunkt**: Täglich um 3:00 Uhr
+- **Schwellenwert**: 30 Tage vor Ablauf
+- **Aktion**: Automatische Erneuerung, sofern aktiviert
+
+### Automatische Erneuerung aktivieren
+
+Die automatische Erneuerung ist standardmäßig aktiviert. So prüfen Sie den Status:
+
+```bash
+curl http://localhost:5000/api/client-certs/CERT_ID \
+ -H "Authorization: Bearer TOKEN"
+```
+
+Achten Sie auf:
+```json
+{
+ "renewal": {
+ "renewal_enabled": true,
+ "renewal_threshold_days": 30
+ }
+}
+```
+
+### Erneuerungsverhalten
+
+Bei automatischer Erneuerung:
+- Neues Zertifikat wird erstellt
+- Gleicher CN (Common Name)
+- Neue Seriennummer
+- Neues Ablaufdatum
+- Ursprüngliche ID bleibt unverändert
+- Altes Zertifikat wird ersetzt
+
+---
+
+## Fehlerbehebung
+
+### Häufige Probleme
+
+#### Zertifikaterstellung fehlgeschlagen
+
+**Fehler**: `Failed to create certificate`
+
+**Lösungen**:
+1. Prüfen Sie, ob der Common Name gültig ist
+2. Überprüfen Sie alle erforderlichen Felder
+3. Stellen Sie sicher, dass die CA initialisiert ist
+4. Überprüfen Sie die Logs für Details
+
+#### Dateidownload fehlgeschlagen
+
+**Fehler**: `File not found`
+
+**Lösungen**:
+1. Überprüfen Sie, ob die Zertifikat-ID existiert
+2. Prüfen Sie den Dateityp (crt, key, csr)
+3. Stellen Sie sicher, dass das Zertifikat nicht gelöscht wurde
+4. Prüfen Sie den verfügbaren Speicherplatz
+
+#### Ratenlimit überschritten
+
+**Fehler**: `HTTP 429 Too Many Requests`
+
+**Lösungen**:
+1. Warten Sie vor einem erneuten Versuch
+2. Verwenden Sie Massenoperationen
+3. Implementieren Sie exponentielles Backoff
+4. Prüfen Sie das Limit für Ihren Endpoint
+
+### Logs prüfen
+
+Anwendungslogs anzeigen:
+```bash
+tail -f logs/certmate.log
+```
+
+Audit-Logs anzeigen:
+```bash
+tail -f logs/audit/certificate_audit.log
+```
+
+---
+
+## Best Practices für die Sicherheit
+
+### Private Schlüssel
+
+- **NIEMALS** private Schlüssel weitergeben
+- **NIEMALS** Schlüssel in git committen
+- Schlüssel sicher aufbewahren
+- Dateiberechtigungen 0600 verwenden
+
+### Zertifikate
+
+- Ablaufdaten überwachen
+- Vor Ablauf erneuern
+- Kompromittierte Zertifikate sofort widerrufen
+- Audit-Logs für Compliance aufbewahren
+
+### API-Token
+
+- Token regelmäßig rotieren
+- In der Produktion HTTPS verwenden
+- Token nicht hartcodieren
+- Umgebungsvariablen verwenden
+
+### Widerruf
+
+Widerrufen Sie immer, wenn:
+- Der Schlüssel kompromittiert wurde
+- Das Zertifikat ersetzt wird
+- Ein Benutzer die Organisation verlässt
+- Ein Dienst außer Betrieb genommen wird
+
+---
+
+## Performance-Tipps
+
+### Bei großen Mengen
+
+Verwenden Sie Massenoperationen statt einzelner Erstellungsaufrufe:
+```bash
+# Gut: Eine Anfrage für 1000 Zertifikate
+POST /api/client-certs/batch
+
+# Schlecht: 1000 Anfragen für 1000 Zertifikate
+POST /api/client-certs/create × 1000
+```
+
+### Beim Filtern
+
+Serverseitig filtern:
+```bash
+# Gut: Server filtert
+GET /api/client-certs?usage=api-mtls
+
+# Schlecht: Client filtert alles
+GET /api/client-certs
+```
+
+### Beim Monitoring
+
+Statistik-Endpoint verwenden:
+```bash
+GET /api/client-certs/stats
+```
+
+---
+
+## Support
+
+### Dokumentation
+
+- [API-Referenz](./api.md) — Alle Endpoints
+- [Architektur](./architecture.md) — Systemdesign
+- [Release-Hinweise](../RELEASE_NOTES.md) — Versionshistorie
+
+### Tests
+
+Verwendungsbeispiele finden Sie in `test_e2e_complete.py`.
+
+---
+
+<div align="center">
+
+[← Zurück zur Dokumentation](./README.md) • [API-Referenz →](./api.md) • [Architektur →](./architecture.md)
+
+</div>

--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -1,0 +1,258 @@
+# CertMate - Client-Zertifikate
+
+<div align="center">
+
+![CertMate](https://img.shields.io/badge/CertMate-Client%20Certificates-blue?style=for-the-badge)
+![Status](https://img.shields.io/badge/Status-Production%20Ready-green?style=for-the-badge)
+
+**Vollständige Client-Zertifikatsverwaltung für CertMate**
+
+[Dokumentation](#dokumentation) • [Schnellstart](#schnellstart) • [API-Referenz](./api.md) • [Architektur](./architecture.md)
+
+</div>
+
+---
+
+## Übersicht
+
+CertMate Client-Zertifikate ist eine umfassende, produktionsreife Lösung für die Verwaltung von Client-Zertifikaten mit:
+
+- **Selbstsignierte CA** — Generieren und verwalten Sie Ihre eigene Zertifizierungsstelle
+- **Vollständiges Lifecycle-Management** — Erstellen, erneuern, widerrufen und überwachen Sie Client-Zertifikate
+- **OCSP & CRL** — Echtzeit-Zertifikatsstatus und Sperrlisten
+- **Web-Dashboard** — Intuitive Benutzeroberfläche für die Zertifikatsverwaltung
+- **REST API** — Vollständige API für die Automatisierung
+- **Batch-Operationen** — Importieren Sie 100 bis 30.000 Zertifikate per CSV
+- **Audit-Protokoll** — Verfolgen Sie alle Vorgänge für die Compliance
+- **Rate Limiting** — Integrierter Schutz gegen Missbrauch
+
+---
+
+## Funktionen
+
+### Phase 1: CA-Grundlage
+- **PrivateCAGenerator**: Selbstsignierte CA mit 4096-Bit-RSA-Schlüsseln, 10 Jahre Gültigkeit
+- **CSRHandler**: Zertifikatsignierungsanfragen validieren, erstellen und analysieren
+- **Sichere Speicherung**: Korrekte Dateiberechtigungen (0600) für private Schlüssel
+
+### Phase 2: Client-Zertifikats-Engine
+- **Vollständiger Lebenszyklus**: Zertifikate erstellen, auflisten, filtern, widerrufen und erneuern
+- **Multi-Filter-Abfragen**: Suche nach Verwendungstyp, Widerrufsstatus, Common Name
+- **Automatische Erneuerung**: Täglich geplante Prüfungen für ablaufende Zertifikate
+- **Unterstützung für 30k+ Zertifikate**: Verzeichnisbasierte Speicherung für lineare Skalierbarkeit
+- **Metadatenverwaltung**: Verfolgung von CN, E-Mail, Organisation, Verwendung, Ablaufdaten
+
+### Phase 3: Benutzeroberfläche und erweiterte Funktionen
+- **Web-Dashboard**: Responsive Verwaltungsoberfläche mit Dark-Mode-Unterstützung
+- **OCSP-Responder**: Zertifikatsstatus in Echtzeit abfragen
+- **CRL-Manager**: Sperrlisten generieren und verteilen (PEM/DER)
+- **REST API**: 10 Endpoints in 3 Namespaces für vollständige Automatisierung
+- **Batch-Operationen**: Zertifikate aus CSV-Dateien importieren
+
+### Phase 4: Quick Wins
+- **Audit-Protokoll**: Alle Zertifikatsvorgänge mit Benutzer-/IP-Informationen verfolgen
+- **Rate Limiting**: Konfigurierbare Limits pro Endpoint mit sinnvollen Standardwerten
+- **Integrationsbereit**: Beide Manager in der Anwendung für den sofortigen Einsatz verfügbar
+
+---
+
+## Schnellstart
+
+### Installation
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Run the application
+python app.py
+```
+
+Der Server startet auf `http://localhost:8000`
+
+### Grundlegende Verwendung
+
+#### 1. Web-Dashboard aufrufen
+```
+Navigate to: http://localhost:8000/client-certificates
+```
+
+#### 2. Zertifikat per API erstellen
+```bash
+curl -X POST http://localhost:8000/api/client-certs/create \
+ -H "Authorization: Bearer YOUR_TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "api-mtls",
+ "days_valid": 365,
+ "generate_key": true
+ }'
+```
+
+#### 3. Zertifikate auflisten
+```bash
+curl http://localhost:8000/api/client-certs \
+ -H "Authorization: Bearer YOUR_TOKEN"
+```
+
+#### 4. Zertifikatsdateien herunterladen
+```bash
+# Download certificate
+curl http://localhost:8000/api/client-certs/USER_ID/download/crt \
+ -H "Authorization: Bearer YOUR_TOKEN" \
+ -o user.crt
+
+# Download private key
+curl http://localhost:8000/api/client-certs/USER_ID/download/key \
+ -H "Authorization: Bearer YOUR_TOKEN" \
+ -o user.key
+```
+
+---
+
+## Dokumentation
+
+### Hauptdokumentation
+
+- **[Installationsanleitung](./installation.md)** — Einrichtung, Abhängigkeiten, Deployment
+- **[Kubernetes-Hinweise](./kubernetes.md)** — Pod-Dimensionierung und OOM-Fehlerbehebung in der Produktion
+- **[DNS-Anbieter](./dns-providers.md)** — Unterstützte Anbieter, Multi-Account, Domain-Alias
+- **[CA-Anbieter](./ca-providers.md)** — Let's Encrypt, Actalis, DigiCert, Private CA
+- **[Docker-Anleitung](./docker.md)** — Docker-Builds, Multi-Plattform, Compose
+- **[Test-Anleitung](./testing.md)** — Test-Framework, CI/CD, Abdeckung
+- **[API-Referenz](./api.md)** — Vollständige REST-API-Dokumentation mit Beispielen
+- **[Architektur](./architecture.md)** — Systemdesign, Komponenten und Datenfluss
+- **[Benutzerhandbuch](./guide.md)** — Schritt-für-Schritt-Anleitung für häufige Aufgaben
+
+### Schnellzugriff
+
+- [API-Endpoints](./api.md#endpoints) — Alle verfügbaren Endpoints
+- [Zertifikatstypen](./api.md#certificate-types) — VPN, API mTLS usw.
+- [Rate Limiting](./api.md#rate-limiting) — Standardlimits und Konfiguration
+- [Audit-Protokoll](./api.md#audit-logging) — Audit-Trails verstehen
+
+---
+
+## Tests
+
+Alle Funktionen wurden umfassend getestet:
+
+```bash
+# Run test suite
+python -m pytest tests/ -v
+```
+
+### Testabdeckung
+- CA-Operationen (3 Tests)
+- CSR-Operationen (3 Tests)
+- Zertifikats-Lebenszyklus (8 Tests)
+- Filterung und Suche (3 Tests)
+- Batch-Operationen (2 Tests)
+- OCSP & CRL (5 Tests)
+- Audit & Rate Limiting (3 Tests)
+
+---
+
+## Übersicht der API-Endpoints
+
+| Methode | Endpoint                                 | Zweck                               |
+| ------- | ---------------------------------------- | ----------------------------------- |
+| `POST`  | `/api/client-certs/create`               | Neues Zertifikat erstellen          |
+| `GET`   | `/api/client-certs`                      | Zertifikate mit Filtern auflisten   |
+| `GET`   | `/api/client-certs/<id>`                 | Zertifikats-Metadaten abrufen       |
+| `GET`   | `/api/client-certs/<id>/download/<type>` | Zertifikat/Schlüssel/CSR herunterladen |
+| `POST`  | `/api/client-certs/<id>/revoke`          | Zertifikat widerrufen               |
+| `POST`  | `/api/client-certs/<id>/renew`           | Zertifikat erneuern                 |
+| `GET`   | `/api/client-certs/stats`                | Statistiken abrufen                 |
+| `POST`  | `/api/client-certs/batch`                | CSV-Batch-Import                    |
+| `GET`   | `/api/ocsp/status/<serial>`              | OCSP-Statusabfrage                  |
+| `GET`   | `/api/crl/download/<format>`             | CRL herunterladen (PEM/DER)         |
+
+---
+
+## Architektur
+
+Das System ist mit einer modularen, mehrschichtigen Architektur aufgebaut:
+
+```
+
+ Web UI & REST API 
+ (/client-certificates, /api/*) 
+
+ API Resources & Managers 
+ (OCSP, CRL, Audit, Rate Limiting) 
+
+ Core Modules 
+ (Certificate Mgmt, CSR, CA, Storage) 
+
+ Cryptography & Storage 
+ (OpenSSL, File System, Backends) 
+
+```
+
+Weitere Informationen finden Sie in der [Architekturdokumentation](./architecture.md).
+
+---
+
+## Sicherheit
+
+### Kryptografische Stärke
+- **CA**: 4096-Bit-RSA-Schlüssel, 10 Jahre Gültigkeit
+- **Client-Zertifikate**: 2048 oder 4096 Bit RSA (konfigurierbar)
+- **Signaturen**: SHA256
+- **Schlüsselspeicherung**: Dateiberechtigungen 0600 auf Unix-Systemen
+
+### Zugriffskontrolle
+- **Bearer-Token-Authentifizierung** auf allen API-Endpoints
+- **Rate Limiting**: Konfigurierbare Limits pro Endpoint
+- **Audit-Protokoll**: Alle Vorgänge werden mit Benutzer-/IP-Informationen erfasst
+
+### Compliance
+- Verfolgung von Zertifikats-Metadaten
+- Audit-Trail für Widerrufe
+- Persistente Betriebsprotokolle
+- Unterstützung für Compliance-Abfragen
+
+---
+
+## Performance
+
+Die Implementierung ist optimiert für:
+- **Skalierbarkeit**: Verzeichnisbasierte Speicherung unterstützt 30k+ gleichzeitige Zertifikate
+- **Geschwindigkeit**: Effiziente Multi-Filter-Abfragen
+- **Zuverlässigkeit**: Automatische Erneuerungsplanung
+- **Reaktionsfähigkeit**: Asynchrones JavaScript in der Web-Benutzeroberfläche
+
+---
+
+## Support
+
+Bei Fragen oder Problemen:
+1. Lesen Sie das [Benutzerhandbuch](./guide.md)
+2. Lesen Sie die [API-Dokumentation](./api.md)
+3. Lesen Sie den Abschnitt [Architektur](./architecture.md)
+4. Prüfen Sie die Testfälle in `test_e2e_complete.py`
+
+---
+
+## Lizenz
+
+Siehe LICENSE-Datei im Repository
+
+---
+
+## Version
+
+**Aktuelle Version**: 2.3.0
+**Status**: Produktionsbereit
+
+---
+
+<div align="center">
+
+[Dokumentation](.) • [Lizenz](../LICENSE)
+
+</div>

--- a/docs/de/installation.md
+++ b/docs/de/installation.md
@@ -1,0 +1,545 @@
+# Installationsanleitung
+
+Diese Anleitung beschreibt alle Methoden zur Installation und zum Deployment von CertMate.
+
+---
+
+## Voraussetzungen
+
+- Python 3.9 oder höher
+- pip (Python-Paketverwaltung)
+- Docker (optional, für containerisiertes Deployment)
+
+---
+
+## Methode 1: Direkte Installation
+
+### 1. Repository klonen
+
+```bash
+git clone https://github.com/fabriziosalmi/certmate.git
+cd certmate
+```
+
+### 2. Virtuelle Umgebung erstellen
+
+```bash
+python3 -m venv venv
+source venv/bin/activate  # Unter Windows: venv\Scripts\activate
+```
+
+### 3. Abhängigkeiten installieren
+
+```bash
+pip install -r requirements.txt
+```
+
+### 4. Umgebung konfigurieren
+
+Erstellen Sie eine `.env`-Datei:
+
+```bash
+cp .env.example .env
+# .env mit Ihren Einstellungen bearbeiten
+```
+
+### 5. Anwendung starten
+
+```bash
+python app.py
+```
+
+---
+
+## Methode 2: Docker-Installation
+
+### Mit Docker Compose (empfohlen)
+
+```bash
+git clone https://github.com/fabriziosalmi/certmate.git
+cd certmate
+docker-compose up -d
+```
+
+### Mit Docker Build
+
+```bash
+git clone https://github.com/fabriziosalmi/certmate.git
+cd certmate
+docker build -t certmate .
+docker run -p 8000:8000 --env-file .env -v ./certificates:/app/certificates certmate
+```
+
+> Für erweitertes Docker-Deployment einschließlich Multi-Plattform-Builds siehe den [Docker-Leitfaden](./docker.md).
+
+---
+
+## Systemabhängigkeiten
+
+### Ubuntu / Debian
+
+```bash
+sudo apt update
+sudo apt install python3-dev python3-venv build-essential libssl-dev libffi-dev
+```
+
+### CentOS / RHEL / Rocky
+
+```bash
+sudo yum install python3-devel gcc openssl-devel libffi-devel
+```
+
+### macOS
+
+```bash
+brew install python3 openssl libffi
+```
+
+---
+
+## DNS-Provider-Einrichtung
+
+Konfigurieren Sie nach der Installation die Zugangsdaten Ihres DNS-Providers. Detaillierte Einrichtungsanweisungen für jeden unterstützten Provider finden Sie im [DNS-Provider-Leitfaden](./dns-providers.md).
+
+Schnelleinrichtung für gängige Provider:
+
+### Cloudflare
+
+1. Öffnen Sie das [Cloudflare-Dashboard](https://dash.cloudflare.com/profile/api-tokens)
+2. Erstellen Sie einen neuen API-Token mit den Berechtigungen `Zone:DNS:Edit`
+3. Fügen Sie den Token in den CertMate-Einstellungen hinzu
+
+### AWS Route53
+
+1. Erstellen Sie einen IAM-Benutzer mit Route53-Berechtigungen
+2. Generieren Sie Zugriffsschlüssel
+3. Fügen Sie die Zugangsdaten in den CertMate-Einstellungen hinzu
+
+### Azure DNS
+
+1. Erstellen Sie einen Service Principal
+2. Weisen Sie die Rolle DNS Zone Contributor zu
+3. Konfigurieren Sie die Abonnementdetails in den CertMate-Einstellungen
+
+### Google Cloud DNS
+
+1. Erstellen Sie einen Service Account mit der Rolle DNS Administrator
+2. Laden Sie die JSON-Schlüsseldatei herunter
+3. Laden Sie diese in den CertMate-Einstellungen hoch
+
+---
+
+## Umgebungsvariablen
+
+```bash
+# API-Authentifizierung (automatisch generiert, wenn keine gesetzt ist)
+# Option A: direkter Wert
+API_BEARER_TOKEN=your_secure_token_here
+# Option B: Pfad zu einer Datei mit dem Token (hat Vorrang vor API_BEARER_TOKEN)
+API_BEARER_TOKEN_FILE=/run/secrets/api_bearer_token
+
+# Geheimer Flask-Sitzungsschlüssel (automatisch generiert, wenn keiner gesetzt ist)
+# Option A: direkter Wert
+SECRET_KEY=your_flask_secret_key
+# Option B: Pfad zu einer Datei mit dem Schlüssel (hat Vorrang vor SECRET_KEY)
+SECRET_KEY_FILE=/run/secrets/secret_key
+
+# Reverse Proxy — auf 'true' setzen, wenn CertMate hinter Nginx,
+# HAProxy, Traefik, Cloudflare usw. betrieben wird. Ohne diese Einstellung
+# löst request.remote_addr für jede Anfrage die IP des Proxys auf, was
+# das Rate-Limiting pro Client in einen einzelnen Bucket zusammenführt.
+# Siehe den Abschnitt "Hinter einem Reverse Proxy" unter Produktions-Deployment.
+BEHIND_PROXY=true
+
+# Backup-Verschlüsselung im Ruhezustand (optional, empfohlen).
+# Wenn gesetzt, werden einheitliche Backups als verschlüsselte .zip.enc-Dateien
+# geschrieben (PBKDF2-SHA256-Schlüsselableitung + Fernet/AES) statt als
+# Klartext-ZIP. Backups enthalten jeden privaten Zertifikatsschlüssel; ohne
+# diese Einstellung stellt eine exfiltrierte Backup-Datei einen vollständigen
+# Schlüssel-Kompromiss dar. Dieselbe Passphrase muss für die Wiederherstellung
+# vorhanden sein. Bewusst nur per Umgebungsvariable: eine in settings.json
+# gespeicherte Passphrase würde selbst in Klartext-Backups landen.
+CERTMATE_BACKUP_PASSPHRASE=choose-a-long-random-passphrase
+
+# DNS-Provider (einen oder mehrere auswählen)
+CLOUDFLARE_TOKEN=your_cloudflare_token
+AWS_ACCESS_KEY_ID=your_aws_access_key
+AWS_SECRET_ACCESS_KEY=your_aws_secret_key
+AZURE_SUBSCRIPTION_ID=your_azure_subscription
+AZURE_TENANT_ID=your_azure_tenant
+AZURE_CLIENT_ID=your_azure_client
+AZURE_CLIENT_SECRET=your_azure_secret
+GOOGLE_PROJECT_ID=your_gcp_project
+POWERDNS_API_URL=https://your-powerdns:8081
+POWERDNS_API_KEY=your_powerdns_key
+```
+
+### Auflösungsreihenfolge
+
+| Variable | Priorität |
+|----------|-----------|
+| `API_BEARER_TOKEN_FILE` | Höchste — wenn gesetzt, wird `API_BEARER_TOKEN` nie gelesen |
+| `API_BEARER_TOKEN` | Wird nur verwendet, wenn `API_BEARER_TOKEN_FILE` fehlt |
+| *(generiert)* | Fallback, wenn keines gesetzt ist oder der Wert die Validierung nicht besteht |
+| `SECRET_KEY_FILE` | Höchste — wenn gesetzt, wird `SECRET_KEY` nie gelesen |
+| `SECRET_KEY` | Wird nur verwendet, wenn `SECRET_KEY_FILE` fehlt |
+| *(generiert + gespeichert)* | In `data/.secret_key` geschrieben, damit Sitzungen Neustarts überleben |
+
+> **Docker-Secrets-Hinweis**: Verwenden Sie `API_BEARER_TOKEN_FILE=/run/secrets/api_bearer_token` und `SECRET_KEY_FILE=/run/secrets/secret_key` mit Docker Swarm oder Kubernetes Secrets, um zu vermeiden, dass sensible Werte in Umgebungsvariablen stehen.
+
+---
+
+## Produktions-Deployment
+
+### Hinter einem Reverse Proxy
+
+Wenn CertMate hinter einem Reverse Proxy betrieben wird (Nginx, HAProxy, Traefik,
+Cloudflare, Kubernetes Ingress) — was die empfohlene Betriebsweise für die
+TLS-Terminierung ist — setzen Sie `BEHIND_PROXY=true` in der Container-Umgebung.
+Dies aktiviert die `ProxyFix`-Middleware von Werkzeug, sodass die folgenden
+Komponenten den `X-Forwarded-*`-Headern Ihres Proxys vertrauen:
+
+- `request.remote_addr` löst auf die ursprüngliche Client-IP auf statt auf die
+  IP des Proxys. Rate-Limiting, Audit-Log-Einträge und die Warnungen
+  "ungültiger API-Token-Versuch von X" werden dadurch pro Client statt pro Proxy
+  ausgegeben.
+- Schema / Host / Präfix-Header des Proxys werden berücksichtigt, wodurch
+  generierte URLs und Cookie-Scopes korrekt bleiben.
+
+```yaml
+# docker-compose.yml-Ausschnitt
+services:
+  certmate:
+    image: fabriziosalmi/certmate:latest
+    environment:
+      BEHIND_PROXY: "true"
+    volumes:
+      - ./data:/app/data
+```
+
+**Wann diese Option NICHT aktiviert werden sollte.** Wenn Sie CertMate ohne
+vorgelagerten Proxy direkt ins Netzwerk exponieren, lassen Sie `BEHIND_PROXY`
+ungesetzt. Mit dieser Einstellung könnte jeder, der den Listener erreicht,
+`X-Forwarded-For` fälschen und das per-Client-Rate-Limiting umgehen. Der Proxy
+ist die Vertrauensgrenze.
+
+Ihr Proxy muss die Header natürlich weiterleiten. Nginx-Beispiel:
+
+```nginx
+proxy_set_header Host              $host;
+proxy_set_header X-Real-IP         $remote_addr;
+proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+```
+
+#### Beispiel: Zion (Rust-TLS-Gateway + WAF)
+
+[Zion](https://github.com/fabriziosalmi/zion) ist ein hochperformanter Rust-TLS-
+Reverse Proxy mit integriertem WAF — eine gute Wahl vor CertMate, wenn Sie
+TLS-1.3-Terminierung und Request-Filterung am Edge wünschen. CertMate bleibt
+im internen Netzwerk auf einfachem HTTP; Zion terminiert TLS und leitet weiter.
+
+`zion.toml`:
+
+```toml
+[server]
+listen_http  = "0.0.0.0:8080"
+listen_https = "0.0.0.0:8443"
+
+[tls]
+cert_path = "/etc/ssl/zion/tls.crt"   # your cert, or use Zion's ACME (--features acme)
+key_path  = "/etc/ssl/zion/tls.key"
+min_version = "1.3"
+alpn = ["h2", "http/1.1"]
+
+[upstream.backend]
+url = "http://certmate:8000"
+
+# Catch-all to the backend. The explicit "/" route is harmless and documents
+# intent; recent Zion also auto-registers "/" for a root catch-all.
+[[route]]
+path = "/"
+upstream = "backend"
+
+[[route]]
+path = "/{*rest}"
+upstream = "backend"
+```
+
+`docker-compose.yml`:
+
+```yaml
+services:
+  certmate:
+    image: certmate:latest          # the published image, or your local build
+    environment:
+      BEHIND_PROXY: "true"          # trust Zion's X-Forwarded-* headers
+    expose:
+      - "8000"                       # internal only; not published to the host
+    volumes:
+      - ./data:/app/data
+
+  zion:
+    image: zion:latest              # the published image, or your local build
+    depends_on:
+      - certmate
+    environment:
+      ZION_CONFIG: /etc/zion/zion.toml
+    volumes:
+      - ./zion.toml:/etc/zion/zion.toml:ro
+      - ./certs:/etc/ssl/zion:ro
+    ports:
+      - "443:8443"                   # host 443 -> Zion's HTTPS listener
+      - "80:8080"                    # host 80  -> Zion's HTTP listener
+```
+
+Behalten Sie `BEHIND_PROXY=true` auf dem CertMate-Service: Zion hängt
+`X-Forwarded-For` an, sodass per-Client-Rate-Limiting, Audit-Einträge und
+Authentifizierungsfehlerwarnungen auf die echte Client-IP statt auf die Zion-IP
+zeigen.
+
+> **`/metrics` wird von Zion bedient, nicht weitergeleitet.** Zion exponiert seinen
+> eigenen Prometheus-Endpunkt unter `/metrics` (`zion_*`-Serien für den Proxy),
+> der CertMates `/metrics` überlagert. Scrapen Sie diese getrennt: Zions `/metrics`
+> aus dem Host-/Cluster-Netzwerk (Zion schränkt es auf private Quell-IPs ein und
+> gibt öffentlichen Clients 403 zurück), und CertMates `certmate_*` direkt gegen
+> das interne `certmate:8000` mit einem Admin-Bearer-Token (siehe
+> [`monitoring/`](../monitoring/) für das Dashboard und die Scrape-Konfiguration).
+
+### Ausgehenden Datenverkehr einschränken (Egress-Hardening)
+
+CertMate stellt ausgehende Verbindungen zu ACME-Zertifizierungsstellen,
+DNS-Provider-APIs, Objektspeicher und Benachrichtigungs-Webhooks über HTTP(S)
+her, sowie SMTP für E-Mail-Benachrichtigungen. Sie können den **HTTP(S)**-Datenverkehr
+einschränken und prüfen, indem Sie ihn über einen **Forward Proxy** leiten und
+CertMate jeden anderen Weg ins Internet verweigern.
+
+CertMates HTTP(S)-Clients (`requests`, `certbot`, Webhook-Zustellung via
+`urllib`, `boto3`) berücksichtigen die Standard-Umgebungsvariablen
+`HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`, sodass keine Code-Änderungen
+erforderlich sind. **SMTP ist die Ausnahme:** E-Mail-Benachrichtigungen
+verwenden `smtplib`, das eine direkte TCP-Verbindung öffnet und die
+HTTP-Proxy-Variablen **nicht** berücksichtigt. In einem abgeschotteten
+Egress-Netzwerk erlauben Sie direkt `host:port` Ihres SMTP-Relays (per
+Firewall-/NetworkPolicy-Regel), oder verwenden Sie einen Webhook-Benachrichtigungskanal
+statt E-Mail.
+
+Beispiel mit [Secure Proxy Manager](https://github.com/fabriziosalmi/secure-proxy-manager),
+einem selbst gehosteten Squid-basierten Forward Proxy mit WAF, DNS-Sinkhole und —
+seit v3.9.0 — einer erstklassigen **Default-deny-Egress-Allowlist** (nur explizit
+freigegebene Ziele sind erreichbar; alles andere wird abgewiesen):
+
+```yaml
+services:
+  certmate:
+    image: certmate:latest
+    environment:
+      HTTP_PROXY:  "http://proxy:3128"
+      HTTPS_PROXY: "http://proxy:3128"
+      NO_PROXY:    "localhost,127.0.0.1"
+    networks:
+      - egress            # CertMate kann NUR den Proxy in diesem Netzwerk erreichen
+  # Der Secure Proxy Manager Stack stellt den `proxy`-Service auf :3128 bereit.
+  # Binden Sie diesen Proxy SOWOHL an das `egress`-Netzwerk (damit CertMate ihn
+  # erreicht) ALS AUCH an ein zweites, nicht-internes Netzwerk (damit der Proxy
+  # selbst das Internet erreicht). Der Proxy ist dann CertMates einziger Ausgang.
+networks:
+  egress:
+    internal: true        # kein Gateway: CertMate hat keinen direkten Internetzugang
+```
+
+CertMate in einem `internal`-Netzwerk (ohne Gateway) zusammen mit dem Proxy zu
+betreiben, macht den Proxy zu seinem **einzigen** Ausgang. Ausgehender Datenverkehr
+wird zu einem einzelnen, prüfbaren Engpass: Erlauben Sie die Ziele, die CertMate
+tatsächlich benötigt (Ihre Zertifizierungsstelle, DNS-Provider, Objektspeicher,
+Benachrichtigungs-Endpunkte), verweigern Sie den Rest; reine IP-Adressen als
+Ziele werden am Proxy blockiert statt blind vertraut. Wenn Sie DNS-Alias-/
+CNAME-Delegation verwenden, erlauben Sie auch `cloudflare-dns.com` — CertMate
+löst diese CNAMEs über DoH auf.
+
+Mit Secure Proxy Manager v3.9.0+ ist dies ein eingebauter Modus statt einer
+manuellen ACL-Übung: Aktivieren Sie **Default-deny egress** in den Einstellungen
+und füllen Sie die **Egress-Allowlist** mit den Zielen, die CertMate benötigt.
+Jeder Eintrag ist eine Domain oder eine IP/CIDR (automatisch klassifiziert), und
+der Endpunkt `/api/egress-allowlist` ermöglicht die Verwaltung der Liste über IaC.
+Eine repräsentative Starter-Allowlist:
+
+- der API-Host Ihrer ACME-Zertifizierungsstelle — z.B. `acme-v02.api.letsencrypt.org`
+  (plus `acme-staging-v02.api.letsencrypt.org`, wenn Sie gegen Staging ausstellen),
+  oder der Endpunkt der von Ihnen konfigurierten Zertifizierungsstelle;
+- der API-Host Ihres DNS-Providers — je nach Provider (z.B. `api.cloudflare.com`);
+- Ihr Objektspeicher-Endpunkt, sofern Off-Site-Backup aktiviert ist;
+- Ihr Benachrichtigungs-Host — der Webhook-, Gotify-, ntfy- oder Telegram-Endpunkt,
+  falls verwendet;
+- `cloudflare-dns.com`, wenn Sie DNS-Alias-/CNAME-Delegation nutzen (wird über
+  DoH aufgelöst, wie oben beschrieben).
+
+Alles andere wird am Proxy abgewiesen, sodass eine Fehlkonfiguration oder eine
+kompromittierte Abhängigkeit nicht unbemerkt zu einem beliebigen Host exfiltrieren
+kann. Für HTTPS gleicht die Allowlist den Host des `CONNECT`-Requests ab, sodass
+sie ohne TLS-Interception funktioniert.
+
+- **Kubernetes:** eine Egress-Default-deny-`NetworkPolicy`, die Datenverkehr
+  nur zum Proxy-Service erlaubt, plus die `HTTP(S)_PROXY`-Umgebungsvariablen
+  auf dem Deployment.
+- **systemd:** `Environment=HTTPS_PROXY=...` in der Unit, plus Host-Firewall-Regeln,
+  die Egress auf den Proxy einschränken.
+
+**HTTPS-Inhaltsinspektion (optional, fortgeschritten).** Ein Forward Proxy sieht
+bei einer HTTPS-Verbindung nur SNI / Host / IP — Ziel-Allow/Deny funktioniert
+darauf ohne Entschlüsselung. Wenn Sie zusätzlich TLS-Interception (SSL-Bump) auf
+dem Proxy aktivieren, um ausgehende *Inhalte* zu inspizieren, muss CertMate der
+**Interceptions-CA des Proxys vertrauen**: Setzen Sie `REQUESTS_CA_BUNDLE`
+(und `SSL_CERT_FILE`) auf ein Bundle, das diese einschließt, oder fügen Sie sie
+dem System-Truststore des Containers hinzu. **Schließen Sie die ACME-Endpunkte
+von der Interception aus (`splice`)** — Sie wollen die Verbindung zu Ihrer
+Zertifizierungsstelle nicht per MITM abfangen, und einige Endpunkte pinnen
+Zertifikate. Dies ist kein mutual TLS; es handelt sich um einseitiges Vertrauen
+in eine private CA.
+
+### Speicherort des Datenverzeichnisses
+
+CertMate verwendet standardmäßiges blockierendes Python-Datei-I/O für alles
+unter `data/` (Einstellungen, Zertifikate, Audit-Log, SQLite-Speicher des
+Schedulers). Lokaler Speicher wird dringend empfohlen.
+
+Wenn Sie `data/` auf einem Netzwerk-Dateisystem (NFS, SMB) einhängen, beachten
+Sie Folgendes:
+
+- Ein eingefrorener NFS-Server kann Python-Datei-Lesevorgänge unbegrenzt
+  blockieren, ohne eingebauten Timeout. Der Erneuerungsworker, der Audit-Log-
+  Schreiber und die /health-Probe blockieren alle auf demselben zugrunde
+  liegenden Einhängepunkt.
+- SQLites WAL-Journal-Modus erfordert Sperrsemantiken, die NFS nicht immer
+  bereitstellt. CertMate protokolliert eine Warnung, wenn es auf einen schwächeren
+  Journal-Modus zurückfallen musste; die Korrektheit bleibt erhalten, aber die
+  Nebenläufigkeit sinkt.
+
+Falls NFS unvermeidbar ist, hängen Sie mit `soft,timeo=30,retrans=3` ein (oder dem
+Äquivalent Ihrer Distribution), damit I/O bei einem blockierten Server schnell
+fehlschlägt statt zu hängen, und prüfen Sie `data/logs/certmate.log` nach dem
+ersten Start auf die WAL-Fallback-Zeile.
+
+### Gunicorn verwenden
+
+```bash
+gunicorn --bind 0.0.0.0:8000 --workers 4 app:app
+```
+
+### systemd verwenden
+
+Erstellen Sie `/etc/systemd/system/certmate.service`:
+
+```ini
+[Unit]
+Description=CertMate SSL Certificate Manager
+After=network.target
+
+[Service]
+Type=simple
+User=certmate
+WorkingDirectory=/opt/certmate
+Environment=PATH=/opt/certmate/venv/bin
+ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 4 app:app
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Aktivieren und starten:
+
+```bash
+sudo systemctl enable certmate
+sudo systemctl start certmate
+```
+
+### Docker im Produktionsbetrieb verwenden
+
+```yaml
+version: '3.8'
+services:
+  certmate:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - API_BEARER_TOKEN=${API_BEARER_TOKEN}
+      - CLOUDFLARE_TOKEN=${CLOUDFLARE_TOKEN}
+    volumes:
+      - ./certificates:/app/certificates
+      - ./data:/app/data
+    restart: unless-stopped
+```
+
+---
+
+## Fehlerbehebung
+
+### Versionskonflikte bei DNS-Plugins
+
+Bei Versionskonflikten verwenden Sie diese spezifischen Versionen:
+
+```txt
+certbot==4.1.1
+certbot-dns-cloudflare==4.1.1
+certbot-dns-route53==4.1.1
+certbot-dns-azure==2.6.1
+certbot-dns-google==4.1.1
+certbot-dns-powerdns==0.2.1
+```
+
+> Die meisten DNS-Plugins erfordern Certbot 4.1.1. Das Azure-Plugin hat eine eigenständige Versionierung (2.6.1), und PowerDNS ist ein neueres Plugin (0.2.1).
+
+### Manuelle Installation von Abhängigkeiten
+
+Falls die automatische Installation fehlschlägt, installieren Sie DNS-Provider einzeln:
+
+```bash
+# Kern-certbot
+pip install certbot==4.1.1
+
+# Cloudflare
+pip install certbot-dns-cloudflare==4.1.1
+
+# AWS Route53
+pip install certbot-dns-route53==4.1.1 boto3==1.35.76
+
+# Azure DNS
+pip install certbot-dns-azure==2.6.1 azure-identity==1.19.0 azure-mgmt-dns==8.1.0
+
+# Google Cloud DNS
+pip install certbot-dns-google==4.1.1 google-cloud-dns==0.35.0
+
+# PowerDNS
+pip install certbot-dns-powerdns==0.2.1
+```
+
+### Validierungsbefehle
+
+```bash
+# Certbot-Plugins prüfen
+certbot plugins --text
+
+# Prüfen, ob der Service läuft
+curl -X GET http://localhost:8000/api/health
+```
+
+---
+
+## Support
+
+Bei Problemen:
+
+1. Prüfen Sie die Logs auf spezifische Fehler
+2. Überprüfen Sie Ihre DNS-Provider-Zugangsdaten
+3. Siehe [DNS-Provider-Leitfaden](./dns-providers.md) für anbieterspezifische Fehlerbehebung
+4. Siehe [Test-Leitfaden](./testing.md) für die Ausführung von Diagnosen
+
+---
+
+<div align="center">
+
+[← Zurück zur Dokumentation](./README.md) • [DNS-Provider →](./dns-providers.md) • [Docker →](./docker.md)
+
+</div>

--- a/docs/de/kubernetes.md
+++ b/docs/de/kubernetes.md
@@ -1,0 +1,96 @@
+# Kubernetes-Produktionshinweise
+
+Dieser Leitfaden enthält die Basiswerte für die Produktionsdimensionierung von CertMate, wenn es hinter einem Kubernetes Ingress/HTTPRoute betrieben wird und ein entferntes Zertifikat-Backend wie Azure Key Vault verwendet.
+
+## Empfohlene Ressourcen
+
+CertMate führt gunicorn zusammen mit certbot-Subprozessen im selben Container aus. Während der Erstellung oder Erneuerung von Zertifikaten können certbot und DNS-Plugins vorübergehend zu einem erheblichen Speicher-Spike führen. Mit Azure Key Vault im Modus `both` werden beim Auflisten von Zertifikaten ebenfalls entfernte Aufrufe durchgeführt, sodass sehr enge Limits Routineoperationen in OOM-Neustarts verwandeln können.
+
+Verwenden Sie diese Basiskonfiguration für Produktions-Pods, die Dutzende von Zertifikaten verwalten:
+
+```yaml
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1536Mi
+env:
+  - name: CERTMATE_CERT_INFO_CACHE_TTL
+    value: "60"
+  - name: GUNICORN_TIMEOUT
+    value: "300"
+```
+
+Für den spezifischen Fehlerfall, bei dem ein Pod mit `memory: 512Mi` während der Zertifikatserstellung neu startet, erhöhen Sie zuerst das Speicherlimit. Der Code-Pfad vermeidet nun die früheren `openssl`-Subprozesse der Listenansicht, verwendet leichtgewichtige Azure Key Vault-Zertifikatsinformationslesungen und schließt certbot-Scratch-/Verlaufsverzeichnisse von Routine-Backups aus — certbot benötigt jedoch beim Ausstellen von Zertifikaten weiterhin Puffer.
+
+## Beispiel für einen Deployment-Patch
+
+```bash
+kubectl -n certificate-management patch deployment certmate --type='strategic' -p '
+spec:
+  template:
+    spec:
+      containers:
+        - name: certmate
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1536Mi
+          env:
+            - name: CERTMATE_CERT_INFO_CACHE_TTL
+              value: "60"
+            - name: GUNICORN_TIMEOUT
+              value: "300"
+'
+```
+
+Überprüfen Sie nach der Anwendung den nächsten Neustart-Grund:
+
+```bash
+kubectl -n certificate-management describe pod -l app=certmate | grep -A6 "Last State"
+kubectl -n certificate-management top pod -l app=certmate
+```
+
+## Anzahl der Replikas
+
+Führen Sie `replicas: 1` aus, es sei denn, alle veränderbaren Pfade (`/app/data`, `/app/certificates`, `/app/backups`, `/app/logs`) werden durch einen Speicher unterstützt, der für gleichzeitige Schreibzugriffe geeignet ist, und Sie haben das Planer-/Erneuerungsverhalten für mehrere Pods validiert. Azure Key Vault kann Zertifikate remote speichern, aber CertMate bewahrt Einstellungen, Metadaten, Backups und den Laufzeitstatus weiterhin lokal auf.
+
+## Das Deployment-Status-Badge zeigt "Backend: Unreachable"
+
+*Aktualisiert am 2026-05-25 (siehe [#263](https://github.com/fabriziosalmi/certmate/issues/263)).*
+
+Das Deployment-Status-Badge auf dem Dashboard ist ein optionaler Gesundheitsindikator und **beeinträchtigt nicht** die Ausstellung, Erneuerung oder den Download. Der CertMate-Prozess selbst öffnet eine einfache TLS-Verbindung zu `<domain>:443` und vergleicht den Fingerabdruck des bereitgestellten Zertifikats mit dem gespeicherten:
+
+- **Deployed** — der Handshake war erfolgreich und der Fingerabdruck stimmt überein.
+- **Wrong Cert** — der Handshake war erfolgreich, aber ein anderes Zertifikat wird bereitgestellt.
+- **Unreachable** — der Pod konnte keine TLS-Verbindung zur Domain aufbauen.
+
+Auf Kubernetes ist **Unreachable für jedes Zertifikat zu erwarten**, wenn der CertMate-Pod keine direkte Verbindung zu Ihrer öffentlichen/Ingress-IP aufbauen kann. Häufige Ursachen:
+
+- Die Domain löst sich in eine öffentliche/Ingress-IP auf, die vom Pod aus nicht routbar ist (Hairpin/NAT oder Split-Horizon-DNS).
+- Eine ausgehende `NetworkPolicy` blockiert den ausgehenden Port 443.
+- TLS wird von Ihrem Ingress-Controller oder einem externen Load Balancer terminiert, sodass kein Endpoint vorhanden ist, den CertMate direkt erreichen kann.
+- Die Probe ist schlicht zu langsam und überschreitet das Standard-Budget von 3 Sekunden.
+
+Wenn das Ziel erreichbar, aber langsam ist, erhöhen Sie das Probe-Budget:
+
+```yaml
+env:
+  - name: CERTMATE_TLS_PROBE_TIMEOUT_SECONDS
+    value: "10"   # accepts 1–30 seconds; default is 3
+```
+
+Andernfalls kann das Badge in einer Ingress/Kubernetes-Topologie bedenkenlos ignoriert werden — die Zertifikate werden korrekt ausgestellt und bereitgestellt, auch wenn CertMate sie selbst nicht prüfen kann.
+
+---
+
+<div align="center">
+
+[← Zurück zur Dokumentation](./README.md) • [Docker-Leitfaden →](./docker.md)
+
+</div>

--- a/docs/de/mcp.md
+++ b/docs/de/mcp.md
@@ -1,0 +1,117 @@
+# CertMate Model Context Protocol (MCP) Server
+
+CertMate enthält einen integrierten Model Context Protocol (MCP) Server, der in Node.js geschrieben ist. Dadurch können agentische KI-Assistenten (wie Claude oder Gemini) Zertifikatsstatus sicher prüfen, Erneuerungen auslösen, Diagnosen anfordern und direkt mit der CertMate API interagieren.
+
+## Funktionen und Tools
+
+Der CertMate MCP Server stellt folgenden KI-Assistenten diese Tools zur Verfügung:
+
+**Inventar und Status**
+1. **`certmate_list_certificates`** — Listet alle vom aktiven CertMate-Instanz verwalteten Zertifikate auf (mit Ablaufdatum, Status, Domains).
+2. **`certmate_get_certificate`** — Vollständige Details für eine Domain: Status, verbleibende Tage bis zum Ablauf, SANs, DNS/CA-Anbieter, Auto-Renew-Flag. Verwenden Sie es, um zu entscheiden, ob ein Zertifikat erneuert werden muss.
+3. **`certmate_get_activity`** — Aktuelle Aktivitäten/Auditprotokoll, um nachzuvollziehen, was sich geändert hat oder fehlgeschlagen ist.
+4. **`certmate_diagnostics`** — Umfassender, bereinigter Diagnose-Snapshot.
+5. **`certmate_get_settings`** — Globale Einstellungen und Konfiguration.
+
+**Lebenszyklus-Operationen**
+6. **`certmate_create_certificate`** — Fordert ein neues TLS-Zertifikat für eine Domain an (optionaler DNS-Anbieter, Account, CA). Kann bei asynchroner Ausstellung eine `job_id` (HTTP 202) zurückgeben.
+7. **`certmate_renew_certificate`** — Erzwingt die Erneuerung eines vorhandenen Zertifikats (kann ebenfalls eine `job_id` zurückgeben).
+8. **`certmate_get_job`** — Fragt einen asynchronen Erstellungs-/Erneuerungsauftrag per `job_id` ab, bis dieser als abgeschlossen oder fehlgeschlagen gemeldet wird.
+9. **`certmate_set_auto_renew`** — Aktiviert oder deaktiviert die automatische Erneuerung für eine einzelne Domain.
+10. **`certmate_deploy_certificate`** — Führt alle konfigurierten deploy hooks für eine Domain manuell aus.
+11. **`certmate_download_certificate`** — Gibt das Zertifikatsmaterial einer Domain als JSON zurück (fullchain, key, chain), damit ein Agent es anderswo einsetzen kann.
+
+**Anbieter**
+12. **`certmate_list_dns_providers`** — Auf dieser Instanz unterstützte und konfigurierte DNS-Anbieter.
+13. **`certmate_list_dns_accounts`** — Konfigurierte DNS-Anbieter-Accounts (Zugangsdaten maskiert); verwenden Sie eine zurückgegebene Account-ID als `account_id` beim Erstellen eines Zertifikats.
+
+## Einrichtung und Konfiguration
+
+### Voraussetzungen
+- Node.js (v18 oder höher)
+- npm
+
+### Installation
+Wechseln Sie in das Verzeichnis `mcp/` im CertMate-Repository und installieren Sie die Abhängigkeiten:
+```bash
+cd mcp
+npm install
+```
+
+### Umgebungsvariablen
+Der MCP Server kommuniziert mit der CertMate REST API und benötigt zwei Umgebungsvariablen:
+- `CERTMATE_URL` — Die URL Ihrer CertMate-Instanz (Standard: `http://localhost:8000`).
+- `CERTMATE_TOKEN` — Ein gültiger API-Bearer-Token mit den entsprechenden Rollenberechtigungen (in der Regel `operator` oder `admin`). Für einen auditierbaren Agenten verwenden Sie einen als Agent-Key markierten Schlüssel (siehe [Audit-Zuordnung](#audit-zuordnung)).
+
+Optional:
+- `CERTMATE_AGENT_SESSION` — Überschreibt die prozessgebundene Session-ID, die der Server bei jedem Aufruf sendet (`X-CertMate-Agent-Session`), damit ein Lauf mit der ID eines externen Orchestrators korreliert werden kann. Wenn nicht gesetzt, wird pro Prozess eine neue UUID generiert.
+- `CERTMATE_AGENT_ID` — Eine Bezeichnung für dieses Agent-Deployment (`X-CertMate-Agent-Id`, Standard `certmate-mcp-server`).
+
+### Integrationsbeispiel (Claude Desktop Konfiguration)
+Um den CertMate MCP Server zu Claude Desktop hinzuzufügen, fügen Sie Folgendes zu Ihrer Konfigurationsdatei hinzu (in der Regel unter `~/Library/Application Support/Claude/claude_desktop_config.json` auf macOS oder `%APPDATA%\Claude\claude_desktop_config.json` unter Windows):
+
+```json
+{
+  "mcpServers": {
+    "certmate": {
+      "command": "node",
+      "args": ["/absolute/path/to/certmate/mcp/index.js"],
+      "env": {
+        "CERTMATE_URL": "http://localhost:8000",
+        "CERTMATE_TOKEN": "your_secure_bearer_token"
+      }
+    }
+  }
+}
+```
+
+### Andere MCP-Clients (Gemini usw.)
+
+Der Server spricht Standard-MCP über stdio, sodass jeder Client, der MCP unterstützt, auf dieselbe Weise funktioniert: Verweisen Sie ihn auf `node /absolute/path/to/certmate/mcp/index.js` und setzen Sie die zwei Umgebungsvariablen. Nichts im Server ist Claude-spezifisch.
+
+## CertMate mit einem KI-Agenten betreiben (geplante Aufgaben)
+
+Die meisten erstklassigen Assistenten unterstützen inzwischen **geplante Aufgaben** (Claude, Gemini und andere). Kombiniert mit diesem MCP Server ergibt sich ein autonomer „Zertifikatswächter": Sie beschreiben die Richtlinie in natürlicher Sprache mit expliziten Bedingungen, das Modell plant sich selbst, und bei jeder Ausführung setzt es die Richtlinie mithilfe der oben genannten Tools durch. Das Muster ist modellunabhängig — alles, was einen gespeicherten Prompt nach Zeitplan ausführen und MCP-Tools aufrufen kann, wird funktionieren.
+
+### Die Schleife, die der Agent durchläuft
+
+1. `certmate_list_certificates` (oder `certmate_get_certificate` pro Domain), um `days_left` / Status zu lesen.
+2. Entscheidung gemäß Ihrer Bedingung, z. B. *erneuern, wenn `days_left < 14`*.
+3. `certmate_renew_certificate` für jede fällige Domain.
+4. Wenn eine Erneuerung eine `job_id` zurückgibt, `certmate_get_job` so lange aufrufen, bis `completed` / `failed` gemeldet wird.
+5. Bei einem Fehler diesen melden — und die eigenen Benachrichtigungskanäle von CertMate (E-Mail, Slack, Discord, Telegram, ntfy, Gotify) werden bei `certificate_failed` ebenfalls ausgelöst, sodass Sie unabhängig davon eine Push-Benachrichtigung erhalten.
+
+### Beispiele für geplante Prompts
+
+> **Täglich, 08:00** — „Verwende die CertMate MCP Tools und liste alle Zertifikate auf. Rufe für alle mit `days_left < 14` `certmate_renew_certificate` auf und frage dann `certmate_get_job` ab, bis der Vorgang abgeschlossen ist. Antworte mit einer einzeiligen Zusammenfassung pro Domain und hebe Fehler hervor."
+
+> **Wöchentlich** — „Rufe `certmate_get_activity` und `certmate_diagnostics` auf. Fasse Auffälligkeiten (fehlgeschlagene Erneuerungen, abgelaufene Zertifikate, nicht laufender Scheduler) in drei Punkten zusammen. Wenn alles in Ordnung ist, sage es."
+
+> **Bei Bedarf** — „Stelle ein Zertifikat für `shop.example.com` aus, indem du `certmate_list_dns_providers` verwendest, um einen konfigurierten Anbieter auszuwählen, und `certmate_list_dns_accounts` für die Account-ID, und verfolge dann den Auftrag bis zum Abschluss."
+
+Da die Bedingungen im Prompt liegen, können Sie die Richtlinie (Schwellenwert, welche Domains, Verhalten bei Fehler) anpassen, ohne Code zu ändern. Geben Sie dem Agenten einen Token, der genau auf das beschränkt ist, was er tun soll — `operator` für Erneuerung/Deployment, `admin` nur wenn er Einstellungen ändern oder Diagnosen lesen muss.
+
+## Sicherheit
+
+1. **Token-Schutz** — Der MCP Server erfordert einen gültigen `CERTMATE_TOKEN`. Er überträgt diesen Token sicher im `Authorization`-Header für alle Anfragen an die CertMate API.
+2. **Minimale Berechtigungen** — Beschränken Sie den Token auf das, was der Agent benötigt. Ein geplanter Erneuerungswächter benötigt `operator`; reservieren Sie `admin`-Tokens für Agenten, die Einstellungen ändern oder Diagnosen abrufen müssen. Widerrufen Sie den Token, um dem Agenten sofort den Zugang zu entziehen.
+3. **Kompatibilität mit Log-Bereinigung** — Tools wie `certmate_diagnostics` rufen Daten ab, nachdem der Log Sanitizer sensible Zugangsdaten entfernt hat, und schützen so Schlüssel und Tokens vor dem Durchsickern in LLM-Kontexte.
+
+## Audit-Zuordnung
+
+Damit das Auditprotokoll die Aktionen eines Agenten von denen eines menschlichen Operators unterscheiden kann, geben Sie dem MCP Server einen **dedizierten, als Agent markierten API-Schlüssel** anstelle des veralteten globalen Bearer-Tokens:
+
+1. Gehen Sie in CertMate zu **Einstellungen → API-Schlüssel**, erstellen Sie einen Schlüssel und aktivieren Sie **KI-Agent-Schlüssel** (oder senden Sie `"is_agent": true` an `POST /api/keys`). Schränken Sie ihn mit `allowed_domains` und der minimal benötigten Rolle ein.
+2. Setzen Sie diesen Schlüssel als `CERTMATE_TOKEN` für den MCP Server.
+
+Jede Zertifikatsaktion, die der Agent daraufhin durchführt, wird mit `actor.kind="agent"`, der stabilen ID des Schlüssels und der prozessgebundenen `X-CertMate-Agent-Session`, die der Server sendet, aufgezeichnet — sodass Sie später genau nachvollziehen können, welche Zertifikatsänderungen ein KI-Agent vorgenommen hat, unter welcher Identität und gruppiert nach Lauf. Der veraltete globale Bearer-Token fasst jeden Aufrufer als `api_user` ohne Schlüssel-ID zusammen und wird als `api_token`, nicht als `agent`, erfasst. Der Agent-Session-Header ist eine informative Angabe und befördert einen Aufrufer niemals allein in den Status `agent`.
+
+Die resultierenden Einträge sind Teil der manipulationssicheren Audit-Kette; siehe [Audit Logging](./api.md#audit-logging) und [compliance.md](./compliance.md).
+
+---
+
+<div align="center">
+
+[← Zurück zur Dokumentation](./README.md)
+
+</div>

--- a/docs/de/probes.md
+++ b/docs/de/probes.md
@@ -1,0 +1,76 @@
+# Deployment Probes
+
+Probes prüfen, ob Ihre Zertifikate im Netzwerk erreichbar sind, indem sie einen Live-TLS-Handshake mit dem deployten Server durchführen.
+
+## Konfiguration
+
+Konfigurieren Sie Probes pro Domain unter **Einstellungen → Deployment Probes**.
+
+| Feld | Beschreibung |
+|---|---|
+| Domain | Die zu prüfende Zertifikatsdomain |
+| Port | TCP-Port (Standard: 443 für HTTPS/TLS, 587 für SMTP STARTTLS) |
+| Protokoll | `HTTPS/TLS` — Standard-HTTPS-Handshake, `TLS` — reines TLS ohne HTTP, `SMTP STARTTLS` — SMTP mit TLS-Upgrade |
+
+Protokoll und Port werden in der `metadata.json` des Zertifikats unter den Schlüsseln `deployment_protocol` und `deployment_port` gespeichert.
+
+## Funktionsweise
+
+### Backend-Probe
+
+1. Das Backend liest den konfigurierten Port und das Protokoll aus den Zertifikatsmetadaten.
+2. Eine Socket-Verbindung wird geöffnet und ein TLS-Handshake durchgeführt.
+3. Der Fingerabdruck des gelieferten Zertifikats wird mit dem lokal gespeicherten Zertifikat verglichen.
+4. Das Ergebnis (erreichbar, deployed, Zertifikatsübereinstimmung) wird für 5 Minuten zwischengespeichert (konfigurierbar).
+
+### Browser-Fallback
+
+Wenn die Backend-Probe den Server als nicht erreichbar meldet **und** das Protokoll `HTTPS/TLS` ist, wird ein browserseitiger Fallback über `fetch(..., { mode: 'no-cors' })` ausgelöst. Dadurch kann die Erreichbarkeit auch dann geprüft werden, wenn das Backend keine Verbindung herstellen kann (z. B. bei Netzwerksegmentierung).
+
+Für die Protokolle `TLS` und `SMTP STARTTLS` wird der Browser-Fallback **übersprungen**, da Browser keine reinen TLS- oder SMTP-Verbindungen aufbauen können. Der Browser-Status zeigt „Nicht geprüft".
+
+### Cache
+
+| Schicht | TTL | Umgehung |
+|---|---|---|
+| Backend (Speicher) | 300 s (Standard) | Query-Parameter `?refresh=1` |
+| Frontend (Speicher) | 300 s | `forceRefresh=true` (Schaltfläche „Probe prüfen") |
+
+## API
+
+### Deployment-Status prüfen
+
+```
+GET /api/certificates/<domain>/deployment-status
+GET /api/certificates/<domain>/deployment-status?refresh=1
+```
+
+Gibt zurück:
+
+| Feld | Typ | Beschreibung |
+|---|---|---|
+| domain | string | Die geprüfte Domain |
+| deployed | boolean | Ob ein Zertifikat ausgeliefert wurde |
+| reachable | boolean | Ob der Server geantwortet hat |
+| certificate_match | boolean/null | Ob das gelieferte Zertifikat mit dem gespeicherten übereinstimmt |
+| method | string | Verwendetes Protokoll (`https-tls`, `tls`, `smtp-starttls`) |
+| port | integer | Geprüfter TCP-Port |
+| protocol | string | Identisch mit method |
+| error | string | Fehlermeldung, wenn die Probe fehlgeschlagen ist |
+| browser | object | Ergebnis des Browser-Fallbacks (nur HTTPS) |
+
+### Probe konfigurieren
+
+```
+PATCH /api/certificates/<domain>
+```
+
+```json
+{ "deployment_port": 444, "deployment_protocol": "https-tls" }
+```
+
+Auf `null` setzen, um die Probe-Konfiguration zu entfernen:
+
+```json
+{ "deployment_port": null, "deployment_protocol": null }
+```

--- a/docs/de/testing.md
+++ b/docs/de/testing.md
@@ -1,0 +1,351 @@
+# Testhandbuch
+
+Dieses Handbuch beschreibt das Test-Framework von CertMate, einschließlich Unit-Tests, Integrationstests und der Validierung von API-Endpoints.
+
+---
+
+## Schnellstart
+
+```bash
+# Virtuelle Umgebung aktivieren
+source .venv/bin/activate
+
+# Testabhängigkeiten installieren
+pip install -r requirements-test.txt
+
+# Alle Tests ausführen
+pytest
+
+# Tests mit Coverage ausführen
+pytest --cov=. --cov-report=html
+```
+
+---
+
+## Teststruktur
+
+```
+Stammverzeichnis:
+  conftest.py                              # Sammlungskonfiguration und gemeinsame Fixtures
+  pytest.ini                               # Testkonfiguration und Marker
+  test_certificate_creation.py             # Tests zur Zertifikatserstellung
+  test_certificate_listing.py              # Tests zur Zertifikatsauflistung
+  test_client_certificates_comprehensive.py # Lifecycle-Tests für Client-Zertifikate
+  test_dns_accounts.py                     # Multi-Account-Operationen
+  test_dns_provider.py                     # Grundlegende Provider-Funktionalität
+  test_dns_provider_inheritance.py         # Konfigurationsvererbung
+  test_domain_alias.py                     # Tests für Domain-Aliase
+  test_infisical_backend.py               # Infisical-Storage-Backend
+  test_shell_executor.py                   # Tests zur Shell-Ausführung
+  test_e2e_complete.py                     # End-to-End-Test-Suite
+```
+
+---
+
+## Tests ausführen
+
+### Häufige Befehle
+
+```bash
+# Alle Tests ausführen
+pytest
+
+# Mit ausführlicher Ausgabe ausführen
+pytest -v
+
+# Eine bestimmte Testdatei ausführen
+pytest test_certificate_creation.py
+
+# Eine bestimmte Testfunktion ausführen
+pytest test_certificate_creation.py::test_specific_function -v -s
+
+# Tests nach einem Muster filtern
+pytest -k "dns_provider"
+
+# Mit Coverage-Bericht ausführen
+pytest --cov=. --cov-report=html
+open htmlcov/index.html
+```
+
+### Mit Make
+
+```bash
+make test              # Alle Tests ausführen
+make test-unit         # Nur Unit-Tests
+make test-integration  # Nur Integrationstests
+make test-coverage     # Tests mit Coverage
+make check             # Alle Qualitätsprüfungen
+```
+
+---
+
+## Testkategorien
+
+Tests sind mit pytest-Markern organisiert:
+
+```bash
+# Unit-Tests (schnell, ohne externe Dienste)
+pytest -m "not integration and not slow"
+
+# Integrationstests
+pytest -m integration
+
+# API-Tests
+pytest -m api
+
+# DNS-Provider-Tests
+pytest -m dns
+
+# End-to-End-Tests (erfordern einen laufenden Server)
+pytest -m e2e
+```
+
+### E2E ohne Docker
+
+Standardmäßig bauen die E2E-Fixtures das Docker-Image und verwalten einen Container
+für die gesamte Sitzung. Wenn Docker nicht verfügbar ist (CI-Sandboxes,
+eingeschränkte Netzwerke), kann die Suite auf eine bereits laufende Instanz gezeigt werden:
+
+```bash
+# Terminal 1: CertMate beliebig starten
+gunicorn --bind 127.0.0.1:18888 --workers 1 --threads 8 app:app
+
+# Terminal 2: auf diese Instanz zeigen (überspringt die gesamte Docker-Lifecycle-Verwaltung)
+CERTMATE_E2E_BASE_URL=http://localhost:18888 pytest -m "e2e and not ui"
+```
+
+Die Tests zur echten Zertifikatsausstellung benötigen zusätzlich `CLOUDFLARE_API_TOKEN` und eine
+`CERTMATE_TEST_DOMAIN`, die Sie kontrollieren, und verbrauchen echte Let's Encrypt-Zertifikate —
+sie werden automatisch übersprungen, wenn der Token fehlt. Die
+Zielinstanz muss mit einem leeren Datenverzeichnis starten: E2E-Tests setzen
+den Erstkonfigurationszustand voraus, sodass eine Wiederverwendung zwischen Läufen zu
+authentifizierungsabhängigen Fehlern führt.
+
+---
+
+## API-Endpoint-Tests
+
+### Schnelles Testskript
+
+Verwenden Sie `quick_test.sh` für eine schnelle Endpoint-Validierung vor jedem Commit:
+
+```bash
+# Vor jedem Commit ausführen
+./quick_test.sh
+
+# Nur öffentliche Endpoints testen
+./quick_test.sh --public-only
+```
+
+Dieses Skript:
+- Prüft, ob der Server läuft
+- Lädt den API-Token automatisch aus `data/settings.json`
+- Testet alle Endpoint-Kategorien
+- Liefert eine eindeutige Erfolg/Fehler-Ausgabe
+
+### Vollständige API-Test-Suite
+
+```bash
+# Token automatisch aus den Einstellungen laden
+python3 test_all_endpoints.py --auto-token
+
+# Mit benutzerdefinierter Server-URL
+python3 test_all_endpoints.py --url http://192.168.1.100:8000
+
+# Mit manuellem API-Token
+python3 test_all_endpoints.py --token your-api-bearer-token
+
+# Schnelltest nur der wesentlichen Endpunkte
+python3 test_all_endpoints.py --quick --auto-token
+
+# Nur öffentliche Endpoints (keine Authentifizierung erforderlich)
+python3 test_all_endpoints.py --public-only
+```
+
+### Getestete Endpoints
+
+| Kategorie | Endpoints |
+|-----------|-----------|
+| **Health** | `GET /api/health`, `GET /health` |
+| **Einstellungen** | `GET /api/settings`, `GET /api/settings/dns-providers`, `POST /api/settings` |
+| **Zertifikate** | `GET /api/certificates`, `POST /api/certificates/create`, download, renew |
+| **Cache** | `GET /api/cache/stats`, `POST /api/cache/clear` |
+| **Backup** | `GET /api/backups`, `POST /api/backups/create`, `POST /api/backups/cleanup` |
+| **Web-Interface** | `/`, `/settings`, `/help`, `/docs/`, `/api/swagger.json` |
+
+### Erwartete Statuscodes
+
+- **200/201**: Erfolg
+- **400/422**: Erwartete Validierungsfehler (normal für Test-Payloads)
+- **404**: Erwartet für nicht vorhandene Ressourcen
+- **401**: Ungültiger/fehlender API-Token
+- **500**: Anwendungsfehler (untersuchen)
+
+---
+
+## Tests schreiben
+
+### Teststruktur
+
+```python
+import pytest
+from unittest.mock import patch, MagicMock
+
+def test_function_name(client, sample_settings):
+    """Test description."""
+    # Arrange
+    setup_data = {...}
+
+    # Act
+    response = client.get('/api/endpoint')
+
+    # Assert
+    assert response.status_code == 200
+    assert 'expected_key' in response.json()
+```
+
+### Fixtures verwenden
+
+```python
+def test_with_app_context(app):
+    """Test that requires app context."""
+    with app.app_context():
+        pass
+
+def test_api_endpoint(client):
+    """Test API endpoint."""
+    response = client.get('/api/test')
+    assert response.status_code == 200
+
+def test_with_mock_data(mock_certificate_data):
+    """Test with mock data."""
+    assert mock_certificate_data['domain'] == 'test.example.com'
+```
+
+### Externe Dienste mocken
+
+```python
+@patch('app.requests.get')
+def test_external_api(mock_get, client):
+    """Test external API call."""
+    mock_get.return_value.json.return_value = {'status': 'success'}
+    response = client.post('/api/certificate/request')
+    assert response.status_code == 200
+```
+
+---
+
+## Kontinuierliche Integration
+
+### GitHub Actions
+
+Die CI-Pipeline läuft bei jedem Push und Pull Request:
+
+1. **Mehrere Python-Versionen**: Tests auf Python 3.9, 3.11, 3.12
+2. **Codequalität**: Linting mit flake8
+3. **Sicherheit**: Scanning mit bandit
+4. **Tests**: Vollständige Test-Suite mit Coverage
+5. **Docker**: Docker-Build testen
+6. **Coverage**: Upload zu Codecov
+
+### Pre-Commit-Hook
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Hooks umfassen: Code-Formatierung (black, isort), Linting (flake8), Sicherheitsprüfungen (bandit).
+
+### CI/CD-API-Tests
+
+```yaml
+# GitHub Actions-Beispiel
+- name: Test API Endpoints
+  run: |
+    python app.py &
+    sleep 5
+    python3 test_all_endpoints.py --auto-token
+```
+
+---
+
+## Coverage-Anforderungen
+
+- Mindestens **80%** gesamte Code-Coverage
+- Kritische Pfade müssen **95%+** Coverage aufweisen
+- Alle neuen Funktionen müssen Tests enthalten
+
+---
+
+## Best Practices
+
+### Empfohlen
+
+- Tests für alle neuen Funktionen schreiben
+- Beschreibende Testnamen verwenden
+- Sowohl Erfolgs- als auch Fehlerfälle testen
+- Externe Abhängigkeiten mocken
+- Passende Test-Marker verwenden
+- Tests isoliert und unabhängig halten
+
+### Nicht empfohlen
+
+- Implementierungsdetails testen
+- Echte API-Keys in Tests verwenden
+- Tests voneinander abhängig machen
+- Testfehler ignorieren
+- Tests für „einfachen" Code weglassen
+
+---
+
+## Tests debuggen
+
+```bash
+# Ausführlich mit Print-Ausgaben
+pytest -v -s
+
+# Bestimmten Test debuggen
+pytest test_api.py::test_specific -v -s
+
+# pdb verwenden
+def test_debug_example():
+    import pdb; pdb.set_trace()
+    # Test code here
+```
+
+---
+
+## Performance-Tests
+
+```python
+import pytest
+import concurrent.futures
+
+@pytest.mark.slow
+def test_api_load(client):
+    """Test API under load."""
+    def make_request():
+        return client.get('/api/certificates')
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [executor.submit(make_request) for _ in range(100)]
+        responses = [f.result() for f in futures]
+
+    assert all(r.status_code == 200 for r in responses)
+```
+
+---
+
+## Exit-Codes
+
+- **0**: Alle Tests bestanden
+- **1**: Einige Tests fehlgeschlagen
+
+---
+
+<div align="center">
+
+[← Zurück zur Dokumentation](./README.md) • [Architektur →](./architecture.md) • [API-Referenz →](./api.md)
+
+</div>

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -1,0 +1,238 @@
+# Documentación de CertMate
+
+Bienvenido a la documentación de CertMate. Esta carpeta contiene guías completas para todas las funcionalidades.
+
+---
+
+## Navegación rápida
+
+### Primeros pasos
+- **[Guía de instalación](./installation.md)** — Configuración, dependencias, despliegue en producción
+- **[Guía de Docker](./docker.md)** — Builds de Docker, multiplataforma, Docker Compose
+- **[Notas de Kubernetes](./kubernetes.md)** — Recursos de producción, dimensionamiento OOM, parches de runtime
+
+### Funcionalidades principales
+- **[Proveedores DNS](./dns-providers.md)** — Proveedores soportados, multi-cuenta, alias de dominio
+- **[Proveedores CA](./ca-providers.md)** — Let's Encrypt, DigiCert, CA privada
+- **[Certificados de cliente](./guide.md)** — Ciclo de vida de certificados de cliente, panel web, operaciones por lotes
+- **[Servidor MCP (Model Context Protocol)](./mcp.md)** — Servidor Node.js independiente para integraciones con agentes de IA
+
+### Referencia
+- **[Referencia de API](./api.md)** — Documentación completa de la API REST
+- **[Arquitectura](./architecture.md)** — Diseño del sistema, componentes, flujo de datos
+- **[Guía de pruebas](./testing.md)** — Framework de pruebas, CI/CD, cobertura
+
+---
+
+## Documentación por audiencia
+
+### Para nuevos usuarios
+
+1. **[Instalación](./installation.md)** — Poner en marcha CertMate
+2. **[Proveedores DNS](./dns-providers.md)** — Configurar tu proveedor DNS
+3. **[Guía de certificados de cliente](./guide.md)** — Crear tu primer certificado
+
+### Para desarrolladores
+
+1. **[Referencia de API](./api.md)** — Todos los endpoints con ejemplos
+2. **[Arquitectura](./architecture.md)** — Funcionamiento interno y diseño
+3. **[Guía de pruebas](./testing.md)** — Cómo escribir y ejecutar pruebas
+
+### Para administradores
+
+1. **[Despliegue con Docker](./docker.md)** — Configuración de Docker para producción
+2. **[Notas de Kubernetes](./kubernetes.md)** — Dimensionamiento de pods y parches operativos
+3. **[Proveedores CA](./ca-providers.md)** — Configurar autoridades de certificación
+4. **[Proveedores DNS](./dns-providers.md#multi-account-support)** — Configuración empresarial multi-cuenta
+
+---
+
+## Descripción general de funcionalidades
+
+### Certificados de servidor
+- **Más de dos docenas de proveedores DNS** para los desafíos DNS-01 de Let's Encrypt (ver [Proveedores DNS](./dns-providers.md) para la lista completa)
+- **Múltiples proveedores CA**: Let's Encrypt, DigiCert, CA privada
+- **Soporte multi-cuenta** por proveedor DNS
+- **Backends de almacenamiento intercambiables**: Local, Azure Key Vault, AWS, Vault, Infisical
+- **Renovación automática** con umbrales configurables
+- **Soporte Docker** con builds multiplataforma (ARM64 + AMD64)
+- **Log Sanitizer** — Elimina automáticamente tokens de API, claves privadas y credenciales sensibles de los logs de CertMate
+- **Zombie Certificate Scanner** — Escáner de sistema de archivos multihilo para identificar y limpiar certificados huérfanos
+- **Servidor MCP (Model Context Protocol)** — Servidor Node.js independiente para integrarse con asistentes de IA agénticos
+
+### Certificados de cliente
+- **CA autofirmada** con claves RSA de 4096 bits
+- **Gestión completa del ciclo de vida** — crear, renovar, revocar, supervisar
+- **OCSP & CRL** — estado en tiempo real y listas de revocación
+- **Panel web** en `/client-certificates`
+- **Operaciones por lotes** — importar entre 100 y 30.000 certificados mediante CSV
+- **Registro de auditoría** y **limitación de peticiones**
+
+---
+
+## Referencia rápida de endpoints de la API
+
+| Método | Endpoint                                 | Descripción                   |
+| ------ | ---------------------------------------- | ----------------------------- |
+| POST   | `/api/client-certs/create`               | Crear certificado             |
+| GET    | `/api/client-certs`                      | Listar certificados           |
+| GET    | `/api/client-certs/<id>`                 | Obtener metadatos             |
+| GET    | `/api/client-certs/<id>/download/<type>` | Descargar cert/clave/csr      |
+| POST   | `/api/client-certs/<id>/revoke`          | Revocar certificado           |
+| POST   | `/api/client-certs/<id>/renew`           | Renovar certificado           |
+| GET    | `/api/client-certs/stats`                | Obtener estadísticas          |
+| POST   | `/api/client-certs/batch`                | Importación CSV por lotes     |
+| GET    | `/api/ocsp/status/<serial>`              | Estado OCSP                   |
+| GET    | `/api/crl/download/<format>`             | Descargar CRL                 |
+
+Ver la [Referencia de API](./api.md#endpoints) para la documentación completa.
+
+---
+
+## Pruebas
+
+Todas las funcionalidades están exhaustivamente probadas:
+
+```bash
+# Ejecutar pruebas
+python -m pytest tests/ -v
+```
+
+La cobertura de pruebas incluye:
+- Operaciones de CA
+- Operaciones de CSR
+- Ciclo de vida de certificados
+- Filtrado y búsqueda
+- Operaciones por lotes
+- OCSP & CRL
+- Auditoría y limitación de peticiones
+
+---
+
+## Funcionalidades de seguridad
+
+- **RSA de 4096 bits** para claves de CA
+- **Algoritmo de firma** SHA256
+- **Autenticación** por Bearer token
+- **Limitación de peticiones** en todos los endpoints
+- **Registro de auditoría** de todas las operaciones
+- **Permisos de archivo** 0600 para claves privadas
+
+---
+
+## Rendimiento
+
+- Soporta **más de 30.000 certificados simultáneos**
+- Consultas **multi-filtro** eficientes
+- Planificación de **renovación automática**
+- **Operaciones por lotes** con seguimiento de errores
+
+---
+
+## Estructura de archivos
+
+```
+docs/
+  README.md            ← Estás aquí
+  index.md             ← Página de inicio de certificados de cliente
+  installation.md      ← Instalación y configuración
+  kubernetes.md        ← Notas de producción de Kubernetes
+  dns-providers.md     ← Proveedores DNS y multi-cuenta
+  ca-providers.md      ← Proveedores de autoridad de certificación
+  docker.md            ← Build y despliegue con Docker
+  testing.md           ← Framework de pruebas y CI/CD
+  guide.md             ← Guía de usuario de certificados de cliente
+  api.md               ← Referencia de API completa
+  architecture.md      ← Arquitectura del sistema
+```
+
+---
+
+## Itinerario de aprendizaje
+
+**Principiante** → [Empezar aquí](./index.md) → [Primeros pasos](./guide.md)
+
+**Desarrollador** → [Referencia de API](./api.md) → [Arquitectura](./architecture.md)
+
+**Avanzado** → [Documentación de API completa](./api.md) → [Detalles de arquitectura](./architecture.md)
+
+---
+
+## Enlaces importantes
+
+- **Panel web**: `http://localhost:8000/client-certificates`
+- **Documentación de API**: `http://localhost:8000/docs/`
+- **Comprobación de salud**: `http://localhost:8000/health`
+- **Registros de auditoría**: `logs/audit/certificate_audit.log`
+
+---
+
+## Panel de estado
+
+| Componente          | Estado       | Pruebas   |
+| ------------------- | ------------ | --------- |
+| Fundación CA        | Listo        | 3/3       |
+| Gestor CSR          | Listo        | 3/3       |
+| Gestor de cert.     | Listo        | 8/8       |
+| Filtrado            | Listo        | 3/3       |
+| Operaciones por lotes | Listo      | 2/2       |
+| OCSP/CRL            | Listo        | 5/5       |
+| Auditoría/Limitación | Listo       | 3/3       |
+| **Total**           | **Listo**    | **27/27** |
+
+---
+
+## Ejemplos rápidos
+
+### Crear un certificado mediante la API
+
+```bash
+curl -X POST http://localhost:8000/api/client-certs/create \
+ -H "Authorization: Bearer YOUR_TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "common_name": "user@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "api-mtls",
+ "days_valid": 365
+ }'
+```
+
+### Listar certificados
+
+```bash
+curl http://localhost:8000/api/client-certs \
+ -H "Authorization: Bearer YOUR_TOKEN"
+```
+
+### Descargar un certificado
+
+```bash
+curl http://localhost:8000/api/client-certs/USER_ID/download/crt \
+ -H "Authorization: Bearer YOUR_TOKEN" \
+ -o certificate.crt
+```
+
+Ver la [Guía de API](./api.md) para más ejemplos.
+
+---
+
+## Licencia
+
+CertMate está publicado bajo la licencia MIT. Ver el archivo LICENSE en el repositorio.
+
+---
+
+## ¿Preguntas o problemas?
+
+- Consulta la página de documentación correspondiente
+- Revisa los archivos de prueba para ver ejemplos de uso
+- Consulta la [Referencia de API](./api.md) para detalles sobre los endpoints
+
+---
+
+<div align="center">
+
+[Inicio](../README.md) • [Documentación](./) • [GitHub](https://github.com/fabriziosalmi/certmate)
+
+</div>

--- a/docs/es/THEME_MIGRATION.md
+++ b/docs/es/THEME_MIGRATION.md
@@ -1,0 +1,227 @@
+# Migración de tema — desacoplamiento claro/oscuro mediante tokens CSS
+
+Estado: **entregado** (Fases 0-5 en v2.9.0; Fase 6 sigue) · Propietario: Fabrizio · Creado: 2026-05-25
+
+## Objetivo
+
+Hoy, cambiar el tema implica editar los colores en ~19 templates y el JS del frontend. Esta migración convierte un único bloque de propiedades personalizadas CSS en la fuente de verdad para toda la paleta, de modo que cambiar de tema (o añadir uno nuevo) significa editar `:root` / `.dark` en un solo archivo — no cientos de puntos de llamada.
+
+## Estado inicial (medido el 2026-05-25)
+
+| Métrica | Valor |
+|---|---|
+| Referencias de clases de color en los templates | ~3 197 en 19 archivos |
+| Pares `dark:` en los templates | ~1 665 |
+| Clases de color en el JS de la aplicación (no vendorizado) | ~789 (dashboard.js 372, settings.js 150, setup-wizard.js 131, certmate.js 60, client-certs.js 57, …) |
+| Hex codificados en el JS de la aplicación | ~17 (paletas toast/gráfico); 80 más en `redoc.standalone.js` son **vendorizados, ignorar** |
+| Clases de componentes R-3 adoptadas | `.card` solo (12×); `.btn-*`, `.badge-*`, `.form-*` = 0 |
+
+Archivos más pesados: `partials/settings_dns.html` (635 / 395 dark:), `index.html` (311 / 150), `partials/settings_deploy.html`, `partials/settings_ca.html`.
+
+## Riesgos de proceso a corregir primero
+
+1. **El CSS compilado se confirma a mano.** `package.json` solo tiene `css:build` / `css:watch`; ningún CI reconstruye `static/css/tailwind.min.css`. Editar `input.css` sin reconstruir entrega silenciosamente un CSS obsoleto. → añadir compilación CI + verificación de frescura en la Fase 0.
+2. **~3 200 ediciones manuales = regresiones garantizadas.** Se necesita una referencia visual (capturas de pantalla claro+oscuro de cada página) y un codemod semi-automático para los pares `dark:` mecánicos, no una sustitución ciega.
+
+## Estrategia: propiedades CSS personalizadas como fuente única
+
+Estilo shadcn sobre Tailwind v3: los colores se convierten en variables CSS en `:root` / `.dark`, expuestas a Tailwind como tokens semánticos (tripletes de canales HSL para que los utilitarios `/opacity` sigan funcionando). Los ~1 665 pares `dark:` se reducen a clases únicas.
+
+### Tabla de correspondencia de tokens propuesta
+
+| Token Tailwind | Reemplaza (ejemplos) | Uso |
+|---|---|---|
+| `bg-background` | `bg-gray-50 dark:bg-surface-dark` | página |
+| `bg-surface` | `bg-white dark:bg-surface-card` | tarjeta |
+| `bg-surface-2` | `bg-gray-100 dark:bg-gray-800` | elevado |
+| `text-foreground` | `text-gray-900 dark:text-white` | texto principal |
+| `text-muted` | `text-gray-500 dark:text-gray-400` | texto secundario |
+| `border-border` | `border-gray-200 dark:border-gray-700` | bordes |
+| `bg-primary` / `text-primary` | marca (ahora basado en var) | marca |
+| `*-success/warning/danger/info` | verde=válido, rojo=expirado… | **estado**, no superficies |
+
+## Fases
+
+Cada fase = un commit atómico (dividir los partials de la Fase 3 en sus propios commits). Las fases se agrupan en uno o más PRs de versión `vX.Y.Z`.
+
+### Fase 0 — Fundamentos y salvaguardas (sin cambio visual)
+- [x] Paso de CI que ejecuta `npm run css:build` y falla si `tailwind.min.css` está obsoleto (`git diff --exit-code`). → job `frontend-css` en `.github/workflows/ci.yml`. El bundle confirmado ya había divergido; reconstruido y confirmado.
+- [x] Definir la capa de tokens: variables CSS en `:root` / `.dark` (input.css) + mapping en `tailwind.config.js`, **en paralelo** con la paleta existente — sin tocar ningún template. Tokens: `bg-background`, `bg-surface`, `bg-surface-2`, `text-foreground`, `text-muted`, `border-border` (en safelist).
+- [x] Escribir el codemod: `scripts/theme_codemod.py` — tabla de correspondencia de los pares `dark:` recurrentes → tokens, informe dry-run + `--apply`. Informe de ambigüedad a continuación.
+- [x] Herramientas de captura de pantalla: `scripts/theme_baseline.py` — construye Docker con un directorio de datos efímero, inicializa un administrador desechable, captura cada página real de la UI en claro + oscuro. Volver a ejecutar tras cada fase y comparar. **Captura aún pendiente** (requiere `playwright install chromium` + una construcción Docker local).
+
+#### Alcance de la referencia (solo páginas reales)
+Capturadas: `/` (setup, luego index), `/login`, `/settings`, `/help`, `/activity`, `/redoc` — 7 páginas × claro/oscuro.
+
+> **Hallazgo (fuera de alcance, señalado):** las rutas `/certificates` y `/audit` en `modules/web/ui_routes.py:25-41` renderizan `certificates.html` / `audit.html`, que **no existen** — ambas devuelven 500. Rutas muertas, excluidas de la referencia. Merece una corrección separada (eliminar las rutas o restaurar los templates).
+
+#### Uso del codemod
+```
+python scripts/theme_codemod.py                     # informe dry-run, todos los templates
+python scripts/theme_codemod.py templates/base.html # informe, un archivo
+python scripts/theme_codemod.py --apply templates/base.html
+```
+Tras cada `--apply`: `npm run css:build`, comparar contra la referencia, revisar las variantes `dark:` residuales.
+
+#### Resumen del informe (2026-05-25)
+**607 pares auto-reducidos** de ~1 665 variantes `dark:`:
+
+| Token | Pares |
+|---|---|
+| `text-muted` | 203 |
+| `border-border` | 169 |
+| `text-foreground` | 141 |
+| `bg-surface` | 77 |
+| `bg-surface-2` | 16 |
+| `bg-background` | 1 |
+
+**557 ocurrencias / 29 variantes sin mapear** — decisiones de diseño para el piloto de la Fase 1, no deducidas automáticamente:
+
+- `dark:bg-gray-700` (137): se empareja con `bg-white` (tarjetas/inputs) **y** `bg-gray-50` — decidir surface vs surface-2 según el contexto.
+- `dark:text-white` (120): los que se emparejan con `text-gray-900` ya se mapean a `text-foreground`; los demás son texto siempre blanco sobre fondos de color — probablemente dejar como están.
+- `dark:text-gray-300` (112): principalmente `text-gray-700 dark:text-gray-300` = el patrón de labels de formulario — decidir un token de label dedicado vs `text-muted`/`text-foreground`.
+- `dark:border-gray-600` (41), `dark:text-gray-200` (39), superficies con sufijo de opacidad (`dark:bg-gray-700/50` etc.), y `dark:border-white/5`.
+
+Unos pocos residuos (`dark:text-gray-400{%`, `dark:text-gray-300'`) son atributos de clase que contienen expresiones Jinja/JS — migrar a mano.
+
+### Fase 1 — Piloto: shell + primitivas
+- [x] Migrar `base.html` (nav/header/footer/barra de pestañas) a tokens. 19 pares reducidos; los valores de los tokens coinciden exactamente con los originales.
+- [x] Migrar `login.html` a tokens. 12 pares reducidos.
+- [ ] Adoptar las clases de componentes `.btn` / `.form-*` (aplazado — el piloto usó solo tokens; los inputs de inicio de sesión difieren en tamaño de `.form-input`, por lo que la adopción de componentes es un paso separado).
+- [x] Validar la paridad claro/oscuro. Verificado en vivo en Docker (base.html + login.html, ambos temas) — piloto aceptado.
+
+#### Decisiones de diseño abiertas (surgidas del piloto)
+1. **Texto de labels de formulario** (`text-gray-700 dark:text-gray-300`). **RESUELTO en la Fase 5 → opción (b):** añadido el token `--color-label` con los valores exactos gray-700/gray-300 (fiel, sin cambio visual) y migradas las 137 ocurrencias a `text-label`. La fusión en `text-foreground` fue rechazada (oscurecería el modo claro de 27%→11% L).
+2. **Unificación de bordes**: `border-gray-300` (inputs) ahora se mapea a `border-border` (= gray-200), por lo que los bordes de los inputs se aclaran un paso en modo claro. Aceptado para el piloto (un único token de borde es el objetivo); revisar con `--color-input-border` solo si el resultado no convence en la revisión.
+3. **Inputs glass / `dark:border-white/5` trazo fino / variantes hover / colores de estado**: intencionalmente NO tokenizados — los controles glass no tienen contrapartida en modo claro, el trazo fino white/5 es el borde canónico de `.card`, y hover/estado requieren su propia pasada de tokens de variante (una fase posterior).
+
+### Fase 2 — Panel de control ✅
+- [x] `index.html` (chrome del panel de control): formulario de creación, tarjetas de lista/estadísticas, cabeceras de tabla + divisores, panel de detalle, modales. Los ternarios Alpine `:class` y `divide-border` tratados a mano.
+- [x] `static/js/dashboard.js`: filas renderizadas en JS, estadísticas, estados vacíos/bienvenida, panel de detalle, salida de verificación de alias. `node --check` limpio.
+- Los colores de estado de salud/despliegue (verde/ámbar/rojo/azul) se dejan intencionalmente como colores de estado literales — llevan significado y tendrán una pasada de tokens de estado dedicada más adelante, no tokens de superficie.
+- Los inputs de formulario glass (`dark:bg-gray-700`/`dark:text-white`), los labels de formulario y las variantes hover se dejan para su propio tratamiento (coherente con el piloto).
+
+### Fase 3 — Cluster de ajustes ✅
+- [x] `settings.html` + 10 partials + `_modal`: 441 pares reducidos. Los pares interiores de los ternarios Alpine `:class` tokenizados por el codemod (las comillas solo unen las clases de borde de rama); estructura ternaria verificada intacta.
+- [x] `settings.js` + `setup-wizard.js`: 49 pares, `node --check` limpio. Los demás `settings-*.js` no tienen clases de color.
+- Dejado como está (coherente con las fases anteriores): inputs glass (`dark:bg-gray-700` ~99), labels de formulario (`dark:text-gray-300` ~78, aplazado), badges de estado, superficies de opacidad, variantes hover, y clases de borde de rama ternarios.
+
+### Fase 4 — Páginas restantes ✅
+- [x] Templates: activity, help, setup, `_client_certs` (123 pares; sin ternarios Alpine aquí).
+- [x] JS: client-certs.js, cmd-palette.js, report-issue.js, shortcuts.js (26 pares, `node --check` limpio). setup-wizard.js ya se hizo en la Fase 3.
+- Las mismas exclusiones que antes: inputs glass, grises de cuerpo/label, superficies de opacidad, colores de estado, hover, y clases en los límites de concatenación de cadenas.
+
+### Fase 5 — Limpieza y consolidación ✅
+- [x] Decisión sobre el label cerrada: token `text-label` + 137 sitios migrados (véase más arriba).
+- [x] Punto ciego del codemod detectado: solo escaneaba `class="..."`, omitiendo las asignaciones `className='...'` y la concatenación de cadenas JS. Añadida una **pasada literal consciente de los límites** (colapsa subcadenas `CLARO OSCURO` adyacentes en cualquier contexto) + la puerta `--check`. Volver a ejecutar el barrido completo colapsó los pares JS restantes (diálogos confirm/prompt, modales de report-issue + shortcuts).
+- [x] Eliminados los alias legacy no utilizados `success`/`warning`/`danger` de `tailwind.config.js` (0 sitios de llamada). Se conservan `primary` (~375) y `secondary` (degradados).
+- [x] **Salvaguarda CI**: `python3 scripts/theme_codemod.py --check` en el job `frontend-css` — falla la compilación si se reintroduce algún par claro+oscuro colapsable en un template o archivo JS de primera parte.
+- **Hex JS dejado como está, por diseño:** la paleta `#60a5fa`/etc. en `certmate.js` es el **logger de consola de depuración** sobre una superficie fija siempre oscura (`bg-black`); `TOAST_COLORS` son clases de estado literales. Ambos son acentos de estado independientes del tema — convencionalmente no pertenecen al theming claro/oscuro — por lo que permanecen literales en lugar de convertirse en tokens de tema. Una futura **pasada de tokens de estado** (success/warning/danger/info como vars) es el lugar adecuado para unificarlos si algún día se desea.
+- Actualización de la referencia: opcional; no ejecutada (la captura se aplazó — se usó la verificación Docker en vivo en cada fase en su lugar).
+
+### Fase 6 — Pasada de tokens de estado ✅
+- [x] Reintroducción de `success`/`warning`/`danger` (+ nuevo `info`) como **grupos de tokens**
+  (`surface`/`line`/`fg`/`strong`), respaldados por variables en `:root`/`.dark` (HSL,
+  fiel a los valores inline, superficies oscuras mezcladas sobre la tarjeta).
+- [x] Extensión del codemod con una tabla de matiz×tono generada (`_expand_status`)
+  que colapsa los pares verde/rojo/ámbar/azul de las info-box sobre los tokens —
+  normalizando la desviación 50-vs-100 / 700-vs-800 que llevaban los callouts inline.
+  **300 pares colapsados** en templates + JS de primera parte.
+- [x] `--check` ahora también guarda los pares de estado (viven en `MAPPINGS`), por lo que
+  un par claro+oscuro de estado reintroducido falla en CI como cualquier otro.
+- Dejado literal por diseño: los acentos de estado únicos sin par claro/oscuro
+  (icono `text-*-500`), y los tintes solo-oscuro (sin contrapartida clara).
+
+### Fase 7 — Superficie de campos de formulario ✅ (v2.9.1)
+- [x] Añadido `--color-input` (blanco / gray-700) → `bg-input`; colapso de 40
+  pares `bg-white dark:bg-gray-700`. Coincidencia exacta de valores.
+
+### Fase 8 — Superficies hover y hundidas ✅ (v2.9.1)
+- [x] Añadidos `--color-hover` (gray-100/700), `border.strong` (gray-300/500) y
+  `--color-sunken` (gray-50/700); colapso de 51 pares hover/hundidos. Los tonos
+  hover minoritarios se dejan literales para que la pasada sea estrictamente sin cambio visual.
+
+### Fase 9 — Tokenización de la capa de componentes + acento ✅
+- [x] Las reglas `@apply` de los componentes R-3 (`.card`, `.form-input`/`.form-select`/
+  `.form-label`, `.btn-secondary`, `.btn-ghost`, `.nav-active`, `.nav-inactive`)
+  eran un **punto ciego del codemod** — `--check` escanea `class="…"`, no `@apply` —
+  y seguían llevando clases raw gray/blue. Migradas a los tokens.
+- [x] Añadido un token `accent` sensible al tema (blue-600 → blue-400 en oscuro) para que
+  `.nav-active` no codifique el azul de forma fija; este es el acento de superficie que
+  faltaba en #254.
+- No hecho (por diseño): adopción de `.btn`/`.form-*` en los sitios de llamada (los sitios
+  de llamada inline ya están tokenizados; forzar los componentes cambiaría el tamaño de los
+  botones sin ninguna ganancia de desacoplamiento). `.btn-danger` (rojo de acción sólido) y
+  las variantes `.badge-*` de estado permanecen literales. La capa `@apply` queda fuera de
+  la puerta `--check` — una mejora futura del codemod podría escanearla.
+
+### Fase 10 — Descomposición de colas de color (planificada, gradual)
+El desacoplamiento dejó **565 utilitarios `dark:`** que el codemod no puede colapsar: no
+tienen un sibling claro con el que emparejarse, por lo que `--check` nunca los detecta. La
+auditoría (2026-05-25) muestra que no se trata de un solo problema sino de tres, con perfiles
+de riesgo opuestos:
+
+| Grupo | Cantidad | Se resuelve en | Nuevos tokens |
+|---|---|---|---|
+| 1 — Neutros (blanco/gris) | 388 (69%) | `foreground / surface / surface-2 / sunken / muted / border` | 0 |
+| 2 — Estado (azul/rojo/ámbar) | 63 (11%) | `info / success / warning / danger` | 0 |
+| 3 — Arcoíris (morado/indigo/naranja) | 111 (20%) | **neutro** (decorativo, degradado) | 0 |
+
+Hallazgo clave: **cero nuevos tokens necesarios.** El sistema de tokens ya entregado *es*
+el contrato; los 565 son todo lo que escapó de él. La corrección es la aplicación + la
+degradación, no un nuevo vocabulario. (El arcoíris fue medido como codificación decorativa
+de secciones — morado = "configuración avanzada", indigo = CA/Enterprise, naranja =
+Storage — no como estado, e inconsistente entre archivos.)
+
+Orden, por riesgo UX creciente:
+- **10a — Neutros (388).** Invisible: `dark:text-white` → `text-foreground`,
+  `dark:bg-gray-700` → `bg-input`/`bg-surface-2`/`bg-sunken` (disambiguado por
+  contexto — mismo gris oscuro, diferente intención *clara*, por lo que se clasifica
+  manualmente por cluster, no con sed ciego). Extender `theme_codemod.py` con una
+  pasada solo-dark→token. Riesgo ~0, resuelve ~70%.
+- **10b — Estado (63).** Mapear los callouts azul/rojo/ámbar sobre los grupos
+  info/success/warning/danger existentes. Normaliza la desviación 50-vs-100. Riesgo bajo.
+- **10c — Arcoíris (111).** La decisión de producto (ver contrato a continuación).
+  Los tonos decorativos de sección se colapsan a neutro. Cambio visible, hecho en último
+  lugar, bloque a bloque con QA de capturas antes/después. Decidido: **contrato α**
+  (color = significado).
+
+## Contrato de color (la norma que los 565 escaparon)
+Decidido el 2026-05-25. Cuatro reglas; los tokens ya entregados son la única paleta.
+
+1. **El color se gana, nunca es decorativo.** Un tono aparece solo si lleva
+   *estado* (info/success/warning/danger) o *marca* (acento: enlaces, nav activa,
+   primario, foco). Todo lo demás es neutro
+   (background/surface/surface-2/sunken/border/foreground/muted/label).
+2. **La identidad viene de la estructura, no del color.** Las secciones se distinguen por
+   el espaciado, los encabezados, los iconos, los divisores — no por un tono de relleno.
+3. **Una sola primitiva de énfasis.** Los bloques de configuración/avanzados usan un único
+   panel neutro hundido (`bg-sunken border-border rounded-md`); un borde izquierdo de marca
+   opcional marca "activo/importante". Sin paleta por sección.
+4. **Los iconos solo se tiñen con marca o estado.** Sin tintes morado/indigo/naranja en iconos.
+
+Aplicación: la puerta `--check` gana una regla que falla en CI con cualquier
+`purple|indigo|orange` en bruto (y cualquier color no tokenizado) en `templates/` — un
+contrato con un compilador detrás, que no puede volver a degradarse.
+
+## Colores de estado — ahora tokenizados (Fase 6)
+Las fases anteriores aplazaron deliberadamente los colores de estado (verde/ámbar/rojo/azul
+con sus variantes `dark:`) como una pasada separada y opcional — llevan significado y son
+convencionalmente invariantes de tema. **La Fase 6 realizó esa pasada:** las
+superficies/bordes/texto de las info-box emparejadas usan ahora `bg-success-surface`,
+`text-danger-strong`, etc. Los acentos de estado *únicos* (icono `text-*-500`, sin par
+oscuro) permanecen literales — son independientes del tema y no forman parte del theming
+claro/oscuro.
+
+## Alineación del flujo de trabajo
+- Cero emoji en commits/PRs/notas de versión.
+- Commits atómicos (uno por fase, o por partial en la Fase 3); un PR por versión.
+- Antes del push público: smoke de Docker + emisión de certificado real contra el dominio de Fab con subdominios aleatorios.
+
+---
+
+<div align="center">
+
+[← Volver a la documentación](./README.md)
+
+</div>

--- a/docs/es/api.md
+++ b/docs/es/api.md
@@ -1,0 +1,764 @@
+# CertMate Certificados de Cliente - Referencia de API
+
+## Descripción general
+
+La API CertMate de gestión de certificados de cliente proporciona endpoints REST para una gestión completa de certificados con autenticación, limitación de tasa y registro de auditoría.
+
+**URL base**: `http://localhost:5000/api`
+**Autenticación**: Bearer Token (obligatoria en todos los endpoints)
+**Content-Type**: `application/json`
+
+---
+
+## Autenticación
+
+Todos los endpoints de la API requieren autenticación mediante Bearer token.
+
+### Formato del encabezado
+
+```
+Authorization: Bearer TU_TOKEN
+```
+
+### Ejemplo de solicitud
+
+```bash
+curl -X GET http://localhost:5000/api/client-certs \
+ -H "Authorization: Bearer TU_TOKEN" \
+ -H "Content-Type: application/json"
+```
+
+---
+
+## Limitación de tasa (Rate Limiting)
+
+Los endpoints de la API tienen límites de tasa para prevenir abusos:
+
+| Endpoint               | Límite | Por     |
+| ---------------------- | ------ | ------- |
+| General                | 100    | minuto  |
+| Crear certificado      | 30     | minuto  |
+| Operaciones por lotes  | 10     | minuto  |
+| Estado OCSP            | 200    | minuto  |
+| Descarga CRL           | 60     | minuto  |
+
+### Respuesta al superar el límite
+
+Cuando se supera el límite de tasa, recibirás:
+
+```
+HTTP 429 Too Many Requests
+
+{
+ "error": "Rate limit exceeded",
+ "message": "Too many requests. Please try again later.",
+ "retry_after": 60
+}
+```
+
+---
+
+## Endpoints
+
+### Gestión de certificados
+
+#### 1. Crear certificado
+
+**Endpoint**: `POST /client-certs/create`
+
+Crea un nuevo certificado de cliente.
+
+**Solicitud**:
+```json
+{
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "organizational_unit": "Engineering",
+ "cert_usage": "api-mtls",
+ "days_valid": 365,
+ "generate_key": true,
+ "notes": "Production certificate"
+}
+```
+
+**Parámetros**:
+- `common_name` (obligatorio) — Asunto del certificado
+- `email` (opcional) — Dirección de correo electrónico
+- `organization` (opcional) — Nombre de la organización
+- `organizational_unit` (opcional) — Nombre del departamento
+- `cert_usage` (opcional) — Tipo de uso: `api-mtls`, `vpn`, o personalizado
+- `days_valid` (opcional) — Validez en días (por defecto: 365)
+- `generate_key` (opcional) — Generar clave privada (por defecto: true)
+- `notes` (opcional) — Notas adicionales
+
+**Respuesta** (201 Created):
+```json
+{
+ "identifier": "cert-abc123",
+ "common_name": "user@example.com",
+ "serial_number": "12345678901234567890",
+ "created_at": "2024-10-30T18:00:00Z",
+ "expires_at": "2025-10-30T18:00:00Z",
+ "cert_usage": "api-mtls",
+ "status": "active"
+}
+```
+
+**Ejemplo**:
+```bash
+curl -X POST http://localhost:5000/api/client-certs/create \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "api-mtls",
+ "days_valid": 365
+ }'
+```
+
+---
+
+#### 2. Listar certificados
+
+**Endpoint**: `GET /client-certs`
+
+Lista todos los certificados de cliente con filtrado opcional.
+
+**Parámetros de consulta**:
+- `usage` (opcional) — Filtrar por tipo de uso (p. ej., `api-mtls`)
+- `revoked` (opcional) — Filtrar por estado (`true` o `false`)
+- `search` (opcional) — Buscar en el nombre común
+
+**Respuesta** (200 OK):
+```json
+{
+ "certificates": [{
+ "identifier": "cert-001",
+ "common_name": "user1@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "api-mtls",
+ "created_at": "2024-10-30T18:00:00Z",
+ "expires_at": "2025-10-30T18:00:00Z",
+ "revoked": false,
+ "status": "active"
+ },
+ {
+ "identifier": "cert-002",
+ "common_name": "user2@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "vpn",
+ "created_at": "2024-10-29T18:00:00Z",
+ "expires_at": "2025-10-29T18:00:00Z",
+ "revoked": true,
+ "status": "revoked"
+ }
+ ],
+ "total": 2
+}
+```
+
+**Ejemplos**:
+```bash
+# Listar todos los certificados
+curl http://localhost:5000/api/client-certs \
+ -H "Authorization: Bearer TOKEN"
+
+# Filtrar por tipo de uso
+curl "http://localhost:5000/api/client-certs?usage=api-mtls" \
+ -H "Authorization: Bearer TOKEN"
+
+# Listar solo los revocados
+curl "http://localhost:5000/api/client-certs?revoked=true" \
+ -H "Authorization: Bearer TOKEN"
+
+# Buscar por nombre común
+curl "http://localhost:5000/api/client-certs?search=user1" \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+#### 3. Obtener detalles de un certificado
+
+**Endpoint**: `GET /client-certs/<identifier>`
+
+Obtiene los metadatos completos de un certificado.
+
+**Respuesta** (200 OK):
+```json
+{
+ "type": "client_certificate",
+ "identifier": "cert-001",
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "organizational_unit": "Engineering",
+ "serial_number": "12345678901234567890",
+ "created_at": "2024-10-30T18:00:00Z",
+ "expires_at": "2025-10-30T18:00:00Z",
+ "cert_usage": "api-mtls",
+ "notes": "Production certificate",
+ "revocation": {
+ "revoked": false,
+ "revoked_at": null,
+ "reason_revoked": null
+ },
+ "renewal": {
+ "renewal_enabled": true,
+ "renewal_threshold_days": 30
+ }
+}
+```
+
+**Ejemplo**:
+```bash
+curl http://localhost:5000/api/client-certs/cert-001 \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+#### 4. Descargar archivos de un certificado
+
+**Endpoint**: `GET /client-certs/<identifier>/download/<type>`
+
+Descarga el certificado, la clave privada o el archivo CSR.
+
+**Parámetros**:
+- `identifier` — ID del certificado
+- `type` — Tipo de archivo: `crt`, `key`, o `csr`
+
+**Respuesta** (200 OK):
+- Content-Type: `application/octet-stream`
+- Archivo adjunto con nombre apropiado
+
+**Ejemplos**:
+```bash
+# Descargar el certificado
+curl http://localhost:5000/api/client-certs/cert-001/download/crt \
+ -H "Authorization: Bearer TOKEN" \
+ -o certificate.crt
+
+# Descargar la clave privada
+curl http://localhost:5000/api/client-certs/cert-001/download/key \
+ -H "Authorization: Bearer TOKEN" \
+ -o private.key
+
+# Descargar el CSR
+curl http://localhost:5000/api/client-certs/cert-001/download/csr \
+ -H "Authorization: Bearer TOKEN" \
+ -o request.csr
+```
+
+---
+
+#### 5. Revocar un certificado
+
+**Endpoint**: `POST /client-certs/<identifier>/revoke`
+
+Revoca un certificado con un motivo opcional.
+
+**Solicitud** (opcional):
+```json
+{
+ "reason": "compromised"
+}
+```
+
+**Respuesta** (200 OK):
+```json
+{
+ "message": "Certificate revoked: cert-001",
+ "revoked_at": "2024-10-30T18:15:00Z",
+ "reason": "compromised"
+}
+```
+
+**Ejemplo**:
+```bash
+curl -X POST http://localhost:5000/api/client-certs/cert-001/revoke \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "reason": "compromised"
+ }'
+```
+
+---
+
+#### 6. Renovar un certificado
+
+**Endpoint**: `POST /client-certs/<identifier>/renew`
+
+Renueva un certificado (mismo CN, nuevo número de serie).
+
+**Respuesta** (201 Created):
+```json
+{
+ "identifier": "cert-001-renewed",
+ "common_name": "user@example.com",
+ "serial_number": "98765432109876543210",
+ "created_at": "2024-10-30T18:20:00Z",
+ "expires_at": "2025-10-30T18:20:00Z",
+ "status": "active"
+}
+```
+
+**Ejemplo**:
+```bash
+curl -X POST http://localhost:5000/api/client-certs/cert-001/renew \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+#### 7. Obtener estadísticas
+
+**Endpoint**: `GET /client-certs/stats`
+
+Obtiene estadísticas de uso de los certificados.
+
+**Respuesta** (200 OK):
+```json
+{
+ "total": 100,
+ "active": 85,
+ "revoked": 15,
+ "expiring_soon": 8,
+ "by_usage": {
+ "api-mtls": 60,
+ "vpn": 35,
+ "other": 5
+ },
+ "created_count": 100,
+ "renewal_enabled": 92
+}
+```
+
+**Ejemplo**:
+```bash
+curl http://localhost:5000/api/client-certs/stats \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+#### 8. Importación por lotes de certificados
+
+**Endpoint**: `POST /client-certs/batch`
+
+Crea múltiples certificados a partir de datos CSV en una sola solicitud.
+
+**Solicitud**:
+```json
+{
+ "headers": ["common_name", "email", "organization", "cert_usage", "days_valid"],
+ "rows": [["user1@example.com", "user1@example.com", "ACME Corp", "api-mtls", "365"],
+ ["user2@example.com", "user2@example.com", "ACME Corp", "vpn", "365"],
+ ["user3@example.com", "user3@example.com", "ACME Corp", "api-mtls", "365"]
+ ]
+}
+```
+
+**Respuesta** (201 Created):
+```json
+{
+ "total": 3,
+ "successful": 3,
+ "failed": 0,
+ "errors": [],
+ "certificates": [{
+ "identifier": "cert-batch-001",
+ "common_name": "user1@example.com"
+ },
+ {
+ "identifier": "cert-batch-002",
+ "common_name": "user2@example.com"
+ },
+ {
+ "identifier": "cert-batch-003",
+ "common_name": "user3@example.com"
+ }
+ ]
+}
+```
+
+**Ejemplo**:
+```bash
+curl -X POST http://localhost:5000/api/client-certs/batch \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "headers": ["common_name", "email", "organization"],
+ "rows": [["user1@example.com", "user1@example.com", "ACME Corp"],
+ ["user2@example.com", "user2@example.com", "ACME Corp"]
+ ]
+ }'
+```
+
+---
+
+### OCSP & CRL
+
+#### 9. Consulta de estado OCSP
+
+**Endpoint**: `GET /ocsp/status/<serial_number>`
+
+Consulta el estado de un certificado mediante OCSP.
+
+**Respuesta** (200 OK):
+```json
+{
+ "response_status": "successful",
+ "certificate_status": "good|revoked|unknown",
+ "certificate_serial": 12345678,
+ "this_update": "2024-10-30T18:00:00Z",
+ "next_update": null,
+ "responder_name": "CertMate OCSP Responder"
+}
+```
+
+**Ejemplo**:
+```bash
+curl http://localhost:5000/api/ocsp/status/12345678 \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+#### 10. Distribución de la CRL
+
+**Endpoint**: `GET /crl/download/<format_type>`
+
+Descarga la lista de revocación de certificados (CRL).
+
+**Parámetros**:
+- `format_type` — `pem`, `der`, o `info`
+
+**Respuesta**:
+- Para `pem` y `der`: Archivo adjunto
+- Para `info`: JSON con metadatos de la CRL
+
+**Ejemplos**:
+```bash
+# Descargar la CRL en formato PEM
+curl http://localhost:5000/api/crl/download/pem \
+ -H "Authorization: Bearer TOKEN" \
+ -o ca.crl
+
+# Descargar la CRL en formato DER
+curl http://localhost:5000/api/crl/download/der \
+ -H "Authorization: Bearer TOKEN" \
+ -o ca.crl
+
+# Obtener información de la CRL
+curl http://localhost:5000/api/crl/download/info \
+ -H "Authorization: Bearer TOKEN"
+```
+
+**Respuesta de información de la CRL**:
+```json
+{
+ "status": "available",
+ "issuer": "CN=CertMate CA, O=CertMate",
+ "last_update": "2024-10-30T18:00:00Z",
+ "next_update": "2024-10-31T18:00:00Z",
+ "revoked_count": 5,
+ "revoked_serials": [12345678,
+ 87654321
+ ]
+}
+```
+
+---
+
+#### 11. Descargar archivos de certificado de dominio
+
+**Endpoint**: `GET /certificates/<domain>/download`
+
+Descarga los archivos de certificado para un dominio específico. Por defecto, este endpoint devuelve un archivo ZIP con todos los componentes del certificado. Se puede solicitar un archivo concreto mediante el parámetro de consulta `file`. También está disponible el modo JSON para la automatización que necesite todos los PEM en una sola respuesta.
+
+**Parámetros**:
+- `domain` (Path) — El nombre de dominio asociado al certificado.
+- `file` (Query, opcional) — Especifica un único archivo a descargar.
+  - Valores admitidos: `fullchain.pem`, `privkey.pem`, `combined.pem`
+- `format` (Query, opcional) — Establece en `json` para devolver todos los archivos del certificado en un objeto JSON.
+
+**Respuesta** (200 OK):
+- **Por defecto**: `application/zip` (un archivo ZIP con todos los archivos PEM)
+- **Con parámetro `file`**: `application/x-pem-file` (el contenido sin procesar del archivo solicitado)
+- **Con `format=json`**: `application/json` con `domain`, `cert_pem`, `chain_pem`, `fullchain_pem` y `private_key_pem`
+
+La forma JSON es el formato de automatización preferido para Ansible, Salt o cualquier otro cliente que desee escribir los archivos PEM directamente.
+
+**Ejemplos**:
+
+```bash
+# Descargar todos los archivos como archivo ZIP
+curl http://localhost:5000/api/certificates/example.com/download \
+ -H "Authorization: Bearer TOKEN" \
+ -o example_com_bundle.zip
+
+# Descargar solo el archivo fullchain.pem
+curl "http://localhost:5000/api/certificates/example.com/download?file=fullchain.pem" \
+ -H "Authorization: Bearer TOKEN" \
+ -o fullchain.pem
+
+# Descargar solo la clave privada
+curl "http://localhost:5000/api/certificates/example.com/download?file=privkey.pem" \
+ -H "Authorization: Bearer TOKEN" \
+ -o privkey.pem
+
+# Descargar el bundle completo de certificados en JSON
+curl "http://localhost:5000/api/certificates/example.com/download?format=json" \
+ -H "Authorization: Bearer TOKEN" \
+ -o example_com_bundle.json
+
+```
+
+---
+
+#### 12. Reemitir un certificado de dominio (editar la configuración)
+
+**Endpoint**: `POST /certificates/<domain>/reissue`
+
+Edita la configuración de un certificado y lo reemite en su lugar — permite ampliar o eliminar entradas SAN sin necesidad de eliminar y volver a crear. Los campos omitidos conservan los valores con los que se emitió el certificado (leídos desde sus metadatos), por lo que la configuración de DNS/alias/CA no es necesario volver a introducirla. El certificado actual sigue sirviéndose hasta que la reemisión tenga éxito. La forma de la clave se preserva salvo cambio explícito (no se envían indicadores de clave y certbot conserva la clave de la cadena de certificados).
+
+**Cuerpo de la solicitud** (todos los campos son opcionales):
+```json
+{
+  "san_domains": ["www.example.com", "api.example.com"],
+  "domain_alias": "",
+  "async": true
+}
+```
+
+- `san_domains`: conjunto de reemplazo de los SAN — omitir para conservar, `[]` para eliminar todos los SAN
+- `domain_alias`: omitir para conservar, `""` para borrar
+- `dns_provider`, `account_id`, `ca_provider`, `challenge_type`: omitir para conservar
+- `key_type`/`key_size`/`elliptic_curve`: omitir para conservar la forma de clave existente
+- `async`: diferir la emisión a un job en segundo plano (202 + ID del job, consultar `GET /certificates/jobs/<job_id>`)
+
+**Respuesta** (200 OK, o 202 Accepted con `async`): message, domain, dns_provider, ca_provider, duration.
+
+**Errores**: 404 cuando no existe ningún certificado para el dominio (usar create), 403 scope, 400 validación, 409 operación en curso, 422 fallo de certbot (el certificado anterior sigue en vigor).
+
+**Ejemplo**:
+```bash
+curl -X POST http://localhost:5000/api/certificates/example.com/reissue \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{"san_domains": ["www.example.com", "api.example.com"]}'
+```
+
+---
+
+## Gestión de errores
+
+### Formato de respuesta de error
+
+```json
+{
+ "error": "Error message",
+ "code": "ERROR_CODE",
+ "status": 400
+}
+```
+
+### Códigos de estado HTTP habituales
+
+| Código | Significado          | Ejemplo                           |
+| ------ | -------------------- | --------------------------------- |
+| 200    | Éxito                | Certificado listado               |
+| 201    | Creado               | Certificado creado                |
+| 400    | Solicitud incorrecta | Campo obligatorio ausente         |
+| 401    | No autorizado        | Token inválido o ausente          |
+| 404    | No encontrado        | El certificado no existe          |
+| 429    | Demasiadas solicitudes | Límite de tasa superado         |
+| 500    | Error del servidor   | Error interno                     |
+| 503    | Servicio no disponible | OCSP/CRL no disponible          |
+
+### Ejemplo de error
+
+```bash
+curl http://localhost:5000/api/client-certs/invalid-id \
+ -H "Authorization: Bearer TOKEN"
+
+# Respuesta
+{
+ "error": "Certificate not found: invalid-id",
+ "code": 404,
+ "status": 404
+}
+```
+
+---
+
+## Registro de auditoría
+
+Las operaciones del ciclo de vida de los certificados y los cambios de configuración y control de acceso se registran en un log de auditoría. Esto incluye las rutas críticas del ciclo de vida — creaciones, renovaciones, reemisiones, despliegues y activaciones/desactivaciones de renovación automática, tanto exitosas como fallidas, así como las **renovaciones no supervisadas (planificadas)** — cada una atribuida al actor que la realizó y al disparador que la causó.
+
+### Formato del log
+
+El log de auditoría se escribe en `logs/audit/certificate_audit.log`. Cada línea es una línea de log Python estándar cuyo mensaje es la entrada de auditoría en JSON:
+
+```
+2026-06-15 18:00:00 - certmate.audit - INFO - {"timestamp": "...", ...}
+```
+
+Para extraer el JSON, divide cada línea por el literal ` - INFO - ` y analiza el resto. Ten en cuenta las dos bases temporales: el prefijo de marca de tiempo de la línea es la hora **local** del servidor, mientras que el campo `timestamp` del JSON está en **UTC** (ISO-8601). Síguela en tiempo real con:
+
+```bash
+tail -f logs/audit/certificate_audit.log
+```
+
+### Estructura de la entrada
+
+```json
+{
+  "timestamp": "2026-06-15T18:00:00.000000+00:00",
+  "operation": "renew",
+  "resource_type": "certificate",
+  "resource_id": "api.example.com",
+  "status": "success",
+  "user": "api_key:renew-bot",
+  "ip_address": "10.0.0.9",
+  "details": {"force": false},
+  "error": null,
+  "actor": {
+    "kind": "agent",
+    "id": "9f2c…",
+    "label": "api_key:renew-bot",
+    "token_prefix": "cm_1a2b",
+    "agent_session": "sess-9f2"
+  },
+  "trigger": {"cause": "agent"}
+}
+```
+
+- **`actor.kind`** — `user` (una sesión humana / inicio de sesión OIDC), `api_token` (una clave de API o el token Bearer global heredado), `agent` (una clave de API marcada explícitamente como agente IA/MCP — ver más abajo), `scheduler` (un job de renovación no supervisado), o `system`. Se deriva **únicamente de la identidad autenticada**.
+- **`actor.id` / `token_prefix`** — el ID de clave de API estable y el prefijo del token que hay detrás de la acción (ausente para el token Bearer global heredado, que no puede distinguirse por llamante — se prefieren las claves con scope).
+- **`actor.agent_session` / `agent_id`** — los valores de los encabezados `X-CertMate-Agent-Session` / `X-CertMate-Agent-Id` proporcionados por el cliente (el servidor MCP los envía). Son una **afirmación meramente informativa**: se registran para correlación pero nunca modifican `actor.kind`, por lo que un llamante que no sea agente no puede forjar una atribución de tipo `agent`.
+- **`trigger.cause`** — `manual`, `api`, `agent`, `scheduled_renewal`, o `event`; para las renovaciones planificadas, `trigger.job_id` identifica el job.
+
+Para que las acciones de un agente queden registradas como `actor.kind="agent"`, crea una clave de API con scope y `is_agent: true` (una casilla en Ajustes → Claves de API, o `is_agent` en `POST /api/keys`) y apunta el servidor MCP hacia ella. Consulta la [guía MCP](./mcp.md).
+
+### Lectura del log de auditoría mediante la API
+
+`GET /api/activity?limit=N` devuelve las entradas más recientes (admin/visor, limitado a 500).
+
+### Prueba de integridad (cadena de hash)
+
+Junto al log legible por humanos, cada entrada se añade a una **cadena de hash** SHA-256 a prueba de manipulaciones en `data/audit/certificate_audit.chain.jsonl`. Cada registro es `{seq, entry, prev_hash, hash}` donde `hash` se compromete con la entrada y el hash del registro anterior, y `seq` es un contador sin huecos — por lo que cualquier modificación, eliminación o reordenación por parte de alguien que no pueda recalcular toda la cadena es detectable y localizable. Está activada por defecto; desactívala con `CERTMATE_AUDIT_CHAIN=0`.
+
+**Verificación desde la API:** `GET /api/audit/verify` (admin) devuelve el resultado del verificador y HTTP `200` cuando está íntegra o `409` cuando está rota:
+
+```json
+{"ok": true, "count": 128, "first_seq": 0, "last_seq": 127, "head_hash": "5ee1…", "reason": "intact"}
+```
+
+**Verificación fuera del servidor:** el verificador autónomo solo depende de la biblioteca estándar de Python, por lo que un auditor puede ejecutarlo sin instalar ni confiar en CertMate:
+
+```bash
+python -m modules.core.audit_verify data/audit/certificate_audit.chain.jsonl
+# OK: audit chain intact (128 entries, seq 0..127)
+# or: FAIL: audit chain broken at seq 42: hash mismatch at seq 42: entry was modified
+```
+
+Código de salida `0` íntegra, `1` rota (con el `seq` y el motivo implicados), `2` archivo ausente o ilegible.
+
+### Bundle de exportación firmado (verificable por terceros)
+
+La instancia posee una clave de firma Ed25519, persistida en `data/.audit_signing_key` (generada en el primer arranque, `0600`; sobreescribe con `AUDIT_SIGNING_KEY_FILE` para mantenerla fuera del servidor). Su identidad pública se expone en `GET /api/audit/public-key` (admin): `{algorithm, public_key_pem, fingerprint}`. El extremo de la cadena se firma en checkpoints periódicos (`certificate_audit.checkpoints.jsonl`).
+
+`GET /api/audit/export` (admin, opcional `?from_seq`/`?to_seq`) devuelve un bundle firmado y autoverificable — `{manifest, entries, bundle_signature}`. El manifiesto fija la huella de la instancia, la clave pública, el rango de `seq` y el `head_hash`; la firma cubre el manifiesto canónico, que (a través de `head_hash`) se compromete transitivamente con cada entrada. Un auditor lo verifica **fuera del servidor** sin ejecutar ni confiar en CertMate, pudiendo fijar la clave de forma externa:
+
+```bash
+python -m modules.core.audit_verify --bundle bundle.json --pubkey instance.pem
+# OK: audit bundle intact and signed (128 entries, seq 0..127; signed by 0m2V5lDmnkPWOUHX)
+```
+
+El verificador comprueba la estructura de la cadena, que el manifiesto coincide con las entradas, la firma Ed25519 y que la huella coincide con la clave pública (fijada opcionalmente).
+
+> **Honestidad del modelo de amenaza.** La cadena y la firma detectan cualquier modificación interior, eliminación o reordenación, y vinculan una exportación a la clave pública de esta instancia — para cualquiera que no posea la clave de firma. **No vinculan** al operador, que posee la clave y podría refirmar una cadena reescrita, y el truncamiento por la cola solo se detecta comparando exportaciones a lo largo del tiempo (una exportación posterior con menos entradas) o con un checkpoint externo. Limitar completamente al operador requiere enviar los checkpoints firmados a un sumidero externo de solo adición — un anclaje externo opcional, una funcionalidad prevista que aún no se ha implementado. Consulta [compliance.md](./compliance.md).
+
+---
+
+## Tipos de certificados
+
+### API mTLS
+
+Para la autenticación de clientes de API mediante TLS mutuo.
+
+```
+cert_usage: "api-mtls"
+```
+
+### VPN
+
+Para la autenticación de clientes VPN.
+
+```
+cert_usage: "vpn"
+```
+
+### Tipos de uso personalizados
+
+Puedes usar cualquier cadena de texto como tipo de uso personalizado:
+
+```
+cert_usage: "custom-application"
+```
+
+---
+
+## Buenas prácticas
+
+### Seguridad
+
+1. **Protege tu token**
+   - Mantén los tokens en secreto
+   - Rota los tokens con regularidad
+   - Usa HTTPS en producción
+
+2. **Gestión de certificados**
+   - Activa la renovación automática
+   - Monitoriza las fechas de expiración
+   - Revisa los logs de auditoría con regularidad
+   - Revoca inmediatamente los certificados comprometidos
+
+3. **Limitación de tasa**
+   - Respeta los límites de tasa
+   - Implementa backoff exponencial
+   - Usa operaciones por lotes cuando sea posible
+
+### Rendimiento
+
+1. **Usa las operaciones por lotes**
+   - Importa varios certificados a la vez
+   - Reduce las llamadas a la API
+   - Mejor gestión de errores
+
+2. **Filtra los resultados**
+   - Usa parámetros de consulta
+   - Filtra por uso o estado
+   - Reduce la transferencia de datos
+
+3. **Usa caché cuando sea apropiado**
+   - Almacena en caché los metadatos de los certificados
+   - Refresca periódicamente
+   - Comprueba la expiración localmente
+
+---
+
+
+---
+
+<div align="center">
+
+[← Volver a la documentación](./README.md) • [Inicio rápido →](./guide.md) • [Arquitectura →](./architecture.md)
+
+</div>

--- a/docs/es/architecture.md
+++ b/docs/es/architecture.md
@@ -1,0 +1,855 @@
+# Arquitectura de CertMate
+
+Este documento cubre la arquitectura completa de CertMate — tanto el sistema principal de certificados de servidor como el subsistema de certificados de cliente.
+
+---
+
+## Tabla de contenidos
+
+- [Arquitectura del sistema principal](#arquitectura-del-sistema-principal)
+- [Diagrama de alto nivel](#diagrama-de-alto-nivel)
+- [Clases de gestión (Managers)](#clases-de-gestión-managers)
+- [Flujo de creación de certificados](#flujo-de-creación-de-certificados)
+- [Arquitectura de almacenamiento](#arquitectura-de-almacenamiento)
+- [Estructura de configuración](#estructura-de-configuración)
+- [Endpoints API](#endpoints-api)
+- [Pila tecnológica](#pila-tecnológica)
+- [Arquitectura de certificados de cliente](#arquitectura-de-certificados-de-cliente)
+
+---
+
+## Arquitectura del sistema principal
+
+CertMate es un sistema modular y extensible de gestión de certificados SSL/TLS construido con Python/Flask. Admite múltiples proveedores CA, más de dos docenas de proveedores DNS y backends de almacenamiento intercambiables.
+
+**Datos clave:**
+- **Lenguaje**: Python 3.9+ (Flask, Flask-RESTX)
+- **Almacenamiento**: Sistema de archivos local por defecto + 4 backends cloud (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical)
+- **Proveedores CA**: Let's Encrypt, DigiCert ACME, CA privada
+- **Proveedores DNS**: más de dos docenas admitidos (Cloudflare, AWS Route53, Azure, Google, y más — véase [Proveedores DNS](./dns-providers.md) para la lista completa)
+- **API**: REST con Swagger/OpenAPI mediante Flask-RESTX
+- **Tipos de certificados actuales**: TLS en el lado del servidor (DV, OV, EV)
+
+---
+
+## Diagrama de alto nivel
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  CertMate Application               │
+│                                                     │
+│  ┌───────────────────────────────────────────────┐  │
+│  │             Web Layer (Flask)                  │  │
+│  │  Dashboard    Settings    Help    Client Certs │  │
+│  └────────────────────┬──────────────────────────┘  │
+│                       ↓                             │
+│  ┌──────────────────┐   ┌────────────────────────┐  │
+│  │  REST API         │   │  Web Routes            │  │
+│  │  /api/certificates│   │  /api/web/certificates │  │
+│  │  /api/client-certs│   │  /client-certificates  │  │
+│  └────────┬─────────┘   └────────┬───────────────┘  │
+│           └──────────┬───────────┘                   │
+│                      ↓                               │
+│  ┌───────────────────────────────────────────────┐  │
+│  │          Manager Layer (Business Logic)        │  │
+│  │                                               │  │
+│  │  CertificateManager    CAManager              │  │
+│  │  DNSManager            StorageManager         │  │
+│  │  AuthManager           SettingsManager        │  │
+│  │  CacheManager          FileOperations         │  │
+│  │  ClientCertManager     OCSPResponder          │  │
+│  │  CRLManager            AuditLogger            │  │
+│  └────────────────────┬──────────────────────────┘  │
+│                       ↓                             │
+│  ┌───────────────────────────────────────────────┐  │
+│  │          Execution Layer                       │  │
+│  │  Certbot (server certs via DNS-01 ACME)       │  │
+│  │  PrivateCA (client certs via direct signing)  │  │
+│  └────────────────────┬──────────────────────────┘  │
+│                       ↓                             │
+│  ┌───────────────────────────────────────────────┐  │
+│  │          Storage Layer (Pluggable Backends)    │  │
+│  │  Local FS │ Azure KV │ AWS SM │ Vault │ Infis │  │
+│  └───────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## Clases de gestión (Managers)
+
+```
+CertMateApp (aplicación principal)
+  ├── FileOperations          # E/S de archivos, copias de seguridad
+  ├── SettingsManager         # Carga/guardado de settings.json
+  ├── AuthManager             # Validación de tokens
+  ├── CertificateManager      # Crear/renovar/info (certificados de servidor)
+  ├── CAManager               # Configuración del proveedor CA, construcción de certbot
+  ├── DNSManager              # Cuentas de proveedores DNS
+  ├── CacheManager            # Caché de despliegue
+  ├── StorageManager          # Abstracción de backends
+  ├── ClientCertificateManager # Ciclo de vida de certificados de cliente
+  ├── PrivateCAGenerator      # Gestión de la CA autofirmada
+  ├── OCSPResponder           # Consultas de estado de certificados
+  ├── CRLManager              # Generación de listas de revocación
+  └── AuditLogger             # Seguimiento de operaciones
+```
+
+---
+
+## Flujo de creación de certificados
+
+### Certificados de servidor (mediante Certbot + ACME)
+
+```
+1. User submits: domain, email, DNS provider, CA provider
+2. Validate inputs (domain format, email, provider existence)
+3. Get CA config (ACME URL, EAB credentials if DigiCert)
+4. Get DNS config (account credentials from settings)
+5. Create directory: certificates/{domain}/
+6. Build certbot command:
+   certbot certonly --non-interactive --agree-tos
+     --server {acme_url}
+     --email {email}
+     --{dns_plugin} --{dns_plugin}-credentials {cred_file}
+     --{dns_plugin}-propagation-seconds {timeout}
+     --eab-kid/--eab-hmac-key (if required)
+     -d {domain}
+7. Create temporary DNS credentials file (600 permissions)
+8. Execute certbot (30-minute timeout)
+9. Resolve symlinks, copy cert files to domain root
+10. Store via configured backend + create metadata.json
+11. Clean up credentials file
+```
+
+### Certificados de cliente (mediante CA privada)
+
+```
+1. User submits: common_name, email, organization, cert_usage
+2. Initialize or load existing CA (4096-bit RSA)
+3. Generate CSR (or accept provided CSR)
+4. Sign CSR with private CA
+5. Store cert/key/csr files + metadata.json
+6. Log in audit trail
+```
+
+---
+
+## Arquitectura de almacenamiento
+
+### Certificados de servidor
+
+```
+certificates/
+  example.com/
+    cert.pem          # Server certificate
+    chain.pem         # Intermediate CA chain
+    fullchain.pem     # cert + chain
+    privkey.pem       # Private key (600 permissions)
+    metadata.json     # Certificate metadata
+```
+
+### Certificados de cliente
+
+```
+data/certs/
+  ca/
+    ca.crt            # CA certificate
+    ca.key            # CA private key (600 permissions)
+    ca_metadata.json  # CA metadata
+    crl.pem           # Certificate Revocation List
+  client/
+    api-mtls/         # Certificates by usage type
+      cert-001/
+        cert.crt
+        cert.key
+        cert.csr
+        metadata.json
+    vpn/
+      cert-002/
+        ...
+```
+
+### Backends de almacenamiento
+
+Todos los backends implementan `CertificateStorageBackend`:
+
+| Backend | Ubicación de almacenamiento |
+|---------|----------------------------|
+| **Sistema de archivos local** | `certificates/{domain}/` (por defecto) |
+| **Azure Key Vault** | Secrets, objetos Certificate nativos, o ambos — véase más abajo |
+| **AWS Secrets Manager** | AWS Secrets Manager |
+| **HashiCorp Vault** | Vault KV v1/v2 |
+| **Infisical** | Secrets de Infisical |
+
+#### Azure Key Vault — modos de almacenamiento
+
+El backend de Azure Key Vault puede persistir los certificados como Secrets (por defecto), como objetos Certificate nativos, o ambos, controlado por `certificate_storage.azure_keyvault.storage_mode` en `settings.json`.
+
+| Modo | Escribe Secrets | Escribe objeto Certificate | Cuándo usarlo |
+|---|---|---|---|
+| `secrets` (por defecto) | sí | no | Comportamiento retrocompatible. Cada `cert.pem` / `chain.pem` / `fullchain.pem` / `privkey.pem` y los metadatos se almacenan como Secrets independientes en Key Vault. |
+| `certificate` | no | sí | Vincula directamente desde App Service, Application Gateway, Front Door, API Management, AKS Ingress, etc. El certificado + cadena + clave privada se importan como un único objeto `Certificate` PKCS12 con `issuer_name="Unknown"` para que Key Vault no intente renovarlo. |
+| `both` | sí | sí | Configuraciones transitorias o con consumidores mixtos. Las lecturas prefieren siempre la ruta de Secrets (más económica). |
+
+Una acción manual **Backfill Certificate objects** en el panel de ajustes de almacenamiento (`POST /api/storage/azure-keyvault/backfill-certificates`) importa un objeto Certificate para cada dominio que ya existe en el vault como Secret pero aún no tiene uno. Los objetos Certificate existentes se omiten. El endpoint acepta un parámetro de consulta opcional `?limit=N` para limitar el número de dominios procesados por llamada; los vaults grandes pueden paginar llamando repetidamente hasta que la respuesta indique `0` restantes.
+
+##### Nota de seguridad — los objetos Certificate exponen la clave privada a través de la API Secrets
+
+Cuando Key Vault importa un objeto Certificate PKCS12, también crea un **Secret** asociado con el mismo nombre cuyo valor es el PFX completo (incluida la clave privada). Esto es deliberado en Azure: es la forma documentada para que las extensiones de VM y App Service consuman el certificado, y cualquier principal con `Secrets/Get` en el vault puede por tanto descargar la clave privada — *el permiso `Get` sobre Certificates por sí solo no es suficiente para extraer la clave privada, pero `Secrets/Get` sí lo es*. Los operadores que ejecuten CertMate en modo `certificate` o `both` deben restringir `Secrets/Get` con cuidado y preferir Azure RBAC sobre las directivas de acceso al vault para un control más granular. Véase [Microsoft Learn — Certificados en Key Vault](https://learn.microsoft.com/azure/key-vault/certificates/about-certificates) para el modelo completo.
+
+##### Permisos del Service Principal
+
+| Modo | Permisos requeridos en el vault |
+|---|---|
+| `secrets` | Secrets `Get/Set/List/Delete` |
+| `certificate` / `both` | Añade Certificates `Get/List/Import/Delete` y conserva Secrets `Get/List` (Key Vault expone el PFX importado, incluida la clave privada, únicamente a través del Secret con el mismo nombre que el objeto Certificate). |
+
+---
+
+## Estructura de configuración
+
+Todos los ajustes se almacenan en `data/settings.json`:
+
+```json
+{
+  "email": "admin@example.com",
+  "domains": ["example.com", "*.example.com"],
+  "auto_renew": true,
+  "renewal_threshold_days": 30,
+  "api_bearer_token": "secure-token",
+  "dns_provider": "cloudflare",
+  "dns_providers": {
+    "cloudflare": {
+      "accounts": {
+        "production": {"api_token": "token-prod"},
+        "staging": {"api_token": "token-staging"}
+      }
+    }
+  },
+  "default_accounts": {
+    "cloudflare": "production"
+  },
+  "ca_providers": {
+    "letsencrypt": {
+      "accounts": {
+        "default": {"email": "admin@example.com"}
+      }
+    }
+  },
+  "certificate_storage": {
+    "backend": "local_filesystem",
+    "cert_dir": "certificates"
+  },
+  "default_key_type": "rsa",
+  "default_key_size": 2048,
+  "default_elliptic_curve": "secp256r1"
+}
+```
+
+### Tipo/tamaño de clave del certificado
+
+Tres claves de primer nivel controlan la forma de la clave pública de los certificados recién emitidos:
+
+| Clave | Valores | Se aplica cuando |
+|---|---|---|
+| `default_key_type` | `rsa` (por defecto) / `ecdsa` | siempre |
+| `default_key_size` | `2048` (por defecto) / `3072` / `4096` | `default_key_type == "rsa"` |
+| `default_elliptic_curve` | `secp256r1` (por defecto) / `secp384r1` | `default_key_type == "ecdsa"` |
+
+Se admite una sobreescritura por certificado: cada entrada en `domains` puede llevar un `key_type` opcional más `key_size` (RSA) o `elliptic_curve` (ECDSA). Cuando la sobreescritura está presente tiene prioridad; en caso contrario se aplica el valor global por defecto. Los valores por defecto `rsa`/`2048` reflejan el valor implícito de certbot que CertMate emitía antes de que existiera este ajuste, por lo que las instalaciones actualizadas no verán ningún cambio a menos que el operador elija otro valor.
+
+Las renovaciones siempre preservan la forma que estaba en vigor en el momento de la creación: certbot persiste `--key-type`, `--rsa-key-size` y `--elliptic-curve` en su propio `renewal/<domain>.conf` durante la primera emisión, y `certbot renew --cert-name <domain>` reutiliza esos valores automáticamente.
+
+---
+
+## Endpoints API
+
+### Certificados de servidor
+
+| Método | Endpoint | Propósito |
+|--------|----------|-----------|
+| GET | `/api/health` | Comprobación de salud |
+| GET | `/api/certificates` | Listar todos los certificados |
+| POST | `/api/certificates` | Crear nuevo certificado |
+| GET | `/api/certificates/{domain}` | Obtener información del certificado |
+| POST | `/api/certificates/{domain}/renew` | Renovar certificado |
+| GET | `/api/certificates/{domain}/download` | Descargar como ZIP |
+| GET | `/{domain}/tls` | Descarga directa de fullchain |
+
+### Certificados de cliente
+
+| Método | Endpoint | Propósito |
+|--------|----------|-----------|
+| POST | `/api/client-certs/create` | Crear certificado |
+| GET | `/api/client-certs` | Listar con filtros |
+| GET | `/api/client-certs/{id}` | Obtener metadatos |
+| GET | `/api/client-certs/{id}/download/{type}` | Descargar cert/clave/csr |
+| POST | `/api/client-certs/{id}/revoke` | Revocar certificado |
+| POST | `/api/client-certs/{id}/renew` | Renovar certificado |
+| GET | `/api/client-certs/stats` | Estadísticas |
+| POST | `/api/client-certs/batch` | Importación CSV por lotes |
+| GET | `/api/ocsp/status/{serial}` | Estado OCSP |
+| GET | `/api/crl/download/{format}` | Descargar CRL |
+
+---
+
+## Pila tecnológica
+
+| Capa | Tecnologías |
+|------|-------------|
+| **Backend** | Python 3.9+, Flask, Flask-RESTX, APScheduler, Certbot |
+| **Frontend** | HTML5, Tailwind CSS, Vanilla JavaScript, Font Awesome |
+| **SDKs Cloud** | Azure SDK, boto3, hvac, infisical-python |
+| **Criptografía** | cryptography (OpenSSL), plugins de certbot |
+| **Despliegue** | Docker, Docker Compose, Gunicorn, systemd |
+
+---
+
+## Limitaciones principales
+
+1. **Solo Certbot para certificados de servidor**: únicamente desafíos DNS-01 ACME
+2. **Almacenamiento de servidor centrado en el dominio**: un certificado por directorio de dominio
+3. **Sin base de datos**: un único archivo JSON para la configuración
+4. **Uso de claves en certificados de servidor**: sin control sobre las extensiones keyUsage/extendedKeyUsage
+
+---
+
+# Arquitectura de certificados de cliente
+
+## Descripción general del sistema
+
+```
+
+ Web UI Layer 
+ (/client-certificates web dashboard) 
+
+ 
+ API Layer 
+ (/api/client-certs, /api/ocsp, /api/crl) 
+ (REST endpoints with Flask-RESTX) 
+
+ 
+ Managers Layer 
+ 
+ ClientCertificateManager (lifecycle + metadata) 
+ OCSPResponder (certificate status queries) 
+ CRLManager (revocation list generation) 
+ AuditLogger (operation tracking) 
+ SimpleRateLimiter (request throttling) 
+ 
+
+ 
+ Core Modules Layer 
+ 
+ PrivateCAGenerator (CA management) 
+ CSRHandler (CSR validation & creation) 
+ ClientCertificateManager (cert operations) 
+ OCSPResponder (status responses) 
+ CRLManager (revocation lists) 
+ AuditLogger (logging) 
+ RateLimitConfig/SimpleRateLimiter (limiting) 
+ 
+
+ 
+ Cryptography & Storage Layer 
+ 
+ Cryptography Library (OpenSSL) 
+ File System Storage (data/certs/) 
+ Storage Backends (Azure, AWS, Vault, etc) 
+ 
+
+```
+
+---
+
+## Componentes principales
+
+### 1. PrivateCAGenerator (`modules/core/private_ca.py`)
+
+**Propósito**: Generar y gestionar la Autoridad de Certificación autofirmada
+
+**Características clave**:
+- Genera claves RSA de 4096 bits para la CA
+- Período de validez de 10 años
+- Certificados autofirmados con las extensiones adecuadas
+- Funcionalidad de copia de seguridad y restauración de la CA
+- Capacidad de firma de CRL
+
+**Archivos creados**:
+- `data/certs/ca/ca.crt` — Certificado CA (PEM)
+- `data/certs/ca/ca.key` — Clave privada CA (PEM, permisos 0600)
+- `data/certs/ca/ca_metadata.json` — Metadatos CA
+- `data/certs/ca/crl.pem` — Lista de revocación de certificados
+
+**Métodos principales**:
+```python
+initialize() # Inicializar o cargar la CA existente
+sign_certificate_request() # Firmar un CSR
+generate_crl() # Generar CRL a partir de números de serie revocados
+get_crl_pem() # Obtener la CRL en formato PEM
+```
+
+---
+
+### 2. CSRHandler (`modules/core/csr_handler.py`)
+
+**Propósito**: Validar, analizar y crear solicitudes de firma de certificado
+
+**Características clave**:
+- Crear nuevos CSR con claves privadas (2048 o 4096 bits)
+- Validar CSR codificados en PEM
+- Extraer información del CSR (CN, Org, Email, SAN, etc.)
+- Soporte para Subject Alternative Names (SAN)
+- Guardar el CSR y los pares de claves en disco
+
+**Métodos principales**:
+```python
+create_csr() # Crear nuevo CSR con clave privada
+validate_csr_pem() # Validar y cargar CSR desde PEM
+get_csr_info() # Extraer información de un CSR
+save_csr_and_key() # Guardar CSR y clave en archivos
+```
+
+---
+
+### 3. ClientCertificateManager (`modules/core/client_certificates.py`)
+
+**Propósito**: Gestión completa del ciclo de vida de los certificados de cliente
+
+**Características clave**:
+- Crear certificados (firmados por CA o mediante CSR)
+- Listar/filtrar certificados (por uso, estado, búsqueda)
+- Revocar certificados con registro de auditoría
+- Renovar certificados (mismo CN, nuevo número de serie)
+- Planificación de renovación automática
+- Almacenamiento de metadatos (JSON por certificado)
+- Soporte para 30 000+ certificados simultáneos
+
+**Estructura de almacenamiento**:
+```
+data/certs/client/
+ api-mtls/ # Certificates for API mTLS
+ cert-001/
+ cert.crt
+ cert.key
+ cert.csr
+ metadata.json
+ vpn/ # Certificates for VPN
+ cert-002/
+ ...
+ other/ # Other usage types
+ ...
+```
+
+**Estructura de metadatos** (JSON):
+```json
+{
+ "type": "client_certificate",
+ "identifier": "cert-001",
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "organizational_unit": "Engineering",
+ "country": "US",
+ "state": "California",
+ "locality": "San Francisco",
+ "serial_number": "12345678901234567890",
+ "key_usage": ["digitalSignature", "keyEncipherment"],
+ "extended_key_usage": ["serverAuth", "clientAuth"],
+ "created_at": "2024-10-30T18:00:00Z",
+ "expires_at": "2025-10-30T18:00:00Z",
+ "cert_usage": "api-mtls",
+ "notes": "Production certificate",
+ "revocation": {
+ "revoked": false,
+ "revoked_at": null,
+ "reason_revoked": null
+ },
+ "renewal": {
+ "renewal_enabled": true,
+ "renewal_threshold_days": 30,
+ "last_renewed_at": null
+ }
+}
+```
+
+**Métodos principales**:
+```python
+create_client_certificate() # Crear nuevo certificado
+list_client_certificates() # Listar con filtros opcionales
+get_certificate_metadata() # Obtener metadatos del certificado
+get_certificate_file() # Obtener archivo cert/clave/csr
+revoke_certificate() # Revocar con motivo
+renew_certificate() # Renovar certificado
+check_renewals() # Comprobación de renovaciones automáticas
+get_statistics() # Obtener estadísticas de uso
+```
+
+---
+
+### 4. OCSPResponder (`modules/core/ocsp_crl.py`)
+
+**Propósito**: Proporcionar respuestas al protocolo de estado de certificado en línea (OCSP)
+
+**Características clave**:
+- Consultar el estado de un certificado (good/revoked/unknown)
+- Generar respuestas OCSP
+- Consultas de estado en tiempo real
+- Soporte para múltiples tipos de estado
+
+**Estados**:
+- `good` — El certificado es válido
+- `revoked` — El certificado ha sido revocado
+- `unknown` — Certificado no encontrado
+
+**Métodos principales**:
+```python
+get_cert_status() # Obtener el estado del certificado
+generate_ocsp_response() # Generar respuesta OCSP
+```
+
+**Formato de respuesta**:
+```json
+{
+ "response_status": "successful",
+ "certificate_status": "good|revoked|unknown",
+ "certificate_serial": 12345678,
+ "this_update": "2024-10-30T18:00:00Z",
+ "next_update": null,
+ "responder_name": "CertMate OCSP Responder",
+ "revocation_time": null,
+ "revocation_reason": null
+}
+```
+
+---
+
+### 5. CRLManager (`modules/core/ocsp_crl.py`)
+
+**Propósito**: Generar y distribuir listas de revocación de certificados
+
+**Características clave**:
+- Generar la CRL con todos los certificados revocados
+- Distribuir en formatos PEM y DER
+- Almacenar metadatos e información de la CRL
+- Actualizaciones automáticas de la CRL
+
+**Métodos principales**:
+```python
+get_revoked_serials() # Obtener números de serie de certificados revocados
+update_crl() # Generar/actualizar la CRL
+get_crl_pem() # Obtener la CRL en formato PEM
+get_crl_der() # Obtener la CRL en formato DER
+get_crl_info() # Obtener metadatos de la CRL
+```
+
+---
+
+### 6. AuditLogger (`modules/core/audit.py`)
+
+**Propósito**: Registrar todas las operaciones sobre certificados para cumplimiento normativo y depuración
+
+**Características clave**:
+- Registro en formato JSON
+- Archivo de auditoría persistente
+- Seguimiento de operaciones, usuarios y direcciones IP
+- Consulta de entradas por recurso o período de tiempo
+
+**Formato del registro**:
+```json
+{
+ "timestamp": "2024-10-30T18:00:00Z",
+ "operation": "create|revoke|renew|download|batch_import",
+ "resource_type": "certificate|endpoint",
+ "resource_id": "cert-001",
+ "status": "success|failure|denied",
+ "user": "admin@example.com",
+ "ip_address": "192.168.1.1",
+ "details": {},
+ "error": null
+}
+```
+
+**Archivo de registro**: `logs/audit/certificate_audit.log`
+
+**Métodos principales**:
+```python
+log_certificate_created() # Registrar la creación de certificado
+log_certificate_revoked() # Registrar la revocación
+log_certificate_renewed() # Registrar la renovación
+log_certificate_downloaded() # Registrar las descargas
+log_batch_operation() # Registrar operaciones por lotes
+log_api_request() # Registrar peticiones API
+get_recent_entries() # Obtener las últimas entradas de auditoría
+get_entries_by_resource() # Obtener entradas para un recurso
+```
+
+---
+
+### 7. Limitación de tasa (`modules/core/rate_limit.py`)
+
+**Propósito**: Proteger la API contra abusos con limitación de la tasa de peticiones
+
+**Configuración**:
+- Por defecto: 100 req/min
+- Creación de certificado: 30 req/min (costoso)
+- Operaciones por lotes: 10 req/min (muy costoso)
+- Estado OCSP: 200 req/min (económico)
+- Descarga CRL: 60 req/min
+
+**Clases principales**:
+```python
+RateLimitConfig # Contenedor de configuración
+SimpleRateLimiter # Limitador en memoria
+rate_limit_decorator # Decorador de endpoint Flask
+```
+
+**Respuesta al superar el límite**:
+```json
+{
+ "error": "Rate limit exceeded",
+ "message": "Too many requests. Please try again later.",
+ "retry_after": 60
+}
+```
+
+Estado HTTP: `429 Too Many Requests`
+
+---
+
+## Flujo de datos
+
+### Flujo de creación de certificados
+
+```
+User/API Request
+ ↓
+ClientCertificateManager.create_client_certificate()
+ Generate CSR (or accept provided CSR)
+ Sign CSR with private CA
+ Create metadata.json
+ Store cert/key/csr files
+ Log in audit trail
+ Return cert data
+ ↓
+Response to User
+```
+
+### Flujo de revocación de certificados
+
+```
+User/API Request (revoke endpoint)
+ ↓
+ClientCertificateManager.revoke_certificate()
+ Load certificate metadata
+ Update revocation status
+ Save updated metadata
+ Log in audit trail
+ Trigger CRL update
+ Return success
+ ↓
+Response to User
+```
+
+### Flujo de consulta OCSP
+
+```
+Client OCSP Request (serial number)
+ ↓
+OCSPResponder.get_cert_status()
+ Search certificate by serial
+ Check revocation status
+ Return status (good/revoked/unknown)
+ ↓
+OCSPResponder.generate_ocsp_response()
+ Format OCSP response
+ Add timestamps
+ Return response
+ ↓
+Response to Client
+```
+
+---
+
+## Arquitectura de almacenamiento
+
+### Estructura de directorios
+
+```
+data/certs/
+ ca/ # Certificate Authority
+ ca.crt # CA certificate (public)
+ ca.key # CA private key (0600)
+ ca_metadata.json # CA metadata
+ crl.pem # Certificate Revocation List
+
+ client/ # Client certificates
+ api-mtls/ # API mTLS certificates
+ cert-001/
+ cert.crt
+ cert.key
+ cert.csr
+ metadata.json
+ ...
+ vpn/ # VPN certificates
+ ...
+ other/ # Other usage types
+ ...
+
+ crl/ # CRL storage
+ (generated CRLs)
+```
+
+### Archivos de metadatos
+
+Cada certificado tiene un archivo `metadata.json` que contiene:
+- Identificación del certificado (CN, número de serie, huella digital)
+- Información del sujeto (Org, email, ubicación)
+- Fechas de validez
+- Estado e historial de revocación
+- Configuración de renovación
+- Notas personalizadas
+
+---
+
+## Modelo de seguridad
+
+### Protección de claves
+
+- **Permisos de archivos**: 0600 (lectura/escritura solo para el propietario)
+- **Formato de claves**: PEM en formato tradicional OpenSSL
+- **Sin cifrado de claves en texto plano**: las claves se almacenan cifradas en reposo cuando se usan backends de almacenamiento
+
+### Firma de certificados
+
+- **Algoritmo de firma**: SHA256withRSA
+- **Tamaño de clave**: RSA de 4096 bits para la CA, 2048/4096 bits para clientes
+- **Validez**: configurable (por defecto 1 año para certificados de cliente)
+
+### Control de acceso
+
+- **Autenticación**: Bearer token en todos los endpoints API
+- **Autorización**: basada en tokens (puede ampliarse con roles)
+- **Limitación de tasa**: protección por endpoint
+
+### Registro de auditoría
+
+- Todas las operaciones registradas con marca de tiempo
+- Seguimiento del usuario y la dirección IP
+- Archivo de registro de auditoría inmutable
+- Consultable para cumplimiento normativo
+
+---
+
+## Escalabilidad
+
+### Almacenamiento de certificados
+
+- **Escalabilidad lineal**: almacenamiento basado en directorios
+- **Capacidad**: probado con 30 000+ certificados
+- **Rendimiento**: análisis de directorios O(n) eficientes
+
+### Rendimiento de la API
+
+- **Limitación de tasa**: evita el agotamiento de recursos
+- **Diseño sin estado**: puede ejecutar múltiples instancias
+- **Operaciones por lotes**: gestiona de 100 a 30 000 certificados por petición
+
+### Renovación automática
+
+- **Programada**: diariamente a las 3 AM (configurable)
+- **Umbral**: 30 días antes de la caducidad (configurable)
+- **Tolerante a fallos**: continúa en caso de errores y registra para revisión
+
+---
+
+## Consideraciones de despliegue
+
+### Requisitos mínimos
+
+- Python 3.9+
+- 100 MB de espacio en disco para la CA y los certificados iniciales
+- 50 MB para los registros de auditoría por cada millón de operaciones
+- Huella de memoria reducida
+
+### Recomendaciones para producción
+
+- Usar un backend de almacenamiento (Azure, AWS, Vault) para alta disponibilidad
+- Habilitar el registro de auditoría para cumplimiento normativo
+- Configurar la limitación de tasa en función de la carga
+- Actualizaciones regulares de la CRL (diarias o en cada revocación)
+- Hacer copia de seguridad de las claves CA y los metadatos
+- Monitorizar los registros de auditoría en busca de actividad sospechosa
+
+### Alta disponibilidad
+
+Para despliegues multi-instancia:
+1. Usar un backend de almacenamiento compartido para los certificados
+2. Sincronizar los registros de auditoría en una ubicación central
+3. Usar un balanceador de carga con sesiones persistentes
+4. Monitorizar los contadores de limitación de tasa entre instancias
+
+---
+
+## Puntos de integración
+
+### Con el sistema principal de CertMate
+
+- Usa los backends de almacenamiento existentes de CertMate
+- Integrado en los managers de app.py
+- Parte de la estructura API de Flask-RESTX
+- Programado con APScheduler
+
+### Sistemas externos
+
+- Puede exportar certificados a través de la API
+- Puede consultar el estado mediante OCSP
+- Puede recuperar la CRL para validación
+- Admite integración mediante webhook/callback (futuro)
+
+---
+
+## Extensibilidad futura
+
+### Mejoras planificadas
+
+1. **Protección con contraseña de la CA** — Cifrar las claves CA con contraseña
+2. **Auditoría avanzada** — Control de acceso basado en roles
+3. **Notificaciones Webhook** — En eventos de certificados
+4. **Firma de certificados** — Aceptar CSR de fuentes externas
+5. **Tokens hardware** — Soporte PKCS#11 para HSM
+
+### Puntos de extensión
+
+1. **Backends de almacenamiento** — Ya admite múltiples backends
+2. **Destinos de auditoría** — Puede enviar registros de auditoría a sistemas externos
+3. **Middleware API** — Añadir autenticación/autorización personalizada
+4. **Sistema de notificaciones** — Integración con sistemas de alertas
+
+---
+
+## Monitorización y observabilidad
+
+### Métricas clave
+
+- Recuento de certificados (total, activos, revocados, próximos a caducar)
+- Rendimiento de los endpoints API
+- Infracciones de límite de tasa
+- Volumen de registros de auditoría
+- Tasa de éxito/fallo de las renovaciones automáticas
+
+### Comprobaciones de salud
+
+- Disponibilidad de la CA
+- Funcionamiento del registro de auditoría
+- Capacidad de respuesta del limitador de tasa
+- Estado de generación de la CRL
+
+---
+
+<div align="center">
+
+[← Volver a la documentación](./README.md) • [Inicio rápido →](./guide.md) • [Referencia API →](./api.md)
+
+</div>

--- a/docs/es/ca-providers.md
+++ b/docs/es/ca-providers.md
@@ -1,0 +1,259 @@
+# Proveedores de autoridad de certificación (CA)
+
+CertMate soporta múltiples proveedores de autoridad de certificación, permitiéndote elegir la CA más adecuada a tus necesidades.
+
+---
+
+## Proveedores CA soportados
+
+### Let's Encrypt (predeterminado)
+
+- **Tipo**: Certificados SSL gratuitos y automatizados
+- **Tipos de certificados**: Domain Validation (DV)
+- **Soporte Wildcard**: Sí
+- **EAB requerido**: No
+- **Ideal para**: Desarrollo, pequeñas empresas, proyectos personales
+
+**Configuración:**
+- **Email**: Requerido para las notificaciones de certificado
+
+### Let's Encrypt (Staging)
+
+- **Tipo**: Certificados de prueba del entorno de staging de Let's Encrypt
+- **Tipos de certificados**: Domain Validation (DV) — NO reconocidos por los navegadores
+- **Soporte Wildcard**: Sí
+- **EAB requerido**: No
+- **Ideal para**: Validar la configuración DNS, el despliegue y la renovación sin consumir los límites de producción
+
+El staging es una entrada de autoridad de certificación independiente (desde v2.12.0), no un indicador por certificado: selecciónala como CA al crear un certificado, o establécela como CA predeterminada durante las pruebas. El email recurre al de la cuenta de Let's Encrypt cuando se deja vacío. Convertir un certificado de staging a producción requiere una reemisión con la CA de producción.
+
+### DigiCert ACME
+
+- **Tipo**: Certificados SSL de nivel empresarial
+- **Tipos de certificados**: DV, OV, EV
+- **Soporte Wildcard**: Sí
+- **EAB requerido**: Sí
+- **Ideal para**: Entornos empresariales, aplicaciones comerciales
+
+**Requisitos de configuración:**
+- **URL del directorio ACME**: `https://acme.digicert.com/v2/acme/directory`
+- **EAB Key ID**: Proporcionado por DigiCert
+- **EAB HMAC Key**: Proporcionada por DigiCert
+- **Email**: Requerido para las notificaciones de certificado
+
+### Actalis
+
+- **Tipo**: Certificados DV gratuitos de 90 días de una CA europea (italiana)
+- **Tipos de certificados**: Domain Validation (DV)
+- **Soporte Wildcard**: No (no disponible vía ACME)
+- **EAB requerido**: Sí
+- **Ideal para**: Usuarios de la UE que buscan una alternativa europea a Let's Encrypt, entornos del ecosistema eIDAS
+
+**Requisitos de configuración:**
+- **URL del directorio ACME**: `https://acme-api.actalis.com/acme/directory` (fija, preconfigurada)
+- **EAB Key ID**: Desde tu área de cliente de Actalis
+- **EAB HMAC Key**: Desde tu área de cliente de Actalis
+- **Email**: Requerido para las notificaciones de certificado
+
+**Límites del plan gratuito:**
+- Solo certificados de dominio único — una solicitud con entradas SAN es rechazada con
+  `Your account only grants single-domain 90-days DV certificates`
+- Validez de 90 días
+- Sin certificados wildcard (los planes SAN de pago cubren hasta 5 nombres de host)
+
+### CA privada
+
+- **Tipo**: Autoridad de certificación interna/corporativa
+- **Tipos de certificados**: Privados/Internos
+- **Soporte Wildcard**: Sí (depende de la implementación de la CA)
+- **EAB requerido**: Opcional
+- **Ideal para**: Redes internas, entornos corporativos, sistemas aislados
+
+**Software compatible:**
+- [step-ca](https://smallstep.com/docs/step-ca/)
+- [Boulder](https://github.com/letsencrypt/boulder)
+- [Pebble](https://github.com/letsencrypt/pebble)
+- Otras CAs privadas compatibles con ACME
+
+**Uso de una CA pública ACME a través de la entrada CA privada:**
+
+La entrada CA privada es también la vía de escape genérica para cualquier CA ACME sin una entrada dedicada en CertMate: apúntala a la URL del directorio de la CA y, si la CA exige vinculación de cuenta, rellena el EAB Key ID y HMAC Key opcionales. Por ejemplo, Actalis funciona tanto a través de su entrada dedicada (recomendado) como como CA privada con:
+
+- **URL del directorio ACME**: `https://acme-api.actalis.com/acme/directory`
+- **EAB Key ID / HMAC Key**: desde el área de cliente de Actalis
+- **Certificado CA**: dejar vacío (raíces de confianza pública)
+
+---
+
+## Configuración
+
+### Mediante la interfaz web
+
+1. Ve a **Ajustes**
+2. Desplázate hasta **Proveedores de autoridad de certificación (CA)**
+3. Selecciona tu proveedor CA predeterminado
+4. Configura los campos requeridos
+5. Haz clic en **Probar conexión CA** para verificar
+6. Guarda los ajustes
+
+### CA predeterminada vs. CA por certificado
+
+Establece una CA predeterminada para todos los nuevos certificados. Puedes sobrescribirla por certificado durante la creación:
+
+1. Ve a la página **Certificados**
+2. Selecciona la CA deseada en el desplegable **Autoridad de certificación**
+3. Continúa con la creación del certificado
+
+### Mediante la API
+
+```bash
+# Create certificate with specific CA
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "domain": "example.com",
+    "ca_provider": "digicert"
+  }'
+
+# Test CA connection
+curl -X POST http://localhost:8000/api/settings/test-ca-provider \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ca_provider": "digicert",
+    "config": {
+      "acme_url": "https://acme.digicert.com/v2/acme/directory",
+      "eab_kid": "your_key_id",
+      "eab_hmac": "your_hmac_key",
+      "email": "admin@example.com"
+    }
+  }'
+```
+
+---
+
+## External Account Binding (EAB)
+
+Algunos proveedores CA (como DigiCert y Actalis) requieren External Account Binding para vincular tu cliente ACME a tu cuenta de CA.
+
+### ¿Qué es EAB?
+
+- **Key ID**: Un identificador único para tu cuenta
+- **HMAC Key**: Una clave secreta utilizada para firmar las solicitudes
+
+### Obtener credenciales EAB
+
+**DigiCert:**
+1. Inicia sesión en tu cuenta de DigiCert
+2. Ve a los ajustes ACME
+3. Genera o recupera tu EAB Key ID y HMAC Key
+
+**Actalis:**
+1. Registra una cuenta gratuita en [actalis.com](https://www.actalis.com/)
+2. En el área de cliente, abre **Manage with ACME**
+3. Recupera el KID y la clave HMAC en **ACME Credentials**
+
+**CA privada:**
+- **step-ca**: EAB puede habilitarse/deshabilitarse por provisioner
+- **Boulder**: Generalmente requiere EAB para producción
+- Consulta la documentación de tu CA privada para los requisitos específicos
+
+---
+
+## Confianza del certificado SSL
+
+### CAs públicas (Let's Encrypt, DigiCert)
+
+Los certificados son reconocidos automáticamente por los navegadores y sistemas operativos.
+
+### CAs privadas
+
+Para que los certificados de CA privada sean reconocidos:
+1. Instala el certificado raíz de la CA en los sistemas cliente
+2. Configura las aplicaciones para una confianza personalizada
+3. Importa el certificado raíz en los almacenes de confianza de los navegadores
+
+Opcionalmente puedes proporcionar el certificado raíz de la CA en CertMate para la verificación de la cadena de confianza durante la creación del certificado.
+
+---
+
+## Resolución de problemas
+
+### Let's Encrypt
+- **Certificado no reconocido tras la emisión**: Comprueba si el certificado fue emitido por la CA de staging — selecciona la entrada de producción "Let's Encrypt" y vuelve a emitir
+- **Límite de peticiones alcanzado**: Cambia a la entrada CA "Let's Encrypt (Staging)" durante las pruebas
+- **Email válido**: Asegúrate de que el formato del email es correcto
+
+### DigiCert
+- **Credenciales EAB inválidas**: Verifica la Key ID y la HMAC Key
+- **Cuenta no autorizada**: Asegúrate de que ACME está habilitado en tu cuenta de DigiCert
+- **URL ACME incorrecta**: Verifica la URL del directorio con el soporte de DigiCert
+
+### Actalis
+- **`Your account only grants single-domain 90-days DV certificates`**: El plan gratuito rechaza las solicitudes SAN/multi-dominio — emite un certificado por nombre de host o actualiza el plan
+- **Credenciales EAB inválidas**: Recupera credenciales nuevas desde el área de cliente en Manage with ACME
+- **Wildcard rechazado**: Los certificados wildcard no están disponibles vía ACME en Actalis
+
+### CA privada
+- **URL ACME inaccesible**: Comprueba la conectividad de red
+- **Certificado CA inválido**: Verifica el formato PEM y la validez
+- **EAB mismatch**: Comprueba si EAB es requerido por tu CA
+
+### General
+- Asegúrate de que el proveedor DNS está correctamente configurado
+- Verifica la propiedad del dominio y la propagación DNS
+- Comprueba las reglas del firewall para el puerto ACME (normalmente 443)
+
+---
+
+## Migración entre CAs
+
+1. **Los nuevos certificados** utilizan la nueva CA predeterminada
+2. **Los certificados existentes** continúan usando su CA original hasta la renovación
+3. **Migración forzada**: Renueva manualmente para cambiar a la nueva CA
+
+**Buenas prácticas:**
+- Prueba la nueva configuración de CA antes de establecerla como predeterminada
+- Planifica la migración durante ventanas de mantenimiento
+- Mantén copias de seguridad de los certificados existentes
+- Monitoriza la validez tras la migración
+
+---
+
+## Consideraciones de seguridad
+
+- Las claves HMAC EAB no se muestran tras guardar
+- Las claves privadas se generan localmente y nunca se transmiten
+- Usa HTTPS para todas las comunicaciones con la CA
+- Considera el uso de VPN para el acceso a la CA privada
+
+---
+
+## Recursos
+
+### Let's Encrypt
+- [Documentación](https://letsencrypt.org/docs/)
+- [Límites de peticiones](https://letsencrypt.org/docs/rate-limits/)
+- [Entorno de staging](https://letsencrypt.org/docs/staging-environment/)
+
+### DigiCert
+- [Documentación ACME](https://docs.digicert.com/certificate-tools/acme-user-guide/)
+- [Configuración de cuenta](https://docs.digicert.com/certificate-tools/acme-user-guide/acme-account-setup/)
+
+### Actalis
+- [Cómo habilitar ACME](https://guide.actalis.com/ssl/activation/acme)
+- [FAQ ACME](https://guide.actalis.com/faq/SSL/ACME)
+
+### CA privada
+- [Documentación de step-ca](https://smallstep.com/docs/step-ca/)
+- [Proyecto Boulder](https://github.com/letsencrypt/boulder)
+- [Servidor de prueba Pebble](https://github.com/letsencrypt/pebble)
+
+---
+
+<div align="center">
+
+[← Volver a la documentación](./README.md) • [Proveedores DNS →](./dns-providers.md) • [Docker →](./docker.md)
+
+</div>

--- a/docs/es/compliance.md
+++ b/docs/es/compliance.md
@@ -1,0 +1,53 @@
+# Cumplimiento normativo y pista de auditoría
+
+Esta página relaciona la pista de auditoría de CertMate con los regímenes que los operadores consultan con mayor frecuencia — el AI Act de la UE, NIS2 y la ISO/IEC 42001 — cuando permiten que un agente IA/MCP gestione certificados de forma programada.
+
+> **Lea esto primero.** CertMate es una herramienta MIT auto-alojada mono-instancia. **No** es un sistema de IA, **no** es un sistema de IA de alto riesgo, **no** es una entidad regulada, y no «cumple» ni «certifica» nada. Las obligaciones de cumplimiento recaen sobre el **operador** que lo ejecuta. Lo que CertMate proporciona son **artefactos de evidencia** que un operador puede utilizar para *sus propias* obligaciones. Cada afirmación a continuación significa «permite al operador evidenciar X», con los límites indicados de forma explícita.
+
+---
+
+## Qué proporciona la pista de auditoría hoy
+
+- **Atribución.** Cada acción del ciclo de vida de los certificados — creación, renovación, reemisión, deploy, activación/desactivación de la renovación automática y renovaciones programadas no supervisadas — queda registrada con un `actor` estructurado (humano vs token de API vs agente IA, hasta el ID de la clave de API) y un `trigger` (manual, API, agente o job del planificador). Las acciones de un agente IA son distinguibles de las de un humano, siempre que el agente utilice una clave marcada como `is_agent`. Véase [API: Audit Logging](./api.md#audit-logging) y la [guía MCP](./mcp.md#audit-attribution).
+- **Prueba de integridad.** Las entradas se escriben en una cadena de hash SHA-256 de solo anexado (`data/audit/certificate_audit.chain.jsonl`). Cualquier modificación, eliminación o reordenamiento por parte de alguien que no pueda recalcular la cadena es detectable y localizable.
+- **Verificación independiente.** Un verificador autónomo (`python -m modules.core.audit_verify`) recalcula la cadena y devuelve PASS/FAIL sin necesidad de ejecutar ni confiar en CertMate; `GET /api/audit/verify` expone la misma comprobación a través de la API.
+- **Exportación firmada verificable por terceros.** La instancia firma el head de la cadena (puntos de control periódicos) y `GET /api/audit/export` produce un bundle firmado con Ed25519. Un auditor lo verifica fuera de la máquina, vinculando la clave pública de la instancia (`GET /api/audit/public-key`) fuera de banda — demostrando tanto que el registro no fue modificado como qué instancia lo produjo.
+
+---
+
+## Correspondencia con los regímenes
+
+### NIS2 (Directiva (UE) 2022/2555) — la mejor adecuación
+
+- **En qué ayuda.** Las operaciones sobre certificados modifican la postura de confianza de los servicios, por lo que son eventos relevantes para la seguridad. CertMate produce un registro infalsificable, atribuido y con marca de tiempo de cada operación, más una verificación independiente — utilizable como parte de las prácticas de registro (Art. 21) y de evidencia de incidentes (Art. 23) del operador.
+- **Límite.** NIS2 obliga a **entidades** esenciales/importantes, no a herramientas de software. CertMate proporciona registros y un verificador que el operador puede usar; no evalúa, monitoriza ni notifica incidentes, y ser una entidad en el ámbito de aplicación (y cumplir NIS2 en su totalidad) es responsabilidad del operador.
+
+### AI Act de la UE — Artículo 50 transparencia (solo en espíritu; la peor adecuación)
+
+- **En qué ayuda.** Cuando un agente IA opera la PKI de forma autónoma, el registro lleva un marcador explícito `actor.kind="agent"` más la sesión del agente, de modo que el operador puede demostrar a posteriori qué cambios realizó un agente IA frente a un humano, bajo qué identidad y qué los desencadenó — respaldando el espíritu de transparencia y supervisión humana del Acto.
+- **Límite.** Las obligaciones del Art. 50 recaen sobre los **proveedores/desplegadores de sistemas de IA** y se refieren a la divulgación a personas físicas que interactúan con la IA. Un agente que renueva certificados TLS no es un caso de manual del Art. 50, y CertMate es una herramienta, no un sistema de IA. Nos alineamos solo con el espíritu de transparencia; CertMate **no** satisface el Art. 50 en nombre de nadie.
+
+### ISO/IEC 42001 (Sistema de gestión de la IA) — registros operacionales
+
+- **En qué ayuda.** Los registros atribuidos e infalsificables son evidencia objetiva de que un agente IA realizó acciones concretas sobre certificados — utilizables para los controles de registros operacionales y trazabilidad del propio AIMS del operador.
+- **Límite.** ISO 42001 certifica el sistema de gestión de una organización, no una herramienta. CertMate no está certificado con ISO 42001 y no puede certificar al operador; produce registros que el operador puede presentar como evidencia para sus propios controles.
+
+---
+
+## Límites honestos (no sobreinterprete estos puntos)
+
+- **La clave de firma no vincula al operador.** Un bundle de exportación firmado (y los puntos de control firmados periódicos) permiten a un tercero verificar, fuera de la máquina, qué instancia produjo el registro y que no fue modificado — para cualquiera que **no** posea la clave de firma. Pero el operador posee la clave y podría re-firmar una cadena reescrita. Restringir completamente al operador requiere enviar los puntos de control firmados a un almacén externo de solo anexado (**anclaje externo opcional — una funcionalidad planificada, aún no disponible**). Trate la garantía actual como «autenticidad, ordenación y atribución a la instancia de las entradas registradas», verificable de forma independiente por un tercero que posea una copia firmada exportada.
+- **Autenticidad, no exhaustividad.** Las escrituras de auditoría son de mejor esfuerzo y nunca bloquean una operación de certificado; la cadena prueba que las entradas registradas son auténticas y están ordenadas, y un `seq` interior faltante prueba una eliminación, pero una escritura que falló antes de ser registrada no deja ninguna entrada que verificar.
+- **El truncado de cola necesita una referencia externa.** La eliminación de entradas del **final** de una sola cadena deja una cadena más corta pero internamente coherente que sigue verificándose como íntegra. Los puntos de control firmados y los bundles de exportación son los anclajes para detectar esto: una exportación firmada posterior con menos entradas que una anterior (o que un punto de control que posea un auditor) revela el truncado. Una exportación única no puede, por sí sola, probar que nada fue eliminado del final — conserve exportaciones firmadas sucesivas, o espere al anclaje externo opcional, si necesita esa garantía.
+- **La cabecera de sesión del agente es una declaración del cliente.** Se registra para correlación, pero la suministra el cliente; la identidad de confianza es la clave de API autenticada.
+- **Límite histórico.** La cadena comienza cuando la funcionalidad se activa por primera vez; el historial de `.log` anterior no forma parte de la cadena verificable.
+
+Las exportaciones firmadas que un auditor externo puede vincular a una clave publicada están disponibles hoy. Si sus obligaciones requieren vincular al operador *en sí mismo* — de modo que incluso el titular de la clave no pueda reescribir el historial sin ser detectado — eso necesita el anclaje externo opcional de los puntos de control firmados a un almacén de solo anexado fuera de la máquina, que está planificado pero aún no disponible. Compruebe su estado antes de depender de él.
+
+---
+
+<div align="center">
+
+[← Volver a la documentación](./README.md)
+
+</div>

--- a/docs/es/deploy-hooks.md
+++ b/docs/es/deploy-hooks.md
@@ -1,0 +1,293 @@
+# Deploy Hooks
+
+Cierra [#117](https://github.com/fabriziosalmi/certmate/issues/117).
+
+Los deploy hooks son comandos shell cortos que CertMate ejecuta **después** de emitir, renovar o revocar un certificado. Úsalos para recargar servicios, enviar el nuevo certificado a un load balancer, publicar una notificación o cualquier otra acción necesaria tras una ejecución exitosa de certbot.
+
+Esta guía cubre:
+
+1. [Qué es un hook](#qué-es-un-hook)
+2. [Configuración de hooks (UI + JSON)](#configuración-de-hooks)
+3. [Variables de entorno pasadas a tu comando](#variables-de-entorno-pasadas-a-tu-comando)
+4. [Disparo manual](#disparo-manual)
+5. [Modelo de seguridad: por qué algunos comandos son rechazados](#modelo-de-seguridad)
+6. [Recetas comunes](#recetas-comunes)
+7. [Auditoría, historial y depuración](#auditoría-historial-y-depuración)
+
+---
+
+## Qué es un hook
+
+Un hook es un objeto JSON con cinco campos:
+
+| Campo | Tipo | Requerido | Notas |
+|---|---|---|---|
+| `id` | string | sí | Identificador estable (un UUID es válido; la UI genera uno automáticamente). Usado por `/api/deploy/test/<id>`. |
+| `name` | string | sí | Etiqueta mostrada en la UI y en el registro de auditoría. |
+| `command` | string | sí | Un único comando shell (`sh -c`). Máximo 1024 caracteres. Ver [seguridad](#modelo-de-seguridad). |
+| `enabled` | boolean | no | Por defecto `true`. Los hooks desactivados se omiten durante el disparo automático pero pueden probarse manualmente. |
+| `timeout` | integer | no | Segundos. Valor por defecto 30, limitado al `MAX_TIMEOUT` del sistema (actualmente 300). |
+| `on_events` | string array | no | Subconjunto de `["created", "renewed", "revoked"]`. Si está ausente, el hook se ejecuta en los tres eventos. |
+
+Los hooks se ubican bajo dos claves en `deploy_hooks`:
+
+- **`global_hooks`** — se disparan para todos los dominios. Ideal para "recargar nginx tras cualquier cambio de certificado".
+- **`domain_hooks`** — indexados por nombre de dominio exacto. Ideal para "enviar el certificado del LB de `api.example.com` a S3 tras la renovación de ese certificado específico".
+
+```jsonc
+{
+  "deploy_hooks": {
+    "enabled": true,
+    "global_hooks": [
+      {
+        "id": "5f8...",
+        "name": "Reload nginx",
+        "command": "/usr/sbin/nginx -s reload",
+        "enabled": true,
+        "timeout": 30,
+        "on_events": ["created", "renewed"]
+      }
+    ],
+    "domain_hooks": {
+      "api.example.com": [
+        {
+          "id": "9b1...",
+          "name": "Push to LB",
+          "command": "/opt/scripts/push-cert-to-lb.sh",
+          "enabled": true,
+          "timeout": 120,
+          "on_events": ["renewed"]
+        }
+      ]
+    }
+  }
+}
+```
+
+Si `enabled` a nivel superior es `false`, ningún hook se ejecuta en los eventos de certificado. Las pruebas manuales (`POST /api/deploy/test/<id>`) siguen funcionando — útil para iterar sobre un hook antes de activar el interruptor principal.
+
+---
+
+## Configuración de hooks
+
+### Mediante la UI
+
+`Ajustes → Deploy Hooks`. Activa o desactiva el interruptor **Habilitado**, luego añade hooks globales o por dominio. Cada fila incluye:
+
+- nombre + comando + timeout + casillas de verificación de eventos
+- un botón **Test** (ejecuta el hook contra el dominio sintético `test.example.com` con `CERTMATE_EVENT=manual`)
+- interruptor de activación/desactivación
+- eliminar
+
+Guarda los ajustes para conservar los cambios.
+
+### Mediante la API
+
+```bash
+# Leer la configuración actual
+curl -H "Authorization: Bearer $TOKEN" \
+  https://certmate.local/api/deploy/config
+
+# Reemplazar la configuración (escritura completa del documento — pasa todo el diccionario deploy_hooks)
+curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d @hooks.json https://certmate.local/api/deploy/config
+```
+
+El POST reemplaza todo el bloque `deploy_hooks`; combina los cambios en el cliente si quieres conservar las entradas existentes.
+
+---
+
+## Variables de entorno pasadas a tu comando
+
+Cada invocación define estas variables en el entorno del proceso del hook:
+
+| Variable | Valor de ejemplo |
+|---|---|
+| `CERTMATE_DOMAIN` | `api.example.com` |
+| `CERTMATE_CERT_PATH` | `/app/certificates/api.example.com/cert.pem` |
+| `CERTMATE_KEY_PATH` | `/app/certificates/api.example.com/privkey.pem` |
+| `CERTMATE_FULLCHAIN_PATH` | `/app/certificates/api.example.com/fullchain.pem` |
+| `CERTMATE_CHAIN_PATH` | `/app/certificates/api.example.com/chain.pem` (solo intermediarios, sin el certificado hoja — para destinos que requieren la cadena como archivo separado) |
+| `CERTMATE_EVENT` | `created` / `renewed` / `revoked` / `manual` |
+| `CERTMATE_DRY_RUN` | Se establece a `1` solo durante un dry-run; ausente en caso contrario. |
+
+Tu comando puede referenciar estas variables como `$CERTMATE_DOMAIN`, `"$CERTMATE_FULLCHAIN_PATH"`, etc. Los valores se pasan por entorno, no por interpolación de cadenas, por lo que las comillas funcionan igual que en cualquier shell normal.
+
+El hook se ejecuta como el usuario del proceso CertMate (en la imagen Docker: `certmate`, UID/GID 1000:1000) dentro del contenedor. Todo lo que hagas con `cp`, `curl`, `ssh`, etc. debe ser accesible desde allí.
+
+---
+
+## Disparo manual
+
+Dos formas de disparar un hook fuera del ciclo de vida normal del certificado:
+
+### Test por hook (admin)
+
+```bash
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  https://certmate.local/api/deploy/test/<hook_id>
+```
+
+Ejecuta únicamente el hook con ese `id`, contra el dominio sintético `test.example.com`, con `CERTMATE_EVENT=manual`. Omite el filtro `on_events` — útil para comprobar "¿funciona realmente este comando?".
+
+### Ejecutar todos los hooks de un dominio (admin)
+
+```bash
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  https://certmate.local/api/certificates/api.example.com/deploy
+```
+
+Dispara todos los hooks globales y específicos del dominio habilitados para `api.example.com` con `CERTMATE_EVENT=manual`, ignorando `on_events`. Devuelve un resumen estructurado:
+
+```jsonc
+{
+  "ok": true,
+  "total": 3,
+  "succeeded": 2,
+  "failed": 1,
+  "results": [
+    {"hook_name": "Reload nginx", "exit_code": 0, "duration_ms": 142, ...},
+    ...
+  ]
+}
+```
+
+Esto es lo que invoca el botón **Ejecutar Deploy Hooks Ahora** en el panel de detalles del certificado.
+
+---
+
+## Modelo de seguridad
+
+Los hooks son ejecución de código arbitrario por diseño — esa es la funcionalidad. Para limitar el radio de impacto, el campo command se valida **en el momento de guardar y de nuevo en tiempo de ejecución** (defensa en profundidad) y se rechaza si contiene:
+
+### Patrones shell bloqueados
+
+| Patrón | Motivo |
+|---|---|
+| `` ` `` (backticks) | sustitución de comando |
+| `$(...)` | sustitución de comando |
+| `${...}` | expansión de parámetro (la expansión de variables de entorno está permitida — solo se bloquea la forma `${...}`) |
+| `&&` / `\|\|` | encadenamiento lógico |
+| `;` | separador de instrucciones |
+| `\|` | pipe |
+| `\r` / `\n` | saltos de línea (evita que `sh -c` los interprete como `;`) |
+| `> /` (redirección a ruta absoluta) | evita sobreescribir archivos del sistema |
+| `<<` | here-doc |
+| `eval`, `source`, `. /` | builtins del shell que cargan código arbitrario |
+
+Si necesitas alguno de estos elementos, coloca la lógica en un archivo script dentro del contenedor e invoca el script directamente:
+
+```sh
+/opt/scripts/deploy.sh
+```
+
+### Referencias de archivos bloqueadas
+
+Las referencias a los archivos sensibles de CertMate se rechazan de plano (sin distinción de mayúsculas/minúsculas):
+
+`settings.json`, `api_bearer_token`, `client_secret`, `vault_token`, `.env`, `private*key`, `.pem`
+
+Así, `cat $CERTMATE_FULLCHAIN_PATH` es válido (la variable la expande el shell y la cadena literal `.pem` no aparece en `command`), pero `cat /app/data/settings.json` se rechazaría al guardar.
+
+### Qué está permitido
+
+- **Comandos simples**: `/usr/sbin/nginx -s reload`, `systemctl reload haproxy`
+- **Peticiones curl (webhooks)**: `curl -X POST -H "Content-Type: application/json" https://hooks.slack.com/...`
+- **Expansión de variables en argumentos**: `curl -d "domain=$CERTMATE_DOMAIN" https://...`
+- **Payloads JSON con `$VAR` (sin `${}`)**: `curl -d '{"domain":"$CERTMATE_DOMAIN"}' ...`
+- **Invocaciones de script único**: `/opt/scripts/deploy.sh "$CERTMATE_DOMAIN"`
+
+Si un comando que antes podías guardar ahora produce `Command blocked at runtime: contains dangerous shell metacharacters`, consulta las notas de la versión — el validador se endureció en v2.4.0 y se relajó ligeramente en v2.4.1+.
+
+---
+
+## Recetas comunes
+
+### Recargar nginx (global, todos los eventos)
+
+```sh
+/usr/sbin/nginx -t && /usr/sbin/nginx -s reload
+```
+
+(Nota: `&&` está bloqueado. Envuelve esto en un script: `/opt/scripts/reload-nginx.sh`.)
+
+### Recargar haproxy
+
+```sh
+systemctl reload haproxy
+```
+
+### Enviar a un webhook de Slack
+
+```sh
+curl -X POST -H 'Content-Type: application/json' -d "{\"text\":\"Cert renewed: $CERTMATE_DOMAIN\"}" https://hooks.slack.com/services/XXX/YYY/ZZZ
+```
+
+### Sincronizar el certificado con un host remoto
+
+(Envuelve en un script — no se permiten `;`, `&&` en línea.)
+
+```sh
+/opt/scripts/sync-cert.sh
+```
+
+Donde `sync-cert.sh` es:
+
+```sh
+#!/bin/sh
+set -eu
+scp "$CERTMATE_FULLCHAIN_PATH" "$CERTMATE_KEY_PATH" deploy@lb:/etc/ssl/$CERTMATE_DOMAIN/
+ssh deploy@lb 'systemctl reload haproxy'
+```
+
+### Omitir hooks durante un dry-run
+
+En tu script:
+
+```sh
+[ -n "${CERTMATE_DRY_RUN:-}" ] && { echo "dry run, skipping"; exit 0; }
+```
+
+---
+
+## Auditoría, historial y depuración
+
+### Feed de actividad
+
+`GET /api/deploy/history?limit=50` y la pestaña **Actividad** de la UI muestran las últimas N ejecuciones de hooks con: nombre del hook, dominio, evento, código de salida, duración, stdout/stderr (truncados a 4096 bytes cada uno) y marca de tiempo.
+
+### Consola de depuración
+
+Ajustes → Deploy Hooks dispone de una consola de depuración (botón de alternancia en la esquina inferior derecha) que muestra en tiempo real los eventos `loadConfig` / `saveConfig` / `testHook` en el lado del cliente. Útil para iterar sobre la UI.
+
+### Registro de auditoría
+
+Cada ejecución de un hook escribe una entrada `operation: deploy_hook` en el registro de auditoría con el estado `success`/`failure` más el nombre del hook, el código de salida y la duración. Visible en la pestaña Actividad y en `/api/audit`.
+
+### Fallos comunes
+
+| Síntoma | Causa probable |
+|---|---|
+| `Hook not found` | El ID del hook en la solicitud de prueba no coincide con ningún hook en la configuración guardada (la UI estaba desactualizada o el hook acaba de eliminarse). Recarga la página. |
+| `Command blocked at runtime` | Uno de los [patrones bloqueados](#patrones-shell-bloqueados) pasó el guardado. Mueve la lógica problemática a un archivo script. |
+| `exit code 127` | Comando no encontrado dentro del contenedor (p. ej., `nginx` no está en `$PATH`). Usa rutas absolutas o instala el binario en la imagen. |
+| `timeout after 30s` | El hook tardó más que su `timeout`. Auméntalo (máximo 300 s) o mueve el trabajo a un script en segundo plano. |
+| `Deploy hooks disabled` | `deploy_hooks.enabled` es `false`. Activa el interruptor principal en Ajustes. |
+| `No hooks configured for <domain>` | Se intenta ejecutar hooks para un dominio sin hooks globales Y sin entrada en `domain_hooks[<domain>]`. Añade un hook (o llama a `/api/deploy/test/<id>` para uno específico). |
+
+---
+
+## Ver también
+
+- [`modules/core/deployer.py`](../modules/core/deployer.py) — implementación
+- [`modules/web/settings_routes.py`](../modules/web/settings_routes.py) — endpoints `/api/deploy/*`
+- [`templates/partials/settings_deploy.html`](../templates/partials/settings_deploy.html) — partial de UI
+- [`static/js/settings-deploy.js`](../static/js/settings-deploy.js) — componente Alpine
+
+---
+
+<div align="center">
+
+[← Volver a la documentación](./README.md)
+
+</div>

--- a/docs/es/dns-providers.md
+++ b/docs/es/dns-providers.md
@@ -1,0 +1,822 @@
+# Proveedores DNS
+
+CertMate soporta una amplia gama de proveedores DNS para los desafíos Let's Encrypt DNS-01 mediante plugins de certbot individuales. La lista completa se encuentra en la tabla a continuación.
+
+---
+
+## Proveedores soportados
+
+| Proveedor | Plugin | Credenciales requeridas | Categoría |
+|---|---|---|---|
+| **Cloudflare** | `certbot-dns-cloudflare` | Token API | Cloud principal |
+| **AWS Route53** | `certbot-dns-route53` | Access Key, Secret Key | Cloud principal |
+| **Azure DNS** | `certbot-dns-azure` | Service Principal | Cloud principal |
+| **Google Cloud DNS** | `certbot-dns-google` | Service Account JSON | Cloud principal |
+| **PowerDNS** | `certbot-dns-powerdns` | URL API, Clave API | Empresa |
+| **DNS Made Easy** | `certbot-dns-dnsmadeeasy` | Clave API, Secret Key | Empresa |
+| **NS1** | `certbot-dns-nsone` | Clave API | Empresa |
+| **DigitalOcean** | `certbot-dns-digitalocean` | Token API | Cloud |
+| **Linode (Akamai Connected Cloud)** | `certbot-dns-linode` | Clave API | Cloud |
+| **Akamai Edge DNS** | `certbot-plugin-edgedns` | EdgeGrid `.edgerc` (client_token, client_secret, access_token, host) | Empresa |
+| **Vultr** | `certbot-dns-vultr` | Clave API | Cloud |
+| **Hetzner (DNS legacy)** | `certbot-dns-hetzner` | Token API | Cloud |
+| **Hetzner Cloud** | `certbot-dns-hetzner-cloud` | Token API | Cloud |
+| **Gandi** | `certbot-dns-gandi` | Token API | Registrar |
+| **Namecheap** | `certbot-dns-namecheap` | Nombre de usuario, Clave API | Registrar |
+| **Porkbun** | `certbot-dns-porkbun` | Clave API, Secret Key | Registrar |
+| **GoDaddy** | `certbot-dns-godaddy` | Clave API, Secret | Registrar |
+| **OVH** | `certbot-dns-ovh` | Credenciales API | Regional |
+| **Infomaniak** | `certbot-dns-infomaniak` | Token API | Regional |
+| **ArvanCloud** | `certbot-dns-arvancloud` | Clave API | Regional |
+| **RFC2136** | `certbot-dns-rfc2136` | Servidor DNS, Clave TSIG | Protocolo estándar |
+| **ACME-DNS** | `certbot-acme-dns` | URL API, Nombre de usuario, Contraseña | Especializado |
+| **Hurricane Electric** | `certbot-dns-he-ddns` | Nombre de usuario, Contraseña | DNS gratuito |
+| **Dynu** | `certbot-dns-dynudns` | Token API | DNS dinámico |
+| **DuckDNS** | `certbot-dns-duckdns` | Token de cuenta | DDNS gratuito (sin dominio propio) |
+| **deSEC** | `certbot-dns-desec` | Token API | Gratuito, UE (DE), DNSSEC — delegar NS a `ns1.desec.io` / `ns2.desec.org` |
+| **Scaleway** | `certbot-dns-scaleway` | Clave secreta API | Cloud soberano UE (FR) — plugin comunitario (alpha), instalar por separado: `pip install certbot-dns-scaleway` |
+| **Script personalizado** | ninguno (certbot `--manual`) | Ruta del script auth (+ script cleanup opcional) | Trae el tuyo propio |
+
+---
+
+## Configuración
+
+### Mediante la interfaz web
+
+1. Ve a **Ajustes**
+2. Selecciona tu proveedor DNS en el menú desplegable
+3. Rellena las credenciales requeridas
+4. Guarda los ajustes
+
+### Mediante la API
+
+```bash
+curl -X POST http://localhost:8000/api/settings \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dns_provider": "cloudflare",
+    "dns_providers": {
+      "cloudflare": {
+        "api_token": "your_cloudflare_token"
+      }
+    }
+  }'
+```
+
+---
+
+## Ejemplos de configuración por proveedor
+
+### Cloudflare
+
+```json
+{
+  "dns_provider": "cloudflare",
+  "dns_providers": {
+    "cloudflare": {
+      "api_token": "your_cloudflare_api_token"
+    }
+  }
+}
+```
+
+### AWS Route53
+
+```json
+{
+  "dns_provider": "route53",
+  "dns_providers": {
+    "route53": {
+      "access_key_id": "AKIAIOSFODNN7EXAMPLE",
+      "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      "region": "us-east-1"
+    }
+  }
+}
+```
+
+### Azure DNS
+
+```json
+{
+  "dns_provider": "azure",
+  "dns_providers": {
+    "azure": {
+      "subscription_id": "your_subscription_id",
+      "resource_group": "your_resource_group",
+      "tenant_id": "your_tenant_id",
+      "client_id": "your_client_id",
+      "client_secret": "your_client_secret"
+    }
+  }
+}
+```
+
+### Google Cloud DNS
+
+```json
+{
+  "dns_provider": "google",
+  "dns_providers": {
+    "google": {
+      "project_id": "your_project_id",
+      "service_account_key": "{ ... service account JSON ... }"
+    }
+  }
+}
+```
+
+### PowerDNS
+
+```json
+{
+  "dns_provider": "powerdns",
+  "dns_providers": {
+    "powerdns": {
+      "api_url": "https://your-powerdns-server:8081",
+      "api_key": "your_powerdns_api_key"
+    }
+  }
+}
+```
+
+### Vultr
+
+```json
+{
+  "dns_provider": "vultr",
+  "dns_providers": {
+    "vultr": {
+      "api_key": "your_vultr_api_key"
+    }
+  }
+}
+```
+
+### DNS Made Easy
+
+```json
+{
+  "dns_provider": "dnsmadeeasy",
+  "dns_providers": {
+    "dnsmadeeasy": {
+      "api_key": "your_api_key",
+      "secret_key": "your_secret_key"
+    }
+  }
+}
+```
+
+### NS1
+
+```json
+{
+  "dns_provider": "nsone",
+  "dns_providers": {
+    "nsone": {
+      "api_key": "your_nsone_api_key"
+    }
+  }
+}
+```
+
+### RFC2136
+
+Para servidores DNS compatibles con RFC2136 (incluido **Technitium DNS Server**):
+
+```json
+{
+  "dns_provider": "rfc2136",
+  "dns_providers": {
+    "rfc2136": {
+      "nameserver": "ns.example.com",
+      "tsig_key": "mykey",
+      "tsig_secret": "base64-encoded-secret",
+      "tsig_algorithm": "HMAC-SHA512"
+    }
+  }
+}
+```
+
+> **Technitium DNS**: Activa Dynamic Updates en Zone Options, crea una clave TSIG (p. ej. `certmate-key` con HMAC-SHA512) y utiliza el secreto generado en la configuración anterior.
+
+### Hetzner (API DNS legacy)
+
+> **Aviso de obsolescencia:** La API de la consola DNS de Hetzner será retirada en mayo de 2025. Los nuevos usuarios deben utilizar el proveedor **Hetzner Cloud** que aparece más abajo. Los usuarios existentes deben migrar a `hetzner-cloud` antes de la fecha de retirada. Consulta la [página de estado de Hetzner](https://status.hetzner.com/incident/c2146c42-6dd2-4454-916a-19f07e0e5a44) para más detalles.
+
+```json
+{
+  "dns_provider": "hetzner",
+  "dns_providers": {
+    "hetzner": {
+      "api_token": "your_hetzner_dns_api_token"
+    }
+  }
+}
+```
+
+### Hetzner Cloud
+
+Utiliza la nueva [API Hetzner Cloud](https://docs.hetzner.cloud/reference/cloud) que reemplaza la API DNS de Hetzner obsoleta. Este es el proveedor recomendado para todos los usuarios de Hetzner.
+
+```json
+{
+  "dns_provider": "hetzner-cloud",
+  "dns_providers": {
+    "hetzner-cloud": {
+      "api_token": "your_hetzner_cloud_api_token"
+    }
+  }
+}
+```
+
+> Genera un token API de Hetzner Cloud desde la [Consola Hetzner Cloud](https://console.hetzner.cloud/) en la sección de tokens API de tu proyecto. El token necesita permisos de lectura/escritura sobre DNS.
+
+### Infomaniak
+
+```json
+{
+  "dns_provider": "infomaniak",
+  "dns_providers": {
+    "infomaniak": {
+      "api_token": "your_infomaniak_api_token"
+    }
+  }
+}
+```
+
+> Obtén el token API desde Infomaniak Manager (sección API con scope "Domain").
+
+### Porkbun
+
+```json
+{
+  "dns_provider": "porkbun",
+  "dns_providers": {
+    "porkbun": {
+      "api_key": "your_porkbun_api_key",
+      "secret_key": "your_porkbun_secret_key"
+    }
+  }
+}
+```
+
+### GoDaddy
+
+```json
+{
+  "dns_provider": "godaddy",
+  "dns_providers": {
+    "godaddy": {
+      "api_key": "your_godaddy_api_key",
+      "secret": "your_godaddy_secret"
+    }
+  }
+}
+```
+
+### OVH
+
+```json
+{
+  "dns_provider": "ovh",
+  "dns_providers": {
+    "ovh": {
+      "endpoint": "ovh-eu",
+      "application_key": "your_app_key",
+      "application_secret": "your_app_secret",
+      "consumer_key": "your_consumer_key"
+    }
+  }
+}
+```
+
+### Hurricane Electric
+
+```json
+{
+  "dns_provider": "he-ddns",
+  "dns_providers": {
+    "he-ddns": {
+      "username": "your_he_username",
+      "password": "your_he_password"
+    }
+  }
+}
+```
+
+### Dynu
+
+```json
+{
+  "dns_provider": "dynudns",
+  "dns_providers": {
+    "dynudns": {
+      "token": "your_dynu_api_token"
+    }
+  }
+}
+```
+
+### ArvanCloud
+
+```json
+{
+  "dns_provider": "arvancloud",
+  "dns_providers": {
+    "arvancloud": {
+      "api_key": "your_arvancloud_api_key"
+    }
+  }
+}
+```
+
+### ACME-DNS
+
+```json
+{
+  "dns_provider": "acme-dns",
+  "dns_providers": {
+    "acme-dns": {
+      "api_url": "https://auth.acme-dns.io",
+      "username": "your_acme_username",
+      "password": "your_acme_password",
+      "subdomain": "your_subdomain"
+    }
+  }
+}
+```
+
+### DuckDNS (sin dominio propio)
+
+DuckDNS proporciona subdominios gratuitos `<nombre>.duckdns.org` — la forma más sencilla de obtener un certificado de confianza pública cuando no se posee un dominio propio. Casos de uso típicos: homelabs, servicios auto-alojados, dispositivos IoT, paneles internos que hasta ahora dependían de certificados autofirmados.
+
+1. Inicia sesión en <https://www.duckdns.org/> (SSO de Google / GitHub / Twitter / Reddit).
+2. Elige un subdominio (p. ej. `mybox` → `mybox.duckdns.org`).
+3. Copia el token de cuenta que aparece en la parte superior de la página.
+
+```json
+{
+  "dns_provider": "duckdns",
+  "domains": ["mybox.duckdns.org"],
+  "dns_providers": {
+    "duckdns": {
+      "api_token": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    }
+  }
+}
+```
+
+Los wildcards como `*.mybox.duckdns.org` están soportados con el mismo token. Dado que DuckDNS solo almacena un registro TXT por dominio a la vez, se requiere una única ejecución de certbot por subdominio DuckDNS — no se soportan certificados SAN que abarquen varios subdominios DuckDNS.
+
+### Script personalizado (trae tu propio proveedor)
+
+Para proveedores DNS sin plugin de certbot — Oracle Cloud (OCI), DNS interno, APIs de appliance — apunta CertMate a tus propios scripts y los ejecutará a través del modo `--manual` de certbot. No se requiere instalación de plugin alguno.
+
+```json
+{
+  "dns_provider": "custom-script",
+  "dns_providers": {
+    "custom-script": {
+      "auth_hook": "/usr/local/bin/certmate-dns-auth.sh",
+      "cleanup_hook": "/usr/local/bin/certmate-dns-cleanup.sh"
+    }
+  }
+}
+```
+
+certbot invoca el auth hook una vez por cada desafío de validación con el entorno estándar de [manual-hook](https://eff-certbot.readthedocs.io/en/stable/using.html#hooks): `CERTBOT_DOMAIN` (el dominio que se valida) y `CERTBOT_VALIDATION` (el valor TXT). El script debe crear el registro TXT `_acme-challenge.$CERTBOT_DOMAIN` **y esperar a que se propague** — certbot valida inmediatamente tras el retorno del hook. El cleanup hook opcional se ejecuta después de la validación para eliminar el registro.
+
+Ejemplo para OCI DNS (cubre [#285](https://github.com/fabriziosalmi/certmate/issues/285)). Ten en cuenta que un certificado que cubra tanto `example.com` como `*.example.com` produce DOS desafíos de validación sobre el mismo nombre `_acme-challenge.example.com`, y certbot ejecuta todos los auth hooks antes de validar — por tanto, el hook debe AÑADIR al rrset TXT, nunca reemplazarlo (una actualización simple del rrset eliminaría el primer token con el segundo):
+
+```bash
+#!/bin/sh
+# /usr/local/bin/certmate-dns-auth.sh
+set -eu
+ZONE="example.com"
+NAME="_acme-challenge.${CERTBOT_DOMAIN}"
+# Merge the new validation token with any records already on the name
+# (apex + wildcard certs place two TXT values on the same name).
+EXISTING=$(oci dns record rrset get --zone-name-or-id "$ZONE" \
+  --domain "$NAME" --rtype TXT \
+  --query 'data.items[].rdata' --raw-output 2>/dev/null || echo '[]')
+ITEMS=$(printf '%s' "$EXISTING" | python3 -c "
+import json, os, sys
+name = os.environ['NAME']
+rdata = [r.strip('\"') for r in json.load(sys.stdin)]
+rdata.append(os.environ['CERTBOT_VALIDATION'])
+print(json.dumps([
+    {'domain': name, 'rdata': v, 'rtype': 'TXT', 'ttl': 60} for v in rdata
+]))
+")
+NAME="$NAME" oci dns record rrset update --force \
+  --zone-name-or-id "$ZONE" \
+  --domain "$NAME" \
+  --rtype TXT \
+  --items "$ITEMS"
+sleep "${CERTMATE_DNS_PROPAGATION_SECONDS:-60}"
+```
+
+Requisitos y modelo de confianza:
+
+- Las rutas deben ser **absolutas**, los archivos deben existir, ser **ejecutables**, no tener permisos de escritura para todos los usuarios, y no contener espacios ni metacaracteres de shell (certbot ejecuta los hooks a través del shell). Se validan en el momento de la emisión y mediante el endpoint API de prueba (`POST /api/web/certificates/test-provider`)
+- Los scripts se ejecutan con los privilegios de CertMate — el mismo modelo de confianza que los deploy hooks: solo los administradores pueden configurarlos; tratalos como parte de tu despliegue
+- El ajuste `dns_propagation_seconds` por proveedor se exporta a los scripts como `CERTMATE_DNS_PROPAGATION_SECONDS` (un campo `propagation_seconds` a nivel de cuenta tiene prioridad sobre él)
+- Las renovaciones replican las rutas de los hooks desde la configuración de renovación de certbot: mantén los scripts en una ruta estable (si los mueves, vuelve a emitir el certificado)
+- Los certificados wildcard funcionan correctamente (el hook recibe cada registro de validación)
+
+---
+
+## Crear certificados
+
+### Usando el proveedor por defecto
+
+```bash
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"domain": "example.com"}'
+```
+
+### Usando un proveedor específico
+
+```bash
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "domain": "example.com",
+    "dns_provider": "vultr"
+  }'
+```
+
+### Usando una cuenta específica
+
+```bash
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "domain": "example.com",
+    "dns_provider": "cloudflare",
+    "account_id": "production"
+  }'
+```
+
+---
+
+## Soporte multi-cuenta
+
+CertMate soporta varias cuentas por proveedor DNS para entornos de empresa.
+
+### Casos de uso
+
+- **Separación de entornos**: Cuentas de producción, staging y DR
+- **Multi-región**: Distintas cuentas para dominios US, UE, APAC
+- **Aislamiento de permisos**: Cuentas de administrador, limitada y CI/CD
+
+### Añadir varias cuentas
+
+```bash
+# Añadir cuenta de producción
+curl -X POST http://localhost:8000/api/settings/dns-providers/cloudflare/accounts \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "account_id": "production",
+    "config": {
+      "name": "Production Environment",
+      "description": "Main production Cloudflare account",
+      "api_token": "cloudflare_production_token"
+    }
+  }'
+
+# Añadir cuenta de staging
+curl -X POST http://localhost:8000/api/settings/dns-providers/cloudflare/accounts \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "account_id": "staging",
+    "config": {
+      "name": "Staging Environment",
+      "description": "Development and testing account",
+      "api_token": "cloudflare_staging_token"
+    }
+  }'
+
+# Establecer producción como cuenta por defecto
+curl -X PUT http://localhost:8000/api/settings/dns-providers/cloudflare/default-account \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"account_id": "production"}'
+```
+
+### Gestionar cuentas
+
+```bash
+# Listar todas las cuentas de un proveedor
+curl -X GET http://localhost:8000/api/settings/dns-providers/cloudflare/accounts \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+
+# Actualizar una cuenta
+curl -X PUT http://localhost:8000/api/settings/dns-providers/cloudflare/accounts/staging \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "config": {
+      "name": "Staging & Testing",
+      "api_token": "new_staging_token"
+    }
+  }'
+
+# Eliminar una cuenta
+curl -X DELETE http://localhost:8000/api/settings/dns-providers/cloudflare/accounts/old-account \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+### Estructura de configuración multi-cuenta
+
+```json
+{
+  "dns_provider": "cloudflare",
+  "default_accounts": {
+    "cloudflare": "production",
+    "route53": "main-aws"
+  },
+  "dns_providers": {
+    "cloudflare": {
+      "production": {
+        "name": "Production Environment",
+        "api_token": "***masked***"
+      },
+      "staging": {
+        "name": "Staging Environment",
+        "api_token": "***masked***"
+      }
+    },
+    "route53": {
+      "main-aws": {
+        "name": "Main AWS Account",
+        "access_key_id": "***masked***",
+        "secret_access_key": "***masked***",
+        "region": "us-east-1"
+      }
+    }
+  }
+}
+```
+
+### Compatibilidad con versiones anteriores
+
+Las configuraciones mono-cuenta existentes se migran automáticamente al formato multi-cuenta en el primer uso. No se requiere tiempo de inactividad ni migración manual.
+
+---
+
+## DNS multi-master y alias de dominio (delegación CNAME)
+
+Cuando tu dominio está gestionado por varios proveedores DNS simultáneamente (configuración multi-master), utiliza la **delegación CNAME** estándar para centralizar la validación ACME DNS en un único proveedor.
+
+### El problema
+
+Con DNS multi-master (p. ej. deSEC + gcore), solo se puede configurar un proveedor DNS por solicitud de certificado, pero la validación ACME requiere crear registros TXT `_acme-challenge`.
+
+### La solución
+
+La validación por alias DNS funciona mediante delegación CNAME. Let's Encrypt sigue las cadenas CNAME durante la validación DNS-01; CertMate escribe el registro TXT requerido en el nombre de validación delegado.
+
+1. **Crea un dominio de validación** en un proveedor soportado de primera clase (p. ej. `validation.example.org` en Cloudflare, PowerDNS, Route53 o ACME-DNS)
+2. **Añade registros CNAME** en todos tus proveedores DNS apuntando al dominio de validación:
+   ```dns
+   _acme-challenge.example.com. 300 IN CNAME _acme-challenge.validation.example.org.
+   ```
+3. **Solicita el certificado** especificando el proveedor que gestiona el dominio de validación:
+   ```bash
+   curl -X POST http://localhost:8000/api/certificates/create \
+     -H "Authorization: Bearer YOUR_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "domain": "example.com",
+       "dns_provider": "cloudflare",
+       "domain_alias": "validation.example.org"
+     }'
+   ```
+
+   Cuando `domain_alias` está definido con un proveedor soportado, CertMate utiliza un hook DNS manual de certbot para crear el registro TXT en `_acme-challenge.validation.example.org`. El CNAME garantiza que Let's Encrypt encuentre ese valor TXT al consultar `_acme-challenge.example.com`.
+
+### Ventajas
+
+- Funciona independientemente del proveedor DNS que sirva la consulta
+- No se necesita sincronización entre proveedores
+- Compatible con proveedores no soportados nativamente por CertMate (deSEC, gcore)
+- Las credenciales DNS se limitan exclusivamente al dominio de validación
+- Implementado para los proveedores DNS de primera clase de CertMate; los proveedores genéricos son rechazados hasta que existan adaptadores de alias dedicados
+
+### Ejemplos por proveedor
+
+Cloudflare, PowerDNS y Route53 utilizan todos la misma forma de solicitud:
+
+```json
+{
+  "domain": "example.com",
+  "dns_provider": "route53",
+  "domain_alias": "validation.example.org"
+}
+```
+
+Para ACME-DNS, `domain_alias` debe coincidir exactamente con el `subdomain`/fulldomain de ACME-DNS configurado. CertMate actualiza ese registro ACME-DNS directamente y no intenta limpiarlo porque ACME-DNS almacena el último valor de validación.
+
+### Certificados wildcard con alias de dominio
+
+```bash
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "domain": "*.example.com",
+    "dns_provider": "cloudflare",
+    "domain_alias": "validation.example.org"
+  }'
+```
+
+Asegúrate de que el CNAME esté en su lugar antes de solicitar el certificado:
+
+```dns
+_acme-challenge.example.com. 300 IN CNAME _acme-challenge.validation.example.org.
+```
+
+### Resolución de problemas con alias de dominio
+
+```bash
+# Verificar la propagación del CNAME
+dig @8.8.8.8 _acme-challenge.example.com CNAME +short
+# Esperado: _acme-challenge.validation.example.org.
+
+# Tras solicitar un certificado, verificar el registro TXT en el dominio de validación
+dig _acme-challenge.validation.example.org TXT +short
+# Esperado: un token de desafío ACME codificado en base64
+```
+
+---
+
+## Variables de entorno
+
+Define las credenciales del proveedor DNS mediante variables de entorno para los flujos de trabajo CI/CD:
+
+```bash
+# Cloudflare
+CLOUDFLARE_API_TOKEN=your_token
+
+# AWS Route53
+AWS_ACCESS_KEY_ID=your_access_key
+AWS_SECRET_ACCESS_KEY=your_secret_key
+AWS_DEFAULT_REGION=us-east-1
+
+# Azure
+AZURE_SUBSCRIPTION_ID=your_subscription_id
+AZURE_RESOURCE_GROUP=your_resource_group
+AZURE_TENANT_ID=your_tenant_id
+AZURE_CLIENT_ID=your_client_id
+AZURE_CLIENT_SECRET=your_client_secret
+
+# Google Cloud
+GOOGLE_PROJECT_ID=your_project_id
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+
+# PowerDNS
+POWERDNS_API_URL=https://your-powerdns-server:8081
+POWERDNS_API_KEY=your_api_key
+```
+
+### Prioridad de configuración (de mayor a menor)
+
+1. Variables de entorno
+2. Ajustes específicos del dominio
+3. Ajustes de la cuenta por defecto
+4. Ajuste global del proveedor
+5. Valor por defecto del sistema (Cloudflare)
+
+---
+
+## Tiempos de propagación DNS
+
+| Velocidad | Proveedores | Segundos |
+|-----------|-------------|----------|
+| Muy rápido | ACME-DNS | 30 |
+| Rápido | Cloudflare, Route53, PowerDNS, DuckDNS | 60 |
+| Medio | DigitalOcean, Linode, Google, ArvanCloud | 120 |
+| Lento | Azure, Gandi, OVH | 180 |
+| Muy lento | Namecheap | 300 |
+
+---
+
+## Características de seguridad
+
+- **Enmascaramiento de credenciales** en la interfaz web y en las respuestas de la API
+- **Permisos de archivo seguros** (600) para todos los archivos de credenciales
+- **Validación del token API** antes de la creación del certificado
+- **Soporte de variables de entorno** para flujos de trabajo CI/CD
+- **Registro de auditoría** para todas las operaciones sobre proveedores DNS
+- **Aislamiento de cuentas** — las credenciales de cada cuenta se almacenan por separado
+
+---
+
+## Arquitectura y guía para desarrolladores
+
+### Clases principales
+
+| Clase | Archivo | Propósito |
+|-------|---------|-----------|
+| `DNSManager` | `modules/core/dns_providers.py` | Gestión de configuración multi-cuenta |
+| `CertificateManager` | `modules/core/certificates.py` | Creación de certificados con proveedores DNS |
+| `SettingsManager` | `modules/core/settings.py` | Persistencia y migración de ajustes |
+| `Utils` | `modules/core/utils.py` | Generación y validación de archivos de credenciales |
+
+### Métodos de almacenamiento de credenciales
+
+1. **Archivo de ajustes** (`data/settings.json`) — el más habitual
+2. **Variables de entorno** — para CI/CD
+3. **Archivos de configuración temporales** (`letsencrypt/config/[provider].ini`) — creados durante las solicitudes de certificado, eliminados después
+
+### Añadir un nuevo proveedor DNS
+
+1. Añade el plugin a `requirements.txt`: `certbot-dns-newprovider`
+2. Crea una función de configuración en `modules/core/utils.py`
+3. Añade la definición de credenciales en `utils.py`
+4. Importa y gestiona en `modules/core/certificates.py`
+5. Añade a la lista de proveedores soportados en `modules/core/settings.py`
+6. Actualiza la documentación
+
+Consulta la [Guía de arquitectura](./architecture.md) para los detalles completos de implementación.
+
+---
+
+## Resolución de problemas
+
+### Problemas frecuentes
+
+| Error | Solución |
+|-------|----------|
+| "DNS provider not configured" | Verifica que se han proporcionado todas las credenciales requeridas |
+| "Certificate creation failed" | Comprueba los permisos DNS y la propiedad del dominio |
+| "Plugin not found" | Ejecuta `pip install -r requirements.txt` o reconstruye Docker |
+| "Provider detection failing" | Comprueba el campo `dns_provider` en los ajustes del dominio |
+
+### Modo de depuración
+
+```bash
+export FLASK_DEBUG=1
+python app.py
+```
+
+### Probar la configuración del proveedor
+
+```bash
+curl -X GET http://localhost:8000/api/settings/dns-providers \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+---
+
+## Guía de migración
+
+### De un proveedor único a múltiples proveedores
+
+Las configuraciones existentes permanecen sin cambios. Simplemente añade nuevos proveedores:
+
+```json
+{
+  "dns_providers": {
+    "cloudflare": {
+      "api_token": "existing_token"
+    },
+    "vultr": {
+      "api_key": "new_vultr_api_key"
+    }
+  }
+}
+```
+
+### Usar distintos proveedores por certificado
+
+```bash
+# Cloudflare para un dominio
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"domain": "example.com", "dns_provider": "cloudflare"}'
+
+# Route53 para otro
+curl -X POST http://localhost:8000/api/certificates/create \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"domain": "test.org", "dns_provider": "route53"}'
+```
+
+---
+
+<div align="center">
+
+[← Volver a la documentación](./README.md) • [Instalación →](./installation.md) • [Proveedores CA →](./ca-providers.md)
+
+</div>

--- a/docs/es/docker.md
+++ b/docs/es/docker.md
@@ -1,0 +1,326 @@
+# Construcción y despliegue con Docker
+
+Esta guía cubre la construcción, el despliegue y la ejecución de CertMate en Docker — incluyendo soporte multiplataforma para ARM y AMD64.
+
+---
+
+## Inicio rápido
+
+### Pull y ejecución
+
+```bash
+# Docker selecciona automáticamente la arquitectura correcta
+docker run -d --name certmate \
+  --env-file .env \
+  -p 8000:8000 \
+  -v certmate_data:/app/data \
+  -v certmate_certificates:/app/certificates \
+  fabriziosalmi/certmate:latest
+```
+
+### Construcción y ejecución local
+
+```bash
+docker build -t certmate:latest .
+docker run -d --name certmate \
+  --env-file .env \
+  -p 8000:8000 \
+  -v certmate_certificates:/app/certificates \
+  -v certmate_data:/app/data \
+  -v certmate_logs:/app/logs \
+  certmate:latest
+```
+
+---
+
+## Seguridad
+
+El proceso de construcción garantiza que no se incluya ningún secreto en la imagen:
+
+- `.dockerignore` excluye todos los archivos `.env` y los datos sensibles
+- Las variables de entorno se proporcionan en **tiempo de ejecución**, no en tiempo de construcción
+- Solo se incluyen los archivos de aplicación esenciales
+- Las imágenes pueden publicarse de forma segura en registros públicos
+
+### Verificar la ausencia de secretos en la imagen
+
+```bash
+docker history certmate:latest
+docker inspect certmate:latest | grep -i env
+docker run --rm certmate:latest find / -name "*.env" 2>/dev/null
+```
+
+---
+
+## Configuración en tiempo de ejecución
+
+### Opción 1: Archivo de entorno
+
+Crea un archivo `.env` en tu host (no dentro de la imagen Docker):
+
+```bash
+SECRET_KEY=your-super-secret-key-here
+# SECRET_KEY_FILE=/run/secrets/secret_key  # Alternative: takes precedence over SECRET_KEY
+API_BEARER_TOKEN=your-api-bearer-token-here
+# API_BEARER_TOKEN_FILE=/run/secrets/api_bearer_token  # Alternative: takes precedence over API_BEARER_TOKEN
+CLOUDFLARE_API_TOKEN=your-cloudflare-api-token
+LOG_LEVEL=INFO
+```
+
+```bash
+docker run -d --name certmate \
+  --env-file .env \
+  -p 8000:8000 \
+  -v certmate_certificates:/app/certificates \
+  -v certmate_data:/app/data \
+  -v certmate_logs:/app/logs \
+  certmate:latest
+```
+
+### Opción 2: Variables de entorno directas
+
+```bash
+docker run -d --name certmate \
+  -e SECRET_KEY="your-secret-key" \
+  # -e SECRET_KEY_FILE="/run/secrets/secret_key" \  # Alternative: takes precedence over SECRET_KEY
+  -e API_BEARER_TOKEN="your-api-bearer-token" \
+  # -e API_BEARER_TOKEN_FILE="/run/secrets/api_bearer_token" \  # Alternative: takes precedence over API_BEARER_TOKEN
+  -e CLOUDFLARE_API_TOKEN="your-api-token" \
+  -p 8000:8000 \
+  -v certmate_certificates:/app/certificates \
+  -v certmate_data:/app/data \
+  certmate:latest
+```
+
+### Referencia de variables de entorno
+
+| Variable | Requerida | Descripción |
+|----------|-----------|-------------|
+| `SECRET_KEY` | No | Clave secreta de Flask para las sesiones (se genera automáticamente si no se define) |
+| `SECRET_KEY_FILE` | No | Ruta a un archivo que contiene la clave secreta de Flask (tiene prioridad sobre `SECRET_KEY`) |
+| `API_BEARER_TOKEN` | No | Token de autenticación para el acceso a la API (se genera automáticamente si no se define) |
+| `API_BEARER_TOKEN_FILE` | No | Ruta a un archivo que contiene el bearer token de la API (tiene prioridad sobre `API_BEARER_TOKEN`) |
+| `LOG_LEVEL` | No | `INFO` (por defecto), `DEBUG`, `WARNING`, `ERROR` |
+| `CERTMATE_BACKUP_PASSPHRASE` | No | Cuando se define, las copias de seguridad unificadas se cifran en reposo (`.zip.enc`, PBKDF2-SHA256 + Fernet). Se requiere la misma frase de contraseña para restaurarlas. Sin definir = copias de seguridad en texto claro `.zip` (comportamiento heredado) |
+| `CLOUDFLARE_API_TOKEN` | No | Token del proveedor DNS de Cloudflare |
+| `AWS_ACCESS_KEY_ID` | No | Clave de acceso de AWS Route53 |
+| `AWS_SECRET_ACCESS_KEY` | No | Clave secreta de AWS Route53 |
+
+Consulta la [Guía de instalación](./installation.md#environment-variables) para ver la lista completa.
+
+---
+
+## Docker Compose
+
+### Configuración básica
+
+```yaml
+version: '3.8'
+
+services:
+  certmate:
+    image: fabriziosalmi/certmate:latest
+    container_name: certmate
+    ports:
+      - "8000:8000"
+    environment:
+      - SECRET_KEY=${SECRET_KEY:-}
+      # - SECRET_KEY_FILE=${SECRET_KEY_FILE:-}  # Alternative: path to a file containing the secret key
+      - API_BEARER_TOKEN=${API_BEARER_TOKEN:-}
+      # - API_BEARER_TOKEN_FILE=${API_BEARER_TOKEN_FILE:-}  # Alternative: path to a file containing the bearer token
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+    volumes:
+      - certmate_certificates:/app/certificates
+      - certmate_data:/app/data
+      - certmate_logs:/app/logs
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+volumes:
+  certmate_certificates:
+  certmate_data:
+  certmate_logs:
+```
+
+```bash
+# Iniciar con el archivo .env en el mismo directorio
+docker-compose up -d
+
+# O especificar un archivo de entorno diferente
+docker-compose --env-file /path/to/.env up -d
+```
+
+---
+
+## Construcciones multiplataforma
+
+CertMate soporta imágenes Docker multiplataforma para las arquitecturas ARM y AMD64.
+
+### Arquitecturas soportadas
+
+| Plataforma | Descripción | Casos de uso habituales |
+|------------|-------------|-------------------------|
+| `linux/amd64` | Intel/AMD 64-bit | La mayoría de servidores cloud, equipos de escritorio |
+| `linux/arm64` | ARM 64-bit | Apple Silicon, instancias cloud ARM |
+| `linux/arm/v7` | ARM 32-bit v7 | Raspberry Pi 3+ |
+| `linux/arm/v6` | ARM 32-bit v6 | Raspberry Pi 1, Zero |
+
+### Scripts de construcción
+
+```bash
+# Construir solo para la plataforma actual
+./build-docker.sh
+
+# Construir para múltiples plataformas (ARM64 + AMD64)
+./build-docker.sh -m
+
+# Construir y publicar en Docker Hub
+./build-docker.sh -m -p -r YOUR_DOCKERHUB_USERNAME
+
+# Script dedicado multiplataforma
+./build-multiplatform.sh -r USERNAME -v v1.0.0 -p
+
+# Construir para Raspberry Pi
+./build-multiplatform.sh --platforms linux/arm/v7 -r USERNAME -p
+```
+
+### Docker Buildx manual
+
+```bash
+# Crear y usar el builder buildx
+docker buildx create --name certmate-builder --use
+
+# Construir para múltiples plataformas
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t USERNAME/certmate:latest .
+
+# Construir y publicar
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t USERNAME/certmate:latest --push .
+```
+
+### Requisitos previos para el modo multiplataforma
+
+```bash
+# Verificar el soporte de buildx
+docker buildx version
+docker buildx inspect --bootstrap
+
+# Activar la emulación QEMU (si es necesario)
+docker run --privileged --rm tonistiigi/binfmt --install all
+```
+
+### Forzar una plataforma específica
+
+```bash
+# Forzar AMD64 (p. ej., en Apple Silicon para pruebas)
+docker run --platform linux/amd64 --rm \
+  --env-file .env -p 8000:8000 certmate:latest
+
+# Detección automática (recomendado)
+docker run --rm --env-file .env -p 8000:8000 certmate:latest
+```
+
+---
+
+## Publicar en Docker Hub
+
+```bash
+# Iniciar sesión
+docker login
+
+# Etiquetar y publicar
+docker build -t USERNAME/certmate:latest .
+docker push USERNAME/certmate:latest
+
+# Con etiqueta de versión
+docker build -t USERNAME/certmate:v1.0.0 .
+docker push USERNAME/certmate:v1.0.0
+```
+
+---
+
+## Integración CI/CD
+
+### GitHub Actions
+
+Secrets requeridos:
+- `DOCKERHUB_USERNAME`
+- `DOCKERHUB_TOKEN`
+
+```bash
+# Activación manual con plataformas personalizadas
+gh workflow run docker-multiplatform.yml \
+  -f platforms="linux/amd64,linux/arm64,linux/arm/v7" \
+  -f push_to_registry=true
+```
+
+---
+
+## Consejos para producción
+
+1. **Usa gestión de secretos**: Docker secrets, Kubernetes secrets o un gestor de secretos
+2. **Activa TLS**: Ejecuta detrás de un reverse proxy con terminación TLS
+3. **Monitoriza los recursos**: Define límites de CPU y memoria
+4. **Haz copias de seguridad de los volúmenes**: Realiza backups periódicos de los volúmenes de certificados y datos
+5. **Actualiza con regularidad**: Mantén la imagen actualizada con los parches de seguridad
+6. **Usa el caché de capas** para construcciones más rápidas:
+   ```bash
+   docker buildx build --cache-from type=registry,ref=USERNAME/certmate:cache .
+   ```
+
+---
+
+## Resolución de problemas
+
+### El contenedor no arranca
+
+```bash
+docker logs certmate
+docker exec certmate env
+```
+
+### El health check falla
+
+```bash
+docker logs certmate
+docker exec certmate curl -v http://localhost:8000/health
+```
+
+### Problemas de permisos
+
+```bash
+docker exec certmate ls -la /app/certificates
+docker exec certmate ls -la /app/data
+```
+
+### Problemas de construcción multiplataforma
+
+| Error | Solución |
+|-------|----------|
+| "multiple platforms not supported for docker driver" | `docker buildx create --name multiplatform --use` |
+| "exec format error" | `docker run --privileged --rm tonistiigi/binfmt --install all` |
+| Construcciones no nativas lentas | Normal debido a la emulación; usa GitHub Actions para producción |
+| No se puede cargar la imagen multiplataforma en Docker local | Usa `--load` con una sola plataforma para pruebas locales |
+
+---
+
+## Tamaños de imagen
+
+Tamaños típicos por arquitectura:
+- **AMD64**: ~200-300 MB
+- **ARM64**: ~200-300 MB
+- **ARM v7**: ~180-250 MB
+
+---
+
+<div align="center">
+
+[← Volver a la documentación](./README.md) • [Instalación →](./installation.md) • [Arquitectura →](./architecture.md)
+
+</div>

--- a/docs/es/guide.md
+++ b/docs/es/guide.md
@@ -1,0 +1,532 @@
+# CertMate Certificados de Cliente - Guía de uso
+
+## Primeros pasos
+
+### Instalación
+
+```bash
+# 1. Instalar las dependencias
+pip install -r requirements.txt
+
+# 2. Ejecutar CertMate
+python app.py
+
+# 3. Abrir el panel de control
+# Navega a: http://localhost:5000/client-certificates
+```
+
+### Primeros pasos
+
+1. **Generar la CA** — Creada automáticamente en el primer arranque
+2. **Acceder al panel de control** — Ve a `/client-certificates`
+3. **Crear un certificado** — Usa el formulario web o la API
+4. **Descargar los archivos** — Obtén el certificado, la clave y el CSR
+
+---
+
+## Panel de control web
+
+### Funcionalidades del panel de control
+
+**URL**: `http://localhost:5000/client-certificates`
+
+#### Panel de estadísticas
+- Total de certificados
+- Número de activos
+- Número de revocados
+- Desglose por tipo de uso
+
+#### Tabla de certificados
+- Lista todos los certificados
+- Búsqueda por nombre común
+- Filtro por tipo de uso
+- Filtro por estado
+- Ordenación por fecha de creación
+
+#### Formulario de creación de certificado
+
+**Campos del formulario**:
+- Nombre común (obligatorio)
+- Dirección de correo electrónico
+- Organización
+- Unidad organizativa
+- Tipo de uso (VPN, API-mTLS, etc.)
+- Días de validez (por defecto: 365)
+- Generar clave (casilla de verificación)
+- Notas
+
+**Ejemplo**:
+```
+Common Name: user@example.com
+Email: user@example.com
+Organization: ACME Corp
+Usage Type: api-mtls
+Days Valid: 365
+```
+
+#### Importación CSV por lotes
+
+1. Haz clic en la pestaña "Importación masiva"
+2. Prepara un archivo CSV con las cabeceras:
+ ```
+ common_name,email,organization,cert_usage,days_valid
+ user1@example.com,user1@example.com,ACME Corp,api-mtls,365
+ user2@example.com,user2@example.com,ACME Corp,vpn,365
+ ```
+3. Arrastra y suelta o haz clic para subir el archivo
+4. Revisa la vista previa
+5. Haz clic en "Importar"
+
+---
+
+## Tareas habituales
+
+### Crear un certificado individual
+
+#### Mediante el panel de control web
+
+1. Ve a `/client-certificates`
+2. Rellena el formulario "Crear certificado"
+3. Haz clic en "Crear"
+4. El certificado aparece en la tabla
+
+#### Mediante la API
+
+```bash
+curl -X POST http://localhost:5000/api/client-certs/create \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "api-mtls",
+ "days_valid": 365,
+ "generate_key": true
+ }'
+```
+
+---
+
+### Descargar los archivos de un certificado
+
+#### Mediante el panel de control web
+
+1. Localiza el certificado en la tabla
+2. Haz clic en el icono de descarga ()
+3. Selecciona el tipo de archivo:
+ - **CRT** — Certificado (público)
+ - **KEY** — Clave privada (mantener en secreto)
+ - **CSR** — Solicitud de firma de certificado
+
+#### Mediante la API
+
+```bash
+# Descargar el certificado
+curl http://localhost:5000/api/client-certs/CERT_ID/download/crt \
+ -H "Authorization: Bearer TOKEN" \
+ -o my-cert.crt
+
+# Descargar la clave
+curl http://localhost:5000/api/client-certs/CERT_ID/download/key \
+ -H "Authorization: Bearer TOKEN" \
+ -o my-key.key
+```
+
+---
+
+### Revocar un certificado
+
+#### Mediante el panel de control web
+
+1. Localiza el certificado en la tabla
+2. Haz clic en el botón "Revocar" ()
+3. Introduce el motivo de revocación (opcional)
+4. Confirma
+
+#### Mediante la API
+
+```bash
+curl -X POST http://localhost:5000/api/client-certs/CERT_ID/revoke \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "reason": "compromised"
+ }'
+```
+
+**Motivos de revocación**:
+- `compromised` — La clave ha sido comprometida
+- `superseded` — Reemplazado por un nuevo certificado
+- `unspecified` — Revocación general
+- Cualquier motivo personalizado
+
+---
+
+### Renovar un certificado
+
+#### Mediante el panel de control web
+
+1. Localiza el certificado en la tabla
+2. Haz clic en el botón "Renovar" ()
+3. Confirma la renovación
+
+#### Mediante la API
+
+```bash
+curl -X POST http://localhost:5000/api/client-certs/CERT_ID/renew \
+ -H "Authorization: Bearer TOKEN"
+```
+
+**Nota**: La renovación crea un nuevo certificado con:
+- El mismo nombre común
+- Un nuevo número de serie
+- Una nueva fecha de expiración
+- El ID original actualizado
+
+---
+
+### Listar y filtrar certificados
+
+#### Mediante el panel de control web
+
+1. Ve a la tabla de certificados
+2. Usa el cuadro de búsqueda para el nombre común
+3. Usa el menú desplegable "Tipo de uso" para filtrar
+4. Usa el menú desplegable "Estado" (Activo/Revocado)
+5. Haz clic en "Aplicar filtros"
+
+#### Mediante la API
+
+```bash
+# Listar todos
+curl http://localhost:5000/api/client-certs \
+ -H "Authorization: Bearer TOKEN"
+
+# Filtrar por uso
+curl "http://localhost:5000/api/client-certs?usage=api-mtls" \
+ -H "Authorization: Bearer TOKEN"
+
+# Filtrar por estado
+curl "http://localhost:5000/api/client-certs?revoked=false" \
+ -H "Authorization: Bearer TOKEN"
+
+# Buscar
+curl "http://localhost:5000/api/client-certs?search=user@" \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+### Comprobar el estado de un certificado (OCSP)
+
+#### Mediante la API
+
+```bash
+curl http://localhost:5000/api/ocsp/status/SERIAL_NUMBER \
+ -H "Authorization: Bearer TOKEN"
+```
+
+**Respuesta**:
+```json
+{
+ "certificate_status": "good",
+ "certificate_serial": 12345678,
+ "this_update": "2024-10-30T18:00:00Z"
+}
+```
+
+---
+
+### Obtener la lista de revocación (CRL)
+
+#### Descargar la CRL
+
+```bash
+# Formato PEM
+curl http://localhost:5000/api/crl/download/pem \
+ -H "Authorization: Bearer TOKEN" \
+ -o ca.crl
+
+# Formato DER
+curl http://localhost:5000/api/crl/download/der \
+ -H "Authorization: Bearer TOKEN" \
+ -o ca.crl
+```
+
+#### Obtener información de la CRL
+
+```bash
+curl http://localhost:5000/api/crl/download/info \
+ -H "Authorization: Bearer TOKEN"
+```
+
+---
+
+## Operaciones por lotes
+
+### Formato CSV
+
+```csv
+common_name,email,organization,cert_usage,days_valid
+user1@example.com,user1@example.com,ACME Corp,api-mtls,365
+user2@example.com,user2@example.com,ACME Corp,vpn,365
+user3@example.com,user3@example.com,ACME Corp,api-mtls,730
+```
+
+### Columnas obligatorias
+
+- `common_name` — Sujeto del certificado (obligatorio)
+
+### Columnas opcionales
+
+- `email` — Dirección de correo electrónico
+- `organization` — Nombre de la organización
+- `organizational_unit` — Nombre del departamento
+- `cert_usage` — Tipo de uso
+- `days_valid` — Vigencia en días
+
+### Mediante el panel de control web
+
+1. Ve a la pestaña "Importación masiva"
+2. Sube el archivo CSV
+3. Revisa la vista previa
+4. Haz clic en "Importar todo"
+
+### Mediante la API
+
+```bash
+curl -X POST http://localhost:5000/api/client-certs/batch \
+ -H "Authorization: Bearer TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "headers": ["common_name", "email", "organization"],
+ "rows": [["user1@example.com", "user1@example.com", "ACME Corp"],
+ ["user2@example.com", "user2@example.com", "ACME Corp"],
+ ["user3@example.com", "user3@example.com", "ACME Corp"]
+ ]
+ }'
+```
+
+### Resultados de la importación
+
+Devuelve los contadores de éxito/error:
+```json
+{
+ "total": 3,
+ "successful": 3,
+ "failed": 0,
+ "errors": [],
+ "certificates": [{"identifier": "cert-batch-001", "common_name": "user1@example.com"},
+ {"identifier": "cert-batch-002", "common_name": "user2@example.com"},
+ {"identifier": "cert-batch-003", "common_name": "user3@example.com"}
+ ]
+}
+```
+
+---
+
+## Tipos de uso de los certificados
+
+### API mTLS
+
+Para la autenticación mutua TLS de clientes API.
+
+```
+Usage Type: api-mtls
+Typical Validity: 1 year (365 days)
+```
+
+### VPN
+
+Para la autenticación de clientes VPN.
+
+```
+Usage Type: vpn
+Typical Validity: 1-2 years (365-730 days)
+```
+
+### Tipos personalizados
+
+Puedes crear certificados para cualquier uso personalizado:
+
+```
+Usage Type: custom-application
+Usage Type: internal-service
+Usage Type: mobile-app
+```
+
+---
+
+## Renovación automática
+
+### Configuración
+
+- **Comprobación**: Diariamente a las 3 AM
+- **Umbral**: 30 días antes de la expiración
+- **Acción**: Renovación automática si está activada
+
+### Activar la renovación automática
+
+La renovación automática está activada por defecto. Para comprobar el estado:
+
+```bash
+curl http://localhost:5000/api/client-certs/CERT_ID \
+ -H "Authorization: Bearer TOKEN"
+```
+
+Busca:
+```json
+{
+ "renewal": {
+ "renewal_enabled": true,
+ "renewal_threshold_days": 30
+ }
+}
+```
+
+### Comportamiento de la renovación
+
+Cuando se renueva automáticamente:
+- Se crea un nuevo certificado
+- Mismo CN (nombre común)
+- Nuevo número de serie
+- Nueva fecha de expiración
+- El ID original permanece igual
+- El certificado antiguo es reemplazado
+
+---
+
+## Resolución de problemas
+
+### Problemas habituales
+
+#### Fallo en la creación del certificado
+
+**Error**: `Failed to create certificate`
+
+**Soluciones**:
+1. Comprueba que el nombre común es válido
+2. Verifica que todos los campos obligatorios están rellenos
+3. Comprueba que la CA está inicializada
+4. Revisa los logs para más detalles
+
+#### Fallo en la descarga del archivo
+
+**Error**: `File not found`
+
+**Soluciones**:
+1. Verifica que el ID del certificado existe
+2. Comprueba el tipo de archivo (crt, key, csr)
+3. Asegúrate de que el certificado no ha sido eliminado
+4. Comprueba el espacio en disco
+
+#### Límite de solicitudes superado
+
+**Error**: `HTTP 429 Too Many Requests`
+
+**Soluciones**:
+1. Espera antes de reintentar
+2. Usa operaciones por lotes
+3. Implementa backoff exponencial
+4. Comprueba el límite para tu endpoint
+
+### Consulta de logs
+
+Ver los logs de la aplicación:
+```bash
+tail -f logs/certmate.log
+```
+
+Ver los logs de auditoría:
+```bash
+tail -f logs/audit/certificate_audit.log
+```
+
+---
+
+## Buenas prácticas de seguridad
+
+### Claves privadas
+
+- **NUNCA** compartas tus claves privadas
+- **NUNCA** hagas commit de claves en git
+- Almacena las claves de forma segura
+- Usa permisos de archivo 0600
+
+### Certificados
+
+- Monitoriza las fechas de expiración
+- Renueva antes de que expiren
+- Revoca inmediatamente los certificados comprometidos
+- Conserva los logs de auditoría para el cumplimiento normativo
+
+### Tokens de API
+
+- Rota los tokens regularmente
+- Usa HTTPS en producción
+- No escribas los tokens directamente en el código
+- Usa variables de entorno
+
+### Revocación
+
+Revoca siempre cuando:
+- La clave esté comprometida
+- El certificado sea reemplazado
+- Un usuario abandone la organización
+- El servicio sea dado de baja
+
+---
+
+## Consejos de rendimiento
+
+### Para lotes grandes
+
+Usa operaciones por lotes en lugar de creaciones individuales:
+```bash
+# Bien: Una solicitud para 1000 certificados
+POST /api/client-certs/batch
+
+# Mal: 1000 solicitudes para 1000 certificados
+POST /api/client-certs/create × 1000
+```
+
+### Para el filtrado
+
+Filtra en el lado del servidor:
+```bash
+# Bien: El servidor filtra
+GET /api/client-certs?usage=api-mtls
+
+# Mal: El cliente filtra todo
+GET /api/client-certs
+```
+
+### Para la monitorización
+
+Usa el endpoint de estadísticas:
+```bash
+GET /api/client-certs/stats
+```
+
+---
+
+## Soporte
+
+### Documentación
+
+- [Referencia de API](./api.md) — Todos los endpoints
+- [Arquitectura](./architecture.md) — Diseño del sistema
+- [Notas de versión](../RELEASE_NOTES.md) — Historial de versiones
+
+### Pruebas
+
+Consulta `test_e2e_complete.py` para ejemplos de uso.
+
+---
+
+<div align="center">
+
+[← Volver a la documentación](./README.md) • [Referencia de API →](./api.md) • [Arquitectura →](./architecture.md)
+
+</div>

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -1,0 +1,252 @@
+# CertMate - Certificados de Cliente
+
+<div align="center">
+
+![CertMate](https://img.shields.io/badge/CertMate-Certificados%20de%20Cliente-blue?style=for-the-badge)
+![Estado](https://img.shields.io/badge/Estado-Listo%20para%20Producción-green?style=for-the-badge)
+
+**Gestión completa de certificados de cliente para CertMate**
+
+[Documentación](#documentación) • [Inicio rápido](#inicio-rápido) • [Referencia API](./api.md) • [Arquitectura](./architecture.md)
+
+</div>
+
+---
+
+## Descripción general
+
+CertMate Certificados de Cliente es una solución completa y lista para producción para la gestión de certificados de cliente con:
+
+- **CA autofirmada** — Genere y gestione su propia Autoridad de Certificación
+- **Gestión completa del ciclo de vida** — Cree, renueve, revoque y supervise certificados de cliente
+- **OCSP & CRL** — Estado de los certificados en tiempo real y listas de revocación
+- **Panel de control web** — Interfaz intuitiva para la gestión de certificados
+- **API REST** — API completa para la automatización
+- **Operaciones por lotes** — Importe entre 100 y 30.000 certificados mediante CSV
+- **Registro de auditoría** — Seguimiento de todas las operaciones para el cumplimiento normativo
+- **Limitación de tasa** — Protección integrada contra el abuso
+
+---
+
+## Funcionalidades
+
+### Fase 1: Fundación CA
+- **PrivateCAGenerator**: CA autofirmada con claves RSA de 4096 bits, validez de 10 años
+- **CSRHandler**: Valide, cree y analice solicitudes de firma de certificado
+- **Almacenamiento seguro**: Permisos de archivo adecuados (0600) para las claves privadas
+
+### Fase 2: Motor de certificados de cliente
+- **Ciclo de vida completo**: Cree, liste, filtre, revoque y renueve certificados
+- **Consultas multi-filtro**: Búsqueda por tipo de uso, estado de revocación, nombre común
+- **Renovación automática**: Verificaciones diarias programadas para certificados próximos a vencer
+- **Soporte para más de 30k certificados**: Almacenamiento por directorio para escalabilidad lineal
+- **Gestión de metadatos**: Seguimiento de CN, email, organización, uso y fechas de expiración
+
+### Fase 3: Interfaz de usuario y funcionalidades avanzadas
+- **Panel de control web**: Interfaz de gestión adaptable con modo oscuro
+- **Respondedor OCSP**: Consulte el estado de los certificados en tiempo real
+- **Gestor CRL**: Genere y distribuya listas de revocación (PEM/DER)
+- **API REST**: 10 endpoints en 3 espacios de nombres para automatización completa
+- **Operaciones por lotes**: Importe certificados desde archivos CSV
+
+### Fase 4: Mejoras rápidas
+- **Registro de auditoría**: Seguimiento de todas las operaciones sobre certificados con información de usuario/IP
+- **Limitación de tasa**: Límites configurables por endpoint con valores predeterminados razonables
+- **Listo para integración**: Ambos gestores disponibles en la aplicación para uso inmediato
+
+---
+
+## Inicio rápido
+
+### Instalación
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+El servidor se iniciará en `http://localhost:8000`
+
+### Uso básico
+
+#### 1. Acceder al panel de control web
+```
+Navegue a: http://localhost:8000/client-certificates
+```
+
+#### 2. Crear un certificado mediante la API
+```bash
+curl -X POST http://localhost:8000/api/client-certs/create \
+ -H "Authorization: Bearer YOUR_TOKEN" \
+ -H "Content-Type: application/json" \
+ -d '{
+ "common_name": "user@example.com",
+ "email": "user@example.com",
+ "organization": "ACME Corp",
+ "cert_usage": "api-mtls",
+ "days_valid": 365,
+ "generate_key": true
+ }'
+```
+
+#### 3. Listar certificados
+```bash
+curl http://localhost:8000/api/client-certs \
+ -H "Authorization: Bearer YOUR_TOKEN"
+```
+
+#### 4. Descargar archivos de certificado
+```bash
+curl http://localhost:8000/api/client-certs/USER_ID/download/crt \
+ -H "Authorization: Bearer YOUR_TOKEN" \
+ -o user.crt
+
+curl http://localhost:8000/api/client-certs/USER_ID/download/key \
+ -H "Authorization: Bearer YOUR_TOKEN" \
+ -o user.key
+```
+
+---
+
+## Documentación
+
+### Documentación principal
+
+- **[Guía de instalación](./installation.md)** — Configuración, dependencias, despliegue
+- **[Notas de Kubernetes](./kubernetes.md)** — Dimensionamiento de pods y resolución de problemas OOM
+- **[Proveedores DNS](./dns-providers.md)** — Proveedores soportados, multi-cuenta, alias de dominio
+- **[Proveedores CA](./ca-providers.md)** — Let's Encrypt, Actalis, DigiCert, CA privada
+- **[Guía de Docker](./docker.md)** — Construcciones Docker, multi-plataforma, Compose
+- **[Guía de pruebas](./testing.md)** — Framework de pruebas, CI/CD, cobertura
+- **[Referencia API](./api.md)** — Documentación completa de la API REST con ejemplos
+- **[Arquitectura](./architecture.md)** — Diseño del sistema, componentes y flujo de datos
+- **[Guía de usuario](./guide.md)** — Guía paso a paso para las tareas más habituales
+
+### Enlaces rápidos
+
+- [Endpoints API](./api.md#endpoints) — Todos los endpoints disponibles
+- [Tipos de certificado](./api.md#certificate-types) — VPN, API mTLS, etc.
+- [Limitación de tasa](./api.md#rate-limiting) — Límites predeterminados y configuración
+- [Registro de auditoría](./api.md#audit-logging) — Comprensión de las trazas de auditoría
+
+---
+
+## Pruebas
+
+Todas las funcionalidades han sido probadas de forma exhaustiva:
+
+```bash
+python -m pytest tests/ -v
+```
+
+### Cobertura de pruebas
+- Operaciones CA (3 pruebas)
+- Operaciones CSR (3 pruebas)
+- Ciclo de vida de certificados (8 pruebas)
+- Filtrado y búsqueda (3 pruebas)
+- Operaciones por lotes (2 pruebas)
+- OCSP y CRL (5 pruebas)
+- Auditoría y limitación de tasa (3 pruebas)
+
+---
+
+## Resumen de endpoints API
+
+| Método | Endpoint                                 | Propósito                              |
+| ------ | ---------------------------------------- | -------------------------------------- |
+| `POST` | `/api/client-certs/create`               | Crear un nuevo certificado             |
+| `GET`  | `/api/client-certs`                      | Listar certificados con filtros        |
+| `GET`  | `/api/client-certs/<id>`                 | Obtener metadatos de un certificado    |
+| `GET`  | `/api/client-certs/<id>/download/<type>` | Descargar cert/key/csr                 |
+| `POST` | `/api/client-certs/<id>/revoke`          | Revocar un certificado                 |
+| `POST` | `/api/client-certs/<id>/renew`           | Renovar un certificado                 |
+| `GET`  | `/api/client-certs/stats`                | Obtener estadísticas                   |
+| `POST` | `/api/client-certs/batch`                | Importación CSV por lotes              |
+| `GET`  | `/api/ocsp/status/<serial>`              | Consulta de estado OCSP                |
+| `GET`  | `/api/crl/download/<format>`             | Descargar la CRL (PEM/DER)             |
+
+---
+
+## Arquitectura
+
+El sistema está construido con una arquitectura modular por capas:
+
+```
+
+ Interfaz Web y API REST
+ (/client-certificates, /api/*)
+
+ Recursos API y gestores
+ (OCSP, CRL, Audit, Limitación de tasa)
+
+ Módulos principales
+ (Gestión de certificados, CSR, CA, Almacenamiento)
+
+ Criptografía y almacenamiento
+ (OpenSSL, Sistema de archivos, Backends)
+
+```
+
+Consulte la [Documentación de arquitectura](./architecture.md) para información detallada.
+
+---
+
+## Seguridad
+
+### Solidez criptográfica
+- **CA**: Claves RSA de 4096 bits, validez de 10 años
+- **Certificados de cliente**: RSA de 2048 o 4096 bits (configurable)
+- **Firmas**: SHA256
+- **Almacenamiento de claves**: Permisos 0600 en sistemas Unix
+
+### Control de acceso
+- **Autenticación mediante token Bearer** en todos los endpoints API
+- **Limitación de tasa**: Límites configurables por endpoint
+- **Registro de auditoría**: Todas las operaciones registradas con información de usuario/IP
+
+### Cumplimiento normativo
+- Seguimiento de metadatos de certificados
+- Traza de auditoría de revocaciones
+- Registros de operaciones persistentes
+- Soporte para consultas de cumplimiento
+
+---
+
+## Rendimiento
+
+La implementación está optimizada para:
+- **Escalabilidad**: El almacenamiento por directorio soporta más de 30k certificados simultáneos
+- **Velocidad**: Consultas multi-filtro eficientes
+- **Fiabilidad**: Programación automática de renovaciones
+- **Capacidad de respuesta**: JavaScript asíncrono en la interfaz web
+
+---
+
+## Soporte
+
+Para preguntas o incidencias:
+1. Consulte la [Guía de usuario](./guide.md)
+2. Consulte la [Documentación API](./api.md)
+3. Consulte la sección [Arquitectura](./architecture.md)
+4. Revise los casos de prueba en `test_e2e_complete.py`
+
+---
+
+## Licencia
+
+Consulte el archivo LICENSE en el repositorio
+
+---
+
+## Versión
+
+**Versión actual**: 2.3.0
+**Estado**: Listo para producción
+
+---
+
+<div align="center">
+
+[Documentación](.) • [Licencia](../LICENSE)
+
+</div>

--- a/docs/es/installation.md
+++ b/docs/es/installation.md
@@ -1,0 +1,536 @@
+# Guía de instalación
+
+Esta guía cubre todos los métodos de instalación y despliegue de CertMate.
+
+---
+
+## Requisitos previos
+
+- Python 3.9 o superior
+- pip (gestor de paquetes de Python)
+- Docker (opcional, para el despliegue en contenedor)
+
+---
+
+## Método 1: Instalación directa
+
+### 1. Clonar el repositorio
+
+```bash
+git clone https://github.com/fabriziosalmi/certmate.git
+cd certmate
+```
+
+### 2. Crear el entorno virtual
+
+```bash
+python3 -m venv venv
+source venv/bin/activate  # Linux/Mac
+# o
+.\venv\Scripts\activate   # Windows
+```
+
+### 3. Instalar las dependencias
+
+```bash
+pip install -r requirements.txt
+```
+
+### 4. Configurar el entorno
+
+Cree un archivo `.env`:
+
+```bash
+cp .env.example .env
+# Edite .env con sus ajustes
+```
+
+### 5. Iniciar la aplicación
+
+```bash
+python app.py
+```
+
+---
+
+## Método 2: Instalación con Docker
+
+### Con Docker Compose (recomendado)
+
+```bash
+git clone https://github.com/fabriziosalmi/certmate.git
+cd certmate
+docker-compose up -d
+```
+
+### Con Docker Build
+
+```bash
+git clone https://github.com/fabriziosalmi/certmate.git
+cd certmate
+docker build -t certmate .
+docker run -p 8000:8000 --env-file .env -v ./certificates:/app/certificates certmate
+```
+
+> Para el despliegue avanzado con Docker, incluyendo builds multiplataforma, consulte la [Guía de Docker](./docker.md).
+
+---
+
+## Dependencias del sistema
+
+### Ubuntu / Debian
+
+```bash
+sudo apt update
+sudo apt install python3-dev python3-venv build-essential libssl-dev libffi-dev
+```
+
+### CentOS / RHEL / Rocky
+
+```bash
+sudo yum install python3-devel gcc openssl-devel libffi-devel
+```
+
+### macOS
+
+```bash
+brew install python3 openssl libffi
+```
+
+---
+
+## Configuración del proveedor DNS
+
+Tras la instalación, configure las credenciales de su proveedor DNS. Consulte la [Guía de proveedores DNS](./dns-providers.md) para instrucciones detalladas.
+
+Configuración rápida para los proveedores más habituales:
+
+### Cloudflare
+
+1. Vaya al [Panel de Cloudflare](https://dash.cloudflare.com/profile/api-tokens)
+2. Cree un nuevo token de API con permisos `Zone:DNS:Edit`
+3. Añada el token en los ajustes de CertMate
+
+### AWS Route53
+
+1. Cree un usuario IAM con permisos de Route53
+2. Genere claves de acceso
+3. Añada las credenciales en los ajustes de CertMate
+
+### Azure DNS
+
+1. Cree un Service Principal
+2. Asigne el rol DNS Zone Contributor
+3. Configure los detalles de la suscripción en los ajustes de CertMate
+
+### Google Cloud DNS
+
+1. Cree una cuenta de servicio con el rol DNS Administrator
+2. Descargue el archivo de clave JSON
+3. Impórtelo en los ajustes de CertMate
+
+---
+
+## Variables de entorno
+
+```bash
+# Autenticación de la API (se genera automáticamente si no se define ninguna)
+# Opción A: valor directo
+API_BEARER_TOKEN=su_token_seguro
+# Opción B: ruta a un archivo que contiene el token (tiene precedencia sobre API_BEARER_TOKEN)
+API_BEARER_TOKEN_FILE=/run/secrets/api_bearer_token
+
+# Clave secreta de sesión de Flask (se genera automáticamente si no se define ninguna)
+# Opción A: valor directo
+SECRET_KEY=su_clave_secreta_flask
+# Opción B: ruta a un archivo que contiene la clave (tiene precedencia sobre SECRET_KEY)
+SECRET_KEY_FILE=/run/secrets/secret_key
+
+# Reverse proxy — establezca 'true' cuando CertMate esté detrás de Nginx,
+# HAProxy, Traefik, Cloudflare, etc. Sin esto, request.remote_addr
+# resuelve a la IP del proxy en cada petición, lo que colapsa la
+# limitación de tasa por cliente en un único bucket.
+BEHIND_PROXY=true
+
+# Cifrado de backups en reposo (opcional, recomendado).
+# Cuando se define, los backups unificados se escriben como archivos
+# .zip.enc cifrados (derivación de clave PBKDF2-SHA256 + Fernet/AES)
+# en lugar de .zip en texto claro. Los backups incluyen cada clave
+# privada de certificado; sin esto, un archivo de backup exfiltrado
+# supone un compromiso total de las claves.
+CERTMATE_BACKUP_PASSPHRASE=elija-una-frase-de-paso-larga-y-aleatoria
+
+# Proveedores DNS (elija uno o varios)
+CLOUDFLARE_TOKEN=su_token_cloudflare
+AWS_ACCESS_KEY_ID=su_access_key_aws
+AWS_SECRET_ACCESS_KEY=su_secret_key_aws
+AZURE_SUBSCRIPTION_ID=su_subscription_azure
+AZURE_TENANT_ID=su_tenant_azure
+AZURE_CLIENT_ID=su_client_azure
+AZURE_CLIENT_SECRET=su_secret_azure
+GOOGLE_PROJECT_ID=su_proyecto_gcp
+POWERDNS_API_URL=https://su-powerdns:8081
+POWERDNS_API_KEY=su_clave_powerdns
+```
+
+### Orden de resolución
+
+| Variable | Prioridad |
+|----------|-----------|
+| `API_BEARER_TOKEN_FILE` | La más alta — si está definida, `API_BEARER_TOKEN` nunca se lee |
+| `API_BEARER_TOKEN` | Se usa solo cuando `API_BEARER_TOKEN_FILE` está ausente |
+| *(generado)* | Fallback cuando ninguna está definida o el valor no supera la validación |
+| `SECRET_KEY_FILE` | La más alta — si está definida, `SECRET_KEY` nunca se lee |
+| `SECRET_KEY` | Se usa solo cuando `SECRET_KEY_FILE` está ausente |
+| *(generado + persistido)* | Se escribe en `data/.secret_key` para que las sesiones sobrevivan a los reinicios |
+
+> **Consejo para Docker Secrets**: Use `API_BEARER_TOKEN_FILE=/run/secrets/api_bearer_token` y `SECRET_KEY_FILE=/run/secrets/secret_key` con Docker Swarm o los secrets de Kubernetes para evitar poner valores sensibles en variables de entorno.
+
+---
+
+## Despliegue en producción
+
+### Detrás de un reverse proxy
+
+Si CertMate está detrás de un reverse proxy (Nginx, HAProxy, Traefik, Cloudflare, Kubernetes Ingress) — que es la forma recomendada de ejecutarlo para la terminación TLS — establezca `BEHIND_PROXY=true` en el entorno del contenedor. Esto activa el middleware `ProxyFix` de Werkzeug para que los siguientes elementos confíen en las cabeceras `X-Forwarded-*` de su proxy:
+
+- `request.remote_addr` resuelve a la IP original del cliente en lugar de la IP del proxy. La limitación de tasa, las entradas del registro de auditoría y las advertencias de "intento de token de API inválido desde X" pasan a ser por cliente en lugar de por proxy.
+- El esquema / host / prefijo del proxy se respetan, lo que mantiene la corrección de las URLs generadas y los scopes de las cookies.
+
+```yaml
+# Fragmento de docker-compose.yml
+services:
+  certmate:
+    image: fabriziosalmi/certmate:latest
+    environment:
+      BEHIND_PROXY: "true"
+    volumes:
+      - ./data:/app/data
+```
+
+**Cuándo NO activarlo.** Si expone CertMate directamente a la red sin ningún proxy delante, deje `BEHIND_PROXY` sin definir. Con esta opción activada, cualquiera que pueda alcanzar el listener podría falsificar `X-Forwarded-For` y eludir los límites de tasa por cliente. El proxy es el límite de confianza.
+
+Su proxy debe, por supuesto, reenviar las cabeceras. Ejemplo con Nginx:
+
+```nginx
+proxy_set_header Host              $host;
+proxy_set_header X-Real-IP         $remote_addr;
+proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+```
+
+#### Ejemplo: Zion (gateway TLS en Rust + WAF)
+
+[Zion](https://github.com/fabriziosalmi/zion) es un reverse proxy Rust de alto rendimiento con un WAF integrado — una buena opción delante de CertMate cuando se desea terminación TLS 1.3 y filtrado de peticiones en el edge. CertMate permanece en HTTP plano en la red interna; Zion termina el TLS y reenvía.
+
+`zion.toml`:
+
+```toml
+[server]
+listen_http  = "0.0.0.0:8080"
+listen_https = "0.0.0.0:8443"
+
+[tls]
+cert_path = "/etc/ssl/zion/tls.crt"
+key_path  = "/etc/ssl/zion/tls.key"
+min_version = "1.3"
+alpn = ["h2", "http/1.1"]
+
+[upstream.backend]
+url = "http://certmate:8000"
+
+[[route]]
+path = "/"
+upstream = "backend"
+
+[[route]]
+path = "/{*rest}"
+upstream = "backend"
+```
+
+`docker-compose.yml`:
+
+```yaml
+services:
+  certmate:
+    image: certmate:latest
+    environment:
+      BEHIND_PROXY: "true"
+    expose:
+      - "8000"
+    volumes:
+      - ./data:/app/data
+
+  zion:
+    image: zion:latest
+    depends_on:
+      - certmate
+    environment:
+      ZION_CONFIG: /etc/zion/zion.toml
+    volumes:
+      - ./zion.toml:/etc/zion/zion.toml:ro
+      - ./certs:/etc/ssl/zion:ro
+    ports:
+      - "443:8443"
+      - "80:8080"
+```
+
+Mantenga `BEHIND_PROXY=true` en el servicio CertMate: Zion añade `X-Forwarded-For`, lo que hace que la limitación de tasa por cliente, las entradas de auditoría y las advertencias de fallo de autenticación resuelvan a la IP real del cliente en lugar de la de Zion.
+
+### Usar Gunicorn
+
+```bash
+pip install gunicorn
+gunicorn --bind 0.0.0.0:8000 --workers 4 --threads 8 app:app
+```
+
+### Usar systemd
+
+Cree `/etc/systemd/system/certmate.service`:
+
+```ini
+[Unit]
+Description=CertMate Gestor de Certificados SSL
+After=network.target
+
+[Service]
+Type=simple
+User=certmate
+WorkingDirectory=/opt/certmate
+Environment=PATH=/opt/certmate/venv/bin
+ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 4 app:app
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Backup y restauración
+
+```bash
+# Crear un backup
+curl -X POST http://localhost:8000/api/backups/create \
+  -H "Authorization: Bearer SU_TOKEN_API"
+
+# Listar los backups
+curl http://localhost:8000/api/backups \
+  -H "Authorization: Bearer SU_TOKEN_API"
+
+# Restaurar un backup
+curl -X POST http://localhost:8000/api/backups/restore \
+  -H "Authorization: Bearer SU_TOKEN_API" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "backup_20240101_120000.zip"}'
+```
+
+---
+
+## Resolución de problemas
+
+### Conflictos de versiones de plugins DNS
+
+Si encuentra conflictos de versiones, use estas versiones específicas:
+
+```txt
+certbot==4.1.1
+certbot-dns-cloudflare==4.1.1
+certbot-dns-route53==4.1.1
+certbot-dns-azure==2.6.1
+certbot-dns-google==4.1.1
+certbot-dns-powerdns==0.2.1
+```
+
+### Comandos de validación
+
+```bash
+# Comprobar los plugins de certbot
+certbot plugins --text
+
+# Verificar que el servicio está en funcionamiento
+curl -X GET http://localhost:8000/api/health
+```
+
+### Errores comunes
+
+| Error | Solución |
+|-------|----------|
+| `ModuleNotFoundError` | Ejecute `pip install -r requirements.txt` |
+| `Port already in use` | Cambie el puerto en las variables de entorno |
+| `certbot not found` | Instale certbot: `pip install certbot` |
+| `Permission denied` | Compruebe los permisos en `/app/data` y `/app/certificates` |
+| `Token API inválido` | Verifique `API_BEARER_TOKEN` en su archivo `.env` |
+
+### Modo de depuración
+
+```bash
+export FLASK_DEBUG=1
+python app.py
+```
+
+### Restricción del tráfico saliente (hardening de egress)
+
+CertMate establece conexiones salientes hacia las autoridades de certificación ACME, las APIs de proveedores DNS, el almacenamiento de objetos y los webhooks de notificación a través de HTTP(S), además de SMTP para las notificaciones por email. Puede restringir y auditar el tráfico **HTTP(S)** enrutándolo a través de un **forward proxy** y denegando a CertMate cualquier otra ruta hacia internet.
+
+Los clientes HTTP(S) de CertMate (`requests`, `certbot`, entrega de webhooks vía `urllib`, `boto3`) respetan las variables de entorno estándar `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`, por lo que no se requieren cambios en el código. **SMTP es la excepción:** las notificaciones por email usan `smtplib`, que abre una conexión TCP directa y **no** consulta las variables de proxy HTTP. En una red de egress restringida, permita directamente el `host:port` de su relay SMTP (regla de firewall / NetworkPolicy), o use un canal de notificación webhook en lugar del email.
+
+Ejemplo con [Secure Proxy Manager](https://github.com/fabriziosalmi/secure-proxy-manager), un forward proxy autoalojado basado en Squid con WAF, DNS sinkhole y — desde v3.9.0 — una **lista de permitidos de egress default-deny** integrada (solo los destinos explícitamente aprobados son alcanzables; todo lo demás se deniega):
+
+```yaml
+services:
+  certmate:
+    image: certmate:latest
+    environment:
+      HTTP_PROXY:  "http://proxy:3128"
+      HTTPS_PROXY: "http://proxy:3128"
+      NO_PROXY:    "localhost,127.0.0.1"
+    networks:
+      - egress            # CertMate solo puede alcanzar el proxy en esta red
+networks:
+  egress:
+    internal: true        # sin gateway: CertMate no tiene internet directo
+```
+
+Colocar CertMate en una red `internal` (sin gateway) compartida con el proxy hace del proxy su **único** camino hacia el exterior. El tráfico saliente se convierte en un único punto de control auditable: permita los destinos que CertMate realmente necesita (su CA, proveedor DNS, almacenamiento de objetos, endpoints de notificación) y deniegue el resto.
+
+**Kubernetes:** una `NetworkPolicy` de egress default-deny que solo permite tráfico hacia el Service del proxy, más las variables de entorno `HTTP(S)_PROXY` en el Deployment.
+
+**systemd:** `Environment=HTTPS_PROXY=...` en la unidad, más reglas de firewall en el host que restringen el egress al proxy.
+
+### Ubicación de almacenamiento del directorio de datos
+
+CertMate utiliza E/S de archivos bloqueante estándar de Python para todo lo que se encuentra bajo `data/` (ajustes, certificados, registro de auditoría, almacenamiento SQLite del planificador). Se recomienda encarecidamente el disco local.
+
+Si monta `data/` en un sistema de archivos de red (NFS, SMB), tenga en cuenta que:
+
+- Un servidor NFS bloqueado puede detener las lecturas de archivos de Python indefinidamente sin timeout integrado. El worker de renovación, el escritor del registro de auditoría y la sonda /health se bloquearán todos en el mismo punto de montaje.
+- El modo journal WAL de SQLite requiere semánticas de bloqueo que NFS no siempre proporciona. CertMate registra una advertencia si tuvo que recurrir a un modo journal más débil; la corrección se preserva, pero la concurrencia disminuye.
+
+Si NFS es inevitable, monte con `soft,timeo=30,retrans=3` (o el equivalente de su distribución) para que las E/S fallen rápidamente en lugar de bloquearse ante un servidor caído.
+
+### Usar Gunicorn
+
+```bash
+gunicorn --bind 0.0.0.0:8000 --workers 4 app:app
+```
+
+### Usar systemd
+
+Cree `/etc/systemd/system/certmate.service`:
+
+```ini
+[Unit]
+Description=CertMate Gestor de Certificados SSL
+After=network.target
+
+[Service]
+Type=simple
+User=certmate
+WorkingDirectory=/opt/certmate
+Environment=PATH=/opt/certmate/venv/bin
+ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 4 app:app
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Active e inicie:
+
+```bash
+sudo systemctl enable certmate
+sudo systemctl start certmate
+```
+
+### Usar Docker en producción
+
+```yaml
+version: '3.8'
+services:
+  certmate:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - API_BEARER_TOKEN=${API_BEARER_TOKEN}
+      - CLOUDFLARE_TOKEN=${CLOUDFLARE_TOKEN}
+    volumes:
+      - ./certificates:/app/certificates
+      - ./data:/app/data
+    restart: unless-stopped
+```
+
+---
+
+## Resolución de problemas
+
+### Instalación manual de dependencias
+
+Si la instalación automática falla, instale los proveedores DNS individualmente:
+
+```bash
+# Núcleo de certbot
+pip install certbot==4.1.1
+
+# Cloudflare
+pip install certbot-dns-cloudflare==4.1.1
+
+# AWS Route53
+pip install certbot-dns-route53==4.1.1 boto3==1.35.76
+
+# Azure DNS
+pip install certbot-dns-azure==2.6.1 azure-identity==1.19.0 azure-mgmt-dns==8.1.0
+
+# Google Cloud DNS
+pip install certbot-dns-google==4.1.1 google-cloud-dns==0.35.0
+
+# PowerDNS
+pip install certbot-dns-powerdns==0.2.1
+```
+
+> La mayoría de los plugins DNS requieren Certbot 4.1.1. El plugin de Azure tiene versionado independiente (2.6.1) y PowerDNS es un plugin más reciente (0.2.1).
+
+### Comandos de validación
+
+```bash
+# Comprobar los plugins de certbot
+certbot plugins --text
+
+# Verificar que el servicio está en funcionamiento
+curl -X GET http://localhost:8000/api/health
+```
+
+### Errores comunes
+
+| Error | Solución |
+|-------|----------|
+| `ModuleNotFoundError` | Ejecute `pip install -r requirements.txt` |
+| `Port already in use` | Cambie el puerto en las variables de entorno |
+| `certbot not found` | Instale certbot: `pip install certbot` |
+| `Permission denied` | Compruebe los permisos en `/app/data` y `/app/certificates` |
+| `Token API inválido` | Verifique `API_BEARER_TOKEN` en su archivo `.env` |
+
+### Modo de depuración
+
+```bash
+export FLASK_DEBUG=1
+python app.py
+```
+
+---
+
+## Soporte
+
+Si encuentra algún problema:
+
+1. Revise los registros en busca de errores específicos
+2. Verifique las credenciales de su proveedor DNS
+3. Consulte la [Guía de proveedores DNS](./dns-providers.md) para la resolución de problemas específicos del proveedor
+4. Consulte la [Guía de pruebas](./testing.md) para ejecutar diagnósticos
+
+---
+
+<div align="center">
+
+[← Volver a la documentación](./README.md) • [Proveedores DNS →](./dns-providers.md) • [Docker →](./docker.md)
+
+</div>

--- a/docs/es/kubernetes.md
+++ b/docs/es/kubernetes.md
@@ -1,0 +1,96 @@
+# Notas de producción en Kubernetes
+
+Esta guía recoge la configuración de dimensionamiento base para CertMate cuando se ejecuta detrás de un Ingress/HTTPRoute de Kubernetes y utiliza un backend de certificados remoto como Azure Key Vault.
+
+## Recursos recomendados
+
+CertMate ejecuta gunicorn junto con subprocesos certbot en el mismo contenedor. Durante la creación o renovación de certificados, certbot y los plugins DNS pueden añadir temporalmente un pico de memoria considerable. Con Azure Key Vault en modo `both`, listar los certificados también realiza llamadas remotas, por lo que límites muy reducidos pueden convertir operaciones rutinarias en reinicios por OOM.
+
+Utiliza esta configuración base para los pods de producción que gestionan decenas de certificados:
+
+```yaml
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1536Mi
+env:
+  - name: CERTMATE_CERT_INFO_CACHE_TTL
+    value: "60"
+  - name: GUNICORN_TIMEOUT
+    value: "300"
+```
+
+Para el modo de fallo específico en el que un pod con `memory: 512Mi` se reinicia durante la creación de un certificado, aumenta primero el límite de memoria. La ruta de código ahora evita los subprocesos `openssl` de la vista de lista anterior, utiliza lecturas ligeras de información de certificado de Azure Key Vault y excluye los directorios temporales e históricos de certbot de las copias de seguridad rutinarias, pero certbot sigue necesitando margen durante la emisión de certificados.
+
+## Ejemplo de aplicación del patch
+
+```bash
+kubectl -n certificate-management patch deployment certmate --type='strategic' -p '
+spec:
+  template:
+    spec:
+      containers:
+        - name: certmate
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1536Mi
+          env:
+            - name: CERTMATE_CERT_INFO_CACHE_TTL
+              value: "60"
+            - name: GUNICORN_TIMEOUT
+              value: "300"
+'
+```
+
+Verifica el motivo del siguiente reinicio tras aplicar el patch:
+
+```bash
+kubectl -n certificate-management describe pod -l app=certmate | grep -A6 "Last State"
+kubectl -n certificate-management top pod -l app=certmate
+```
+
+## Número de réplicas
+
+Ejecuta `replicas: 1` a menos que todas las rutas mutables (`/app/data`, `/app/certificates`, `/app/backups`, `/app/logs`) estén respaldadas por almacenamiento seguro para escritores concurrentes y hayas validado el comportamiento del planificador/renovación con múltiples pods. Azure Key Vault puede almacenar los certificados de forma remota, pero CertMate sigue conservando localmente los ajustes, metadatos, copias de seguridad y el estado de ejecución.
+
+## El badge de estado de despliegue muestra "Backend: Unreachable"
+
+*Actualizado el 2026-05-25 (ver [#263](https://github.com/fabriziosalmi/certmate/issues/263)).*
+
+El badge de estado de despliegue en el panel de control es un indicador de salud opcional y **no afecta** a la emisión, renovación ni descarga de certificados. El propio proceso de CertMate abre una conexión TLS directa a `<domain>:443` y compara la huella digital del certificado servido con la almacenada:
+
+- **Deployed** — el handshake fue exitoso y la huella digital coincide.
+- **Wrong Cert** — el handshake fue exitoso pero se sirve un certificado diferente.
+- **Unreachable** — el pod no pudo abrir una conexión TLS al dominio.
+
+En Kubernetes, **Unreachable para cada certificado es lo esperado** cuando el pod de CertMate no puede conectarse directamente a tu IP pública/Ingress. Causas frecuentes:
+
+- El dominio resuelve a una IP pública/Ingress que no es enrutable desde dentro del pod (hairpin/NAT o DNS split-horizon).
+- Una `NetworkPolicy` de egreso bloquea el puerto 443 saliente.
+- TLS está terminado por tu controlador Ingress o por un balanceador de carga externo, por lo que no existe ningún endpoint al que CertMate pueda conectarse directamente.
+- La sonda es simplemente lenta y supera el presupuesto predeterminado de 3 segundos.
+
+Si el destino es accesible pero lento, aumenta el presupuesto de la sonda:
+
+```yaml
+env:
+  - name: CERTMATE_TLS_PROBE_TIMEOUT_SECONDS
+    value: "10"   # accepts 1–30 seconds; default is 3
+```
+
+De lo contrario, el badge puede ignorarse con seguridad en una topología Ingress/Kubernetes — los certificados se emiten y sirven correctamente aunque CertMate no pueda sondearlos por sí mismo.
+
+---
+
+<div align="center">
+
+[← Volver a la documentación](./README.md) • [Guía de Docker →](./docker.md)
+
+</div>

--- a/docs/es/mcp.md
+++ b/docs/es/mcp.md
@@ -1,0 +1,118 @@
+# Servidor MCP (Model Context Protocol) de CertMate
+
+CertMate incluye un servidor MCP (Model Context Protocol) integrado escrito en Node.js. Esto permite a los asistentes de IA agentivos (como Claude o Gemini) inspeccionar de forma segura el estado de los certificados, disparar renovaciones, solicitar diagnósticos e interactuar directamente con la API de CertMate.
+
+## Funcionalidades y herramientas
+
+El servidor MCP de CertMate expone las siguientes herramientas a los asistentes de IA:
+
+**Inventario y estado**
+1. **`certmate_list_certificates`** — Lista todos los certificados gestionados por la instancia activa de CertMate (con fecha de expiración, estado y dominios).
+2. **`certmate_get_certificate`** — Detalle completo de un dominio: estado, días hasta la expiración, SANs, proveedor DNS/CA, flag de renovación automática. Úsalo para decidir si un certificado necesita renovarse.
+3. **`certmate_get_activity`** — Registro de actividad reciente/auditoría para diagnosticar qué cambió o falló.
+4. **`certmate_diagnostics`** — Instantánea de diagnóstico completa y saneada.
+5. **`certmate_get_settings`** — Ajustes globales y configuración.
+
+**Operaciones del ciclo de vida**
+6. **`certmate_create_certificate`** — Solicita un nuevo certificado TLS para un dominio (proveedor DNS, account y CA opcionales). Puede devolver un `job_id` (HTTP 202) para emisión asíncrona.
+7. **`certmate_renew_certificate`** — Fuerza la renovación de un certificado existente (también puede devolver un `job_id`).
+8. **`certmate_get_job`** — Consulta un trabajo asíncrono de creación/renovación por `job_id` hasta que notifique que ha completado o fallado.
+9. **`certmate_set_auto_renew`** — Activa o desactiva la renovación automática para un único dominio.
+10. **`certmate_deploy_certificate`** — Ejecuta manualmente todos los deploy hooks configurados para un dominio.
+11. **`certmate_download_certificate`** — Devuelve el material del certificado de un dominio en JSON (fullchain, key, chain) para que un agente pueda desplegarlo en otro lugar.
+
+**Proveedores**
+12. **`certmate_list_dns_providers`** — Proveedores DNS compatibles y configurados en esta instancia.
+13. **`certmate_list_dns_accounts`** — Cuentas de proveedores DNS configuradas (credenciales enmascaradas); usa el `account_id` devuelto al crear un certificado.
+
+## Configuración
+
+### Requisitos previos
+- Node.js (v18 o superior)
+- npm
+
+### Instalación
+Navega al directorio `mcp/` del repositorio de CertMate e instala las dependencias:
+```bash
+cd mcp
+npm install
+```
+
+### Variables de entorno
+El servidor MCP se comunica con la API REST de CertMate y requiere dos variables de entorno:
+- `CERTMATE_URL` — La URL de tu instancia de CertMate (por defecto: `http://localhost:8000`).
+- `CERTMATE_TOKEN` — Un token Bearer de API válido con los permisos de rol adecuados (normalmente `operator` o `admin`). Para un agente auditable, usa una clave marcada como clave de agente (ver [Atribución de auditoría](#atribución-de-auditoría)).
+
+Opcionales:
+- `CERTMATE_AGENT_SESSION` — Sobreescribe el ID de sesión por proceso que el servidor envía en cada llamada (`X-CertMate-Agent-Session`), de modo que una ejecución pueda correlacionarse con el ID de un orquestador externo. Se genera un UUID nuevo por proceso si no se define.
+- `CERTMATE_AGENT_ID` — Una etiqueta para este despliegue de agente (`X-CertMate-Agent-Id`, por defecto `certmate-mcp-server`).
+
+### Ejemplo de integración (configuración de Claude Desktop)
+
+Para añadir el servidor MCP de CertMate a Claude Desktop, agrega lo siguiente a tu archivo de configuración (normalmente en `~/Library/Application Support/Claude/claude_desktop_config.json` en macOS o `%APPDATA%\Claude\claude_desktop_config.json` en Windows):
+
+```json
+{
+  "mcpServers": {
+    "certmate": {
+      "command": "node",
+      "args": ["/ruta/absoluta/a/certmate/mcp/index.js"],
+      "env": {
+        "CERTMATE_URL": "http://localhost:8000",
+        "CERTMATE_TOKEN": "tu_token_bearer_seguro"
+      }
+    }
+  }
+}
+```
+
+### Otros clientes MCP (Gemini, etc.)
+
+El servidor habla MCP estándar sobre stdio, por lo que cualquier cliente que soporte MCP funciona de la misma manera: apúntalo a `node /ruta/absoluta/a/certmate/mcp/index.js` y define las dos variables de entorno. Nada en el servidor es específico de Claude.
+
+## Operar CertMate con un agente de IA (tareas programadas)
+
+La mayoría de los asistentes de primer nivel ya soportan **tareas programadas** (Claude, Gemini y otros). Combina esto con este servidor MCP y obtendrás un "guardián de certificados" autónomo: describes la política en lenguaje natural con condiciones explícitas, el modelo se programa a sí mismo, y en cada ejecución usa las herramientas anteriores para aplicar la política. El patrón es agnóstico al modelo — cualquier cosa que pueda ejecutar un prompt guardado según un calendario y llamar a herramientas MCP funcionará.
+
+### El bucle que ejecuta el agente
+
+1. `certmate_list_certificates` (o `certmate_get_certificate` por dominio) para leer `days_left` / estado.
+2. Decide según tu condición, p. ej. *renovar cuando `days_left < 14`*.
+3. `certmate_renew_certificate` para cada dominio pendiente.
+4. Si una renovación devuelve un `job_id`, `certmate_get_job` hasta que notifique `completed` / `failed`.
+5. Ante un fallo, expónlo — y los canales de notificación propios de CertMate (email, Slack, Discord, Telegram, ntfy, Gotify) también se activarán en `certificate_failed`, de modo que recibirás un aviso en cualquier caso.
+
+### Ejemplos de prompts programados
+
+> **Diario, 08:00** — "Usando las herramientas MCP de CertMate, lista todos los certificados. Para cualquiera con `days_left < 14`, llama a `certmate_renew_certificate`, luego consulta `certmate_get_job` hasta que termine. Responde con un resumen de una línea por dominio e indica cualquier fallo."
+
+> **Semanal** — "Llama a `certmate_get_activity` y `certmate_diagnostics`. Resume cualquier anomalía (renovaciones fallidas, certificados expirados, planificador detenido) en tres puntos. Si no hay nada incorrecto, indícalo."
+
+> **Bajo demanda** — "Emite un certificado para `shop.example.com` usando `certmate_list_dns_providers` para elegir un proveedor configurado y `certmate_list_dns_accounts` para el ID de cuenta, luego supervisa el trabajo hasta su finalización."
+
+Como las condiciones viven en el prompt, puedes ajustar la política (umbral, dominios, qué hacer ante un fallo) sin tocar ningún código. Dale al agente un token con el alcance exacto de lo que debe hacer — `operator` para renovar/desplegar, `admin` solo si tiene que cambiar ajustes o leer diagnósticos.
+
+## Seguridad
+
+1. **Protección del token** — El servidor MCP requiere un `CERTMATE_TOKEN` válido. Transmite este token de forma segura en la cabecera `Authorization` para todas las peticiones a la API de CertMate.
+2. **Mínimo privilegio** — Limita el token a lo que el agente necesita. Un guardián de renovaciones programadas necesita `operator`; reserva los tokens `admin` para agentes que deban cambiar ajustes o extraer diagnósticos. Revoca el token para cortar el acceso del agente de inmediato.
+3. **Compatibilidad con saneamiento de logs** — Herramientas como `certmate_diagnostics` recuperan datos después de que el saneador de logs haya eliminado las credenciales sensibles, protegiendo claves y tokens de filtrarse en contextos LLM.
+
+## Atribución de auditoría
+
+Para que el registro de auditoría pueda distinguir las acciones de un agente de las de un operador humano, dale al servidor MCP una **clave API dedicada y marcada como agente** en lugar del token Bearer global heredado:
+
+1. En CertMate, ve a **Ajustes → Claves API**, crea una clave y marca **Clave de agente de IA** (o envía `"is_agent": true` a `POST /api/keys`). Limítala con `allowed_domains` y el rol mínimo necesario.
+2. Define esa clave como `CERTMATE_TOKEN` para el servidor MCP.
+
+Cada acción sobre certificados que realice el agente quedará registrada con `actor.kind="agent"`, el ID estable de la clave y el `X-CertMate-Agent-Session` por proceso que envía el servidor — así puedes mostrar exactamente qué cambios en certificados realizó un agente de IA, bajo qué identidad y agrupados por ejecución. El token Bearer global heredado reduce a cada llamante a `api_user` sin ID de clave y se registra como `api_token`, no como `agent`. La cabecera de sesión de agente es una declaración informativa y por sí sola nunca promueve a un llamante a `agent`.
+
+Los registros resultantes forman parte de la cadena de auditoría a prueba de manipulaciones; ver [Registro de auditoría](./api.md#audit-logging) y [compliance.md](./compliance.md).
+
+---
+
+<div align="center">
+
+[← Volver a la documentación](./README.md)
+
+</div>

--- a/docs/es/probes.md
+++ b/docs/es/probes.md
@@ -1,0 +1,76 @@
+# Sondas de Despliegue (Probes)
+
+Las sondas verifican que sus certificados son accesibles en la red realizando un handshake TLS en vivo contra el servidor desplegado.
+
+## Configuración
+
+Configure las sondas por dominio en **Ajustes → Sondas de despliegue**.
+
+| Campo | Descripción |
+|---|---|
+| Dominio | El dominio del certificado a sondear |
+| Puerto | Puerto TCP (por defecto: 443 para HTTPS/TLS, 587 para SMTP STARTTLS) |
+| Protocolo | `HTTPS/TLS` — handshake HTTPS estándar, `TLS` — TLS sin HTTP, `SMTP STARTTLS` — SMTP con actualización a TLS |
+
+El protocolo y el puerto se almacenan en el `metadata.json` del certificado bajo las claves `deployment_protocol` y `deployment_port`.
+
+## Funcionamiento
+
+### Sonda backend
+
+1. El backend lee el puerto y el protocolo configurados en los metadatos del certificado.
+2. Se abre una conexión socket y se realiza un handshake TLS.
+3. La huella digital del certificado servido se compara con la del certificado almacenado localmente.
+4. El resultado (accesible, desplegado, coincidencia de certificado) se almacena en caché durante 5 minutos (configurable).
+
+### Sonda de navegador (fallback)
+
+Cuando la sonda backend indica que el servidor es inaccesible **y** el protocolo es `HTTPS/TLS`, se activa una sonda de respaldo en el lado del navegador mediante `fetch(..., { mode: 'no-cors' })`. Esto permite verificar la accesibilidad incluso cuando el backend no puede conectarse (p. ej., segmentación de red).
+
+Para los protocolos `TLS` y `SMTP STARTTLS`, la sonda de navegador se **omite** porque los navegadores no pueden realizar conexiones TLS sin HTTP ni SMTP. El estado del navegador muestra "No verificado".
+
+### Caché
+
+| Capa | Duración | Omisión |
+|---|---|---|
+| Backend (memoria) | 300 s (por defecto) | Parámetro `?refresh=1` |
+| Frontend (memoria) | 300 s | `forceRefresh=true` (botón Verificar sonda) |
+
+## API
+
+### Verificar el estado de despliegue
+
+```
+GET /api/certificates/<domain>/deployment-status
+GET /api/certificates/<domain>/deployment-status?refresh=1
+```
+
+Devuelve:
+
+| Campo | Tipo | Descripción |
+|---|---|---|
+| domain | string | El dominio sondeado |
+| deployed | boolean | Si se sirvió un certificado |
+| reachable | boolean | Si el servidor respondió |
+| certificate_match | boolean/null | Si el certificado servido coincide con el almacenado |
+| method | string | Protocolo utilizado (`https-tls`, `tls`, `smtp-starttls`) |
+| port | integer | Puerto TCP sondeado |
+| protocol | string | Igual que method |
+| error | string | Mensaje de error si la sonda falló |
+| browser | object | Resultado de la sonda de navegador (solo HTTPS) |
+
+### Configurar una sonda
+
+```
+PATCH /api/certificates/<domain>
+```
+
+```json
+{ "deployment_port": 444, "deployment_protocol": "https-tls" }
+```
+
+Establecer a `null` para eliminar la configuración de la sonda:
+
+```json
+{ "deployment_port": null, "deployment_protocol": null }
+```

--- a/docs/es/testing.md
+++ b/docs/es/testing.md
@@ -1,0 +1,351 @@
+# Guía de pruebas
+
+Esta guía cubre el framework de pruebas de CertMate, incluyendo pruebas unitarias, pruebas de integración y validación de endpoints API.
+
+---
+
+## Inicio rápido
+
+```bash
+# Activar el entorno virtual
+source .venv/bin/activate
+
+# Instalar las dependencias de prueba
+pip install -r requirements-test.txt
+
+# Ejecutar todas las pruebas
+pytest
+
+# Ejecutar las pruebas con cobertura
+pytest --cov=. --cov-report=html
+```
+
+---
+
+## Estructura de las pruebas
+
+```
+Directorio raíz:
+  conftest.py                              # Configuración de recolección y fixtures compartidas
+  pytest.ini                               # Configuración y marcadores de prueba
+  test_certificate_creation.py             # Pruebas de creación de certificados
+  test_certificate_listing.py              # Pruebas de listado de certificados
+  test_client_certificates_comprehensive.py # Pruebas de ciclo de vida de certificados cliente
+  test_dns_accounts.py                     # Operaciones multi-cuenta
+  test_dns_provider.py                     # Funcionalidad básica de proveedores
+  test_dns_provider_inheritance.py         # Herencia de configuración
+  test_domain_alias.py                     # Pruebas de alias de dominio
+  test_infisical_backend.py               # Backend de almacenamiento Infisical
+  test_shell_executor.py                   # Pruebas de ejecución shell
+  test_e2e_complete.py                     # Suite de pruebas de extremo a extremo
+```
+
+---
+
+## Ejecución de las pruebas
+
+### Comandos comunes
+
+```bash
+# Ejecutar todas las pruebas
+pytest
+
+# Ejecutar con salida detallada
+pytest -v
+
+# Ejecutar un archivo de prueba específico
+pytest test_certificate_creation.py
+
+# Ejecutar una función de prueba específica
+pytest test_certificate_creation.py::test_specific_function -v -s
+
+# Ejecutar pruebas que coincidan con un patrón
+pytest -k "dns_provider"
+
+# Ejecutar con informe de cobertura
+pytest --cov=. --cov-report=html
+open htmlcov/index.html
+```
+
+### Con Make
+
+```bash
+make test              # Ejecutar todas las pruebas
+make test-unit         # Solo pruebas unitarias
+make test-integration  # Solo pruebas de integración
+make test-coverage     # Pruebas con cobertura
+make check             # Todas las verificaciones de calidad
+```
+
+---
+
+## Categorías de pruebas
+
+Las pruebas están organizadas con marcadores de pytest:
+
+```bash
+# Pruebas unitarias (rápidas, sin servicios externos)
+pytest -m "not integration and not slow"
+
+# Pruebas de integración
+pytest -m integration
+
+# Pruebas de API
+pytest -m api
+
+# Pruebas de proveedores DNS
+pytest -m dns
+
+# Pruebas de extremo a extremo (requieren servidor en ejecución)
+pytest -m e2e
+```
+
+### E2E sin Docker
+
+Por defecto, las fixtures e2e construyen la imagen Docker y gestionan un contenedor
+para toda la sesión. Cuando Docker no está disponible (sandbox de CI,
+redes restringidas), apunte la suite a una instancia ya en ejecución:
+
+```bash
+# Terminal 1: ejecute CertMate como prefiera
+gunicorn --bind 127.0.0.1:18888 --workers 1 --threads 8 app:app
+
+# Terminal 2: apunte a esa instancia (omite toda la gestión del ciclo de vida Docker)
+CERTMATE_E2E_BASE_URL=http://localhost:18888 pytest -m "e2e and not ui"
+```
+
+Las pruebas de emisión real necesitan además `CLOUDFLARE_API_TOKEN` y un
+`CERTMATE_TEST_DOMAIN` que usted controle, y consumen certificados reales de
+Let's Encrypt — se omiten automáticamente cuando el token no está presente. La
+instancia destino debe arrancar desde un directorio de datos limpio: las pruebas
+e2e asumen un estado de primer arranque, por lo que reutilizarla entre ejecuciones
+provoca fallos relacionados con la autenticación.
+
+---
+
+## Pruebas de endpoints API
+
+### Script de prueba rápida
+
+Use `quick_test.sh` para una validación rápida de endpoints antes de cada commit:
+
+```bash
+# Ejecutar antes de cada commit
+./quick_test.sh
+
+# Probar solo los endpoints públicos
+./quick_test.sh --public-only
+```
+
+Este script:
+- Comprueba si el servidor está en ejecución
+- Carga automáticamente el token API desde `data/settings.json`
+- Prueba todas las categorías de endpoints
+- Proporciona una salida clara de éxito/fallo
+
+### Suite de pruebas API completa
+
+```bash
+# Carga automática del token desde los ajustes
+python3 test_all_endpoints.py --auto-token
+
+# Con URL de servidor personalizada
+python3 test_all_endpoints.py --url http://192.168.1.100:8000
+
+# Con token API manual
+python3 test_all_endpoints.py --token your-api-bearer-token
+
+# Prueba rápida solo de lo esencial
+python3 test_all_endpoints.py --quick --auto-token
+
+# Solo endpoints públicos (sin autenticación requerida)
+python3 test_all_endpoints.py --public-only
+```
+
+### Endpoints probados
+
+| Categoría | Endpoints |
+|-----------|-----------|
+| **Salud** | `GET /api/health`, `GET /health` |
+| **Ajustes** | `GET /api/settings`, `GET /api/settings/dns-providers`, `POST /api/settings` |
+| **Certificados** | `GET /api/certificates`, `POST /api/certificates/create`, download, renew |
+| **Cache** | `GET /api/cache/stats`, `POST /api/cache/clear` |
+| **Copia de seguridad** | `GET /api/backups`, `POST /api/backups/create`, `POST /api/backups/cleanup` |
+| **Interfaz web** | `/`, `/settings`, `/help`, `/docs/`, `/api/swagger.json` |
+
+### Códigos de estado esperados
+
+- **200/201**: Éxito
+- **400/422**: Errores de validación esperados (normales para payloads de prueba)
+- **404**: Esperado para recursos inexistentes
+- **401**: Token API inválido o ausente
+- **500**: Error de la aplicación (investigar)
+
+---
+
+## Escritura de pruebas
+
+### Estructura de prueba
+
+```python
+import pytest
+from unittest.mock import patch, MagicMock
+
+def test_function_name(client, sample_settings):
+    """Descripción del test."""
+    # Arrange
+    setup_data = {...}
+
+    # Act
+    response = client.get('/api/endpoint')
+
+    # Assert
+    assert response.status_code == 200
+    assert 'expected_key' in response.json()
+```
+
+### Uso de fixtures
+
+```python
+def test_with_app_context(app):
+    """Prueba que requiere contexto de la aplicación."""
+    with app.app_context():
+        pass
+
+def test_api_endpoint(client):
+    """Prueba de endpoint API."""
+    response = client.get('/api/test')
+    assert response.status_code == 200
+
+def test_with_mock_data(mock_certificate_data):
+    """Prueba con datos simulados."""
+    assert mock_certificate_data['domain'] == 'test.example.com'
+```
+
+### Simulación de servicios externos
+
+```python
+@patch('app.requests.get')
+def test_external_api(mock_get, client):
+    """Prueba de llamada a API externa."""
+    mock_get.return_value.json.return_value = {'status': 'success'}
+    response = client.post('/api/certificate/request')
+    assert response.status_code == 200
+```
+
+---
+
+## Integración continua
+
+### GitHub Actions
+
+El pipeline de CI se ejecuta en cada push y pull request:
+
+1. **Múltiples versiones de Python**: Pruebas en Python 3.9, 3.11, 3.12
+2. **Calidad de código**: Linting con flake8
+3. **Seguridad**: Escaneo con bandit
+4. **Pruebas**: Suite completa con cobertura
+5. **Docker**: Prueba del build de Docker
+6. **Cobertura**: Envío a Codecov
+
+### Hook Pre-Commit
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Los hooks incluyen: formateo de código (black, isort), linting (flake8), verificaciones de seguridad (bandit).
+
+### Pruebas de API en CI/CD
+
+```yaml
+# Ejemplo de GitHub Actions
+- name: Test API Endpoints
+  run: |
+    python app.py &
+    sleep 5
+    python3 test_all_endpoints.py --auto-token
+```
+
+---
+
+## Requisitos de cobertura
+
+- Mínimo **80%** de cobertura de código global
+- Las rutas críticas deben tener **95%+** de cobertura
+- Toda nueva funcionalidad debe incluir pruebas
+
+---
+
+## Buenas prácticas
+
+### Hacer
+
+- Escribir pruebas para todas las nuevas funcionalidades
+- Usar nombres de prueba descriptivos
+- Probar tanto los casos de éxito como los de fallo
+- Simular las dependencias externas
+- Usar los marcadores de prueba adecuados
+- Mantener las pruebas aisladas e independientes
+
+### No hacer
+
+- Probar detalles de implementación
+- Usar claves API reales en las pruebas
+- Hacer que las pruebas dependan unas de otras
+- Ignorar los fallos de prueba
+- Omitir pruebas para código "simple"
+
+---
+
+## Depuración de pruebas
+
+```bash
+# Detallado con sentencias print
+pytest -v -s
+
+# Depurar una prueba específica
+pytest test_api.py::test_specific -v -s
+
+# Usar pdb
+def test_debug_example():
+    import pdb; pdb.set_trace()
+    # Código de prueba aquí
+```
+
+---
+
+## Pruebas de rendimiento
+
+```python
+import pytest
+import concurrent.futures
+
+@pytest.mark.slow
+def test_api_load(client):
+    """Prueba de la API bajo carga."""
+    def make_request():
+        return client.get('/api/certificates')
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [executor.submit(make_request) for _ in range(100)]
+        responses = [f.result() for f in futures]
+
+    assert all(r.status_code == 200 for r in responses)
+```
+
+---
+
+## Códigos de salida
+
+- **0**: Todas las pruebas superadas
+- **1**: Algunas pruebas han fallado
+
+---
+
+<div align="center">
+
+[← Volver a la documentación](./README.md) • [Arquitectura →](./architecture.md) • [Referencia de API →](./api.md)
+
+</div>


### PR DESCRIPTION
German (`docs/de/`) and Spanish (`docs/es/`) documentation trees — 16 files each, mirroring the French (#327) and Italian (#338) trees.

- Translated from the canonical English sources, French versions used as structural reference.
- Code/commands/links/section structure preserved verbatim; only prose translated.
- Heading parity verified vs English (no sections dropped); no stray emoji.

**Machine-translated — not yet reviewed by native speakers.** To be verified by DE/ES contributors before being relied upon (per the agreed plan). Holding for contributor review rather than merging on CI alone.