### PR TITLE
P1: gated release script + CI marker-coverage guard

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+#
+# CertMate release - the single, gated path to a release. Fail-closed: any gate
+# that does not pass aborts the release. No step depends on remembering to run
+# it. Mirrors the process the repo already enforces (fresh branch off main,
+# squash-merge, tag, GH release) and the real-cert policy (path-aware, with an
+# explicit, logged override for non-issuance patches only).
+#
+# Usage:
+#   scripts/release.sh prepare X.Y.Z [--skip-real-cert "reason"] [--dry-run]
+#       Validate + run every gate, then (unless --dry-run) branch off main,
+#       bump the version, commit, push and open the release PR.
+#   scripts/release.sh publish X.Y.Z
+#       After that PR is merged to main: tag vX.Y.Z and create the GH release
+#       from the RELEASE_NOTES.md section. Run this only once CI is green.
+#
+# Gates (prepare): flake8 (syntax/undefined), bandit, unit+integration suite,
+# UI (Playwright), real-cert E2E (LE staging via Cloudflare from .env), Docker
+# build. The unit suite includes the version-consistency and CI-marker-coverage
+# guards. Docker must be running for the UI and real-cert gates.
+#
+set -euo pipefail
+
+# --- setup --------------------------------------------------------------------
+cd "$(dirname "$0")/.."
+ROOT="$(pwd)"
+PY="${ROOT}/.venv/bin/python"
+[ -x "$PY" ] || PY="python3"
+# macOS: Docker Desktop's CLI is not always on PATH.
+if ! command -v docker >/dev/null 2>&1 && [ -x /Applications/Docker.app/Contents/Resources/bin/docker ]; then
+  export PATH="/Applications/Docker.app/Contents/Resources/bin:$PATH"
+fi
+
+# Paths whose change makes the real-cert E2E MANDATORY (issuance pipeline).
+SENSITIVE_RE='^(modules/(core/(certificate|client_cert|deployer|acme|storage)|dns|api/(certificate|resources|client_cert))|requirements.*\.txt|Dockerfile|tests/(e2e_support|test_cert_lifecycle|test_async_issuance|test_health_ready))'
+
+die()  { echo "ERROR: $*" >&2; exit 1; }
+info() { echo ">>> $*"; }
+gate() { echo; echo "[GATE] $1"; shift; "$@"; }
+
+emoji_scan() {  # fail on emoji (arrows / em-dash allowed) in the given file
+  "$PY" - "$1" <<'PY'
+import re, sys, pathlib
+EMOJI = re.compile("[\U0001F000-\U0001FAFF\U00002600-\U000026FF"
+                   "\U00002700-\U000027BF\U00002B50\U00002B55\U0000FE0F]")
+p = pathlib.Path(sys.argv[1])
+bad = [(n, l.strip()) for n, l in enumerate(p.read_text(encoding="utf-8").splitlines(), 1)
+       if EMOJI.search(l)]
+if bad:
+    for n, l in bad:
+        print(f"  {p}:{n}: {l}", file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+notes_section() {  # print the RELEASE_NOTES.md block for vX.Y.Z (stops at the --- rule)
+  awk -v v="## v$1 " '
+    index($0, v)==1 {f=1}
+    f && /^---$/ {exit}
+    f {print}
+  ' RELEASE_NOTES.md
+}
+
+semver_ok() { [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; }
+version_gt() {  # $1 > $2 ?
+  [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ]
+}
+
+# --- prepare ------------------------------------------------------------------
+cmd_prepare() {
+  local version="" skip_reason="" dry=0
+  version="${1:-}"; shift || true
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --skip-real-cert) skip_reason="${2:-}"; shift 2 || die "--skip-real-cert needs a reason";;
+      --dry-run) dry=1; shift;;
+      *) die "unknown flag: $1";;
+    esac
+  done
+  [ -n "$version" ] || die "usage: release.sh prepare X.Y.Z [--skip-real-cert \"reason\"] [--dry-run]"
+  semver_ok "$version" || die "not a semver X.Y.Z: $version"
+
+  info "Preconditions"
+  [ -f modules/__init__.py ] || die "run from the repo root"
+  [ -z "$(git status --porcelain)" ] || die "working tree is dirty - commit or stash first"
+  git fetch origin --quiet
+  git rev-parse --verify origin/main >/dev/null 2>&1 || die "no origin/main"
+  local cur; cur="$("$PY" -c 'from modules import __version__; print(__version__)')"
+  version_gt "$version" "$cur" || die "version $version is not greater than current $cur"
+
+  info "RELEASE_NOTES.md must document v$version"
+  [ -n "$(notes_section "$version")" ] || die "no '## v$version' section in RELEASE_NOTES.md - write the notes first"
+  emoji_scan RELEASE_NOTES.md || die "emoji in RELEASE_NOTES.md (arrows/em-dash are fine)"
+
+  info "Real-cert policy (path-aware)"
+  local last_tag changed touches=0
+  last_tag="$(git describe --tags --abbrev=0 origin/main 2>/dev/null || true)"
+  if [ -n "$last_tag" ]; then
+    changed="$(git diff --name-only "$last_tag..origin/main")"
+  else
+    changed=""; touches=1  # no tag reachable -> be safe, require real-cert
+  fi
+  if [ -n "$changed" ] && echo "$changed" | grep -Eq "$SENSITIVE_RE"; then touches=1; fi
+  local run_real_cert=1
+  if [ "$touches" = 1 ]; then
+    [ -z "$skip_reason" ] || die "real-cert is MANDATORY (release touches the issuance pipeline); --skip-real-cert is not allowed here. Changed:
+$(echo "$changed" | grep -E "$SENSITIVE_RE" | sed 's/^/  /')"
+    info "  issuance pipeline changed since ${last_tag:-<no tag>} -> real-cert MANDATORY"
+  elif [ -n "$skip_reason" ]; then
+    run_real_cert=0
+    info "  no issuance-pipeline change; real-cert SKIPPED (logged): $skip_reason"
+  else
+    info "  no issuance-pipeline change; real-cert still run by default (use --skip-real-cert to override)"
+  fi
+
+  # --- gates (fail-closed) ---
+  docker info >/dev/null 2>&1 || die "Docker daemon is not running (needed for UI + real-cert gates)"
+  export FLASK_ENV=testing TESTING=true
+
+  gate "flake8 (syntax / undefined names)" bash -c '
+    "'"$PY"'" -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics'
+  gate "bandit (medium+)" bash -c '"'"$PY"'" -m bandit -r modules/ app.py --severity-level medium -q'
+  gate "unit + integration suite (incl. version + marker-coverage guards)" \
+    "$PY" -m pytest -q -m "not ui and not e2e" -p no:cacheprovider
+  gate "UI suite (Playwright)" "$PY" -m pytest -q -m ui -p no:cacheprovider
+  if [ "$run_real_cert" = 1 ]; then
+    [ -f .env ] || die "real-cert gate needs .env with CLOUDFLARE_API_TOKEN / CERTMATE_TEST_DOMAIN"
+    gate "real-cert E2E (LE staging via Cloudflare)" bash -c '
+      set -a; . ./.env; set +a
+      [ -n "${CLOUDFLARE_API_TOKEN:-}" ] || { echo "CLOUDFLARE_API_TOKEN empty in .env" >&2; exit 1; }
+      CERTMATE_E2E_CA_PROVIDER=letsencrypt_staging "'"$PY"'" -m pytest -q -m e2e \
+        tests/test_health_ready_e2e.py tests/test_cert_lifecycle.py tests/test_async_issuance_e2e.py \
+        -p no:cacheprovider'
+  fi
+  gate "Docker build" docker build -t certmate:release-check .
+
+  echo; info "ALL GATES PASSED for v$version"
+  if [ "$dry" = 1 ]; then info "--dry-run: stopping before any branch/commit/push"; return 0; fi
+
+  # --- orchestration ---
+  local branch="release-v$version"
+  git rev-parse --verify "$branch" >/dev/null 2>&1 && die "branch $branch already exists"
+  info "Branch $branch off origin/main"
+  git checkout -q -b "$branch" origin/main
+  "$PY" - "$version" <<'PY'
+import json, pathlib, re, sys
+v = sys.argv[1]
+init = pathlib.Path("modules/__init__.py")
+init.write_text(re.sub(r"__version__ = '[^']+'", f"__version__ = '{v}'", init.read_text()), encoding="utf-8")
+pkg = pathlib.Path("package.json"); d = json.loads(pkg.read_text())
+d["version"] = v
+pkg.write_text(json.dumps(d, indent=2) + "\n", encoding="utf-8")
+PY
+  [ "$("$PY" -c 'import json;from modules import __version__;print(json.load(open("package.json"))["version"]==__version__)')" = "True" ] \
+    || die "version files disagree after bump"
+  local body="chore(release): v$version"
+  [ "$run_real_cert" = 0 ] && body="$body
+
+real-cert E2E skipped (non-issuance change): $skip_reason"
+  git add modules/__init__.py package.json
+  git commit -q -m "$body
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+  info "Push + open PR"
+  git push -u origin "$branch" --quiet
+  local pr_body; pr_body="$(notes_section "$version")
+$( [ "$run_real_cert" = 1 ] && echo "Gates: unit+integration, UI, real-cert E2E (LE staging), Docker build - all green locally." \
+     || echo "Gates: unit+integration, UI, Docker build - all green locally. Real-cert E2E skipped (non-issuance): $skip_reason." )"
+  gh pr create --base main --head "$branch" \
+    --title "v$version - $(notes_section "$version" | head -1 | sed 's/^## v[0-9.]* (\?//; s/)\?$//')" \
+    --body "$pr_body"
+  echo; info "PR opened. When CI is green and it is merged, run: scripts/release.sh publish $version"
+}
+
+# --- publish ------------------------------------------------------------------
+cmd_publish() {
+  local version="${1:-}"
+  [ -n "$version" ] || die "usage: release.sh publish X.Y.Z"
+  semver_ok "$version" || die "not a semver X.Y.Z: $version"
+  git fetch origin --quiet
+  git checkout -q main
+  git pull --ff-only origin main --quiet
+  local head_v; head_v="$("$PY" -c 'from modules import __version__; print(__version__)')"
+  [ "$head_v" = "$version" ] || die "main is at v$head_v, not v$version - is the release PR merged?"
+  git log -1 --format='%s' | grep -q "v$version" || die "main HEAD is not the v$version release commit"
+  git rev-parse --verify "v$version" >/dev/null 2>&1 && die "tag v$version already exists"
+  emoji_scan RELEASE_NOTES.md || die "emoji in RELEASE_NOTES.md"
+  local notes; notes="$(notes_section "$version")"
+  [ -n "$notes" ] || die "no RELEASE_NOTES section for v$version"
+  local title; title="$(echo "$notes" | head -1 | sed 's/^## //')"
+  info "Tag + push v$version"
+  git tag -a "v$version" -m "$title" HEAD
+  git push origin "v$version" --quiet
+  info "GH release"
+  printf '%s\n' "$notes" | gh release create "v$version" --title "$title" --notes-file - --latest
+  info "Released v$version"
+}
+
+# --- dispatch -----------------------------------------------------------------
+case "${1:-}" in
+  prepare) shift; cmd_prepare "$@";;
+  publish) shift; cmd_publish "$@";;
+  *) die "usage: release.sh {prepare|publish} X.Y.Z [...]";;
+esac

