### PR TITLE
ci/test: stop a UI-test rot and a false-green e2e gate

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -5,15 +5,25 @@ name: E2E (staging)
 # regression net for the DNS / provider / ACME wiring that the mocked unit
 # suite cannot exercise (the class of bug behind most recent cert churn).
 #
-# Opt-in only. It needs a Cloudflare secret and is NOT a required PR check:
-# real ACME + DNS propagation are slow and externally flaky, and it runs on
-# the single self-hosted host. Trigger it by hand (workflow_dispatch) or let
-# the weekly schedule catch wiring regressions proactively.
+# HONEST GATING (see the job-level `if` below). Real ACME + DNS propagation are
+# slow, externally flaky, and need a Cloudflare token, so this is opt-in and is
+# NOT a required PR check. It runs only when EXPLICITLY enabled, and when it is
+# not enabled the job is SKIPPED (neutral) rather than reporting a green no-op —
+# a gate must never claim success without actually issuing a certificate.
 #
-# To activate, add these repository secrets:
-#   CLOUDFLARE_API_TOKEN  - token with Zone:DNS:Edit on the test zone (required)
-#   CERTMATE_TEST_DOMAIN  - the Cloudflare-managed zone, e.g. example.org (required)
-#   CERTMATE_TEST_EMAIL   - ACME account email (optional; a default is used)
+# The authoritative real-cert gate is run LOCALLY before each release, with
+# credentials kept in .env (never in CI):
+#   set -a; . ./.env; set +a
+#   CERTMATE_E2E_CA_PROVIDER=letsencrypt_staging python -m pytest -v -m e2e \
+#     tests/test_health_ready_e2e.py tests/test_cert_lifecycle.py \
+#     tests/test_async_issuance_e2e.py
+#
+# To ALSO run it in CI (optional drift detection), set BOTH:
+#   - repository variable E2E_STAGING_ENABLED = true   (enables the scheduled run)
+#   - repository secrets:
+#       CLOUDFLARE_API_TOKEN  - token with Zone:DNS:Edit on the test zone (required)
+#       CERTMATE_TEST_DOMAIN  - the Cloudflare-managed zone, e.g. example.org (required)
+#       CERTMATE_TEST_EMAIL   - ACME account email (optional; a default is used)
 # Issuance defaults to Let's Encrypt STAGING (tests/e2e_support.py), so a run
 # never consumes a production rate limit or mints a publicly trusted cert.
 
@@ -34,31 +44,30 @@ concurrency:
 jobs:
   e2e-staging:
     name: e2e-staging
