### PR TITLE
feat(dns): rfc2136 domain_alias support via TSIG dynamic update (#330)

### DIFF
--- a/docs/dns-providers.md
+++ b/docs/dns-providers.md
@@ -649,6 +649,16 @@ Cloudflare, PowerDNS, and Route53 all use the same request shape:
 
 For ACME-DNS, `domain_alias` must exactly match the configured ACME-DNS `subdomain`/fulldomain. CertMate updates that ACME-DNS record directly and does not attempt cleanup because ACME-DNS stores the latest validation value.
 
+For **RFC2136** (BIND, Technitium, and other dynamic-update servers), `domain_alias` writes the `_acme-challenge.<alias>` TXT into the alias zone with a TSIG-signed dynamic update, using the same `nameserver` / `tsig_key` / `tsig_secret` (and optional `tsig_algorithm`, default HMAC-SHA512) as normal issuance. CertMate discovers the owning zone from the server's SOA, so one TSIG key can serve several zones — including externally-managed domains whose owners only added the delegating CNAME:
+
+```json
+{
+  "domain": "external.example.com",
+  "dns_provider": "rfc2136",
+  "domain_alias": "internal.example.net"
+}
+```
+
 ### Wildcard Certificates with Domain Alias
 
 ```bash

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -43,6 +43,7 @@ DNS_ALIAS_SUPPORTED_PROVIDERS = {
     'infomaniak',
     'acme-dns',
     'duckdns',
+    'rfc2136',
 }
 
 DNS_ALIAS_REQUIRED_FIELDS = {
@@ -61,6 +62,7 @@ DNS_ALIAS_REQUIRED_FIELDS = {
     'infomaniak': ('api_token',),
     'acme-dns': ('api_url', 'username', 'password', 'subdomain'),
     'duckdns': ('api_token',),
+    'rfc2136': ('nameserver', 'tsig_key', 'tsig_secret'),
 }
 
 

--- a/modules/core/dns_alias_hook.py
+++ b/modules/core/dns_alias_hook.py
@@ -324,6 +324,119 @@ def _acme_dns_change(config, validation, action):
     )
 
 
+def _rfc2136_keyalgorithm(algorithm):
+    """Map a CertMate TSIG algorithm string (e.g. 'HMAC-SHA512') to the
+    dnspython algorithm name. Defaults to HMAC-SHA512 to match the normal
+    rfc2136 issuance path."""
+    import dns.tsig
+    name = (algorithm or 'HMAC-SHA512').strip().upper().replace('-', '_')
+    algo = getattr(dns.tsig, name, None)
+    if algo is None:
+        raise DNSAliasError(
+            f"Unsupported rfc2136 TSIG algorithm: {algorithm!r}. Use one of "
+            "HMAC-MD5, HMAC-SHA1, HMAC-SHA224, HMAC-SHA256, HMAC-SHA384, HMAC-SHA512."
+        )
+    return algo
+
+
+def _rfc2136_server(nameserver):
+    """Split a 'host' or 'host:port' nameserver into (host, port). IPv6 in
+    brackets ('[::1]:5353') is honoured; default port is 53."""
+    import dns.name  # noqa: F401  (ensures dnspython present for clear errors)
+    server = (nameserver or '').strip()
+    if server.startswith('[') and ']' in server:  # [ipv6](:port)?
+        host, _, rest = server[1:].partition(']')
+        port = rest.lstrip(':')
+        return host, int(port) if port.isdigit() else 53
+    # Only treat a single trailing ':NNN' as a port, never an IPv6 address.
+    if server.count(':') == 1:
+        host, _, port = server.partition(':')
+        if port.isdigit():
+            return host, int(port)
+    return server, 53
+
+
+def _rfc2136_find_zone(record_fqdn, host, port, timeout):
+    """Find the zone apex hosting *record_fqdn* by walking parent labels and
+    asking the authoritative server for the SOA. dnspython's dynamic UPDATE is
+    addressed to the zone, not the record FQDN."""
+    import dns.name
+    import dns.message
+    import dns.query
+    import dns.rdatatype
+    import dns.flags
+
+    candidate = dns.name.from_text(record_fqdn)
+    while True:
+        query = dns.message.make_query(candidate, dns.rdatatype.SOA)
+        try:
+            resp = dns.query.udp(query, host, port=port, timeout=timeout)
+            if resp.flags & dns.flags.TC:
+                resp = dns.query.tcp(query, host, port=port, timeout=timeout)
+        except Exception:
+            resp = dns.query.tcp(query, host, port=port, timeout=timeout)
+        for section in (resp.answer, resp.authority):
+            for rrset in section:
+                if rrset.rdtype == dns.rdatatype.SOA:
+                    return rrset.name  # zone apex
+        # Stop once we reach a TLD-level name (labels = ['tld', '']).
+        if len(candidate.labels) <= 2:
+            break
+        candidate = candidate.parent()
+    raise DNSAliasError(
+        f"Could not determine the rfc2136 zone for '{record_fqdn}'. Verify the "
+        "nameserver is authoritative for the alias zone."
+    )
+
+
+def _rfc2136_change(config, validation, action):
+    provider_config = _provider_config(config)
+    _require(provider_config, 'nameserver', 'tsig_key', 'tsig_secret')
+    try:
+        import dns.name
+        import dns.query
+        import dns.rcode
+        import dns.tsigkeyring
+        import dns.update
+    except Exception as exc:
+        raise DNSAliasError("dnspython is required for rfc2136 alias mode") from exc
+
+    record = _record_name(config['domain_alias'])
+    host, port = _rfc2136_server(provider_config['nameserver'])
+    keyalgorithm = _rfc2136_keyalgorithm(provider_config.get('tsig_algorithm'))
+    try:
+        keyring = dns.tsigkeyring.from_text(
+            {provider_config['tsig_key']: provider_config['tsig_secret']}
+        )
+    except Exception as exc:
+        raise DNSAliasError(f"Invalid rfc2136 TSIG key/secret: {exc}") from exc
+
+    timeout = 30
+    zone = _rfc2136_find_zone(record, host, port, timeout)
+    rel_name = dns.name.from_text(record).relativize(zone)
+
+    update = dns.update.Update(zone, keyring=keyring, keyalgorithm=keyalgorithm)
+    if action == 'create':
+        update.add(rel_name, 60, 'TXT', validation)
+    else:
+        update.delete(rel_name, 'TXT', validation)
+
+    try:
+        response = dns.query.tcp(update, host, port=port, timeout=timeout)
+    except Exception as exc:
+        raise DNSAliasError(f"rfc2136 TSIG update to {host}:{port} failed: {exc}") from exc
+
+    rcode = response.rcode()
+    if rcode != dns.rcode.NOERROR:
+        # NXRRSET on a delete just means the record was already gone — benign.
+        if action == 'delete' and rcode == dns.rcode.NXRRSET:
+            return
+        raise DNSAliasError(
+            f"rfc2136 TSIG update rejected by {host}:{port}: "
+            f"{dns.rcode.to_text(rcode)}"
+        )
+
+
 def _change_txt(config, action):
     validation = os.environ.get('CERTBOT_VALIDATION')
     if not validation:
@@ -338,6 +451,8 @@ def _change_txt(config, action):
         _edgedns_change(config, validation, action)
     elif provider == 'acme-dns':
         _acme_dns_change(config, validation, action)
+    elif provider == 'rfc2136':
+        _rfc2136_change(config, validation, action)
     else:
         raise DNSAliasError(f"Unsupported DNS alias provider: {provider}")
 

--- a/tests/test_domain_alias.py
+++ b/tests/test_domain_alias.py
@@ -12,7 +12,7 @@ from modules.core.shell import MockShellExecutor
 CORE_ALIAS_PROVIDERS = [
     'cloudflare', 'route53', 'azure', 'google', 'powerdns', 'digitalocean',
     'linode', 'edgedns', 'gandi', 'ovh', 'namecheap', 'arvancloud',
-    'infomaniak', 'acme-dns', 'duckdns',
+    'infomaniak', 'acme-dns', 'duckdns', 'rfc2136',
 ]
 
 
@@ -323,14 +323,15 @@ def test_dns_alias_check_reports_missing_and_ok_records(tmp_path):
 
 
 def test_domain_alias_rejects_unsupported_provider(tmp_path):
-    mgr, _ = _manager(tmp_path, provider='rfc2136')
+    # hetzner is a real DNS provider but has no alias-zone writer.
+    mgr, _ = _manager(tmp_path, provider='hetzner')
 
     with patch('modules.core.certificates.check_certbot_plugin_installed', return_value=True):
         with pytest.raises(RuntimeError) as exc_info:
             mgr.create_certificate(
                 domain='example.com',
                 email='test@example.com',
-                dns_provider='rfc2136',
+                dns_provider='hetzner',
                 staging=True,
                 domain_alias='validation.example.org',
             )

--- a/tests/test_provider_wiring_consistency.py
+++ b/tests/test_provider_wiring_consistency.py
@@ -129,10 +129,11 @@ def test_dns_manager_advertised_providers_match_factory():
 # free to recur in the alias subsystem. These ratchets lock the contract.
 # ---------------------------------------------------------------------------
 
-# edgedns and acme-dns are alias-capable but handled by dedicated change
-# functions (_edgedns_change / _acme_dns_change) rather than a Lexicon adapter,
-# so they are intentionally absent from LEXICON_PROVIDER_MAP.
-_ALIAS_NATIVE_ADAPTERS = {'edgedns', 'acme-dns'}
+# edgedns, acme-dns and rfc2136 are alias-capable but handled by dedicated
+# change functions (_edgedns_change / _acme_dns_change / _rfc2136_change) rather
+# than a Lexicon adapter, so they are intentionally absent from
+# LEXICON_PROVIDER_MAP.
+_ALIAS_NATIVE_ADAPTERS = {'edgedns', 'acme-dns', 'rfc2136'}
 
 
 def test_dns_alias_supported_set_matches_required_fields():

--- a/tests/test_rfc2136_alias_hook.py
+++ b/tests/test_rfc2136_alias_hook.py
@@ -102,8 +102,8 @@ def test_create_builds_tsig_update_to_alias_record(captured_update):
     msg = captured_update['message']
     # Signed with TSIG, addressed to the discovered zone.
     assert msg.keyname is not None
+    assert msg.origin == dns.name.from_text('example.com.')
     rendered = msg.to_text()
-    assert 'example.com' in rendered
     assert '_acme-challenge.validation' in rendered
     assert 'TXT' in rendered
     assert 'validation-token-123' in rendered

--- a/tests/test_rfc2136_alias_hook.py
+++ b/tests/test_rfc2136_alias_hook.py
@@ -1,0 +1,147 @@
+"""rfc2136 DNS-alias hook (CNAME delegation via TSIG dynamic update, #330).
+
+domain_alias mode writes _acme-challenge.<alias> TXT directly into the alias
+zone. For rfc2136 that means a dnspython dynamic UPDATE signed with the same
+TSIG key used for normal issuance, addressed to the zone discovered by an SOA
+walk.
+"""
+import dns.name
+import dns.rcode
+import dns.tsig
+import pytest
+
+from modules.core import dns_alias_hook
+from modules.core.dns_alias_hook import (
+    DNSAliasError,
+    _rfc2136_change,
+    _rfc2136_keyalgorithm,
+    _rfc2136_server,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+# --- algorithm + server parsing -------------------------------------------
+
+def test_keyalgorithm_default_is_sha512():
+    assert _rfc2136_keyalgorithm(None) == dns.tsig.HMAC_SHA512
+    assert _rfc2136_keyalgorithm('') == dns.tsig.HMAC_SHA512
+
+
+@pytest.mark.parametrize('name,expected', [
+    ('HMAC-SHA256', dns.tsig.HMAC_SHA256),
+    ('hmac-sha512', dns.tsig.HMAC_SHA512),
+    ('HMAC-MD5', dns.tsig.HMAC_MD5),
+])
+def test_keyalgorithm_maps_known(name, expected):
+    assert _rfc2136_keyalgorithm(name) == expected
+
+
+def test_keyalgorithm_rejects_unknown():
+    with pytest.raises(DNSAliasError):
+        _rfc2136_keyalgorithm('ROT13')
+
+
+@pytest.mark.parametrize('value,expected', [
+    ('ns1.example.com', ('ns1.example.com', 53)),
+    ('10.0.0.1', ('10.0.0.1', 53)),
+    ('10.0.0.1:5353', ('10.0.0.1', 5353)),
+    ('[2001:db8::1]:5353', ('2001:db8::1', 5353)),
+    ('[2001:db8::1]', ('2001:db8::1', 53)),
+    ('2001:db8::1', ('2001:db8::1', 53)),  # bare IPv6 -> not split into port
+])
+def test_server_parsing(value, expected):
+    assert _rfc2136_server(value) == expected
+
+
+# --- the update itself ----------------------------------------------------
+
+_CFG = {
+    'provider': 'rfc2136',
+    'domain_alias': 'validation.example.com',
+    'config': {
+        'nameserver': '10.0.0.1',
+        'tsig_key': 'certmate-key',
+        # base64 secret (dnspython requires valid base64)
+        'tsig_secret': 'c2VjcmV0LXNlY3JldC1zZWNyZXQ=',
+        'tsig_algorithm': 'HMAC-SHA512',
+    },
+}
+
+
+@pytest.fixture
+def captured_update(monkeypatch):
+    """Stub the SOA walk + the wire send; capture the UPDATE message built."""
+    monkeypatch.setattr(dns_alias_hook, '_rfc2136_find_zone',
+                        lambda *a, **k: dns.name.from_text('example.com.'))
+    sent = {}
+
+    class _Resp:
+        def __init__(self, rcode):
+            self._rcode = rcode
+
+        def rcode(self):
+            return self._rcode
+
+    def fake_tcp(message, host, port=53, timeout=None):
+        sent['message'] = message
+        sent['host'] = host
+        sent['port'] = port
+        return _Resp(sent.get('rcode', dns.rcode.NOERROR))
+
+    import dns.query
+    monkeypatch.setattr(dns.query, 'tcp', fake_tcp)
+    return sent
+
+
+def test_create_builds_tsig_update_to_alias_record(captured_update):
+    _rfc2136_change(_CFG, 'validation-token-123', 'create')
+
+    assert captured_update['host'] == '10.0.0.1'
+    assert captured_update['port'] == 53
+    msg = captured_update['message']
+    # Signed with TSIG, addressed to the discovered zone.
+    assert msg.keyname is not None
+    rendered = msg.to_text()
+    assert 'example.com' in rendered
+    assert '_acme-challenge.validation' in rendered
+    assert 'TXT' in rendered
+    assert 'validation-token-123' in rendered
+
+
+def test_delete_uses_delete_action(captured_update):
+    _rfc2136_change(_CFG, 'validation-token-123', 'delete')
+    rendered = captured_update['message'].to_text()
+    assert '_acme-challenge.validation' in rendered
+    # a delete carries the record in the update section with TTL 0 / NONE class
+    assert 'TXT' in rendered
+
+
+def test_delete_tolerates_nxrrset(captured_update):
+    captured_update['rcode'] = dns.rcode.NXRRSET
+    # already-gone on cleanup must not raise
+    _rfc2136_change(_CFG, 'validation-token-123', 'delete')
+
+
+def test_nonzero_rcode_on_create_raises(captured_update):
+    captured_update['rcode'] = dns.rcode.REFUSED
+    with pytest.raises(DNSAliasError):
+        _rfc2136_change(_CFG, 'validation-token-123', 'create')
+
+
+def test_missing_credentials_raises():
+    cfg = {'provider': 'rfc2136', 'domain_alias': 'a.example.com',
+           'config': {'nameserver': '10.0.0.1'}}
+    with pytest.raises(DNSAliasError):
+        _rfc2136_change(cfg, 'v', 'create')
+
+
+# --- dispatch -------------------------------------------------------------
+
+def test_change_txt_routes_rfc2136(monkeypatch):
+    called = {}
+    monkeypatch.setattr(dns_alias_hook, '_rfc2136_change',
+                        lambda c, v, a: called.update({'v': v, 'a': a}))
+    monkeypatch.setenv('CERTBOT_VALIDATION', 'tok')
+    dns_alias_hook._change_txt({'provider': 'rfc2136', 'domain_alias': 'x.example.com'}, 'create')
+    assert called == {'v': 'tok', 'a': 'create'}


### PR DESCRIPTION
Closes #330.

`domain_alias` (CNAME delegation) rejected rfc2136 — so an operator with one rfc2136 TSIG key across several zones couldn't issue for externally-managed domains whose owners only add the delegating CNAME.

**Note on the issue's root cause:** it pointed at the `_ZONE_DISCOVERY` registry, but the real gate is `DNS_ALIAS_SUPPORTED_PROVIDERS` and the per-provider writer in `dns_alias_hook.py` — so this is a native alias adapter, not a one-line registry add.

- Register rfc2136 in the alias gate + required fields (`nameserver`, `tsig_key`, `tsig_secret`).
- New `_rfc2136_change`: discovers the owning zone via SOA walk, writes/removes `_acme-challenge.<alias>` TXT with a TSIG-signed dynamic update (reuses normal-issuance creds + optional `tsig_algorithm`, default HMAC-SHA512). Honours `host:port` and `[ipv6]:port`. NXRRSET on cleanup = already-gone.
- **No new dependency** (dnspython is transitive via certbot-dns-rfc2136).
- Tests: dedicated hook tests + extended the alias-parametrised and wiring-consistency ratchets. Full suite green (1623). Docs updated.

Verified against Technitium-style TSIG (HMAC-SHA512) per the reporter's setup, via mocked dnspython.