--- a/tests/test_ci_marker_coverage.py
+++ b/tests/test_ci_marker_coverage.py
@@ -1,0 +1,80 @@
+"""Rigor gate: every pytest marker that has tests must be selected by at least
+one CI pytest invocation.
+
+This is the guard that would have caught the UI-test rot: the ``ui`` tests
+existed, but the only CI invocation was ``-m "not ui"``, so they ran nowhere
+and two of them silently went stale. If a marker carries tests but is excluded
+by *every* CI ``-m`` expression, this test fails.
+"""
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+WF_DIR = ROOT / ".github" / "workflows"
+TESTS_DIR = ROOT / "tests"
+
+
+def _declared_markers():
+    """Marker names declared in pytest.ini's ``markers =`` block."""
+    ini = (ROOT / "pytest.ini").read_text(encoding="utf-8")
+    out, in_block = set(), False
+    for line in ini.splitlines():
+        if re.match(r"^markers\s*=", line):
+            in_block = True
+            continue
+        if in_block:
+            m = re.match(r"^\s+(\w+):", line)
+            if m:
+                out.add(m.group(1))
+            elif line and not line[0].isspace():
+                break
+    return out
+
+
+def _markers_with_tests(declared):
+    """Declared markers that actually appear on a test (explicit @pytest.mark.X
+    or module-level pytestmark = pytest.mark.X)."""
+    used = set()
+    pat = re.compile(r"pytest\.mark\.(\w+)")
+    for f in TESTS_DIR.rglob("test_*.py"):
+        for name in pat.findall(f.read_text(encoding="utf-8")):
+            if name in declared:
+                used.add(name)
+    return used
+
+
+def _ci_marker_exprs(declared):
+    """`-m` expressions used by pytest in CI workflows, limited to those that
+    reference a declared marker (drops the `-m` of `python -m pytest`)."""
+    exprs, pat = [], re.compile(r"-m\s+(\"[^\"]+\"|'[^']+'|\S+)")
+    for f in WF_DIR.glob("*.yml"):
+        for raw in pat.findall(f.read_text(encoding="utf-8")):
+            expr = raw.strip("\"'")
+            if any(re.search(rf"\b{re.escape(m)}\b", expr) for m in declared):
+                exprs.append(expr)
+    return exprs
+
+
+def _selects(expr, marker, declared):
+    """True if `expr` selects a test carrying ONLY `marker`."""
+    ns = {m: (m == marker) for m in declared}
+    try:
+        return bool(eval(expr, {"__builtins__": {}}, ns))  # noqa: S307 - our own workflow strings
+    except Exception:
+        return False
+
+
+def test_every_used_marker_is_run_by_ci():
+    declared = _declared_markers()
+    assert declared, "no markers declared in pytest.ini"
+    used = _markers_with_tests(declared)
+    exprs = _ci_marker_exprs(declared)
+    assert exprs, "no pytest `-m` invocations referencing a declared marker found in CI workflows"
+
+    uncovered = [m for m in sorted(used)
+                 if not any(_selects(e, m, declared) for e in exprs)]
+    assert not uncovered, (
+        f"markers that carry tests but are excluded by EVERY CI pytest "
+        f"invocation (they run nowhere -> rot risk): {uncovered}. "
+        f"CI -m expressions seen: {exprs}"
+    )


