### PR TITLE
ci: PyPI Trusted Publishing workflow for the clients

### DIFF
--- a/.github/workflows/publish-clients.yml
+++ b/.github/workflows/publish-clients.yml
@@ -1,0 +1,67 @@
+name: Publish clients (PyPI)
+
+# Publishes certmate-sdk + certmate-cli via PyPI Trusted Publishing (OIDC) — no
+# API tokens, no stored secrets. Fires on a clients-specific tag (clients-v*),
+# kept independent of the server's v* release tags so the two version streams
+# never collide, or manually (workflow_dispatch) for a TestPyPI dry run. The SDK
+# publishes BEFORE the CLI, which depends on it at install time.
+
+on:
+  push:
+    tags:
+      - 'clients-v*'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Index to publish to'
+        type: choice
+        options: [testpypi, pypi]
+        default: testpypi
+
+permissions:
+  contents: read
+
+jobs:
+  publish-sdk:
+    name: publish certmate-sdk
+    runs-on: ubuntu-latest
+    # Per-package environment names: PyPI forbids two pending trusted publishers
+    # sharing the same (repo, workflow, environment), so each package gets its
+    # own. Must match the PyPI/TestPyPI Trusted Publisher config.
+    environment: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'testpypi-sdk' || 'pypi-sdk' }}
+    permissions:
+      id-token: write   # OIDC — the only credential trusted publishing needs
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install --upgrade build twine
+      - run: python -m build clients/certmate-sdk --outdir dist
+      - run: twine check dist/*
+      - name: Publish certmate-sdk
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          repository-url: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'https://test.pypi.org/legacy/' || '' }}
+
+  publish-cli:
+    name: publish certmate-cli
+    needs: publish-sdk   # SDK must land on the index first (the CLI depends on it)
+    runs-on: ubuntu-latest
+    environment: ${{ (github.event_name == 'workflow_dispatch' && inputs.target) || 'pypi' }}
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install --upgrade build twine
+      - run: python -m build clients/certmate-cli --outdir dist
+      - run: twine check dist/*
+      - name: Publish certmate-cli
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          repository-url: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'https://test.pypi.org/legacy/' || '' }}

--- a/clients/certmate-cli/pyproject.toml
+++ b/clients/certmate-cli/pyproject.toml
@@ -11,6 +11,23 @@ requires-python = ">=3.9"
 license = { text = "MIT" }
 authors = [{ name = "Fabrizio Salmi", email = "fabrizio.salmi@gmail.com" }]
 keywords = ["certmate", "acme", "letsencrypt", "tls", "cli"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Security",
+    "Topic :: System :: Systems Administration",
+    "Topic :: Utilities",
+]
 # Built ON the SDK (never the reverse). typer for the command surface, rich
 # for tables/spinners. Still light — no server deps.
 dependencies = [

--- a/clients/certmate-sdk/pyproject.toml
+++ b/clients/certmate-sdk/pyproject.toml
@@ -11,6 +11,22 @@ requires-python = ">=3.9"
 license = { text = "MIT" }
 authors = [{ name = "Fabrizio Salmi", email = "fabrizio.salmi@gmail.com" }]
 keywords = ["certmate", "acme", "letsencrypt", "tls", "certificates", "sdk"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Security",
+    "Topic :: System :: Systems Administration",
+    "Topic :: Internet :: WWW/HTTP",
+]
 # Deliberately tiny: the SDK is an HTTP client, not the server. No certbot,
 # no DNS plugins, no cloud SDKs — `pip install certmate-sdk` stays light.
 dependencies = ["httpx>=0.24"]


### PR DESCRIPTION
Adds `.github/workflows/publish-clients.yml` — publishes `certmate-sdk` + `certmate-cli` via PyPI Trusted Publishing (OIDC, no tokens). SDK before CLI; per-package environments; `clients-v*` tag for PyPI, `workflow_dispatch target=testpypi` for a dry run; builds twine-checked. Pending publishers are configured on PyPI + TestPyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)