### PR TITLE
feat(api): configurable API rate limits (#319)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -42,6 +42,26 @@ API endpoints have rate limits to prevent abuse:
 | OCSP Status        | 200   | minute |
 | CRL Download       | 60    | minute |
 
+The bucket is per API key (requests authenticated with the same bearer key share one limit) and per IP for session/anonymous requests, so several clients behind one NAT or proxy do not share — and abuse — a single bucket.
+
+### Configuring rate limits
+
+The limits are configurable per instance (admin only), so a trusted automation fleet behind a single address can raise them instead of tripping the default. Settings → API Keys → **API Rate Limits** exposes a value-per-endpoint form and an on/off toggle; changes apply immediately, with no restart.
+
+The same configuration is available over the API:
+
+```
+GET /api/settings/rate-limits
+  -> { "enabled": true,
+       "limits": { "default": 100, "certificate_create": 30, ... },
+       "defaults": { ... } }
+
+PUT /api/settings/rate-limits
+  { "enabled": true, "limits": { "certificate_create": 500 } }
+```
+
+Each limit is requests per minute (1–100000). Only the endpoint keys returned by `GET` are accepted; omitted keys keep their default. Setting `"enabled": false` turns API rate limiting off entirely (the login endpoint keeps its own separate limiter regardless).
+
 ### Rate Limit Response
 
 When rate limited, you'll receive:

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -446,7 +446,7 @@ def initialize_managers(container: AppContainer, app):
     from .oidc import OIDCManager
     oidc_manager = OIDCManager(settings_manager, auth_manager, audit_logger)
 
-    rate_limit_config = RateLimitConfig()
+    rate_limit_config = RateLimitConfig(settings_manager=settings_manager)
     rate_limiter = SimpleRateLimiter(rate_limit_config)
 
     notifier = Notifier(settings_manager, data_dir=str(container.data_dir))
@@ -890,6 +890,11 @@ def setup_rate_limiting(app, container: AppContainer):
             return None
         # Only skip rate limiting for auth endpoints (login needs its own limiter)
         if path.startswith('/api/auth/'):
+            return None
+        # Admin can turn API rate limiting off entirely from settings (#319),
+        # e.g. when a trusted automation fleet behind one IP would otherwise
+        # trip a shared bucket. Defaults to on.
+        if not rate_limiter.config.is_enabled():
             return None
 
         client_ip = flask_request.remote_addr or '0.0.0.0'  # nosec B104

--- a/modules/core/rate_limit.py
+++ b/modules/core/rate_limit.py
@@ -28,18 +28,63 @@ class RateLimitConfig:
         'crl_download': 60,
     }
 
-    def __init__(self, custom_limits: Optional[Dict[str, int]] = None):
+    def __init__(self, custom_limits: Optional[Dict[str, int]] = None,
+                 settings_manager=None):
         """
         Initialize Rate Limit Config.
 
         Args:
-            custom_limits: Custom rate limit overrides
+            custom_limits: Static rate limit overrides (applied over the defaults).
+            settings_manager: Optional SettingsManager. When wired, per-endpoint
+                overrides and the on/off toggle are read LIVE from
+                ``settings['rate_limits']`` on each lookup, so an admin can retune
+                the limits from the UI/API without a restart (#319). Reads are
+                request-scope-cached and never raise.
         """
         self.limits = dict(self.DEFAULT_LIMITS)
         if custom_limits:
             self.limits.update(custom_limits)
+        self.settings_manager = settings_manager
 
         logger.info(f"Rate limiting configured with {len(self.limits)} endpoint limits")
