### PR TITLE
ci: run the Playwright UI suite (path-filtered + nightly)

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -26,13 +26,21 @@ on:
 permissions: read-all
 
 concurrency:
-  group: certmate-selfhosted-test-container
-  cancel-in-progress: false
+  group: ui-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ui:
     name: ui
     runs-on: [self-hosted, Linux, X64]
+    # Same host-global lock ci.yml's `test` job uses: the UI suite binds the
+    # fixed-name test container on port 18888, so it must queue behind (never
+    # run beside) any other test job on the self-hosted host. Putting this
+    # shared group at workflow level instead made a co-triggered workflow cancel
+    # this run at 1s; keep it job-level, cancel-in-progress false so it queues.
+    concurrency:
+      group: certmate-selfhosted-test-container
+      cancel-in-progress: false
     steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,0 +1,63 @@
+name: UI tests
+
+# Runs the Playwright UI suite (-m ui) so it cannot rot silently the way two
+# settings tests did. The main CI job runs `-m "not ui"`, so without this the
+# UI tests would never execute. Path-filtered to frontend changes to spare the
+# single self-hosted host, plus a nightly run to catch drift, plus manual.
+#
+# Shares the host-global container lock with ci.yml's `test` job and
+# e2e-staging: all three bind the fixed-name test container on port 18888 and
+# must never run at once on the self-hosted host (#295).
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - 'templates/**'
+      - 'static/**'
+      - 'tests/test_ui.py'
+      - 'tests/conftest.py'
+      - 'Dockerfile'
+      - '.github/workflows/ui-tests.yml'
+  schedule:
+    - cron: '41 4 * * *'  # nightly drift catch
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: certmate-selfhosted-test-container
+  cancel-in-progress: false
+
+jobs:
+  ui:
+    name: ui
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      with:
+        python-version: '3.12'
+
+    - name: Cache pip dependencies
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-test.txt
+
+    - name: Install Playwright Chromium
+      run: python -m playwright install chromium
+
+    - name: UI tests
+      run: python -m pytest -v -m ui


### PR DESCRIPTION
Draconian-plan P0. No product change. Adds a UI-test workflow so `-m ui` actually runs in CI (the main job runs `-m "not ui"`, which is why two settings tests rotted). Path-filtered to frontend changes + nightly + manual, in the shared self-hosted container-lock group.

Generated with Claude Code (https://claude.com/claude-code)