### PR TITLE
fix(cli): suppress redundant intact reason on audit verify (#378)

### DIFF
--- a/clients/certmate-cli/certmate_cli/main.py
+++ b/clients/certmate-cli/certmate_cli/main.py
@@ -285,8 +285,14 @@ def audit_verify(ctx: typer.Context):
     if not ok and any(k in reason.lower() for k in ("does not exist", "empty")):
         out.print(f"audit chain: [dim]none yet[/] — {reason}")
         return
-    out.print(f"audit chain: {'[green]intact[/]' if ok else '[red]BROKEN[/]'}"
-              f"{(' — ' + reason) if reason else ''}")
+    detail = (
+        f" — {reason}"
+        if reason and not (ok and reason.lower() == "intact")
+        else ""
+    )
+    out.print(
+        f"audit chain: {'[green]intact[/]' if ok else '[red]BROKEN[/]'}{detail}"
+    )
     if cp is not None:
         out.print(f"  signed checkpoint: {'[green]verified[/]' if cp else '[dim]not cross-checked[/]'}"
                   f"{(' @ seq ' + str(res.get('checkpoint_seq'))) if res.get('checkpoint_seq') is not None else ''}")

--- a/tests/test_cli_audit_verify_output.py
+++ b/tests/test_cli_audit_verify_output.py
@@ -1,0 +1,32 @@
+"""CLI output for `certmate audit verify` (issue #378)."""
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from certmate_cli.main import app
+
+runner = CliRunner()
+
+
+def _invoke_audit_verify(api_response: dict):
+    with patch("certmate_cli.main._client", return_value=MagicMock()):
+        with patch("certmate_cli.main._run", return_value=api_response):
+            return runner.invoke(app, ["audit", "verify"])
+
+
+def test_audit_verify_healthy_suppresses_redundant_intact_reason():
+    result = _invoke_audit_verify(
+        {"ok": True, "reason": "intact", "checkpoint_verified": False}
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "intact — intact" not in result.stdout
+    assert "audit chain:" in result.stdout
+
+
+def test_audit_verify_broken_still_shows_reason():
+    result = _invoke_audit_verify(
+        {"ok": False, "reason": "hash mismatch at seq 3", "checkpoint_verified": None}
+    )
+    assert result.exit_code == 1
+    assert "BROKEN" in result.stdout
+    assert "hash mismatch at seq 3" in result.stdout


### PR DESCRIPTION
## Summary
Fixes #378 — when the audit chain is healthy, `certmate audit verify` no longer prints redundant `intact — intact`; the reason suffix is omitted when `ok` is true and `reason` is `intact` (case-insensitive). BROKEN and `none yet` paths unchanged.

## Test plan
- [x] `pytest tests/test_cli_audit_verify_output.py` (2/2 pass)