+
+    def _settings_block(self) -> dict:
+        """Read the ``rate_limits`` settings block, defensively. Never raises."""
+        if self.settings_manager is None:
+            return {}
+        try:
+            settings = self.settings_manager.load_settings() or {}
+            block = settings.get('rate_limits')
+            return block if isinstance(block, dict) else {}
+        except Exception:  # pragma: no cover - defensive
+            logger.debug("Failed to read rate_limits settings; using defaults",
+                         exc_info=True)
+            return {}
+
+    def is_enabled(self) -> bool:
+        """Whether API rate limiting is active. Defaults to True when unset."""
+        return bool(self._settings_block().get('enabled', True))
+
+    def effective_limits(self) -> Dict[str, int]:
+        """Static limits overlaid with the live, sanitised settings overrides.
+
+        Only known endpoint keys with a positive integer value are honoured, so
+        a malformed settings entry can never disable a limit or crash a lookup.
+        """
+        merged = dict(self.limits)
+        overrides = self._settings_block().get('limits')
+        if isinstance(overrides, dict):
+            for key, value in overrides.items():
+                if key not in self.DEFAULT_LIMITS:
+                    continue
+                # Only a positive int is a valid limit. bool is an int subclass,
+                # so exclude it; floats/strings are treated as malformed and the
+                # default is kept rather than silently truncated.
+                if isinstance(value, bool) or not isinstance(value, int):
+                    continue
+                if value > 0:
+                    merged[key] = value
+        return merged
 
     def get_limit(self, endpoint: str) -> int:
         """
@@ -51,17 +96,19 @@ class RateLimitConfig:
         Returns:
             Rate limit (requests per minute)
         """
+        limits = self.effective_limits()
+
         # Try exact match first
-        if endpoint in self.limits:
-            return self.limits[endpoint]
+        if endpoint in limits:
+            return limits[endpoint]
 
         # Try prefix match
-        for limit_key in self.limits:
+        for limit_key in limits:
             if endpoint.startswith(limit_key):
-                return self.limits[limit_key]
+                return limits[limit_key]
 
         # Return default
