### PR TITLE
docs: fix dead API Documentation badge link (localhost -> #api-usage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![Docker](https://img.shields.io/badge/docker-ready-blue)](https://hub.docker.com/)
-[![API Documentation](https://img.shields.io/badge/API-Swagger-green)](http://localhost:8000/docs/)
+[![API Documentation](https://img.shields.io/badge/API-Swagger-green)](#api-usage)
 [![CI](https://github.com/fabriziosalmi/certmate/actions/workflows/ci.yml/badge.svg)](https://github.com/fabriziosalmi/certmate/actions/workflows/ci.yml)
 [![Build Multi-Platform Docker Images](https://github.com/fabriziosalmi/certmate/actions/workflows/docker-multiplatform.yml/badge.svg)](https://github.com/fabriziosalmi/certmate/actions/workflows/docker-multiplatform.yml)
 [![CodeQL](https://github.com/fabriziosalmi/certmate/actions/workflows/codeql.yml/badge.svg)](https://github.com/fabriziosalmi/certmate/actions/workflows/codeql.yml)


### PR DESCRIPTION
## What
The header **API Documentation** badge linked to `http://localhost:8000/docs/` — a dead link for anyone reading the README on GitHub (the Swagger UI only exists at runtime on a running instance).

## Fix
Point the badge at the README's **[API Usage](#api-usage)** section (a real, public, in-repo destination). The `localhost:8000` URLs elsewhere (service-access table, `curl` usage examples) correctly describe the locally-running service and are left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)