### PR DESCRIPTION
## P1: single gated release path + CI marker-coverage guard

No product change. Closes the two "done by memory" gaps from the draconian plan.

### build: scripts/release.sh
The one, fail-closed way to cut a release. `prepare X.Y.Z`:
- Preconditions: clean tree, valid semver, version strictly greater than current.
- Requires a `## vX.Y.Z` section in RELEASE_NOTES.md (no auto-generated slop) and scans it emoji-free.
- Runs every gate and aborts on the first failure: flake8 (syntax/undefined), bandit, unit+integration suite (which includes the version-consistency and marker-coverage guards), UI (Playwright), real-cert E2E (LE staging via Cloudflare from `.env`), Docker build.
- Real-cert is **path-aware**: mandatory when the issuance pipeline changed since the last tag; skippable only for non-issuance patches via an explicit, logged `--skip-real-cert "reason"` (recorded in the release commit + PR body).
- Then branches off `main`, bumps both version files, commits `chore(release)`, pushes and opens the PR. `--dry-run` stops after the gates.

`publish X.Y.Z` (after the PR is merged): verifies `main` is at that version, tags `vX.Y.Z`, and creates the GH release from the RELEASE_NOTES section.

### test: CI marker-coverage guard
Fails if any pytest marker that carries tests is excluded by every CI `-m` expression (i.e. runs nowhere). This is exactly the invariant the UI-test rot violated. Verified: passes today; flags `ui` if the UI job is removed.

Generated with Claude Code (https://claude.com/claude-code)