-        return self.limits.get('default', 100)
+        return limits.get('default', 100)
 
 
 class SimpleRateLimiter:

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -42,6 +42,7 @@ PUBLIC_SETTINGS_WRITABLE_KEYS = frozenset({
     'certificate_storage',
     'backup_storage',          # off-site backup target (S3-compatible)
     'notifications',
+    'rate_limits',             # configurable API rate limits (#319); no side-effects
     'setup_completed',
     # Per-install "stop nagging me with the first-run wizard" flag. Distinct
     # from setup_completed, which must stay truthful for recovery/downgrade
@@ -328,6 +329,7 @@ _DEEP_MERGE_SETTINGS_KEYS = frozenset({
     'backup_storage',
     'ca_providers',
     'notifications',
+    'rate_limits',
 })
 
 

--- a/modules/web/misc_routes.py
+++ b/modules/web/misc_routes.py
@@ -362,6 +362,81 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
             logger.error(f"Failed to save notifications config: {e}")
             return jsonify({'error': 'Failed to save notifications config'}), 500
 
+    @app.route('/api/settings/rate-limits', methods=['GET', 'PUT'])
+    @auth_manager.require_role('admin')
+    def api_rate_limits_config():
+        """Get or replace the configurable API rate limits (#319).
+
+        GET  -> {enabled, limits (effective = defaults + overrides), defaults}
+        PUT  -> {enabled?: bool, limits?: {endpoint: requests_per_minute}}
+        Only the known endpoint keys are accepted, each a positive integer.
+        """
+        from modules.core.rate_limit import RateLimitConfig
+        settings_manager = managers.get('settings')
+        if settings_manager is None:
+            return jsonify({'error': 'Settings not available'}), 503
+        defaults = dict(RateLimitConfig.DEFAULT_LIMITS)
+
+        if request.method == 'GET':
+            try:
+                block = (settings_manager.load_settings() or {}).get('rate_limits') or {}
+                overrides = block.get('limits') if isinstance(block.get('limits'), dict) else {}
+                return jsonify({
+                    'enabled': bool(block.get('enabled', True)),
+                    'limits': {**defaults, **{k: v for k, v in overrides.items() if k in defaults}},
+                    'defaults': defaults,
+                })
+            except Exception as e:
+                logger.error(f"Failed to read rate limits: {e}")
+                return jsonify({'error': 'Failed to read rate limits'}), 500
+
+        try:
+            data = request.json or {}
+            if not isinstance(data, dict):
+                return jsonify({'error': 'Body must be a JSON object'}), 400
+
+            enabled = bool(data.get('enabled', True))
+            raw_limits = data.get('limits', {})
+            if not isinstance(raw_limits, dict):
+                return jsonify({'error': 'limits must be an object'}), 400
+
+            clean_limits = {}
+            for key, value in raw_limits.items():
+                if key not in defaults:
+                    return jsonify({'error': f'Unknown rate-limit key: {key}'}), 400
+                # bool is an int subclass; reject it and any non-int (float/str).
+                if isinstance(value, bool) or not isinstance(value, int):
+                    return jsonify({'error': f'{key} must be an integer'}), 400
+                if value < 1 or value > 100000:
+                    return jsonify({'error': f'{key} must be between 1 and 100000'}), 400
+                clean_limits[key] = value
+
+            def _mutator(s):
+                s['rate_limits'] = {'enabled': enabled, 'limits': clean_limits}
+                return s
+
+            settings_manager.update(_mutator)
+            audit_logger = managers.get('audit')
+            if audit_logger:
+                actor = getattr(request, 'current_user', {}) or {}
+                audit_logger.log_operation(
+                    operation='update',
+                    resource_type='rate_limits_config',
+                    resource_id='rate_limits',
+                    status='success',
+                    details={'enabled': enabled, 'overrides': sorted(clean_limits.keys())},
+                    user=actor.get('username'),
+                    ip_address=request.remote_addr,
+                )
+            return jsonify({
+                'message': 'Rate limits updated',
+                'enabled': enabled,
+                'limits': {**defaults, **clean_limits},
+            })
+        except Exception as e:
+            logger.error(f"Failed to save rate limits: {e}")
+            return jsonify({'error': 'Failed to save rate limits'}), 500
+
     @app.route('/api/notifications/test', methods=['POST'])
     @auth_manager.require_role('admin')
     def api_notifications_test():

--- a/static/js/settings-apikeys.js
+++ b/static/js/settings-apikeys.js
@@ -183,4 +183,64 @@
     }
 
     window.apiKeyManager = apiKeyManager;
+
+    // Configurable API rate limits (#319). Self-contained: reads/writes the
+    // dedicated /api/settings/rate-limits endpoint, independent of the main
+    // settings form.
+    function rateLimitManager() {
+        return {
+            enabled: true,
+            limits: {},
+            keys: [],
+            loading: true,
+            saving: false,
+            load: function () {
+                var self = this;
+                fetch('/api/settings/rate-limits', { credentials: 'same-origin' })
+                    .then(function (r) { return r.json(); })
+                    .then(function (d) {
+                        self.enabled = d.enabled !== false;
+                        self.keys = Object.keys(d.defaults || {});
+                        self.limits = Object.assign({}, d.defaults || {}, d.limits || {});
+                        self.loading = false;
+                    })
+                    .catch(function () {
+                        self.loading = false;
+                        showMessage('Failed to load rate limits', 'error');
+                    });
+            },
+            save: function () {
+                var self = this;
+                self.saving = true;
+                var limits = {};
+                self.keys.forEach(function (k) {
+                    var v = parseInt(self.limits[k], 10);
+                    if (!isNaN(v)) limits[k] = v;
+                });
+                fetch('/api/settings/rate-limits', {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    credentials: 'same-origin',
+                    body: JSON.stringify({ enabled: self.enabled, limits: limits })
+                })
+                    .then(function (r) {
+                        return r.json().then(function (b) { return { ok: r.ok, b: b }; });
+                    })
+                    .then(function (res) {
+                        self.saving = false;
+                        if (res.ok) showMessage('Rate limits saved', 'success');
+                        else showMessage((res.b && res.b.error) || 'Failed to save rate limits', 'error');
+                    })
+                    .catch(function () {
+                        self.saving = false;
+                        showMessage('Failed to save rate limits', 'error');
+                    });
+            },
+            label: function (k) {
+                return k.replace(/_/g, ' ').replace(/\b\w/g, function (c) { return c.toUpperCase(); });
+            }
+        };
+    }
+
+    window.rateLimitManager = rateLimitManager;
 })();

--- a/templates/partials/settings_apikeys.html
+++ b/templates/partials/settings_apikeys.html
@@ -163,4 +163,44 @@
             </div>
         </div>
 
