### PR TITLE
fix(sdk): retry the gunicorn keep-alive race (clients 0.1.1)

### DIFF
--- a/clients/certmate-cli/certmate_cli/__init__.py
+++ b/clients/certmate-cli/certmate_cli/__init__.py
@@ -1,2 +1,2 @@
 """certmate-cli — the CertMate SSL lifecycle from your terminal (built on certmate-sdk)."""
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/clients/certmate-cli/pyproject.toml
+++ b/clients/certmate-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "certmate-cli"
-version = "0.1.0"
+version = "0.1.1"
 description = "CertMate command-line interface — the SSL certificate lifecycle from your terminal"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -31,7 +31,7 @@ classifiers = [
 # Built ON the SDK (never the reverse). typer for the command surface, rich
 # for tables/spinners. Still light — no server deps.
 dependencies = [
-    "certmate-sdk>=0.1.0",
+    "certmate-sdk>=0.1.1",
     "typer>=0.9",
     "rich>=13",
 ]

--- a/clients/certmate-sdk/certmate/__init__.py
+++ b/clients/certmate-sdk/certmate/__init__.py
@@ -9,7 +9,7 @@ from .errors import (APIError, AuthError, CertMateError, ConflictError,
                      JobFailed, JobTimeout, NotFoundError)
 from .models import Certificate, Job
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __all__ = [
     "Client", "Certificate", "Job",
     "CertMateError", "APIError", "AuthError", "NotFoundError", "ConflictError",

--- a/clients/certmate-sdk/certmate/client.py
+++ b/clients/certmate-sdk/certmate/client.py
@@ -35,8 +35,17 @@ class Client:
         headers = {"Accept": "application/json"}
         if token:
             headers["Authorization"] = f"Bearer {token}"
+        # gunicorn closes idle keep-alive connections after ~2s. httpx must not
+        # reuse a connection older than that or it surfaces as a
+        # RemoteProtocolError ("Server disconnected without sending a
+        # response"); expire pooled connections well under that window and
+        # retry connection-level blips.
+        transport = httpx.HTTPTransport(
+            retries=3, verify=verify,
+            limits=httpx.Limits(keepalive_expiry=1.0),
+        )
         self._http = httpx.Client(base_url=base_url, headers=headers,
-                                  timeout=timeout, verify=verify)
+                                  timeout=timeout, transport=transport)
         self.base_url = base_url
 
     # -- lifecycle -----------------------------------------------------------

--- a/clients/certmate-sdk/pyproject.toml
+++ b/clients/certmate-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "certmate-sdk"
-version = "0.1.0"
+version = "0.1.1"
 description = "Thin Python client for the CertMate REST API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
The SDK reused httpx keep-alive connections gunicorn had already closed (idle > ~2s) → `RemoteProtocolError` ("Server disconnected"), e.g. `certmate cert create --wait` failing immediately. Fix: `keepalive_expiry=1.0` + transport `retries=3` (matching the e2e client). Bumps sdk+cli to **0.1.1** (cli 0.1.0 already on PyPI can't be re-uploaded; released as a pair) and pins cli → `certmate-sdk>=0.1.1`. Builds twine-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)