+    # Run only when explicitly enabled (scheduled drift detection) or on a
+    # manual dispatch. Otherwise the job is SKIPPED, not falsely green. `vars`
+    # is used for the switch because `secrets` is not available in job `if`.
+    if: ${{ vars.E2E_STAGING_ENABLED == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: [self-hosted, Linux, X64]
     steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
     - name: Preflight - require Cloudflare secret
-      id: preflight
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       run: |
         if [ -z "${CLOUDFLARE_API_TOKEN}" ]; then
-          echo "::notice::CLOUDFLARE_API_TOKEN is not configured - skipping real-cert E2E."
-          echo "run=false" >> "$GITHUB_OUTPUT"
-        else
-          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "::error::CLOUDFLARE_API_TOKEN is not configured, so the real-cert E2E cannot issue a certificate. Failing loudly instead of passing a no-op. Add the CLOUDFLARE_API_TOKEN / CERTMATE_TEST_DOMAIN repository secrets to run it in CI, or run the gate locally with credentials from .env (see the comment at the top of this workflow)."
+          exit 1
         fi
 
     - name: Set up Python 3.12
-      if: steps.preflight.outputs.run == 'true'
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
       with:
         python-version: '3.12'
 
     - name: Cache pip dependencies
-      if: steps.preflight.outputs.run == 'true'
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
       with:
         path: ~/.cache/pip
@@ -67,14 +76,12 @@ jobs:
           ${{ runner.os }}-pip-
 
     - name: Install dependencies
-      if: steps.preflight.outputs.run == 'true'
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements-test.txt
 
     - name: Real-cert E2E against Let's Encrypt staging
-      if: steps.preflight.outputs.run == 'true'
       env:
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         CERTMATE_TEST_DOMAIN: ${{ secrets.CERTMATE_TEST_DOMAIN }}

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -158,9 +158,15 @@ class TestSettingsUI:
     def test_dns_provider_selector(self, browser_page):
         browser_page.goto(f"{BASE_URL}/settings")
         browser_page.wait_for_load_state("networkidle")
-        # Should have DNS provider radio buttons
-        cloudflare_radio = browser_page.locator('input[name="dns_provider"][value="cloudflare"]')
-        expect(cloudflare_radio).to_be_visible()
+        # DNS provider cards live in the DNS tab; the default tab is General,
+        # so open the DNS tab first.
+        browser_page.locator('button[role="tab"][aria-label="DNS"]').click(timeout=10000)
+        browser_page.wait_for_timeout(300)
+        # The radio itself is sr-only (visually hidden); assert its visible
+        # wrapping card instead of the input.
+        cloudflare_card = browser_page.locator(
+            'label:has(input[name="dns_provider"][value="cloudflare"])')
+        expect(cloudflare_card).to_be_visible(timeout=5000)
 
     def test_auth_security_banner_visible(self, browser_page):
         browser_page.goto(f"{BASE_URL}/settings")
@@ -243,7 +249,12 @@ class TestCAAndChallengeToggles:
         browser_page.goto(f"{BASE_URL}/settings")
         browser_page.wait_for_load_state("networkidle")
 
-        # On the DNS tab (default). Select a provider so its config panel shows.
+        # The DNS challenge/provider controls live in the DNS tab; the default
+        # tab is General, so open the DNS tab first.
+        browser_page.locator('button[role="tab"][aria-label="DNS"]').click(timeout=10000)
+        browser_page.wait_for_timeout(300)
+
+        # Select a provider so its config panel shows.
         browser_page.click('label:has(input[name="dns_provider"][value="cloudflare"])')
         browser_page.wait_for_timeout(300)
         expect(browser_page.locator('#cloudflare-config')).to_be_visible(timeout=5000)


### PR DESCRIPTION
## CI/test hardening: stop a UI-test rot and a false-green e2e gate

No product behaviour change; tests and CI only. No version bump.

### test(ui): open the DNS tab before exercising the DNS provider selector
`test_dns_provider_selector` and `test_http01_hides_dns_config_panels` assumed the DNS tab was active by default, but the default Settings tab is General, so the hidden tab panel made the provider controls "not visible" and both tests failed (they failed identically on the v2.19.4 baseline — pre-existing). They now open the DNS tab first; and since the provider radio is `sr-only`, the visibility assertion targets the visible wrapping card rather than the input. Verified: full `-m ui` suite 12 passed, 0 failed (was 2 failed).

### ci(e2e-staging): skip honestly instead of reporting a green no-op
The scheduled real-cert E2E reported success while doing nothing: the preflight skipped every step when `CLOUDFLARE_API_TOKEN` was absent, so the job went green without issuing a certificate. A gate that claims success without running is worse than none.

The job is now gated on the `E2E_STAGING_ENABLED` repository variable (or a manual dispatch), so when not enabled it is **skipped** (neutral) rather than falsely green; and if it is reached without the secret it **fails loudly** (misconfiguration). The authoritative real-cert gate is run locally before each release, with credentials kept in `.env` (never in CI). To also run it in CI for weekly drift detection, set the `E2E_STAGING_ENABLED` variable plus the Cloudflare secrets (documented at the top of the workflow).

Generated with Claude Code (https://claude.com/claude-code)