+        <!-- TAB: API Keys — Configurable API rate limits (#319) -->
+        <div x-show="tab === 'apikeys'" x-cloak
+             x-data="rateLimitManager()" x-init="load()"
+             class="bg-surface border-border rounded-lg shadow-sm border p-6 mt-6">
+
+            <div class="flex items-center justify-between mb-4">
+                <h3 class="text-lg font-semibold text-foreground flex items-center">
+                    <i class="fas fa-gauge-high mr-2 text-primary"></i>
+                    API Rate Limits
+                </h3>
+                <label class="inline-flex items-center cursor-pointer text-sm text-muted">
+                    <input type="checkbox" x-model="enabled" class="mr-2" title="Enable API rate limiting">
+                    Enabled
+                </label>
+            </div>
+
+            <p class="text-muted text-sm mb-6">
+                Requests per minute per client &mdash; per API key, or per IP for session and anonymous requests. Raise these if a trusted automation fleet behind one address trips a shared bucket. Turning the toggle off disables API rate limiting entirely.
+            </p>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4" :class="enabled ? '' : 'opacity-50'">
+                <template x-for="k in keys" :key="k">
+                    <div>
+                        <label class="block text-xs text-muted mb-1" x-text="label(k)"></label>
+                        <input type="number" min="1" max="100000" x-model.number="limits[k]" :disabled="!enabled"
+                               :aria-label="label(k) + ' requests per minute'"
+                               class="w-full px-3 py-2 border border-border rounded-md text-sm dark:bg-gray-700 dark:text-white">
+                    </div>
+                </template>
+            </div>
+
+            <div class="mt-6 flex justify-end">
+                <button type="button" @click="save()" :disabled="saving" title="Save rate limits"
+                        class="px-4 py-2 bg-yellow-600 text-white rounded-md hover:bg-yellow-700 text-sm whitespace-nowrap">
+                    <i class="fas fa-save mr-1"></i>
+                    <span x-text="saving ? 'Saving...' : 'Save Rate Limits'"></span>
+                </button>
+            </div>
+        </div>
+
         

--- a/tests/test_rate_limits_config.py
+++ b/tests/test_rate_limits_config.py
@@ -1,0 +1,155 @@
+"""Configurable API rate limits (#319).
+
+Two layers:
+1. RateLimitConfig reads per-endpoint overrides and the on/off toggle LIVE from
+   settings['rate_limits'], sanitising bad values so a malformed entry can never
+   disable a limit or crash a lookup.
+2. The admin route PUT /api/settings/rate-limits validates and persists them.
+"""
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from modules.core.rate_limit import RateLimitConfig
+
+pytestmark = [pytest.mark.unit]
+
+
+def _config(settings_dict):
+    sm = MagicMock()
+    sm.load_settings.return_value = settings_dict
+    return RateLimitConfig(settings_manager=sm)
+
+
+# --- RateLimitConfig: live settings overrides -----------------------------
+
+def test_defaults_when_no_settings_manager():
+    cfg = RateLimitConfig()
+    assert cfg.get_limit('default') == 100
+    assert cfg.get_limit('certificate_create') == 30
+    assert cfg.is_enabled() is True
+
+
+def test_override_changes_effective_limit():
+    cfg = _config({'rate_limits': {'limits': {'certificate_create': 500}}})
+    assert cfg.get_limit('certificate_create') == 500
+    # untouched keys keep their default
+    assert cfg.get_limit('default') == 100
+
+
+def test_enabled_toggle():
+    assert _config({'rate_limits': {'enabled': False}}).is_enabled() is False
+    assert _config({'rate_limits': {'enabled': True}}).is_enabled() is True
+    assert _config({}).is_enabled() is True  # default on
+
+
+@pytest.mark.parametrize('bad', [0, -5, 'abc', None, 1.5])
+def test_malformed_override_ignored_falls_back_to_default(bad):
+    cfg = _config({'rate_limits': {'limits': {'default': bad}}})
+    # A non-positive / non-int value must never override the default away.
+    assert cfg.get_limit('default') == 100
+
+
+def test_unknown_override_key_ignored():
+    cfg = _config({'rate_limits': {'limits': {'not_a_real_endpoint': 9}}})
+    assert cfg.get_limit('default') == 100
+
+
+def test_live_reread_picks_up_change():
+    sm = MagicMock()
+    sm.load_settings.return_value = {'rate_limits': {'limits': {'default': 100}}}
+    cfg = RateLimitConfig(settings_manager=sm)
+    assert cfg.get_limit('default') == 100
+    sm.load_settings.return_value = {'rate_limits': {'limits': {'default': 999}}}
+    assert cfg.get_limit('default') == 999  # no restart, no re-instantiation
+
+
+def test_settings_read_failure_is_swallowed():
+    sm = MagicMock()
+    sm.load_settings.side_effect = RuntimeError('disk gone')
+    cfg = RateLimitConfig(settings_manager=sm)
+    assert cfg.get_limit('default') == 100
+    assert cfg.is_enabled() is True
+
+
+# --- PUT/GET /api/settings/rate-limits route ------------------------------
+
+def _passthrough_role(_min_role):
+    def deco(fn):
+        return fn
+    return deco
+
+
+@pytest.fixture
+def route_client(tmp_path):
+    settings_path = tmp_path / "settings.json"
+
+    def _read():
+        return json.loads(settings_path.read_text()) if settings_path.exists() else {}
+
+    def _update(mutator, reason="auto_save"):
+        doc = _read()
+        mutator(doc)
+        settings_path.write_text(json.dumps(doc, indent=2))
+        return True
+
+    settings_manager = MagicMock()
+    settings_manager.load_settings.side_effect = _read
+    settings_manager.update.side_effect = _update
+
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_role)
+
+    managers = {"auth": auth_manager, "settings": settings_manager, "audit": MagicMock()}
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    from modules.web.misc_routes import register_misc_routes
+    register_misc_routes(app, managers, lambda fn: fn, auth_manager)
+    return app.test_client(), settings_path
+
+
+def test_get_returns_defaults_and_enabled(route_client):
+    client, _ = route_client
+    r = client.get('/api/settings/rate-limits')
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body['enabled'] is True
+    assert body['limits']['default'] == 100
+    assert body['defaults']['certificate_create'] == 30
+
+
+def test_put_persists_and_get_reflects(route_client):
+    client, settings_path = route_client
+    r = client.put('/api/settings/rate-limits',
+                   json={'enabled': True, 'limits': {'certificate_create': 500}})
+    assert r.status_code == 200
+    # persisted on disk
+    disk = json.loads(settings_path.read_text())['rate_limits']
+    assert disk['limits']['certificate_create'] == 500
+    # GET reflects the override merged over defaults
+    body = client.get('/api/settings/rate-limits').get_json()
+    assert body['limits']['certificate_create'] == 500
+    assert body['limits']['default'] == 100
+
+
+def test_put_disable(route_client):
+    client, settings_path = route_client
+    r = client.put('/api/settings/rate-limits', json={'enabled': False, 'limits': {}})
+    assert r.status_code == 200
+    assert json.loads(settings_path.read_text())['rate_limits']['enabled'] is False
+
+
+def test_put_rejects_unknown_key(route_client):
+    client, _ = route_client
+    r = client.put('/api/settings/rate-limits', json={'limits': {'bogus': 5}})
+    assert r.status_code == 400
+
+
+@pytest.mark.parametrize('bad', [0, -1, 100001, 'x', None])
+def test_put_rejects_bad_value(route_client, bad):
+    client, _ = route_client
+    r = client.put('/api/settings/rate-limits', json={'limits': {'default': bad}})
+    assert r.status_code == 400


### PR DESCRIPTION
Closes #319.

Per-endpoint API rate limits were hardcoded; a cron deploy fanning out across VMs behind one egress IP tripped the shared bucket with no way to raise it.

**What's configurable** — every endpoint limit (req/min) + a master on/off toggle, **live (no restart)**:
- `RateLimitConfig` reads `settings['rate_limits']` on each lookup (request-scope cached, sanitised — a malformed value never disables a limit).
- New admin endpoint `GET/PUT /api/settings/rate-limits` → `{enabled, limits, defaults}`, strict validation (known keys only, int 1–100000).
- Settings → API Keys → **API Rate Limits** card (self-contained Alpine, no main-form coupling).
- `before_request` honours the toggle; the login limiter stays separate; per-key vs per-IP bucketing unchanged.

20 unit/route tests; full suite green (1605 passed); docs updated (docs/api.md). No new Tailwind classes (bundle unchanged).