### PR TITLE
ci/test: version-drift guard + emoji lint for release notes

### DIFF
--- a/.github/workflows/lint-emoji.yml
+++ b/.github/workflows/lint-emoji.yml
@@ -1,0 +1,41 @@
+name: Lint (emoji)
+
+# Mechanises the "zero emoji in public artifacts" rule for the most public one:
+# RELEASE_NOTES.md. Arrows and the em-dash are typography, not emoji, and are
+# deliberately allowed. Runs on a GitHub-hosted runner so it never competes for
+# the single self-hosted host.
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  emoji:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+    - name: Scan RELEASE_NOTES.md for emoji
+      run: |
+        python3 - <<'PY'
+        import re, sys, pathlib
+        # True-emoji ranges. Deliberately EXCLUDES arrows (U+2190-21FF) and the
+        # em-dash (U+2014), which the project treats as typography.
+        EMOJI = re.compile(
+            "[\U0001F000-\U0001FAFF\U00002600-\U000026FF"
+            "\U00002700-\U000027BF\U00002B50\U00002B55\U0000FE0F]"
+        )
+        p = pathlib.Path("RELEASE_NOTES.md")
+        bad = []
+        for n, line in enumerate(p.read_text(encoding="utf-8").splitlines(), 1):
+            if EMOJI.search(line):
+                bad.append((n, line.strip()))
+        if bad:
+            for n, line in bad:
+                print(f"::error file=RELEASE_NOTES.md,line={n}::emoji not allowed: {line}")
+            sys.exit(1)
+        print("RELEASE_NOTES.md: no emoji")
+        PY

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1361,7 +1361,7 @@ Domain-scope denials have audited via `log_authz_denied` since v2.4.12; role-lev
 
 ### Certificate download — private-key role split
 
-Escalation of a finding the audit rated INFO/⚠️ in its coverage matrix. `DownloadCertificate.get` required only `viewer` and returned private-key material via four code paths: `?format=json`, `?file=privkey.pem`, `?file=combined.pem`, default ZIP. A scoped viewer key could therefore pull the private key for every certificate in its scope — information disclosure inconsistent with the read-only-monitoring intent of the role.
+Escalation of a finding the audit rated INFO/WARN in its coverage matrix. `DownloadCertificate.get` required only `viewer` and returned private-key material via four code paths: `?format=json`, `?file=privkey.pem`, `?file=combined.pem`, default ZIP. A scoped viewer key could therefore pull the private key for every certificate in its scope — information disclosure inconsistent with the read-only-monitoring intent of the role.
 
 The decorator stays `viewer` so the authn check still fires, and the handler now gates per file:
 

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,16 @@
+"""Single-source-of-truth guard: package.json and modules.__version__ must
+agree. A drift here means a release bumped one and forgot the other."""
+import json
+import pathlib
+
+from modules import __version__
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_package_json_matches_module_version():
+    pkg = json.loads((REPO_ROOT / "package.json").read_text(encoding="utf-8"))
+    assert pkg["version"] == __version__, (
+        f"package.json version {pkg['version']!r} != modules.__version__ "
+        f"{__version__!r} - bump both (or neither) in the same release commit."
+    )


### PR DESCRIPTION
Draconian-plan P0 (invariants). No product change.

- **test:** `package.json.version` must equal `modules.__version__` (catches the two-place version bump drift).
- **ci:** a GitHub-hosted `Lint (emoji)` job fails the build on emoji in RELEASE_NOTES.md (arrows / em-dash allowed). It already caught a pre-existing U+26A0, removed here.

Generated with Claude Code (https://claude.com/claude-code)