### PR TITLE
harden: truth in reporting across server, clients and CI (v2.21.1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,17 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # The ACME stack is deliberately held (issue #103): certbot 3.x/4.x and
+      # josepy 2.x break the pinned resolver set, so dependabot must not keep
+      # reopening bumps for it. Core packages: ignore ALL updates.
+      - dependency-name: "certbot"
+      - dependency-name: "josepy"
+      - dependency-name: "acme"
+      # DNS plugins version-track certbot majors; block majors only so
+      # compatible minor/patch plugin fixes still arrive.
+      - dependency-name: "certbot-dns-*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directories:
@@ -44,3 +55,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      # New python interpreter lines are blocked by the held ACME stack
+      # (python 3.14 breaks via josepy — issue #103). The base tag is
+      # `python:3.12-slim-trixie`, so dependabot classifies 3.12 -> 3.14 as
+      # semver-MINOR (major stays 3); CPython's breaking boundary is its
+      # minor number, so both major and minor are ignored here. Patch and
+      # digest updates within 3.12 still flow.
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -82,6 +82,9 @@ jobs:
       uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
       with:
         images: ${{ env.REGISTRY }}/${{ steps.ns.outputs.namespace }}/${{ env.IMAGE_NAME }}
+        # latest = released: only v* tag builds (cut after the release.sh
+        # real-cert e2e gate) may publish :latest; pushes to main get branch
+        # tags only (e.g. :main), because CI performs no real-ACME validation.
         tags: |
           type=ref,event=branch
           type=ref,event=pr
@@ -90,7 +93,7 @@ jobs:
           type=semver,pattern={{major}}
           type=semver,pattern=v{{version}}
           type=semver,pattern=v{{major}}.{{minor}}
-          type=raw,value=latest,enable={{is_default_branch}}
+          type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
         flavor: |
           latest=auto
           

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -10,6 +10,9 @@ name: E2E (staging)
 # NOT a required PR check. It runs only when EXPLICITLY enabled, and when it is
 # not enabled the job is SKIPPED (neutral) rather than reporting a green no-op —
 # a gate must never claim success without actually issuing a certificate.
+# The flip side: on SCHEDULED runs a disabled gate must not skip silently
+# either, or the weekly coverage dies unnoticed — the `gate-disabled` job
+# below fails loudly in that case so disablement shows as a red X.
 #
 # The authoritative real-cert gate is run LOCALLY before each release, with
 # credentials kept in .env (never in CI):
@@ -93,3 +96,18 @@ jobs:
           tests/test_health_ready_e2e.py \
           tests/test_cert_lifecycle.py \
           tests/test_async_issuance_e2e.py
+
+  gate-disabled:
+    name: gate-disabled
+    # Visibility guard: with E2E_STAGING_ENABLED unset/false, the e2e-staging
+    # job above skips (neutral) on every weekly cron — dead real-cert coverage
+    # that never surfaces anywhere. Fail loudly on scheduled runs instead so
+    # disablement produces a visible red X each week. Manual dispatch is
+    # unaffected: this job never runs for workflow_dispatch.
+    if: ${{ github.event_name == 'schedule' && vars.E2E_STAGING_ENABLED != 'true' }}
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+    - name: Fail - scheduled real-cert e2e is disabled
+      run: |
+        echo "::error::Scheduled real-cert e2e is disabled: set repo variable E2E_STAGING_ENABLED=true and secrets CLOUDFLARE_API_TOKEN (token scoped ONLY to the test zone) + CERTMATE_TEST_DOMAIN, or remove the cron trigger."
+        exit 1

--- a/.github/workflows/publish-clients.yml
+++ b/.github/workflows/publish-clients.yml
@@ -21,13 +21,59 @@ on:
 permissions:
   contents: read
 
+# NOTE on environment names: they are asymmetric BY CONFIGURATION on PyPI's
+# side — the SDK's trusted publishers are registered against 'testpypi-sdk' /
+# 'pypi-sdk', the CLI's against plain 'testpypi' / 'pypi'. PyPI forbids two
+# pending trusted publishers sharing the same (repo, workflow, environment)
+# tuple, so the names cannot be "normalized" to match each other without
+# re-registering both publishers. Do not tidy them.
+
 jobs:
+  check-versions:
+    name: tag matches package versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Fail unless both package versions equal the pushed tag
+        # PyPI uploads are write-once: publishing a clients-vX.Y.Z tag whose
+        # pyproject versions disagree would irrevocably ship the wrong
+        # version. workflow_dispatch runs carry no tag, but the two packages
+        # must still agree with each other (they release as a pair).
+        run: |
+          python3 - <<'EOF'
+          import os
+          import sys
+          import tomllib
+
+          def version(path):
+              with open(path, "rb") as f:
+                  return tomllib.load(f)["project"]["version"]
+
+          sdk = version("clients/certmate-sdk/pyproject.toml")
+          cli = version("clients/certmate-cli/pyproject.toml")
+          problems = []
+          if sdk != cli:
+              problems.append(f"certmate-sdk {sdk} != certmate-cli {cli}")
+          ref = os.environ.get("GITHUB_REF", "")
+          if ref.startswith("refs/tags/clients-v"):
+              tag_version = ref[len("refs/tags/clients-v"):]
+              if sdk != tag_version:
+                  problems.append(f"tag says {tag_version}, certmate-sdk says {sdk}")
+              if cli != tag_version:
+                  problems.append(f"tag says {tag_version}, certmate-cli says {cli}")
+          if problems:
+              sys.exit("version gate failed: " + "; ".join(problems))
+          print(f"version gate OK: sdk={sdk} cli={cli} ref={ref or '(manual dispatch)'}")
+          EOF
+
   publish-sdk:
     name: publish certmate-sdk
+    needs: check-versions
     runs-on: ubuntu-latest
     # Per-package environment names: PyPI forbids two pending trusted publishers
     # sharing the same (repo, workflow, environment), so each package gets its
-    # own. Must match the PyPI/TestPyPI Trusted Publisher config.
+    # own. Must match the PyPI/TestPyPI Trusted Publisher config (see the
+    # asymmetry note above the jobs block).
     environment: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'testpypi-sdk' || 'pypi-sdk' }}
     permissions:
       id-token: write   # OIDC — the only credential trusted publishing needs
@@ -40,7 +86,7 @@ jobs:
       - run: python -m build clients/certmate-sdk --outdir dist
       - run: twine check dist/*
       - name: Publish certmate-sdk
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           packages-dir: dist
           repository-url: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'https://test.pypi.org/legacy/' || '' }}
@@ -49,6 +95,8 @@ jobs:
     name: publish certmate-cli
     needs: publish-sdk   # SDK must land on the index first (the CLI depends on it)
     runs-on: ubuntu-latest
+    # Plain 'testpypi' / 'pypi' here vs 'testpypi-sdk' / 'pypi-sdk' above is
+    # intentional — see the asymmetry note above the jobs block.
     environment: ${{ (github.event_name == 'workflow_dispatch' && inputs.target) || 'pypi' }}
     permissions:
       id-token: write
@@ -61,7 +109,7 @@ jobs:
       - run: python -m build clients/certmate-cli --outdir dist
       - run: twine check dist/*
       - name: Publish certmate-cli
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           packages-dir: dist
           repository-url: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'https://test.pypi.org/legacy/' || '' }}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,40 @@
+## v2.21.1 (Hardening — truth in reporting, across server, clients and CI)
+
+One theme: every path that could report success while silently not doing the thing now tells the truth. Found by a full-project adversarial review (six parallel audit passes over the codebase, the shipped clients, the previously-open P2 tail, GitHub state and CI), and every defect below was hand-verified in code before being fixed.
+
+### Server
+
+- **Renewal no-op detection now works in production.** The v2.20.0 "not yet due" detection matched certbot's notification text, but the renew command ran with `--quiet`, which routes exactly that text to /dev/null in certbot 2.10.0 — so the detection was dead code outside tests: a daily no-op renew stamped `renewed_at`, counted as renewed, audited success and fired deploy hooks. Detection is now artifact-based (the SHA256 of the live `cert.pem` before vs after certbot, with the text sentinel kept as a cross-check), `--quiet` is gone, the renew API and web responses carry a machine-readable `renewed: true/false` field, and the `certificate_renewed` event only fires when something was actually renewed.
+- **Audit verify fails closed on unreadable integrity evidence.** An I/O error reading the checkpoint file was treated as "no checkpoints ever existed", so wiping the chain file while making checkpoints unreadable yielded a benign `200 state='absent'`. Checkpoint read errors are now distinct from absence and verify answers `409` ("checkpoint file unreadable"). The absent-vs-tampered decision also moved from reason-string matching to a structured `chain_file_missing` flag.
+- **Four DNS providers were silently broken; all fixed and now contract-tested.** Porkbun wrote the wrong credential keys (community fix by @cre8ivejp, #363/#364); the same hunt found Vultr (`dns_vultr_key`), ArvanCloud (`dns_arvancloud_api_token`) and Dynu (wrong plugin name `dns-dynudns` — the plugin registers `dns-dynu` — plus wrong credential key) equally dead. A new contract test pins the credential-file key names CertMate writes, the plugin entry-point names and the flag namespaces against what each pinned certbot plugin actually reads, for every provider — a silently dead provider can no longer pass CI.
+- **DNS provider preflight usable from the terminal.** `POST /api/dns/test-provider` with an empty config now falls back to the stored account credentials for that provider (explicit config still wins), which is what a CLI preflight means.
+- **`reset_admin_password.py` actually creates the admin user** (#383). On a fresh settings.json with no `users` key, the script printed "reset successfully" while writing a file with no user at all — the operator stayed locked out of a brand-new install. Regression tests now run the script end-to-end against users-less, empty-users and existing-admin settings files.
+- **Deploy-hook output is redacted before it is stored.** Hook stdout/stderr flowed verbatim into deploy history, the audit log and the append-only hash chain — any secret a hook echoed became unredactable without breaking the chain. Output now passes the secret-pattern sanitizer at the single choke point that feeds all three.
+- **Google service-account keys no longer linger on disk**: the per-operation SA JSON is deleted in the same `finally` that removes the credentials INI (the hourly orphan sweep stays as belt and braces).
+- **Group-writable custom DNS hook scripts are rejected**, not just warned about, matching the existing world-writable rule.
+- **The edit-certificate drawer is titled "Edit Certificate"** instead of presenting as create (#382).
+
+### Terminal clients 0.1.2 (`certmate-sdk`, `certmate-cli`)
+
+0.1.1 shipped several commands that lied; 0.1.2 makes them honest and is the recommended upgrade for anyone scripting against the API.
+
+- **`audit verify` no longer exits 0 on a tampered chain.** The CLI matched the human reason string, which is identical for "fresh instance" (benign) and "chain file deleted after signed checkpoints" (the tamper case the server answers with 409). Benign is now only the server's explicit `state='absent'`; anything else broken exits 1, and the SDK preserves the HTTP status on the result (`_http_status`) so clients cannot lose the distinction.
+- **`cert renew --force` actually forces.** The SDK sent `force` as a query parameter; the server reads the JSON body. It is in the body now.
+- **`cert renew` reports the real outcome** — renewed, "not due" with the server's message, or a neutral "server did not report the outcome" against pre-2.21.1 servers. It never fabricates a green "renewed", and the renew call gets a 600s timeout so real DNS-01 renewals stop dying client-side at 30s.
+- **`--dry-run` and `dns test` work.** The SDK sent a body shape the server never accepted, so the documented preflight failed on every server, including perfectly configured ones. Paired with the server-side stored-credentials fallback above.
+- **No more raw tracebacks.** Transport failures (server down, timeout, keep-alive race) surface as one clean error line via the new `TransportError`; `wait_for_job` tolerates transient poll blips and treats a job evicted after completion as success when the certificate exists.
+- **Smaller truths**: `download` format mapping fixed (json/zip/pem/pfx now request what the server actually serves); staging certificates no longer render `CA: True`; SAN parsing drops empty entries; `--token` on argv warns that `CERTMATE_TOKEN` is preferred (thanks @gitcommit90 for #378/#379, folded in).
+
+### CI and supply chain
+
+- **`:latest` now means released.** The Docker Hub `latest` tag is published only by `v*` tag builds — cut after the release gate that includes real-certificate issuance against Let's Encrypt staging. Pushes to main get branch tags only; previously every merge to main shipped `:latest` with zero real-ACME validation.
+- **The weekly real-ACME e2e can no longer be silently off.** If the scheduled run fires while its gate is disabled, a guard job fails loudly with wiring instructions instead of skipping green forever.
+- **Dependabot stops fighting the pinned ACME stack** (ignore rules for certbot/josepy/acme and plugin majors, referencing #103).
+- **The open `cryptography` CVE alerts are documented, not ignored.** Fixing GHSA-537c-gmf6-5ccf requires cryptography >=48.0.1, which requires pyOpenSSL >=26.2.0, which removed an API that acme 3.3.0 imports — every certbot invocation crashes (verified empirically). SECURITY.md now carries the full constraint chain and the exposure analysis: the vulnerable OpenSSL routine (`PKCS7_verify()`) is unreachable from CertMate's code paths. The real fix is the certbot 5.x migration (#103).
+- **The clients publish workflow is pinned and gated**: `pypa/gh-action-pypi-publish` moved from a mutable branch ref to a commit SHA, and a version-consistency job refuses to publish when the pushed `clients-v*` tag does not match both package versions.
+
+---
+
 ## v2.21.0 (Feature — terminal SDK + CLI, and an audit-verify semantics fix)
 
 Adds first-class terminal clients for the CertMate API and fixes a monitoring false-alarm in the audit-verify endpoint.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -103,6 +103,65 @@ Treat the admin role as highly privileged: grant it only to trusted operators,
 and prefer scoped, non-admin API keys for automation that only needs to create
 or download certificates.
 
+## Known dependency constraint
+
+### GHSA-537c-gmf6-5ccf — vulnerable OpenSSL statically linked in `cryptography` wheels
+
+CertMate currently pins `cryptography==46.0.7`, which is flagged HIGH by
+GHSA-537c-gmf6-5ccf: wheels of `cryptography` prior to `48.0.1` statically
+link an OpenSSL vulnerable to CVE-2026-45447 (heap use-after-free in
+`PKCS7_verify()`, OpenSSL security advisory of 2026-06-09). The fixed
+versions are `48.0.1` and later; there is no backported fix on the `46.x`
+or `47.x` lines (`46.0.7` is the final `46.x` release).
+
+**Why the bump is blocked.** The constraint chain, verified against PyPI
+metadata and a clean-room install on 2026-07-07:
+
+- `acme==3.3.0` requires `pyOpenSSL>=25.0.0`; `josepy==1.13.0` also depends
+  on pyOpenSSL. These pins, together with `certbot==2.10.0`, are
+  deliberately held (see issue #103).
+- The first pyOpenSSL release whose metadata admits cryptography `48.x` is
+  `26.2.0` (`cryptography>=46.0.0,<49`). The pinned `pyopenssl==26.0.0`
+  caps at `<47`, and `26.1.0` caps at `<48`.
+- pyOpenSSL `26.2.0` (2026-05-04) removed the long-deprecated
+  `OpenSSL.crypto.X509Extension`.
+- `acme==3.3.0` references `crypto.X509Extension` in the signature of
+  `acme.crypto_util.gen_ss_cert()` without `from __future__ import
+  annotations`, so the name is evaluated at import time. With
+  `pyopenssl>=26.2.0`, `import acme.crypto_util` — and therefore every
+  `certbot` invocation — fails with `AttributeError: module 'OpenSSL.crypto'
+  has no attribute 'X509Extension'` (reproduced with
+  `cryptography==48.0.1` + `pyopenssl==26.2.0`: `certbot --version`
+  crashes).
+- The same applies to `cryptography` `49.x`, which needs `pyopenssl>=26.3.0`.
+
+In short: every cryptography version that fixes the GHSA requires a
+pyOpenSSL that breaks the pinned ACME stack at import.
+
+**Mitigation / actual exposure.** The vulnerable code path is
+`PKCS7_verify()` (PKCS#7 / S/MIME signature verification):
+
+- No CertMate code path reaches it. Nothing in `modules/` or `app.py`, nor
+  in the pinned `certbot` / `acme` / `josepy` stack, performs PKCS#7 or
+  S/MIME verification, and pyca/cryptography's Python API does not expose
+  PKCS#7 signature verification at all (it can only create and serialize
+  PKCS#7 structures). The vulnerable function is present in the statically
+  linked library but unreachable from CertMate.
+- The operations that do run inside the statically linked OpenSSL —
+  X.509 parsing and issuance, CSR handling, the private CA, client
+  certificates, OCSP/CRL checks, and audit-log signing — do not touch the
+  PKCS#7 routines.
+- CertMate's TLS network I/O (gunicorn/Flask, `requests` to ACME and DNS
+  provider APIs) uses Python's `ssl` module, which links the interpreter's
+  own OpenSSL, not the copy inside the cryptography wheel.
+
+**Fix path.** The certbot 5.x migration epic (issue #103): newer `acme`
+releases drop the removed pyOpenSSL API but require `josepy>=2` and a newer
+certbot line. Once that migration lands, `pyopenssl>=26.2.0` and
+`cryptography>=48.0.1` unblock together, and the Dependabot alerts for
+GHSA-537c-gmf6-5ccf can be closed. Until then the alerts remain open by
+choice, not by oversight.
+
 ## Coordinated disclosure
 
 We coordinate disclosure with the reporter. For high or critical severity:

--- a/clients/README.md
+++ b/clients/README.md
@@ -33,6 +33,23 @@ certmate cert create app.example.com --dns cloudflare --dry-run   # validate, do
 certmate audit verify
 ```
 
+Pass the token via `CERTMATE_TOKEN` (as above), not `--token`: command-line
+arguments are visible to other local processes (`ps`) and land in shell
+history. `--token` still works for compatibility, but the CLI warns when it is
+used interactively.
+
+## Server compatibility
+
+The clients work against any CertMate v2.x server, with two features that
+need v2.21.1+ (the server started reporting them in that release):
+
+- `cert renew` outcome: v2.21.1+ returns `renewed: true/false`, so the CLI can
+  say "renewed" vs "not due". Against older servers it reports neutrally that
+  the server did not state the outcome (it never claims success it cannot know).
+- `dns test <provider>` / `cert create --dry-run` without explicit credentials:
+  v2.21.1+ falls back to the provider's stored account credentials on an empty
+  config. Older servers reject the empty config with a clear error.
+
 Working from a checkout instead? Install the in-repo copies editable:
 
 ```bash

--- a/clients/certmate-cli/README.md
+++ b/clients/certmate-cli/README.md
@@ -17,3 +17,5 @@ certmate audit verify
 ```
 
 Connection comes from `--url`/`--token` or `CERTMATE_URL`/`CERTMATE_TOKEN`.
+Prefer the `CERTMATE_TOKEN` environment variable over `--token`: command-line
+arguments are visible to other local processes (`ps`) and shell history.

--- a/clients/certmate-cli/certmate_cli/__init__.py
+++ b/clients/certmate-cli/certmate_cli/__init__.py
@@ -1,2 +1,2 @@
 """certmate-cli — the CertMate SSL lifecycle from your terminal (built on certmate-sdk)."""
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/clients/certmate-cli/certmate_cli/main.py
+++ b/clients/certmate-cli/certmate_cli/main.py
@@ -285,8 +285,14 @@ def audit_verify(ctx: typer.Context):
     if not ok and any(k in reason.lower() for k in ("does not exist", "empty")):
         out.print(f"audit chain: [dim]none yet[/] — {reason}")
         return
-    out.print(f"audit chain: {'[green]intact[/]' if ok else '[red]BROKEN[/]'}"
-              f"{(' — ' + reason) if reason else ''}")
+    detail = (
+        f" — {reason}"
+        if reason and not (ok and reason.lower() == "intact")
+        else ""
+    )
+    out.print(
+        f"audit chain: {'[green]intact[/]' if ok else '[red]BROKEN[/]'}{detail}"
+    )
     if cp is not None:
         out.print(f"  signed checkpoint: {'[green]verified[/]' if cp else '[dim]not cross-checked[/]'}"
                   f"{(' @ seq ' + str(res.get('checkpoint_seq'))) if res.get('checkpoint_seq') is not None else ''}")

--- a/clients/certmate-cli/certmate_cli/main.py
+++ b/clients/certmate-cli/certmate_cli/main.py
@@ -10,6 +10,7 @@ Connection comes from --url/--token or CERTMATE_URL/CERTMATE_TOKEN.
 from __future__ import annotations
 
 import re
+import sys
 from typing import List, Optional
 
 import typer
@@ -41,14 +42,38 @@ _DOMAIN_RE = re.compile(
     r"^(\*\.)?([a-zA-Z0-9_](-*[a-zA-Z0-9_])*\.)+[a-zA-Z]{2,}$")
 
 
+def _token_on_argv() -> bool:
+    """True when the token was passed as a command-line flag (as opposed to
+    the CERTMATE_TOKEN environment variable). argv is what leaks to `ps`
+    output and shell history, so it is exactly the thing to check."""
+    return any(a == "--token" or a.startswith("--token=") for a in sys.argv)
+
+
+def _stderr_isatty() -> bool:
+    # Indirection so tests can stub interactivity; CliRunner's captured
+    # stderr never reports a TTY.
+    try:
+        return sys.stderr.isatty()
+    except Exception:
+        return False
+
+
 @app.callback()
 def _main(
     ctx: typer.Context,
     url: Optional[str] = typer.Option(None, "--url", envvar="CERTMATE_URL",
                                       help="CertMate base URL (default http://localhost:8000)."),
     token: Optional[str] = typer.Option(None, "--token", envvar="CERTMATE_TOKEN",
-                                        help="API bearer token."),
+                                        help="API bearer token. Prefer the CERTMATE_TOKEN "
+                                             "environment variable: --token is visible to other "
+                                             "local processes (ps) and shell history."),
 ):
+    # Kept for compatibility, but discourage --token interactively: argv is
+    # world-readable via ps and lands in shell history. Warn only on a TTY so
+    # scripts and pipelines stay quiet.
+    if token and _token_on_argv() and _stderr_isatty():
+        err.print("[yellow]warning[/]: --token is visible in ps output and shell history; "
+                  "prefer the CERTMATE_TOKEN environment variable.")
     ctx.obj = {"url": url, "token": token}
 
 
@@ -156,7 +181,9 @@ def cert_create(
                                  help="Validate inputs and preflight the DNS provider WITHOUT issuing."),
 ):
     """Issue a certificate (async; waits for completion by default)."""
-    sans: List[str] = [s.strip() for s in san.split(",")] if san else []
+    # Drop empties so a trailing comma ("a.com,b.com,") never produces a
+    # bogus "" SAN entry — mirrors cert_reissue.
+    sans: List[str] = [s.strip() for s in san.split(",") if s.strip()] if san else []
     client = _client(ctx)
 
     if dry_run:
@@ -213,10 +240,18 @@ def cert_renew(ctx: typer.Context, domain: str,
                force: bool = typer.Option(False, "--force", help="Force renewal even if not due.")):
     """Renew a certificate."""
     res = _run(lambda: _client(ctx).renew_certificate(domain, force=force))
-    if res.get("renewed") is False:
-        out.print(f"[yellow]not due[/] — {domain} was not yet due for renewal.")
-    else:
+    renewed = res.get("renewed")
+    # Only servers v2.21.1+ report the outcome (`renewed: true/false`). Green
+    # requires an explicit true — an absent key means the server did not say,
+    # and claiming success would be a lie.
+    if renewed is True:
         out.print(f"[green]renewed[/] {domain}.")
+    elif renewed is False:
+        msg = res.get("message") or f"{domain} was not yet due for renewal."
+        out.print(f"[yellow]not due[/] — {msg}")
+    else:
+        out.print(f"renew requested for [bold]{domain}[/] — server did not report "
+                  "the outcome (server v2.21.1+ reports it).")
 
 
 @cert_app.command("rm")
@@ -280,10 +315,13 @@ def audit_verify(ctx: typer.Context):
     ok = bool(res.get("ok"))
     reason = res.get("reason") or ""
     cp = res.get("checkpoint_verified")
-    # "chain file does not exist" / "empty chain" is a fresh instance that has
-    # not audited anything yet — benign, not a tamper alarm. Show it neutrally.
-    if not ok and any(k in reason.lower() for k in ("does not exist", "empty")):
-        out.print(f"audit chain: [dim]none yet[/] — {reason}")
+    # Benign ONLY when the server says state='absent' (200: fresh instance,
+    # nothing audited yet). The reason wording is NOT a signal: a chain file
+    # DELETED after signed checkpoints attested it existed comes back as a 409
+    # with the very same "chain file does not exist" text — that is tampering
+    # and must exit non-zero, like every other not-ok result.
+    if not ok and res.get("state") == "absent":
+        out.print(f"audit chain: [dim]none yet[/] — {reason or 'nothing audited yet'}")
         return
     detail = (
         f" — {reason}"

--- a/clients/certmate-cli/pyproject.toml
+++ b/clients/certmate-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "certmate-cli"
-version = "0.1.1"
+version = "0.1.2"
 description = "CertMate command-line interface — the SSL certificate lifecycle from your terminal"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -30,8 +30,10 @@ classifiers = [
 ]
 # Built ON the SDK (never the reverse). typer for the command surface, rich
 # for tables/spinners. Still light — no server deps.
+# The SDK floor tracks the CLI release: 0.1.2 needs TransportError and the
+# renew/audit semantics introduced in certmate-sdk 0.1.2.
 dependencies = [
-    "certmate-sdk>=0.1.1",
+    "certmate-sdk>=0.1.2",
     "typer>=0.9",
     "rich>=13",
 ]

--- a/clients/certmate-sdk/certmate/__init__.py
+++ b/clients/certmate-sdk/certmate/__init__.py
@@ -6,12 +6,12 @@
 """
 from .client import Client
 from .errors import (APIError, AuthError, CertMateError, ConflictError,
-                     JobFailed, JobTimeout, NotFoundError)
+                     JobFailed, JobTimeout, NotFoundError, TransportError)
 from .models import Certificate, Job
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __all__ = [
     "Client", "Certificate", "Job",
     "CertMateError", "APIError", "AuthError", "NotFoundError", "ConflictError",
-    "JobFailed", "JobTimeout",
+    "JobFailed", "JobTimeout", "TransportError",
 ]

--- a/clients/certmate-sdk/certmate/client.py
+++ b/clients/certmate-sdk/certmate/client.py
@@ -11,11 +11,25 @@ from typing import Any, Callable, Dict, List, Optional
 
 import httpx
 
-from .errors import (APIError, AuthError, ConflictError, JobFailed, JobTimeout,
-                     NotFoundError)
+from .errors import (APIError, AuthError, CertMateError, ConflictError,
+                     JobFailed, JobTimeout, NotFoundError, TransportError)
 from .models import Certificate, Job
 
 _DEFAULT_URL = "http://localhost:8000"
+
+# Real DNS-01 renewals block on propagation and can take minutes; the client
+# default (30s) would kill the call while the server keeps renewing.
+_RENEW_TIMEOUT = 600.0
+
+# Fallback text for httpx exceptions whose str() is empty (timeouts often are).
+_TRANSPORT_DETAIL = {
+    "ConnectError": "connection failed",
+    "ConnectTimeout": "connection timed out",
+    "ReadTimeout": "server did not respond in time",
+    "WriteTimeout": "sending the request timed out",
+    "PoolTimeout": "no free connection in the pool",
+    "RemoteProtocolError": "server closed the connection unexpectedly",
+}
 
 
 class Client:
@@ -60,7 +74,15 @@ class Client:
 
     # -- low level -----------------------------------------------------------
     def _request(self, method: str, path: str, **kw) -> Any:
-        resp = self._http.request(method, path, **kw)
+        try:
+            resp = self._http.request(method, path, **kw)
+        except httpx.HTTPError as e:
+            # Network-level failures become one clean SDK exception instead of
+            # a raw httpx traceback (connection refused, DNS, timeout, ...).
+            detail = str(e).strip() or _TRANSPORT_DETAIL.get(
+                type(e).__name__, type(e).__name__)
+            raise TransportError(
+                f"cannot reach server at {self.base_url}: {detail}") from e
         if resp.status_code // 100 == 2:
             if not resp.content:
                 return None
@@ -120,11 +142,13 @@ class Client:
         return self.wait_for_job(job.job_id, on_progress=on_progress) if wait else job
 
     def renew_certificate(self, domain: str, *, force: bool = False) -> Dict[str, Any]:
-        # Always send an (empty) JSON body so endpoints that read request.json
-        # don't 415 on a bodyless POST.
-        params = {"force": "true"} if force else None
+        # The server reads force from the JSON body (payload.get('force')),
+        # never from the query string. Always send a body — even when force is
+        # False — so endpoints that read request.json don't 415 on a bodyless
+        # POST. The per-request timeout covers multi-minute DNS-01 renewals.
         return self._request("POST", f"/api/certificates/{domain}/renew",
-                             params=params, json={}) or {}
+                             json={"force": bool(force)},
+                             timeout=_RENEW_TIMEOUT) or {}
 
     def reissue_certificate(self, domain: str, **body: Any) -> Dict[str, Any]:
         return self._request("POST", f"/api/certificates/{domain}/reissue", json=body) or {}
@@ -134,9 +158,28 @@ class Client:
 
     def download_certificate(self, domain: str, fmt: str = "json") -> Any:
         """Download the bundle. ``fmt`` is one of json/pem/zip/pfx (json returns
-        a dict, the binary formats return bytes)."""
+        a dict, the binary formats return bytes).
+
+        The endpoint only accepts ``?format=json``; the other shapes are the
+        bare default (zip) or selected via ``?file=``, so each fmt maps to the
+        exact query the API understands:
+
+        - ``json`` -> ``?format=json`` (dict, PEM strings inline)
+        - ``zip``  -> no params (the endpoint's default bundle)
+        - ``pem``  -> ``?file=fullchain.pem``
+        - ``pfx``  -> ``?file=cert.pfx``
+        """
+        params_by_fmt: Dict[str, Optional[Dict[str, str]]] = {
+            "json": {"format": "json"},
+            "zip": None,
+            "pem": {"file": "fullchain.pem"},
+            "pfx": {"file": "cert.pfx"},
+        }
+        if fmt not in params_by_fmt:
+            raise ValueError(
+                f"unknown download format {fmt!r}; use one of json/pem/zip/pfx")
         return self._request("GET", f"/api/certificates/{domain}/download",
-                             params={"format": fmt})
+                             params=params_by_fmt[fmt])
 
     def set_auto_renew(self, domain: str, enabled: bool) -> Dict[str, Any]:
         return self._request("PUT", f"/api/certificates/{domain}/auto-renew",
@@ -151,10 +194,40 @@ class Client:
 
     def wait_for_job(self, job_id: str, *, interval: float = 2.0, timeout: float = 600.0,
                      on_progress: Optional[Callable[[Job], None]] = None) -> Job:
-        deadline = None  # computed lazily to avoid importing time at module import
         start = time.monotonic()
+        last: Optional[Job] = None       # last successfully polled state
+        transient = 0                    # consecutive transport failures
         while True:
-            job = self.get_job(job_id)
+            try:
+                job = self.get_job(job_id)
+            except TransportError:
+                # A blip mid-poll (server restart, proxy hiccup) must not
+                # abort a multi-minute issuance; only a sustained outage —
+                # three consecutive failed polls — gives up.
+                transient += 1
+                if transient >= 3:
+                    raise
+                if time.monotonic() - start > timeout:
+                    raise JobTimeout(
+                        f"job {job_id} did not finish within {timeout:.0f}s")
+                time.sleep(interval)
+                continue
+            except NotFoundError:
+                # Finished jobs can be evicted from the server's job table
+                # between polls. If the job was seen at least once and its
+                # certificate now exists, the eviction means "completed" —
+                # confirm against the certificate before declaring failure.
+                if last is not None and last.domain:
+                    try:
+                        self.get_certificate(last.domain)
+                    except CertMateError:
+                        pass
+                    else:
+                        last.status = "succeeded"
+                        return last
+                raise
+            transient = 0
+            last = job
             if on_progress:
                 on_progress(job)
             if job.is_terminal:
@@ -174,23 +247,39 @@ class Client:
         return self._request("GET", path)
 
     def test_dns_provider(self, provider: str, **config: Any) -> Dict[str, Any]:
-        """Preflight a DNS provider without issuing. Backs the CLI ``--dry-run``."""
-        body = {"provider": provider}
-        body.update(config)
+        """Preflight a DNS provider without issuing. Backs the CLI ``--dry-run``.
+
+        The endpoint expects ``{"provider": ..., "config": {...}}`` — the
+        credentials nested under ``config``, never flattened into the top
+        level. An empty config asks the server (v2.21.1+) to fall back to the
+        provider's stored account credentials."""
+        body = {"provider": provider, "config": config or {}}
         return self._request("POST", "/api/web/certificates/test-provider", json=body) or {}
 
     # -- audit / misc --------------------------------------------------------
     def audit_verify(self) -> Dict[str, Any]:
-        """Verify the audit chain. The endpoint returns 200 when intact and
-        409 (WITH the full result body) when the chain is broken/absent — both
-        are valid verification results, so return the dict in either case and
+        """Verify the audit chain. The endpoint returns 200 when intact (or
+        when a fresh instance has no chain yet — ``state == 'absent'``) and
+        409 (WITH the full result body) when the chain is broken — both are
+        valid verification results, so return the dict in either case and
         only raise on a genuine transport/auth error. Inspect ``result['ok']``.
+
+        The returned dict always carries ``_http_status`` (int: 200 or 409) so
+        callers never lose the intact-vs-broken distinction: the body reason
+        can read the same in both cases ("chain file does not exist" is benign
+        on a 200 with ``state='absent'`` but tampering on a 409 — a chain
+        deleted after signed checkpoints attested it existed).
         """
         try:
-            return self._request("GET", "/api/audit/verify") or {}
+            res = self._request("GET", "/api/audit/verify") or {}
+            if isinstance(res, dict):
+                res["_http_status"] = 200
+            return res
         except ConflictError as e:
             if isinstance(e.payload, dict):
-                return e.payload
+                res = dict(e.payload)
+                res["_http_status"] = e.status
+                return res
             raise
 
     def activity(self, limit: int = 100) -> Any:

--- a/clients/certmate-sdk/certmate/errors.py
+++ b/clients/certmate-sdk/certmate/errors.py
@@ -8,6 +8,15 @@ class CertMateError(Exception):
     """Base class for every SDK error."""
 
 
+class TransportError(CertMateError):
+    """The server could not be reached or the connection died mid-request
+    (DNS failure, connection refused, timeout, protocol error).
+
+    Wraps ``httpx.HTTPError`` so callers — the CLI in particular — can catch
+    one SDK exception type and print a clean message instead of surfacing a
+    raw httpx traceback."""
+
+
 class APIError(CertMateError):
     """The API returned a non-2xx response.
 

--- a/clients/certmate-sdk/certmate/models.py
+++ b/clients/certmate-sdk/certmate/models.py
@@ -30,7 +30,11 @@ class Certificate:
             expiry_date=d.get("expiry_date") or d.get("expires") or d.get("not_after"),
             days_until_expiry=d.get("days_until_expiry"),
             needs_renewal=d.get("needs_renewal"),
-            ca_provider=d.get("ca_provider") or d.get("staging"),
+            # Older payloads carry a boolean `staging` flag instead of a CA
+            # name; map it to the staging CA identifier rather than leaking
+            # a bare True into the CA column.
+            ca_provider=d.get("ca_provider")
+            or ("letsencrypt-staging" if d.get("staging") else None),
             dns_provider=d.get("dns_provider"),
             auto_renew=d.get("auto_renew"),
             san_domains=list(d.get("san_domains") or []),

--- a/clients/certmate-sdk/pyproject.toml
+++ b/clients/certmate-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "certmate-sdk"
-version = "0.1.1"
+version = "0.1.2"
 description = "Thin Python client for the CertMate REST API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -1943,13 +1943,22 @@ def create_api_resources(api, models, managers):
                     audit_ctx=audit_ctx,
                 )
 
+                # renewed=False is certbot's "not yet due" no-op: nothing was
+                # replaced, so deploy hooks must not fire and the response must
+                # not claim a renewal happened. Default True keeps the frozen
+                # REST contract for older manager results without the flag.
+                renewed = bool(result.get('renewed', True))
+
                 event_bus = current_app.config.get('EVENT_BUS')
-                if event_bus:
+                if event_bus and renewed:
                     event_bus.publish('certificate_renewed', {'domain': domain})
 
                 return {
-                    'message': f'Certificate renewed successfully for {domain}',
+                    'message': (f'Certificate renewed successfully for {domain}'
+                                if renewed
+                                else f'Certificate not yet due for renewal: {domain}'),
                     'domain': domain,
+                    'renewed': renewed,
                     'dns_provider': result.get('dns_provider'),
                     'duration': result.get('duration')
                 }, 200

--- a/modules/core/audit.py
+++ b/modules/core/audit.py
@@ -221,7 +221,9 @@ class AuditLogger:
         """True if at least one signed checkpoint has been written. Used to tell
         a genuinely fresh instance (no chain, no checkpoints — benign) from a
         chain file that was DELETED after checkpoints attested it existed
-        (tamper)."""
+        (tamper). Deliberately propagates
+        :class:`audit_chain.CheckpointReadError`: an UNREADABLE checkpoint
+        file must fail closed at the caller, never read as "no checkpoints"."""
         return bool(audit_chain.read_checkpoints(self.audit_checkpoint_file))
 
     def verify_chain(self) -> Dict[str, Any]:
@@ -262,7 +264,16 @@ class AuditLogger:
         if not pubkey:
             result["checkpoint_reason"] = "signer has no public key"
             return
-        checkpoints = audit_chain.read_checkpoints(self.audit_checkpoint_file)
+        try:
+            checkpoints = audit_chain.read_checkpoints(self.audit_checkpoint_file)
+        except audit_chain.CheckpointReadError as e:
+            # Fail closed: an unreadable anchor means the chain CANNOT be
+            # verified against it, which must not read as "intact".
+            result["ok"] = False
+            result["checkpoint_unreadable"] = True
+            result["checkpoint_reason"] = str(e)
+            result["reason"] = "checkpoint file unreadable — cannot verify integrity"
+            return
         if not checkpoints:
             result["checkpoint_reason"] = "no checkpoints written yet"
             return

--- a/modules/core/audit_chain.py
+++ b/modules/core/audit_chain.py
@@ -29,6 +29,14 @@ CHAIN_FILENAME = "certificate_audit.chain.jsonl"
 GENESIS_PREV = ""
 
 
+class CheckpointReadError(OSError):
+    """The checkpoint file exists but cannot be read (permissions, I/O).
+    Callers MUST treat this as "verification impossible" and fail closed —
+    an unreadable checkpoint file is NOT the same as no checkpoints ever
+    having been written, and conflating the two turns a tampered box into a
+    clean 'absent' verdict."""
+
+
 def canon_bytes(obj: Any) -> bytes:
     """Byte-stable canonical serialization. MUST be identical on the writer and
     every verifier, across Python versions: sorted keys, no whitespace, UTF-8,
@@ -79,6 +87,9 @@ def verify_chain(path) -> Dict[str, Any]:
             raw_lines = f.read().splitlines()
     except FileNotFoundError:
         result["reason"] = "chain file does not exist"
+        # Structured flag so callers deciding absent-vs-tampered do not have
+        # to substring-match the human-readable reason.
+        result["chain_file_missing"] = True
         return result
     except OSError as e:
         result["reason"] = f"cannot read chain file: {e}"
@@ -262,12 +273,19 @@ def checkpoint_signing_bytes(checkpoint: Dict[str, Any]) -> bytes:
 
 def read_checkpoints(path):
     """Read all parseable checkpoint records (oldest first). Stdlib-only;
-    verifying each checkpoint's signature is the caller's job (needs crypto)."""
+    verifying each checkpoint's signature is the caller's job (needs crypto).
+
+    A missing file means no checkpoints were ever written ([]); any other
+    read failure raises :class:`CheckpointReadError` — it must not be
+    silently treated as "no checkpoints", or an attacker who makes the file
+    unreadable (and deletes the chain) gets a benign 'absent' verdict."""
     try:
         with open(path, "r", encoding="utf-8") as f:
             raw_lines = [ln for ln in f.read().splitlines() if ln.strip()]
-    except OSError:
+    except FileNotFoundError:
         return []
+    except OSError as e:
+        raise CheckpointReadError(f"cannot read checkpoint file: {e}") from e
     out = []
     for raw in raw_lines:
         try:

--- a/modules/core/cert_jobs.py
+++ b/modules/core/cert_jobs.py
@@ -122,7 +122,11 @@ class IssuanceExecutor:
             sanitized = self._sanitize_result(result)
             # Publish the completion event BEFORE marking the job terminal, so a
             # poller that observes 'succeeded' is guaranteed the event has fired.
-            self._publish(_SUCCESS_EVENT.get(kind), {'domain': domain})
+            # Exception: a renew that no-oped (renewed=False, certbot "not yet
+            # due") replaced nothing, so deploy hooks must not fire for it —
+            # mirrors the synchronous renew route.
+            if not (isinstance(result, dict) and result.get('renewed') is False):
+                self._publish(_SUCCESS_EVENT.get(kind), {'domain': domain})
             self._set(job_id, status='succeeded', finished_at=utc_now_iso(),
                       result=sanitized)
         except Exception as e:  # record every failure on the job, never crash the worker

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -927,6 +927,10 @@ class CertificateManager:
         # Track timing for metrics
         start_time = time.time()
         credentials_file = None
+        # Secret files created NEXT TO the credentials file (Google's SA JSON,
+        # which the ini only references): the finally block must delete these
+        # too, or a live cloud private key outlives the operation on disk.
+        extra_credential_files = []
         # Initialized early: the finally block reads ca_extra_env to clean up
         # the REQUESTS_CA_BUNDLE temp file, and an exception raised before the
         # ca_manager.build_certbot_command call (e.g. plugin-not-installed)
@@ -1252,6 +1256,8 @@ class CertificateManager:
                     san_domains=all_domains[1:] if len(all_domains) > 1 else None,
                 )
                 credentials_file = strategy.create_config_file(strategy_config)
+                extra_credential_files = list(
+                    getattr(strategy, 'extra_credential_files', []) or [])
 
                 # Configure Args
                 strategy.configure_certbot_arguments(certbot_cmd, credentials_file, domain_alias=domain_alias)
@@ -1419,12 +1425,15 @@ class CertificateManager:
             raise
         finally:
             domain_lock.release()
-            # Always clean up credential files (even on failure)
-            if credentials_file:
-                try:
-                    os.unlink(credentials_file)
-                except (FileNotFoundError, OSError):
-                    pass
+            # Always clean up credential files (even on failure), including
+            # side files the ini references (Google's SA JSON) — the sweep in
+            # create_google_config only mops up crashed runs, not live ones.
+            for cred_path in [credentials_file, *extra_credential_files]:
+                if cred_path:
+                    try:
+                        os.unlink(cred_path)
+                    except (FileNotFoundError, OSError):
+                        pass
             # Clean up CA bundle temp file if created
             ca_bundle = ca_extra_env.get('REQUESTS_CA_BUNDLE')
             if ca_bundle:
@@ -1451,6 +1460,9 @@ class CertificateManager:
             raise DomainOperationInProgress(domain)
         alias_hook_config = None
         credentials_file = None
+        # Secret side files the credentials ini references (Google's SA
+        # JSON); deleted in the finally alongside the ini.
+        extra_credential_files = []
         try:
             # Use the same config/work/log directories as during creation
             cert_dir = self.cert_dir
@@ -1565,6 +1577,8 @@ class CertificateManager:
                         dns_provider, dns_config, domain, san_domains=renew_sans,
                     )
                     credentials_file = strategy.create_config_file(strategy_config)
+                    extra_credential_files = list(
+                        getattr(strategy, 'extra_credential_files', []) or [])
                     # Pass the authenticator + credentials explicitly at renew
                     # (mirrors the create path) so renewal does not depend on the
                     # credentials path certbot baked into renewal/<domain>.conf at
@@ -1718,11 +1732,13 @@ class CertificateManager:
                     os.unlink(alias_hook_config)
                 except (FileNotFoundError, OSError):
                     pass
-            if credentials_file:
-                try:
-                    os.unlink(credentials_file)
-                except (FileNotFoundError, OSError):
-                    pass
+            # Includes side files the ini references (Google's SA JSON).
+            for cred_path in [credentials_file, *extra_credential_files]:
+                if cred_path:
+                    try:
+                        os.unlink(cred_path)
+                    except (FileNotFoundError, OSError):
+                        pass
             domain_lock.release()
 
     def check_renewals(self):

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -5,6 +5,7 @@ Handles certificate creation, renewal, and information retrieval
 
 import os
 import copy
+import hashlib
 import json
 import shlex
 import subprocess
@@ -1432,6 +1433,17 @@ class CertificateManager:
                 except (FileNotFoundError, OSError):
                     pass
 
+    @staticmethod
+    def _cert_fingerprint(cert_path):
+        """SHA256 of the certificate file bytes, or None when unreadable.
+        Used to detect whether a certbot run actually replaced the live
+        certificate — the artifact is the only renewal signal certbot
+        cannot suppress (its "not yet due" text vanishes under --quiet)."""
+        try:
+            return hashlib.sha256(Path(cert_path).read_bytes()).hexdigest()
+        except OSError:
+            return None
+
     def renew_certificate(self, domain, force=False):
         """Renew a certificate"""
         domain_lock = self._get_domain_lock(domain)
@@ -1460,7 +1472,13 @@ class CertificateManager:
             cmd = [
                 'certbot', 'renew',
                 '--cert-name', domain,
-                '--quiet',
+                # No --quiet: under --quiet certbot routes its "not yet due
+                # for renewal" notification to /dev/null, so a no-op renew
+                # exits 0 with EMPTY output and becomes indistinguishable
+                # from a real renewal by output alone. Output is captured
+                # programmatically (never emailed), so verbosity costs
+                # nothing; the no-op sentinel below needs it as a secondary
+                # signal next to the primary cert-fingerprint comparison.
                 # certbot's default `renew` injects a random sleep of up
                 # to ~8 minutes before contacting the ACME server, to
                 # avoid stampeding Let's Encrypt when run from a flock
@@ -1580,6 +1598,19 @@ class CertificateManager:
                         f"account '{metadata.get('account_id') or 'default'}' is not configured"
                     )
 
+            # certbot `renew` exits 0 BOTH when it renews and when nothing is
+            # due, and its "not yet due" messages are display-channel output
+            # certbot may suppress (it does under --quiet). The only signal
+            # that cannot lie is the artifact itself: fingerprint the live
+            # cert before the run and compare after. Skipped for
+            # non-artifact-producing doubles (MockShellExecutor), which stage
+            # no real files — those fall back to the output sentinel below.
+            live_cert_file = domain_dir / 'live' / domain / 'cert.pem'
+            fingerprint_check = getattr(self.shell_executor, 'produces_artifacts', True)
+            pre_renew_fingerprint = None
+            if fingerprint_check:
+                pre_renew_fingerprint = self._cert_fingerprint(live_cert_file)
+
             # 30-minute cap, mirroring the create path (see the timeout on the
             # create certbot call). Without it a wedged certbot — an
             # unresponsive ACME server, or a manual-auth / DNS-alias hook that
@@ -1592,15 +1623,26 @@ class CertificateManager:
                                              timeout=1800, env=process_env)
 
             if result.returncode == 0:
-                # certbot `renew` exits 0 BOTH when it renews and when nothing
-                # was due. If CertMate's renewal_threshold_days is wider than
-                # certbot's own ~30-day window, check_renewals calls this daily,
-                # certbot no-ops, and stamping renewed_at + reporting a renewal
-                # would be false telemetry that masks a genuinely stuck renewal.
-                # Detect the no-op and report it honestly (renewed=False) without
-                # touching the metadata timestamp.
+                # If CertMate's renewal_threshold_days is wider than certbot's
+                # own ~30-day window, check_renewals calls this daily, certbot
+                # no-ops, and stamping renewed_at + reporting a renewal would
+                # be false telemetry that masks a genuinely stuck renewal.
+                # Primary no-op detection: the live cert bytes are unchanged
+                # (or still absent) after an exit-0 run. The output sentinel
+                # is the fallback for non-artifact-producing executors and a
+                # belt-and-braces cross-check; it MUST NOT be the primary
+                # signal because certbot suppresses it under --quiet.
                 _out = f"{result.stdout or ''}\n{result.stderr or ''}".lower()
-                if 'not yet due for renewal' in _out or 'no renewals were attempted' in _out:
+                sentinel_no_op = ('not yet due for renewal' in _out
+                                  or 'no renewals were attempted' in _out)
+                if fingerprint_check:
+                    post_renew_fingerprint = self._cert_fingerprint(live_cert_file)
+                    renewed = (post_renew_fingerprint is not None
+                               and post_renew_fingerprint != pre_renew_fingerprint)
+                else:
+                    renewed = not sentinel_no_op
+
+                if not renewed:
                     logger.info(f"Certificate for {domain} is not yet due for renewal; no action taken")
                     self._invalidate_certificate_info_cache(domain)
                     return {

--- a/modules/core/deployer.py
+++ b/modules/core/deployer.py
@@ -12,6 +12,8 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from .structured_logging import sanitize_text
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 30
@@ -197,11 +199,17 @@ class DeployManager:
                 env=deploy_env,
             )
             result['exit_code'] = proc.returncode
-            result['stdout'] = (proc.stdout or '')[:4096]
-            result['stderr'] = (proc.stderr or '')[:4096]
+            # Redact secret patterns HERE, at the single point where hook
+            # output enters the result dict: everything downstream (history
+            # file, audit log, the immutable hash chain) stores this dict, so
+            # a hook that echoes a token or key would otherwise persist it
+            # forever. Sanitize before truncating so a PEM block cut by the
+            # size cap cannot dodge the pattern match.
+            result['stdout'] = sanitize_text(proc.stdout or '')[:4096]
+            result['stderr'] = sanitize_text(proc.stderr or '')[:4096]
             result['success'] = proc.returncode == 0
             if proc.returncode != 0:
-                stderr_snippet = (proc.stderr or '').strip()[:200]
+                stderr_snippet = result['stderr'].strip()[:200]
                 if stderr_snippet:
                     result['error'] = f"exit code {proc.returncode}: {stderr_snippet}"
                 else:

--- a/modules/core/dns_strategies.py
+++ b/modules/core/dns_strategies.py
@@ -475,6 +475,15 @@ class DuckDNSStrategy(DNSProviderStrategy):
 
 
 class GenericMultiProviderStrategy(DNSProviderStrategy):
+    # CertMate provider name -> certbot entry-point name, where the plugin
+    # does not follow the dns-<provider> convention. Everything keyed on the
+    # plugin name (--authenticator, --<name>-credentials,
+    # --<name>-propagation-seconds, the installed-plugin check, and the
+    # dns_<name>_* ini key prefix in _MULTI_PROVIDER_TEMPLATE_MAP) must use
+    # the entry-point name: certbot-dns-dynudns registers 'dns-dynu'
+    # (setup.py entry_points), so 'dns-dynudns' selects nothing.
+    _PLUGIN_NAME_OVERRIDES = {'dynudns': 'dns-dynu'}
+
     def __init__(self, provider_name: str):
         self.provider_name = provider_name
 
@@ -483,7 +492,8 @@ class GenericMultiProviderStrategy(DNSProviderStrategy):
 
     @property
     def plugin_name(self) -> str:
-        return f'dns-{self.provider_name}'
+        return self._PLUGIN_NAME_OVERRIDES.get(
+            self.provider_name, f'dns-{self.provider_name}')
 
 
 class CustomScriptStrategy(DNSProviderStrategy):

--- a/modules/core/dns_strategies.py
+++ b/modules/core/dns_strategies.py
@@ -225,11 +225,20 @@ class AzureStrategy(DNSProviderStrategy):
     # can fall through to it unchanged.
 
 class GoogleStrategy(DNSProviderStrategy):
+    def __init__(self):
+        # Extra secret files created alongside the returned credentials ini.
+        # The create/renew finally blocks read this so the SA JSON (a live
+        # GCP private key) is deleted with the ini instead of sitting on
+        # disk until the orphan sweep.
+        self.extra_credential_files: list = []
+
     def create_config_file(self, config_data: Dict[str, Any]) -> Optional[Path]:
-        return create_google_config(
+        config_file, sa_file = create_google_config(
             config_data.get('project_id', ''),
             config_data.get('service_account_key', ''),
         )
+        self.extra_credential_files = [sa_file]
+        return config_file
 
     @property
     def plugin_name(self) -> str:
@@ -559,9 +568,14 @@ class CustomScriptStrategy(DNSProviderStrategy):
                 f"Refusing to execute a script anyone on the host can modify."
             )
         if mode & 0o020:
-            logger.warning(
-                f"custom-script {label} {path} is group-writable "
-                f"({oct(mode & 0o777)}); consider chmod 755 or stricter."
+            # Same trust boundary as the world-writable branch above: the
+            # script runs with CertMate's privileges, and any group member
+            # who can rewrite it gets those privileges. A warning here was
+            # advice nobody reads at issuance time; refuse instead.
+            raise ValueError(
+                f"custom-script {label} is group-writable ({oct(mode & 0o777)}): {path}. "
+                f"Refusing to execute a script other group members can modify; "
+                f"chmod 755 or stricter."
             )
         return str(path)
 

--- a/modules/core/structured_logging.py
+++ b/modules/core/structured_logging.py
@@ -40,6 +40,18 @@ from functools import wraps
 _log_context: ContextVar[Dict[str, Any]] = ContextVar('log_context', default={})
 
 
+def sanitize_text(s: str) -> str:
+    """Replace PEM blocks and sensitive key=value assignments in unstructured
+    text. Module-level so choke points that PERSIST free-form command output
+    (deploy hooks: history, audit log, immutable hash chain) can redact it
+    before it is stored — the JSON log formatter reuses the same rules."""
+    if not isinstance(s, str):
+        return s
+    s = JSONFormatter.PEM_RE.sub('[PEM REDACTED]', s)
+    s = JSONFormatter.SENSITIVE_KV_RE.sub(r'\1"[REDACTED]"', s)
+    return s
+
+
 class JSONFormatter(logging.Formatter):
     """JSON log formatter for structured logging"""
     
@@ -81,13 +93,7 @@ class JSONFormatter(logging.Formatter):
 
     def _sanitize_string(self, s: str) -> str:
         """Replace PEM blocks and key-value secrets in unstructured text"""
-        if not isinstance(s, str):
-            return s
-        # Redact PEM blocks
-        s = self.PEM_RE.sub('[PEM REDACTED]', s)
-        # Redact inline key-value secrets
-        s = self.SENSITIVE_KV_RE.sub(r'\1"[REDACTED]"', s)
-        return s
+        return sanitize_text(s)
 
     def sanitize_data(self, data: Any, key_context: Optional[str] = None) -> Any:
         """Recursively sanitize keys and values in data structures"""

--- a/modules/core/utils.py
+++ b/modules/core/utils.py
@@ -90,8 +90,12 @@ _MULTI_PROVIDER_PLUGIN_FILES = {
 # A data-driven template for building multi-provider config files.
 # Maps the final .ini key to the key from the input config_data dictionary.
 # A tuple value indicates an optional key: (input_key, default_value)
+# The ini key MUST be <entry_point_name with '-'->'_'>_<credential var> as
+# derived by certbot's dns_common (see Authenticator.dest); each mapping is
+# pinned against the plugin source by
+# tests/test_provider_credential_key_contract.py.
 _MULTI_PROVIDER_TEMPLATE_MAP = {
-    'vultr': {'dns_vultr_api_key': 'api_key'},
+    'vultr': {'dns_vultr_key': 'api_key'},
     'dnsmadeeasy': {'dns_dnsmadeeasy_api_key': 'api_key', 'dns_dnsmadeeasy_secret_key': 'secret_key'},
     'nsone': {'dns_nsone_api_key': 'api_key'},
     'rfc2136': {
@@ -102,10 +106,13 @@ _MULTI_PROVIDER_TEMPLATE_MAP = {
     },
     'hetzner': {'dns_hetzner_api_token': 'api_token'},
     'hetzner-cloud': {'dns_hetzner_cloud_api_token': 'api_token'},
-    'porkbun': {'dns_porkbun_api_key': 'api_key', 'dns_porkbun_secret_key': 'secret_key'},
+    'porkbun': {'dns_porkbun_key': 'api_key', 'dns_porkbun_secret': 'secret_key'},
     'godaddy': {'dns_godaddy_key': 'api_key', 'dns_godaddy_secret': 'secret'},
     'he-ddns': {'dns_he_ddns_username': 'username', 'dns_he_ddns_password': 'password'},
-    'dynudns': {'dns_dynudns_token': 'token'},
+    # certbot-dns-dynudns registers its entry point as 'dns-dynu' with the
+    # credential var 'auth-token', so the ini key prefix is dns_dynu_, not
+    # dns_dynudns_ (see the plugin-name override in GenericMultiProviderStrategy).
+    'dynudns': {'dns_dynu_auth_token': 'token'},
     'desec': {'dns_desec_token': 'api_token'},
     'scaleway': {'dns_scaleway_application_token': 'application_token'},
 }
@@ -679,8 +686,14 @@ def create_namecheap_config(username: str, api_key: str) -> Path:
     return _create_config_file("namecheap", content)
 
 def create_arvancloud_config(api_key: str) -> Path:
-    """Create ArvanCloud DNS credentials file."""
-    content = f"dns_arvancloud_api_key = {api_key}\n"
+    """Create ArvanCloud DNS credentials file.
+
+    certbot-dns-arvancloud (0.1.0) requires the ``dns_arvancloud_api_token``
+    property (certbot_dns_arvancloud/dns_arvancloud.py, _configure_credentials
+    var ``api_token``); the previously written ``dns_arvancloud_api_key`` key
+    made every ArvanCloud issuance fail with "Property not found".
+    """
+    content = f"dns_arvancloud_api_token = {api_key}\n"
     return _create_config_file("arvancloud", content)
 
 def create_infomaniak_config(api_token: str) -> Path:

--- a/modules/core/utils.py
+++ b/modules/core/utils.py
@@ -593,8 +593,13 @@ def create_azure_config(subscription_id: str, resource_group: str, tenant_id: st
     )
     return _create_config_file("azure", content)
 
-def create_google_config(project_id: str, service_account_key: str) -> Path:
-    """Create Google Cloud DNS credentials file.
+def create_google_config(project_id: str, service_account_key: str) -> Tuple[Path, Path]:
+    """Create Google Cloud DNS credentials files.
+
+    Returns ``(config_file, sa_file)``: the ini handed to certbot AND the
+    service-account JSON it references, so the caller can delete BOTH in its
+    ``finally`` — the ini alone was returned before, leaving the live GCP
+    private key on disk until the orphan sweep (up to an hour later).
 
     The service-account JSON is a live GCP private key. It previously landed at
     a FIXED path (``google-service-account.json``), written 0644-then-chmod, and
@@ -613,7 +618,7 @@ def create_google_config(project_id: str, service_account_key: str) -> Path:
         f.write(service_account_key)
 
     content = f"dns_google_project_id = {project_id}\ndns_google_service_account_key = {str(sa_file)}\n"
-    return _create_config_file("google", content)
+    return _create_config_file("google", content), sa_file
 
 
 def _sweep_orphaned_files(directory: Path, pattern: str, max_age_seconds: int = 3600) -> None:

--- a/modules/web/cert_routes.py
+++ b/modules/web/cert_routes.py
@@ -265,9 +265,25 @@ def register_cert_routes(app, managers, require_web_auth, auth_manager,
             if not provider:
                 return jsonify({'error': 'Provider name required'}), 400
 
+            # An explicit config always wins. Without one, test the stored
+            # account (body 'account_id', or the same default-account
+            # resolution issuance uses) so a preflight like
+            # `certmate dns test cloudflare` can succeed against a
+            # configured server instead of always failing on empty config.
+            # No stored account leaves config empty -> the usual 400.
+            used_account = None
+            if not config:
+                stored_config, used_account = dns_manager.get_dns_provider_account_config(
+                    provider, data.get('account_id'))
+                if stored_config:
+                    config = stored_config
+
             success, message = dns_manager.test_provider(provider, config)
             if success:
-                return jsonify({'message': message})
+                response = {'message': message}
+                if used_account:
+                    response['used_account'] = used_account
+                return jsonify(response)
             return jsonify({'error': message}), 400
         except Exception as e:
             logger.error(f"Provider test failed: {e}")

--- a/modules/web/cert_routes.py
+++ b/modules/web/cert_routes.py
@@ -291,7 +291,13 @@ def register_cert_routes(app, managers, require_web_auth, auth_manager,
                 user=user, ip_address=request.remote_addr,
                 audit_ctx=audit_context_from_request(),
             )
-            return jsonify({'message': result.get('message', 'Certificate renewed successfully')})
+            # 'renewed' distinguishes a real renewal from certbot's "not yet
+            # due" no-op; the manager's message already states which happened.
+            # Default True preserves the response contract for older results.
+            return jsonify({
+                'message': result.get('message', 'Certificate renewed successfully'),
+                'renewed': bool(result.get('renewed', True)),
+            })
         except DomainOutOfScope:
             return jsonify({'error': 'API key not authorized for this domain', 'code': 'DOMAIN_OUT_OF_SCOPE'}), 403
         except FileNotFoundError as e:

--- a/modules/web/misc_routes.py
+++ b/modules/web/misc_routes.py
@@ -1,4 +1,5 @@
 import logging
+from ..core.audit_chain import CheckpointReadError
 from ..core.metrics import generate_metrics_response
 from flask import request, jsonify, Response, stream_with_context
 
@@ -65,9 +66,20 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
             if audit_logger is None or not hasattr(audit_logger, 'verify_chain'):
                 return jsonify({'error': 'Audit chain not available'}), 503
             result = audit_logger.verify_chain()
-            if not result.get('ok') and 'does not exist' in (result.get('reason') or ''):
-                # No chain file. Benign only if nothing ever attested one.
-                has_cp = getattr(audit_logger, 'has_checkpoints', lambda: False)()
+            # Structured flag from the verifier, not a reason-substring match:
+            # the absent-vs-tampered call must not hinge on message wording.
+            if not result.get('ok') and result.get('chain_file_missing'):
+                # No chain file. Benign only if nothing ever attested one —
+                # and only decidable when the checkpoint file is readable.
+                try:
+                    has_cp = getattr(audit_logger, 'has_checkpoints', lambda: False)()
+                except CheckpointReadError:
+                    # Fail closed: cannot rule out that checkpoints attest a
+                    # deleted chain. 409 (integrity not verifiable), not 200
+                    # 'absent' and not a 500 traceback.
+                    result['checkpoint_unreadable'] = True
+                    result['reason'] = 'checkpoint file unreadable — cannot verify integrity'
+                    return jsonify(result), 409
                 if not has_cp:
                     result['state'] = 'absent'
                     return jsonify(result), 200

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -20,8 +20,8 @@ urllib3>=2.6.0,!=2.2.0,<3      # CVE-2025-66418, CVE-2025-66471, CVE-2026-21441 
 requests==2.33.0
 python-dotenv==1.2.2
 APScheduler==3.10.4
-cryptography==46.0.7
-pyopenssl==26.0.0
+cryptography==46.0.7               # GHSA-537c-gmf6-5ccf (HIGH) open by choice; blocked by acme 3.3.0 (see SECURITY.md "Known dependency constraint")
+pyopenssl==26.0.0                  # Do not bump to 26.2.0+: removes X509Extension, breaks acme 3.3.0 at import (see SECURITY.md)
 
 # Production server
 gunicorn==23.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,8 +67,8 @@ urllib3>=2.6.0,!=2.2.0,<3      # CVE-2025-66418, CVE-2025-66471, CVE-2026-21441 
 requests==2.33.0
 python-dotenv==1.2.2
 APScheduler==3.10.4
-cryptography==46.0.7
-pyopenssl==26.0.0                      # Requires cryptography>=46.0.0,<47
+cryptography==46.0.7               # GHSA-537c-gmf6-5ccf (HIGH) is open by choice: 48.0.1 needs pyopenssl>=26.2.0, which breaks acme 3.3.0 at import. See SECURITY.md "Known dependency constraint"; unblocked by the certbot 5.x epic (#103).
+pyopenssl==26.0.0                  # Requires cryptography>=46.0.0,<47. Do not bump to 26.2.0+: it removes OpenSSL.crypto.X509Extension, which acme==3.3.0 evaluates at import time (certbot crashes). See SECURITY.md.
 bcrypt==4.2.0                      # Secure password hashing
 Authlib>=1.3.2,<2.0.0              # OIDC/OAuth2 client (Authorization Code + PKCE) for SSO. Floor at 1.3.2 (CVE GHSA-9c64-2c4r-vf2g fixed there); allow patch + minor pickup, ceiling at 2.0.0 because any major bump warrants an explicit compatibility check.
 

--- a/scripts/reset_admin_password.py
+++ b/scripts/reset_admin_password.py
@@ -52,7 +52,11 @@ def main() -> int:
         print(f"ERROR: {settings_path} top-level value is not an object.")
         return 1
 
-    users = data.get("users", {})
+    # setdefault, NOT get: on a fresh install settings.json has no "users"
+    # key at all, and a plain get() hands back an orphan dict that never
+    # lands in the file — the script then reports success while writing no
+    # user at all (issue #383).
+    users = data.setdefault("users", {})
     if not isinstance(users, dict):
         print("WARNING: 'users' key is not a dict; replacing with empty dict.")
         users = {}

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -2032,6 +2032,25 @@
         if (!form) return;
         var submitBtn = form.querySelector('button[type="submit"]');
         var banner = document.getElementById('reissue-edit-banner');
+        // The drawer header must state the actual operation (#382): opened
+        // for an existing certificate it edits, it does not create. The
+        // create markup is stashed on the node (same pattern as the submit
+        // button below) so leaving edit mode restores it exactly.
+        var title = document.getElementById('drawerTitle');
+        var dialog = document.getElementById('createCertFormContainer');
+        if (title) {
+            if (editing) {
+                if (!title.dataset.createHtml) {
+                    title.dataset.createHtml = title.innerHTML;
+                }
+                title.innerHTML = '<i class="fas fa-pen mr-2 text-primary"></i>Edit Certificate';
+            } else if (title.dataset.createHtml) {
+                title.innerHTML = title.dataset.createHtml;
+            }
+        }
+        if (dialog) {
+            dialog.setAttribute('aria-label', editing ? 'Edit certificate' : 'New certificate');
+        }
         if (editing) {
             if (!banner) {
                 banner = document.createElement('div');

--- a/templates/index.html
+++ b/templates/index.html
@@ -83,7 +83,10 @@
             <div class="px-6 py-5 border-b border-border bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-gray-800 dark:to-gray-700">
                 <div class="flex items-center justify-between">
                     <div>
-                        <h3 class="text-xl font-bold text-foreground flex items-center">
+                        <!-- Title is parameterized by mode: setReissueFormMode
+                             (dashboard.js) swaps it to "Edit Certificate" when
+                             the drawer is opened for an existing cert (#382). -->
+                        <h3 id="drawerTitle" class="text-xl font-bold text-foreground flex items-center">
                             <i class="fas fa-plus-circle mr-2 text-primary"></i>
                             Create New Certificate
                         </h3>

--- a/tests/test_async_issuance.py
+++ b/tests/test_async_issuance.py
@@ -69,6 +69,19 @@ class TestIssuanceExecutorLifecycle:
         _wait_terminal(ex, jid)
         bus.publish.assert_called_once_with('certificate_renewed', {'domain': 'a.example.com'})
 
+    def test_noop_renew_does_not_publish_renewed(self):
+        """A renew that no-oped (certbot 'not yet due', renewed=False) replaced
+        nothing — deploy hooks must not fire, mirroring the sync route."""
+        bus = MagicMock()
+        ex = _exec(event_bus=bus)
+        jid = ex.submit('renew', 'a.example.com',
+                        lambda: {'success': True, 'renewed': False,
+                                 'message': 'Certificate not yet due for renewal'})
+        job = _wait_terminal(ex, jid)
+        assert job['status'] == 'succeeded'
+        assert job['result']['renewed'] is False
+        bus.publish.assert_not_called()
+
     def test_get_unknown_returns_none(self):
         assert _exec().get('does-not-exist') is None
 

--- a/tests/test_audit_checkpoint_crosscheck.py
+++ b/tests/test_audit_checkpoint_crosscheck.py
@@ -6,6 +6,7 @@ newest signed checkpoint that verifies under the current key — fail-closed.
 This does NOT bind an operator who holds the signing key (that needs off-box
 anchoring); it closes the gap for anyone WITHOUT the key, and turns the
 previously-dead checkpoint file into a real anchor."""
+import os
 from types import SimpleNamespace
 
 import pytest
@@ -194,3 +195,78 @@ def test_verify_endpoint_deleted_chain_with_checkpoints_is_409(make_audit, tmp_p
     r = _verify_route(audit)
     assert r.status_code == 409
     assert r.get_json().get('state') != 'absent'
+
+
+# --------------------------------------------------------------------------
+# Fail-closed on an UNREADABLE checkpoint file: it must never read as "no
+# checkpoints ever existed" (which, with a deleted chain, produced a clean
+# 200 state='absent' verdict on a tampered box).
+# --------------------------------------------------------------------------
+
+def _make_unreadable(path):
+    """chmod 000 and verify it took effect; as root (some CI) the file stays
+    readable and the scenario cannot be reproduced — skip, don't false-pass."""
+    os.chmod(path, 0)
+    if os.access(path, os.R_OK):
+        pytest.skip("cannot make the file unreadable (running as root?)")
+
+
+def test_read_checkpoints_missing_file_is_empty(tmp_path):
+    assert audit_chain.read_checkpoints(tmp_path / 'nope.jsonl') == []
+
+
+def test_read_checkpoints_raises_on_unreadable_file(tmp_path):
+    cp_file = tmp_path / audit_chain.CHECKPOINT_FILENAME
+    cp_file.write_text('{"seq": 2, "hash": "abc"}\n')
+    _make_unreadable(cp_file)
+    try:
+        with pytest.raises(audit_chain.CheckpointReadError):
+            audit_chain.read_checkpoints(cp_file)
+    finally:
+        os.chmod(cp_file, 0o600)
+
+
+def test_verify_chain_missing_file_sets_structured_flag(tmp_path):
+    """The absent-vs-tampered decision keys on 'chain_file_missing', not on
+    substring-matching the human-readable reason."""
+    result = audit_chain.verify_chain(tmp_path / 'no-such-chain.jsonl')
+    assert result['ok'] is False
+    assert result['chain_file_missing'] is True
+    assert result['reason'] == 'chain file does not exist'  # wording unchanged
+
+
+def test_verify_endpoint_unreadable_checkpoints_and_deleted_chain_is_409(make_audit, tmp_path):
+    """chmod-000 checkpoint file + deleted chain used to return 200 'absent'
+    (fail-open): the OSError was swallowed as 'no checkpoints'. It must be a
+    409 — integrity cannot be verified — and not a 500 traceback either."""
+    audit = make_audit(tmp_path, signer=AuditSigner(tmp_path), checkpoint_interval=3)
+    _emit(audit, 3)  # writes a checkpoint at seq 2
+    (tmp_path / audit_chain.CHAIN_FILENAME).unlink()
+    cp_file = tmp_path / audit_chain.CHECKPOINT_FILENAME
+    _make_unreadable(cp_file)
+    try:
+        r = _verify_route(audit)
+    finally:
+        os.chmod(cp_file, 0o600)
+    assert r.status_code == 409
+    body = r.get_json()
+    assert body.get('state') != 'absent'
+    assert body.get('checkpoint_unreadable') is True
+    assert 'unreadable' in (body.get('reason') or '')
+
+
+def test_verify_intact_chain_with_unreadable_checkpoints_fails_closed(make_audit, tmp_path):
+    """Even with an intact chain, an unreadable anchor means the cross-check
+    cannot run — report NOT verified (409), never a silent pass."""
+    audit = make_audit(tmp_path, signer=AuditSigner(tmp_path), checkpoint_interval=3)
+    _emit(audit, 3)
+    cp_file = tmp_path / audit_chain.CHECKPOINT_FILENAME
+    _make_unreadable(cp_file)
+    try:
+        r = _verify_route(audit)
+    finally:
+        os.chmod(cp_file, 0o600)
+    assert r.status_code == 409
+    body = r.get_json()
+    assert body['ok'] is False
+    assert body.get('checkpoint_unreadable') is True

--- a/tests/test_cli_audit_verify_output.py
+++ b/tests/test_cli_audit_verify_output.py
@@ -1,0 +1,32 @@
+"""CLI output for `certmate audit verify` (issue #378)."""
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from certmate_cli.main import app
+
+runner = CliRunner()
+
+
+def _invoke_audit_verify(api_response: dict):
+    with patch("certmate_cli.main._client", return_value=MagicMock()):
+        with patch("certmate_cli.main._run", return_value=api_response):
+            return runner.invoke(app, ["audit", "verify"])
+
+
+def test_audit_verify_healthy_suppresses_redundant_intact_reason():
+    result = _invoke_audit_verify(
+        {"ok": True, "reason": "intact", "checkpoint_verified": False}
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "intact — intact" not in result.stdout
+    assert "audit chain:" in result.stdout
+
+
+def test_audit_verify_broken_still_shows_reason():
+    result = _invoke_audit_verify(
+        {"ok": False, "reason": "hash mismatch at seq 3", "checkpoint_verified": None}
+    )
+    assert result.exit_code == 1
+    assert "BROKEN" in result.stdout
+    assert "hash mismatch at seq 3" in result.stdout

--- a/tests/test_clients_cli_unit.py
+++ b/tests/test_clients_cli_unit.py
@@ -1,0 +1,194 @@
+"""Unit tests for certmate-cli 0.1.2 output semantics (no server required).
+
+The 0.1.1 CLI lied in two places: `audit verify` treated a tampered chain
+(409, "chain file does not exist" AFTER signed checkpoints) as the benign
+fresh-instance case, and `cert renew` printed a green "renewed" no matter
+what the server did. These tests pin the corrected exit codes and wording,
+driving the real command functions with the SDK client mocked out."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+pytest.importorskip("certmate_cli", reason="certmate-cli not installed")
+from certmate import APIError, Job, TransportError  # noqa: E402
+from certmate_cli.main import app  # noqa: E402
+
+pytestmark = [pytest.mark.unit]
+
+runner = CliRunner()
+
+
+def _all_output(result) -> str:
+    # click >= 8.2 separates stderr; older versions mix it into output.
+    text = result.output
+    try:
+        text += result.stderr
+    except Exception:
+        pass
+    return text
+
+
+def _invoke_with_client(args, **client_methods):
+    client = MagicMock()
+    for name, value in client_methods.items():
+        if isinstance(value, Exception):
+            getattr(client, name).side_effect = value
+        else:
+            getattr(client, name).return_value = value
+    with patch("certmate_cli.main._client", return_value=client):
+        result = runner.invoke(app, args)
+    return result, client
+
+
+# --------------------------------------------------------------------------
+# BUG 1 — audit verify: state='absent' is the ONLY benign not-ok result
+# --------------------------------------------------------------------------
+
+def test_audit_verify_absent_state_is_benign_exit_zero():
+    result, _ = _invoke_with_client(
+        ["audit", "verify"],
+        audit_verify={"ok": False, "reason": "chain file does not exist",
+                      "state": "absent", "_http_status": 200})
+    assert result.exit_code == 0, _all_output(result)
+    assert "none yet" in result.stdout
+    assert "BROKEN" not in result.stdout
+
+
+def test_audit_verify_deleted_chain_after_checkpoints_is_broken_exit_one():
+    # Identical reason text, but a 409 without state='absent': the chain was
+    # deleted after signed checkpoints attested it existed. Tampering.
+    result, _ = _invoke_with_client(
+        ["audit", "verify"],
+        audit_verify={"ok": False, "reason": "chain file does not exist",
+                      "_http_status": 409})
+    assert result.exit_code == 1
+    assert "BROKEN" in result.stdout
+    assert "chain file does not exist" in result.stdout
+
+
+def test_audit_verify_unreadable_checkpoint_fail_closed_is_broken():
+    result, _ = _invoke_with_client(
+        ["audit", "verify"],
+        audit_verify={"ok": False, "reason": "checkpoint file unreadable",
+                      "_http_status": 409})
+    assert result.exit_code == 1
+    assert "BROKEN" in result.stdout
+
+
+def test_audit_verify_intact_exit_zero_without_redundant_reason():
+    # Behavior contributed in PR #379: never print "intact — intact".
+    result, _ = _invoke_with_client(
+        ["audit", "verify"],
+        audit_verify={"ok": True, "reason": "intact", "checkpoint_verified": True,
+                      "checkpoint_seq": 7, "_http_status": 200})
+    assert result.exit_code == 0, _all_output(result)
+    assert "intact" in result.stdout
+    assert "intact — intact" not in result.stdout
+
+
+# --------------------------------------------------------------------------
+# BUG 3 — cert renew: three-way outcome, never a fake green
+# --------------------------------------------------------------------------
+
+def test_renew_reports_green_only_when_server_says_renewed_true():
+    result, client = _invoke_with_client(
+        ["cert", "renew", "app.example.com", "--force"],
+        renew_certificate={"message": "Certificate renewed successfully",
+                           "renewed": True})
+    assert result.exit_code == 0
+    assert "renewed" in result.stdout
+    client.renew_certificate.assert_called_once_with("app.example.com", force=True)
+
+
+def test_renew_not_due_shows_server_message_exit_zero():
+    result, _ = _invoke_with_client(
+        ["cert", "renew", "app.example.com"],
+        renew_certificate={"message": "Certificate not due for renewal",
+                           "renewed": False})
+    assert result.exit_code == 0
+    assert "not due" in result.stdout
+    assert "Certificate not due for renewal" in result.stdout
+
+
+def test_renew_older_server_without_outcome_is_neutral_not_green():
+    # 0.1.1-era servers return no `renewed` key; the CLI must not claim
+    # success it cannot know about.
+    result, _ = _invoke_with_client(
+        ["cert", "renew", "app.example.com"],
+        renew_certificate={"message": "Certificate renewed successfully for app.example.com"})
+    assert result.exit_code == 0
+    assert "renew requested" in result.stdout
+    assert "did not report" in result.stdout
+    assert "renewed app.example.com" not in result.stdout
+
+
+# --------------------------------------------------------------------------
+# BUG 4 — transport failures print one clean red line, no traceback
+# --------------------------------------------------------------------------
+
+def test_health_unreachable_server_clean_error_exit_one():
+    result, _ = _invoke_with_client(
+        ["health"],
+        health=TransportError("cannot reach server at http://127.0.0.1:1: "
+                              "connection refused"))
+    assert result.exit_code == 1
+    text = _all_output(result)
+    assert "cannot reach server" in text
+    assert "Traceback" not in text
+
+
+def test_dns_test_older_server_400_shows_error_cleanly():
+    # Older servers 400 on an empty config instead of falling back to stored
+    # credentials; the CLI must relay the message, not a traceback.
+    result, _ = _invoke_with_client(
+        ["dns", "test", "cloudflare"],
+        test_dns_provider=APIError("Cloudflare API token required", status=400))
+    assert result.exit_code == 1
+    text = _all_output(result)
+    assert "Cloudflare API token required" in text
+    assert "Traceback" not in text
+
+
+# --------------------------------------------------------------------------
+# BUG 8 — cert create SAN parsing drops empties from trailing commas
+# --------------------------------------------------------------------------
+
+def test_create_san_trailing_comma_produces_no_empty_entry():
+    result, client = _invoke_with_client(
+        ["cert", "create", "app.example.com",
+         "--san", "a.example.com, b.example.com,", "--no-wait"],
+        create_certificate=Job.from_dict({"job_id": "j1", "status": "pending"}))
+    assert result.exit_code == 0, _all_output(result)
+    kwargs = client.create_certificate.call_args.kwargs
+    assert kwargs["san_domains"] == ["a.example.com", "b.example.com"]
+
+
+# --------------------------------------------------------------------------
+# BUG 9 — --token on argv warns interactively; CERTMATE_TOKEN stays silent
+# --------------------------------------------------------------------------
+
+def test_token_flag_warns_on_a_tty(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["certmate", "--token", "sekrit", "cert", "ls"])
+    with patch("certmate_cli.main._stderr_isatty", return_value=True):
+        result, _ = _invoke_with_client(["--token", "sekrit", "cert", "ls"],
+                                        list_certificates=[])
+    text = _all_output(result)
+    assert "warning" in text
+    assert "CERTMATE_TOKEN" in text
+
+
+def test_token_from_environment_does_not_warn(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["certmate", "cert", "ls"])
+    monkeypatch.setenv("CERTMATE_TOKEN", "sekrit")
+    with patch("certmate_cli.main._stderr_isatty", return_value=True):
+        result, _ = _invoke_with_client(["cert", "ls"], list_certificates=[])
+    assert "warning" not in _all_output(result)
+
+
+def test_token_flag_stays_quiet_when_not_interactive(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["certmate", "--token", "sekrit", "cert", "ls"])
+    with patch("certmate_cli.main._stderr_isatty", return_value=False):
+        result, _ = _invoke_with_client(["--token", "sekrit", "cert", "ls"],
+                                        list_certificates=[])
+    assert "warning" not in _all_output(result)

--- a/tests/test_clients_e2e.py
+++ b/tests/test_clients_e2e.py
@@ -4,7 +4,9 @@ endpoints in lockstep with the API it wraps.
 
 Requires the clients to be installed (requirements-test.txt installs them
 editable). Skipped cleanly if the SDK is not importable."""
+import os
 import shutil
+import socket
 import subprocess
 
 import pytest
@@ -40,6 +42,8 @@ def test_sdk_audit_verify_fresh_is_ok_or_absent(sdk):
     assert isinstance(res, dict) and "ok" in res
     # Fresh instance: either intact (something got audited) or explicitly absent.
     assert res["ok"] is True or res.get("state") == "absent"
+    # SDK 0.1.2 always preserves the intact-vs-broken HTTP status.
+    assert res.get("_http_status") == 200
 
 
 def test_sdk_backup_create_and_list(sdk):
@@ -78,6 +82,80 @@ def test_cli_audit_verify_fresh_exit_zero(docker_container):
     r = subprocess.run(["certmate", "--url", docker_container, "audit", "verify"],
                        capture_output=True, text=True, timeout=30)
     assert r.returncode == 0, r.stderr
+
+
+# Must match CONTAINER_NAME in tests/conftest.py — the docker_container fixture
+# only yields the base URL, so container-level tampering goes through docker
+# exec on the well-known name.
+_CONTAINER_NAME = "certmate-test-suite"
+_AUDIT_DIR = "/app/data/audit"  # factory wires chain_dir = data_dir / "audit"
+_CHAIN = f"{_AUDIT_DIR}/certificate_audit.chain.jsonl"
+_CHECKPOINTS = f"{_AUDIT_DIR}/certificate_audit.checkpoints.jsonl"
+
+
+def _container_sh(cmd: str):
+    """Run a shell command inside the fixture container."""
+    return subprocess.run(["docker", "exec", _CONTAINER_NAME, "sh", "-c", cmd],
+                          capture_output=True, text=True, timeout=60)
+
+
+@pytest.mark.skipif(shutil.which("certmate") is None, reason="certmate CLI not on PATH")
+def test_cli_audit_verify_broken_after_chain_deletion(docker_container):
+    """A chain file deleted AFTER signed checkpoints attested it existed is
+    tampering: `audit verify` must exit non-zero (the 0.1.1 CLI treated the
+    reason text as the benign fresh-instance case and exited 0)."""
+    if os.environ.get("CERTMATE_E2E_BASE_URL"):
+        pytest.skip("externally managed instance: no docker exec access")
+    if shutil.which("docker") is None:
+        pytest.skip("docker not available")
+    probe = _container_sh(f"mkdir -p {_AUDIT_DIR}")
+    if probe.returncode != 0:
+        pytest.skip(f"docker exec unavailable for {_CONTAINER_NAME}: {probe.stderr}")
+
+    # Snapshot the files this test mutates; the container is shared with the
+    # rest of the session, so the exact pre-test state must come back.
+    _container_sh(f"[ -f {_CHAIN} ] && cp -p {_CHAIN} {_CHAIN}.e2ebak; true")
+    _container_sh(f"[ -f {_CHECKPOINTS} ] && cp -p {_CHECKPOINTS} {_CHECKPOINTS}.e2ebak; true")
+    try:
+        # Any parseable {seq, hash} record makes has_checkpoints() true; the
+        # server then treats a missing chain file as a deletion (409), not a
+        # fresh instance (200 + state='absent').
+        fake_cp = ('{"seq": 0, "hash": "e2e-fake-checkpoint", "count": 1, '
+                   '"timestamp": "2026-01-01T00:00:00Z"}')
+        r = _container_sh(f"printf '%s\\n' '{fake_cp}' >> {_CHECKPOINTS}")
+        assert r.returncode == 0, r.stderr
+        r = _container_sh(f"rm -f {_CHAIN}")
+        assert r.returncode == 0, r.stderr
+
+        r = subprocess.run(["certmate", "--url", docker_container, "audit", "verify"],
+                           capture_output=True, text=True, timeout=30)
+        assert r.returncode != 0, (
+            "audit verify must fail when the chain was deleted after "
+            f"checkpoints; stdout={r.stdout!r} stderr={r.stderr!r}")
+        assert "BROKEN" in r.stdout
+        assert "Traceback" not in r.stdout + r.stderr
+    finally:
+        _container_sh(f"if [ -f {_CHAIN}.e2ebak ]; then mv {_CHAIN}.e2ebak {_CHAIN}; fi")
+        _container_sh(f"if [ -f {_CHECKPOINTS}.e2ebak ]; "
+                      f"then mv {_CHECKPOINTS}.e2ebak {_CHECKPOINTS}; "
+                      f"else rm -f {_CHECKPOINTS}; fi")
+
+
+@pytest.mark.skipif(shutil.which("certmate") is None, reason="certmate CLI not on PATH")
+def test_cli_health_unreachable_server_clean_error():
+    """`certmate health` against a closed port: one clean error line, exit 1,
+    no traceback. Needs no container — the point is that nothing listens."""
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()  # freed again: nothing listens on this port
+    r = subprocess.run(["certmate", "--url", f"http://127.0.0.1:{port}", "health"],
+                       capture_output=True, text=True, timeout=60)
+    assert r.returncode == 1, r.stdout + r.stderr
+    combined = r.stdout + r.stderr
+    assert "Traceback" not in combined
+    assert "cannot reach server" in combined
+    assert "error" in combined.lower()
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_clients_sdk_unit.py
+++ b/tests/test_clients_sdk_unit.py
@@ -1,0 +1,356 @@
+"""Unit tests for certmate-sdk 0.1.2 wire-level fixes (no server required).
+
+Each test pins the EXACT request the SDK sends (method, path, query, body) or
+the exact error surface, using an httpx.MockTransport — these are the contracts
+that were silently wrong in 0.1.1 (renew force dropped, dns test flat body,
+download formats rejected, raw httpx tracebacks, audit 409 flattened into a
+body indistinguishable from the benign fresh-instance case)."""
+import json
+
+import httpx
+import pytest
+
+certmate = pytest.importorskip("certmate", reason="certmate-sdk not installed")
+from certmate import (Certificate, Client, Job, JobFailed,  # noqa: E402
+                      NotFoundError, TransportError)
+
+pytestmark = [pytest.mark.unit]
+
+BASE = "http://testserver"
+
+
+def _mock_client(handler) -> Client:
+    """A Client whose HTTP layer is an httpx.MockTransport around ``handler``.
+
+    The transport is swapped after construction so the SDK's public surface
+    stays untouched (Client deliberately exposes no transport parameter)."""
+    c = Client(BASE, token="test-token")
+    c._http = httpx.Client(base_url=BASE, transport=httpx.MockTransport(handler),
+                           headers={"Accept": "application/json"})
+    return c
+
+
+def _json_response(body, status=200):
+    return httpx.Response(status, json=body)
+
+
+# --------------------------------------------------------------------------
+# BUG 2 / BUG 3 — renew: force travels in the JSON body, with a long timeout
+# --------------------------------------------------------------------------
+
+def test_renew_sends_force_in_json_body_not_query():
+    seen = {}
+
+    def handler(request):
+        seen["params"] = dict(request.url.params)
+        seen["body"] = json.loads(request.content)
+        return _json_response({"message": "ok", "renewed": True})
+
+    with _mock_client(handler) as c:
+        res = c.renew_certificate("app.example.com", force=True)
+    # The server reads payload.get('force') only; a query param is dropped.
+    assert seen["body"] == {"force": True}
+    assert "force" not in seen["params"]
+    assert res["renewed"] is True
+
+
+def test_renew_always_sends_a_body_even_without_force():
+    seen = {}
+
+    def handler(request):
+        seen["body"] = json.loads(request.content)
+        return _json_response({"message": "ok"})
+
+    with _mock_client(handler) as c:
+        c.renew_certificate("app.example.com")
+    assert seen["body"] == {"force": False}
+
+
+def test_renew_uses_long_per_request_timeout():
+    # Real DNS-01 renewals take minutes; the default 30s read timeout used to
+    # kill the CLI while the server kept renewing.
+    seen = {}
+
+    def handler(request):
+        seen["timeout"] = request.extensions.get("timeout") or {}
+        return _json_response({"message": "ok"})
+
+    with _mock_client(handler) as c:
+        c.renew_certificate("app.example.com", force=True)
+    assert seen["timeout"].get("read") == 600.0
+
+
+# --------------------------------------------------------------------------
+# BUG 6 — download_certificate maps fmt to the query the API accepts
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("fmt,expected_params", [
+    ("json", {"format": "json"}),
+    ("zip", {}),                          # bare request: zip is the default
+    ("pem", {"file": "fullchain.pem"}),
+    ("pfx", {"file": "cert.pfx"}),
+])
+def test_download_certificate_query_per_format(fmt, expected_params):
+    seen = {}
+
+    def handler(request):
+        seen["path"] = request.url.path
+        seen["params"] = dict(request.url.params)
+        if fmt == "json":
+            return _json_response({"certificate_pem": "..."})
+        return httpx.Response(200, content=b"BYTES",
+                              headers={"content-type": "application/octet-stream"})
+
+    with _mock_client(handler) as c:
+        res = c.download_certificate("app.example.com", fmt=fmt)
+    assert seen["path"] == "/api/certificates/app.example.com/download"
+    assert seen["params"] == expected_params
+    if fmt == "json":
+        assert isinstance(res, dict)
+    else:
+        assert res == b"BYTES"
+
+
+def test_download_certificate_unknown_format_raises_value_error():
+    def handler(request):  # pragma: no cover - must never be reached
+        raise AssertionError("no request may be sent for an unknown format")
+
+    with _mock_client(handler) as c:
+        with pytest.raises(ValueError):
+            c.download_certificate("app.example.com", fmt="der")
+
+
+# --------------------------------------------------------------------------
+# BUG 5 — test_dns_provider nests credentials under "config"
+# --------------------------------------------------------------------------
+
+def test_dns_test_sends_nested_config_body():
+    seen = {}
+
+    def handler(request):
+        seen["body"] = json.loads(request.content)
+        return _json_response({"message": "ok"})
+
+    with _mock_client(handler) as c:
+        c.test_dns_provider("cloudflare")
+        empty = seen["body"]
+        c.test_dns_provider("cloudflare", api_token="tok")
+        with_config = seen["body"]
+    # Empty config asks v2.21.1+ servers to fall back to stored credentials.
+    assert empty == {"provider": "cloudflare", "config": {}}
+    assert with_config == {"provider": "cloudflare", "config": {"api_token": "tok"}}
+
+
+# --------------------------------------------------------------------------
+# BUG 1 (SDK side) — audit_verify preserves the HTTP status in the result
+# --------------------------------------------------------------------------
+
+def test_audit_verify_attaches_http_status_200():
+    def handler(request):
+        return _json_response({"ok": True, "reason": "intact"})
+
+    with _mock_client(handler) as c:
+        res = c.audit_verify()
+    assert res["ok"] is True
+    assert res["_http_status"] == 200
+
+
+def test_audit_verify_409_payload_keeps_broken_distinction():
+    # A chain file deleted AFTER signed checkpoints returns the SAME reason
+    # text as a fresh instance; only the status (and state) tell them apart.
+    def handler(request):
+        return _json_response({"ok": False, "reason": "chain file does not exist"},
+                              status=409)
+
+    with _mock_client(handler) as c:
+        res = c.audit_verify()
+    assert res["ok"] is False
+    assert res["_http_status"] == 409
+    assert "state" not in res
+
+
+def test_audit_verify_absent_state_is_a_200():
+    def handler(request):
+        return _json_response({"ok": False, "reason": "chain file does not exist",
+                               "state": "absent"})
+
+    with _mock_client(handler) as c:
+        res = c.audit_verify()
+    assert res["state"] == "absent"
+    assert res["_http_status"] == 200
+
+
+# --------------------------------------------------------------------------
+# BUG 4 — httpx errors become TransportError (one clean SDK exception)
+# --------------------------------------------------------------------------
+
+def test_connect_error_becomes_transport_error():
+    def handler(request):
+        raise httpx.ConnectError("connection refused")
+
+    with _mock_client(handler) as c:
+        with pytest.raises(TransportError) as exc:
+            c.health()
+    assert "cannot reach server at" in str(exc.value)
+    assert BASE in str(exc.value)
+
+
+def test_read_timeout_becomes_transport_error_with_readable_detail():
+    def handler(request):
+        raise httpx.ReadTimeout("")  # httpx timeouts often stringify empty
+
+    with _mock_client(handler) as c:
+        with pytest.raises(TransportError) as exc:
+            c.health()
+    assert "cannot reach server at" in str(exc.value)
+    # The empty str() must be replaced by a human-readable fallback.
+    assert not str(exc.value).endswith(": ")
+
+
+def test_transport_error_against_a_real_closed_port():
+    import socket
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()  # nothing listens here any more
+    with Client(f"http://127.0.0.1:{port}", token=None, timeout=2.0) as c:
+        with pytest.raises(TransportError):
+            c.health()
+
+
+# --------------------------------------------------------------------------
+# BUG 4 — wait_for_job resilience
+# --------------------------------------------------------------------------
+
+def _job(status, domain="app.example.com"):
+    return Job.from_dict({"job_id": "j1", "status": status, "domain": domain})
+
+
+def test_wait_for_job_tolerates_two_transient_blips(monkeypatch):
+    c = Client(BASE)
+    polls = iter([TransportError("blip"), TransportError("blip"), _job("succeeded")])
+
+    def fake_get_job(job_id):
+        item = next(polls)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    monkeypatch.setattr(c, "get_job", fake_get_job)
+    monkeypatch.setattr("time.sleep", lambda s: None)
+    job = c.wait_for_job("j1", interval=0)
+    assert job.succeeded
+
+
+def test_wait_for_job_gives_up_after_three_consecutive_transport_errors(monkeypatch):
+    c = Client(BASE)
+    calls = {"n": 0}
+
+    def fake_get_job(job_id):
+        calls["n"] += 1
+        raise TransportError("down")
+
+    monkeypatch.setattr(c, "get_job", fake_get_job)
+    monkeypatch.setattr("time.sleep", lambda s: None)
+    with pytest.raises(TransportError):
+        c.wait_for_job("j1", interval=0)
+    assert calls["n"] == 3
+
+
+def test_wait_for_job_transient_counter_resets_on_success(monkeypatch):
+    # blip, ok, blip, blip, done: never three CONSECUTIVE failures.
+    c = Client(BASE)
+    polls = iter([TransportError("blip"), _job("running"), TransportError("blip"),
+                  TransportError("blip"), _job("succeeded")])
+
+    def fake_get_job(job_id):
+        item = next(polls)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    monkeypatch.setattr(c, "get_job", fake_get_job)
+    monkeypatch.setattr("time.sleep", lambda s: None)
+    assert c.wait_for_job("j1", interval=0).succeeded
+
+
+def test_wait_for_job_evicted_job_checks_certificate(monkeypatch):
+    # The job was seen once, then evicted (404). Its certificate exists, so
+    # the SDK reports success instead of a spurious NotFoundError.
+    c = Client(BASE)
+    polls = iter([_job("running"), NotFoundError("gone", status=404)])
+
+    def fake_get_job(job_id):
+        item = next(polls)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    monkeypatch.setattr(c, "get_job", fake_get_job)
+    monkeypatch.setattr(c, "get_certificate",
+                        lambda d: Certificate.from_dict({"domain": d}))
+    monkeypatch.setattr("time.sleep", lambda s: None)
+    job = c.wait_for_job("j1", interval=0)
+    assert job.status == "succeeded"
+    assert job.domain == "app.example.com"
+
+
+def test_wait_for_job_evicted_job_without_certificate_still_fails(monkeypatch):
+    c = Client(BASE)
+    polls = iter([_job("running"), NotFoundError("gone", status=404)])
+
+    def fake_get_job(job_id):
+        item = next(polls)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    def missing_cert(domain):
+        raise NotFoundError("no such cert", status=404)
+
+    monkeypatch.setattr(c, "get_job", fake_get_job)
+    monkeypatch.setattr(c, "get_certificate", missing_cert)
+    monkeypatch.setattr("time.sleep", lambda s: None)
+    with pytest.raises(NotFoundError) as exc:
+        c.wait_for_job("j1", interval=0)
+    # The original job 404 propagates, not the certificate probe's.
+    assert "gone" in str(exc.value)
+
+
+def test_wait_for_job_not_found_on_first_poll_raises(monkeypatch):
+    # Never seen the job at all: a 404 is a genuine unknown-job error.
+    c = Client(BASE)
+
+    def fake_get_job(job_id):
+        raise NotFoundError("unknown job", status=404)
+
+    monkeypatch.setattr(c, "get_job", fake_get_job)
+    with pytest.raises(NotFoundError):
+        c.wait_for_job("j1", interval=0)
+
+
+def test_wait_for_job_still_raises_job_failed(monkeypatch):
+    c = Client(BASE)
+    monkeypatch.setattr(c, "get_job", lambda job_id: _job("failed"))
+    with pytest.raises(JobFailed):
+        c.wait_for_job("j1", interval=0)
+
+
+# --------------------------------------------------------------------------
+# BUG 7 — a boolean staging flag must not leak into the CA column
+# --------------------------------------------------------------------------
+
+def test_certificate_staging_flag_maps_to_staging_ca_name():
+    c = Certificate.from_dict({"domain": "a.example.com", "staging": True})
+    assert c.ca_provider == "letsencrypt-staging"
+
+
+def test_certificate_explicit_ca_provider_wins_over_staging():
+    c = Certificate.from_dict({"domain": "a.example.com",
+                               "ca_provider": "letsencrypt", "staging": True})
+    assert c.ca_provider == "letsencrypt"
+
+
+def test_certificate_without_ca_or_staging_has_no_ca():
+    c = Certificate.from_dict({"domain": "a.example.com", "staging": False})
+    assert c.ca_provider is None

--- a/tests/test_custom_script_dns.py
+++ b/tests/test_custom_script_dns.py
@@ -152,6 +152,17 @@ def test_world_writable_script_rejected(tmp_path):
         CustomScriptStrategy().create_config_file({'auth_hook': str(script)})
 
 
+def test_group_writable_script_rejected(tmp_path):
+    """Group-writable used to be a log-only warning nobody sees at issuance
+    time; it is the same execute-with-CertMate's-privileges trust boundary as
+    world-writable, so it must refuse just as loudly."""
+    script = tmp_path / 'hook.sh'
+    script.write_text('#!/bin/sh\nexit 0\n')
+    script.chmod(0o775)
+    with pytest.raises(ValueError, match='group-writable'):
+        CustomScriptStrategy().create_config_file({'auth_hook': str(script)})
+
+
 def test_propagation_hint_exported(auth_hook):
     strategy = CustomScriptStrategy()
     env = {}

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -470,3 +470,35 @@ class TestEventListener:
     def test_ignores_missing_domain(self, deploy_manager, shell_executor):
         deploy_manager.on_certificate_event('certificate_created', {})
         assert shell_executor.call_count == 0
+
+
+class TestHookOutputSanitization:
+    """Hook stdout/stderr is persisted verbatim into the history file, the
+    audit log and the immutable hash chain, so secrets a hook echoes must be
+    redacted at the single choke point where the result dict is built."""
+
+    HOOK = {
+        'id': 'h9', 'name': 'Leaky', 'command': 'echo leak',
+        'enabled': True, 'timeout': 10, 'on_events': ['created'],
+    }
+
+    def test_stdout_secret_assignment_redacted(self, deploy_manager, shell_executor):
+        shell_executor.set_next_result(
+            returncode=0, stdout='deploying with api_token = hunter2-secret\n')
+        result = deploy_manager._run_hook(self.HOOK, 'example.com', 'created')
+        assert 'hunter2-secret' not in result['stdout']
+        assert '[REDACTED]' in result['stdout']
+
+    def test_stderr_pem_block_redacted(self, deploy_manager, shell_executor):
+        pem = '-----BEGIN PRIVATE KEY-----\nMIIabc\n-----END PRIVATE KEY-----'
+        shell_executor.set_next_result(returncode=1, stderr=pem)
+        result = deploy_manager._run_hook(self.HOOK, 'example.com', 'created')
+        assert 'MIIabc' not in result['stderr']
+        assert '[PEM REDACTED]' in result['stderr']
+        # The error snippet is derived from the SANITIZED stderr.
+        assert 'MIIabc' not in (result['error'] or '')
+
+    def test_plain_output_untouched(self, deploy_manager, shell_executor):
+        shell_executor.set_next_result(returncode=0, stdout='reloaded nginx\n')
+        result = deploy_manager._run_hook(self.HOOK, 'example.com', 'created')
+        assert result['stdout'] == 'reloaded nginx\n'

--- a/tests/test_dns_manager_coverage.py
+++ b/tests/test_dns_manager_coverage.py
@@ -606,3 +606,98 @@ class TestSetDefaultAccount:
         })
         sm.update.side_effect = RuntimeError("boom")
         assert mgr.set_default_account('cloudflare', 'prod') is False
+
+
+# ---------------------------------------------------------------------------
+# POST /api/web/certificates/test-provider — stored-credential fallback.
+# An empty/missing 'config' previously always failed "Missing required
+# credential field(s)", so a preflight against a fully configured server
+# (e.g. `certmate dns test cloudflare`) could never succeed.
+# ---------------------------------------------------------------------------
+
+
+def _passthrough_role(*args, **kwargs):
+    if len(args) == 1 and callable(args[0]) and not kwargs:
+        return args[0]
+
+    def _wrap(fn):
+        return fn
+    return _wrap
+
+
+@pytest.fixture
+def test_provider_client(manager_factory):
+    """Return a callable building a Flask test client whose test-provider
+    route wraps a real DNSManager over the given seed settings."""
+    from flask import Flask
+    from modules.core.constants import CERTIFICATE_FILES
+    from modules.web.cert_routes import register_cert_routes
+
+    def _build(settings):
+        mgr, _ = manager_factory(settings)
+        auth = MagicMock()
+        auth.require_role = MagicMock(side_effect=_passthrough_role)
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        register_cert_routes(
+            app, {'audit': MagicMock(), 'cert_service': MagicMock()},
+            _passthrough_role, auth, MagicMock(), MagicMock(), MagicMock(),
+            MagicMock(), mgr, CERTIFICATE_FILES,
+        )
+        return app.test_client()
+
+    return _build
+
+
+_CF_STORED = {
+    'dns_providers': {
+        'cloudflare': {
+            'accounts': {
+                'default': {'api_token': 'stored-token'},
+                'secondary': {'api_token': 'other-token'},
+            }
+        }
+    },
+    'default_accounts': {'cloudflare': 'default'},
+}
+
+
+class TestTestProviderStoredCredentialFallback:
+    def test_empty_config_falls_back_to_stored_default_account(self, test_provider_client):
+        client = test_provider_client(_CF_STORED)
+        r = client.post('/api/web/certificates/test-provider',
+                        json={'provider': 'cloudflare'})
+        assert r.status_code == 200, r.get_json()
+        body = r.get_json()
+        assert 'message' in body
+        assert body.get('used_account') == 'default'
+
+    def test_explicit_account_id_selects_that_account(self, test_provider_client):
+        client = test_provider_client(_CF_STORED)
+        r = client.post('/api/web/certificates/test-provider',
+                        json={'provider': 'cloudflare', 'account_id': 'secondary'})
+        assert r.status_code == 200, r.get_json()
+        assert r.get_json().get('used_account') == 'secondary'
+
+    def test_explicit_config_takes_precedence_over_stored(self, test_provider_client):
+        """An explicit (here: incomplete) config must be tested as-is, never
+        silently patched with the stored account."""
+        client = test_provider_client(_CF_STORED)
+        r = client.post('/api/web/certificates/test-provider',
+                        json={'provider': 'cloudflare', 'config': {'api_token': ''}})
+        assert r.status_code == 400
+        assert 'api_token' in r.get_json()['error']
+
+    def test_no_stored_account_keeps_the_400(self, test_provider_client):
+        client = test_provider_client({})
+        r = client.post('/api/web/certificates/test-provider',
+                        json={'provider': 'cloudflare'})
+        assert r.status_code == 400
+        assert 'Missing required credential field' in r.get_json()['error']
+
+    def test_valid_explicit_config_has_no_used_account(self, test_provider_client):
+        client = test_provider_client({})
+        r = client.post('/api/web/certificates/test-provider',
+                        json={'provider': 'cloudflare', 'config': {'api_token': 'tok'}})
+        assert r.status_code == 200
+        assert 'used_account' not in r.get_json()

--- a/tests/test_frontend_provider_coverage.py
+++ b/tests/test_frontend_provider_coverage.py
@@ -88,3 +88,32 @@ def test_add_account_buttons_have_modal_field_schema():
         f"providers with an Add-Account button but no getProviderFields schema "
         f"(empty modal): {sorted(missing)}"
     )
+
+
+# ---------------------------------------------------------------------------
+# #382: the unified create/edit certificate drawer must be titled by mode.
+# Static ratchets (no browser): the title node is parameterizable and the
+# edit-mode switch actually swaps it — the drawer used to say "Create New
+# Certificate" while editing an existing certificate.
+# ---------------------------------------------------------------------------
+
+def test_cert_drawer_title_is_parameterizable():
+    html = _read('templates/index.html')
+    m = re.search(r'<h3 id="drawerTitle"[^>]*>.*?</h3>', html, re.S)
+    assert m, "index.html must expose the drawer title as #drawerTitle"
+    assert 'Create New Certificate' in m.group(0), (
+        "the default (create-mode) drawer title must remain the create title"
+    )
+
+
+def test_edit_mode_swaps_drawer_title():
+    js = _read('static/js/dashboard.js')
+    mode_fn = re.search(r'function setReissueFormMode\(.*?\n    \}', js, re.S)
+    assert mode_fn, "setReissueFormMode not found in dashboard.js"
+    body = mode_fn.group(0)
+    assert "getElementById('drawerTitle')" in body, (
+        "edit mode must retitle the drawer (#382), not only swap the submit button"
+    )
+    assert 'Edit Certificate' in body
+    # Leaving edit mode must restore the stashed create-mode markup.
+    assert 'title.dataset.createHtml' in body

--- a/tests/test_p2_quick_wins.py
+++ b/tests/test_p2_quick_wins.py
@@ -7,8 +7,9 @@
    predictable path, no concurrent clobber), 0600, and orphans are swept."""
 import os
 import stat
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask, request
@@ -95,3 +96,84 @@ def test_sweep_removes_orphaned_sa_files_only(tmp_path):
     _sweep_orphaned_files(tmp_path, 'google-sa-*.json', max_age_seconds=3600)
     assert not old.exists()      # older than cutoff → swept
     assert fresh.exists()        # recent → kept
+
+
+# --- S1 follow-up: the SA JSON is deleted WITH the operation, not left for
+# the orphan sweep. create_google_config returns both paths, GoogleStrategy
+# records the side file, and the create/renew finally blocks unlink it.
+
+def test_create_google_config_returns_both_secret_paths(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config_file, sa_file = create_google_config('proj-1', '{"type":"service_account"}')
+    assert config_file.exists() and sa_file.exists()
+    assert sa_file.name.startswith('google-sa-')
+    assert str(sa_file) in config_file.read_text()
+
+
+def test_google_strategy_records_sa_file_for_cleanup(tmp_path, monkeypatch):
+    from modules.core.dns_strategies import GoogleStrategy
+    monkeypatch.chdir(tmp_path)
+    strategy = GoogleStrategy()
+    config_file = strategy.create_config_file(
+        {'project_id': 'p', 'service_account_key': '{"type":"service_account"}'})
+    assert config_file is not None
+    assert [Path(p).name.startswith('google-sa-') for p in strategy.extra_credential_files] == [True]
+
+
+def _google_cert_mgr(tmp_path, shell):
+    from modules.core.certificates import CertificateManager
+    settings_mgr = MagicMock()
+    settings_mgr.load_settings.return_value = {
+        'default_ca': 'letsencrypt', 'challenge_type': 'dns-01',
+        'dns_propagation_seconds': {}, 'default_key_type': 'ecdsa',
+        'default_elliptic_curve': 'secp384r1',
+    }
+    settings_mgr.get_domain_dns_provider.return_value = 'google'
+    dns_mgr = MagicMock()
+    dns_mgr.get_dns_provider_account_config.return_value = (
+        {'project_id': 'p', 'service_account_key': '{"type":"service_account"}'},
+        'default',
+    )
+    return CertificateManager(
+        cert_dir=tmp_path / 'certs', settings_manager=settings_mgr,
+        dns_manager=dns_mgr, storage_manager=None, ca_manager=None,
+        shell_executor=shell,
+    )
+
+
+def test_create_unlinks_google_sa_json_in_finally(tmp_path, monkeypatch):
+    from modules.core.certificates import CertificateManager
+    from modules.core.shell import MockShellExecutor
+    monkeypatch.chdir(tmp_path)
+    shell = MockShellExecutor()
+    shell.set_next_result(returncode=0)
+    mgr = _google_cert_mgr(tmp_path, shell)
+    with patch('modules.core.certificates.check_certbot_plugin_installed',
+               return_value=True), \
+         patch.object(CertificateManager, '_write_pfx', return_value=None):
+        mgr.create_certificate(domain='g.example.com', email='t@example.com',
+                               dns_provider='google', staging=True)
+    cfg = tmp_path / 'letsencrypt' / 'config'
+    assert not list(cfg.glob('google-sa-*.json')), (
+        "the SA JSON (a live GCP private key) must not outlive the operation"
+    )
+    assert not list(cfg.glob('google-*.ini'))
+
+
+def test_renew_unlinks_google_sa_json_in_finally(tmp_path, monkeypatch):
+    import json as _json
+    from modules.core.certificates import CertificateManager
+    from modules.core.shell import MockShellExecutor
+    monkeypatch.chdir(tmp_path)
+    shell = MockShellExecutor()
+    shell.set_next_result(returncode=0, stdout='no renewals were attempted')
+    mgr = _google_cert_mgr(tmp_path, shell)
+    d = tmp_path / 'certs' / 'g.example.com'
+    d.mkdir(parents=True)
+    (d / 'cert.pem').write_bytes(b'existing\n')
+    (d / 'metadata.json').write_text(_json.dumps({'dns_provider': 'google'}))
+    with patch.object(CertificateManager, '_write_pfx', return_value=None):
+        mgr.renew_certificate('g.example.com')
+    cfg = tmp_path / 'letsencrypt' / 'config'
+    assert not list(cfg.glob('google-sa-*.json'))
+    assert not list(cfg.glob('google-*.ini'))

--- a/tests/test_per_cert_renewal.py
+++ b/tests/test_per_cert_renewal.py
@@ -210,13 +210,16 @@ def test_renew_pushes_renewed_cert_to_storage_backend(cert_manager):
     live_dir = domain_dir / "live" / domain
     live_dir.mkdir(parents=True)
     (domain_dir / "cert.pem").write_text("old cert")  # existing cert lets renew proceed
-    # The renewed files certbot would have written into live/<domain>/.
-    for name in CERTIFICATE_FILES:
-        (live_dir / name).write_bytes(f"renewed-{name}".encode())
 
-    cert_manager.shell_executor.run = MagicMock(
-        return_value=SimpleNamespace(returncode=0, stdout="", stderr="")
-    )
+    # Stage the renewed files DURING the mocked certbot run, exactly as the
+    # real binary does: no-op detection fingerprints the live cert before and
+    # after the run, so files staged ahead of it would read as "unchanged".
+    def _run(cmd, **kwargs):
+        for name in CERTIFICATE_FILES:
+            (live_dir / name).write_bytes(f"renewed-{name}".encode())
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    cert_manager.shell_executor.run = MagicMock(side_effect=_run)
     cert_manager._write_pfx = MagicMock()  # isolate from the openssl PFX step
 
     storage = MagicMock()
@@ -242,14 +245,19 @@ def test_renew_without_storage_backend_succeeds(cert_manager):
     succeeds — the upload is best-effort, guarded by `if self.storage_manager`."""
     domain = "nostore.example.com"
     domain_dir = cert_manager.cert_dir / domain
-    (domain_dir / "live" / domain).mkdir(parents=True)
+    live_dir = domain_dir / "live" / domain
+    live_dir.mkdir(parents=True)
     (domain_dir / "cert.pem").write_text("old cert")
 
-    cert_manager.shell_executor.run = MagicMock(
-        return_value=SimpleNamespace(returncode=0, stdout="", stderr="")
-    )
+    def _run(cmd, **kwargs):
+        for name in CERTIFICATE_FILES:
+            (live_dir / name).write_bytes(f"renewed-{name}".encode())
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    cert_manager.shell_executor.run = MagicMock(side_effect=_run)
     cert_manager._write_pfx = MagicMock()
 
     assert cert_manager.storage_manager is None
     result = cert_manager.renew_certificate(domain)
     assert result["success"] is True
+    assert result["renewed"] is True

--- a/tests/test_provider_credential_key_contract.py
+++ b/tests/test_provider_credential_key_contract.py
@@ -1,0 +1,220 @@
+"""Change-detector for the certbot credentials-file key contract.
+
+CertMate writes the INI credentials file each certbot DNS plugin reads. The
+key names are an unversioned, undocumented contract: certbot derives them as
+``<entry_point_name with '-' -> '_'>_<credential var>`` (see
+``certbot.plugins.common.dest_namespace`` + ``DNSAuthenticator.dest``), and a
+drifted key fails only at issuance time with the plugin's "Property not
+found" error — or, worse, with a baffling plugin-selection failure when the
+entry-point name itself is wrong. This is exactly how the porkbun bug
+(#364: ``dns_porkbun_api_key`` instead of ``dns_porkbun_key``) shipped.
+
+Every expected value below is pinned against the plugin source:
+
+* plugins installed in the venv were read directly
+  (``certbot_dns_<x>/...``, the ``_configure_credentials`` /
+  ``_add_provider_option`` calls);
+* plugins NOT importable here (he-ddns 0.1.0, dynudns 0.0.6, scaleway 0.0.7,
+  desec 1.3.2, powerdns 0.2.1, infomaniak, namecheap 1.0.0) were pinned from
+  their sdist source / README, as noted per entry.
+
+This is the guard for the future certbot-5.x migration: bump a plugin, and a
+changed credential contract fails HERE instead of in production.
+"""
+from importlib.metadata import entry_points
+
+import pytest
+
+from modules.core.dns_strategies import DNSStrategyFactory
+from modules.core.utils import (
+    _MULTI_PROVIDER_TEMPLATE_MAP,
+    create_arvancloud_config,
+    create_cloudflare_config,
+    create_digitalocean_config,
+    create_duckdns_config,
+    create_edgedns_config,
+    create_gandi_config,
+    create_infomaniak_config,
+    create_linode_config,
+    create_namecheap_config,
+    create_ovh_config,
+    create_powerdns_config,
+)
+from modules.core import utils as utils_module
+
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------------
+# Generic multi-providers (_MULTI_PROVIDER_TEMPLATE_MAP)
+# ---------------------------------------------------------------------------
+
+# provider -> (certbot entry-point name, {expected ini key, ...}).
+# Provenance is cited per entry; "venv" means read from the installed plugin
+# in this repo's virtualenv, "sdist" from the downloaded source distribution.
+EXPECTED_MULTI_PROVIDER_CONTRACT = {
+    # venv certbot-dns-vultr 1.1.0: _configure_credentials var 'key'.
+    'vultr': ('dns-vultr', {'dns_vultr_key'}),
+    # venv certbot-dns-dnsmadeeasy 2.10.0 (lexicon): options 'api-key',
+    # 'secret-key'.
+    'dnsmadeeasy': ('dns-dnsmadeeasy',
+                    {'dns_dnsmadeeasy_api_key', 'dns_dnsmadeeasy_secret_key'}),
+    # venv certbot-dns-nsone 2.10.0 (lexicon): option 'api-key'.
+    'nsone': ('dns-nsone', {'dns_nsone_api_key'}),
+    # venv certbot-dns-rfc2136 2.10.0: required 'server', 'name', 'secret';
+    # 'algorithm' is a documented optional.
+    'rfc2136': ('dns-rfc2136',
+                {'dns_rfc2136_server', 'dns_rfc2136_name',
+                 'dns_rfc2136_secret', 'dns_rfc2136_algorithm'}),
+    # venv certbot-dns-hetzner 3.0.0: var 'api_token'.
+    'hetzner': ('dns-hetzner', {'dns_hetzner_api_token'}),
+    # venv certbot-dns-hetzner-cloud 1.0.5: var 'api_token'.
+    'hetzner-cloud': ('dns-hetzner-cloud', {'dns_hetzner_cloud_api_token'}),
+    # venv certbot-dns-porkbun 0.11.0: vars 'key', 'secret' (the #364 bug:
+    # CertMate wrote dns_porkbun_api_key / dns_porkbun_secret_key).
+    'porkbun': ('dns-porkbun', {'dns_porkbun_key', 'dns_porkbun_secret'}),
+    # venv certbot-dns-godaddy 2.8.0 (lexicon): options 'key', 'secret'.
+    'godaddy': ('dns-godaddy', {'dns_godaddy_key', 'dns_godaddy_secret'}),
+    # sdist certbot-dns-he-ddns 0.1.0: only 'password' is required
+    # (dns_he_ddns.py). The username line CertMate also writes is not read
+    # by the plugin; certbot ignores unknown ini keys, so it is harmless,
+    # but it must never REPLACE the required password key.
+    'he-ddns': ('dns-he-ddns',
+                {'dns_he_ddns_username', 'dns_he_ddns_password'}),
+    # sdist certbot-dns-dynudns 0.0.6: entry point 'dns-dynu' (NOT
+    # dns-dynudns) with var 'auth-token' -> dns_dynu_auth_token.
+    'dynudns': ('dns-dynu', {'dns_dynu_auth_token'}),
+    # sdist certbot-dns-desec 1.3.2: var 'token'.
+    'desec': ('dns-desec', {'dns_desec_token'}),
+    # sdist certbot-dns-scaleway 0.0.7: var 'application_token'.
+    'scaleway': ('dns-scaleway', {'dns_scaleway_application_token'}),
+}
+
+
+def test_contract_covers_every_template_provider():
+    """Adding a provider to the template map without extending this contract
+    must fail loudly, or the change-detector silently stops detecting."""
+    assert set(EXPECTED_MULTI_PROVIDER_CONTRACT) == set(_MULTI_PROVIDER_TEMPLATE_MAP)
+
+
+@pytest.mark.parametrize('provider', sorted(EXPECTED_MULTI_PROVIDER_CONTRACT))
+def test_multi_provider_ini_keys_match_plugin_contract(provider):
+    _, expected_keys = EXPECTED_MULTI_PROVIDER_CONTRACT[provider]
+    generated_keys = set(_MULTI_PROVIDER_TEMPLATE_MAP[provider])
+    assert generated_keys == expected_keys, (
+        f"{provider}: generated ini keys {sorted(generated_keys)} do not match "
+        f"the certbot plugin's credential keys {sorted(expected_keys)} — the "
+        f"plugin would fail at issuance with 'Property not found'"
+    )
+
+
+@pytest.mark.parametrize('provider', sorted(EXPECTED_MULTI_PROVIDER_CONTRACT))
+def test_strategy_plugin_name_matches_entry_point(provider):
+    """--authenticator, --<name>-credentials and the ini key prefix all key on
+    the plugin's ENTRY-POINT name; a mismatch selects nothing (the dynudns
+    bug: the plugin registers 'dns-dynu', not 'dns-dynudns')."""
+    expected_plugin, _ = EXPECTED_MULTI_PROVIDER_CONTRACT[provider]
+    strategy = DNSStrategyFactory.get_strategy(provider)
+    assert strategy.plugin_name == expected_plugin
+
+
+@pytest.mark.parametrize('provider', sorted(EXPECTED_MULTI_PROVIDER_CONTRACT))
+def test_ini_key_prefix_matches_certbot_dest_namespace(provider):
+    """certbot resolves ini keys as dest_namespace(entry_point_name) + var
+    ('-' -> '_'), so every generated key must carry that exact prefix."""
+    expected_plugin, _ = EXPECTED_MULTI_PROVIDER_CONTRACT[provider]
+    prefix = expected_plugin.replace('-', '_') + '_'
+    for ini_key in _MULTI_PROVIDER_TEMPLATE_MAP[provider]:
+        assert ini_key.startswith(prefix), (
+            f"{provider}: ini key '{ini_key}' does not start with the "
+            f"dest namespace '{prefix}' of plugin '{expected_plugin}'"
+        )
+
+
+def _installed_certbot_plugins():
+    return {ep.name for ep in entry_points(group='certbot.plugins')}
+
+
+@pytest.mark.parametrize('provider', sorted(EXPECTED_MULTI_PROVIDER_CONTRACT))
+def test_expected_entry_point_exists_when_plugin_installed(provider):
+    """For plugins present in this venv, the expected entry-point name must be
+    REAL (registered), not just internally consistent. Skips plugins that are
+    documented as install-separately."""
+    expected_plugin, _ = EXPECTED_MULTI_PROVIDER_CONTRACT[provider]
+    installed = _installed_certbot_plugins()
+    if expected_plugin not in installed:
+        pytest.skip(f"plugin {expected_plugin} not installed in this venv")
+    assert expected_plugin in installed
+
+
+# ---------------------------------------------------------------------------
+# Dedicated create_*_config creators (single-provider ini writers)
+# ---------------------------------------------------------------------------
+
+def _captured_ini_keys(monkeypatch, creator, *args):
+    """Run a create_*_config creator with _create_config_file stubbed out and
+    return the set of ini keys it would have written."""
+    captured = {}
+
+    def _fake_create(plugin_name, content):
+        captured['content'] = content
+        return f'/dev/null/{plugin_name}.ini'
+
+    monkeypatch.setattr(utils_module, '_create_config_file', _fake_create)
+    creator(*args)
+    return {
+        line.split('=')[0].strip()
+        for line in captured['content'].splitlines() if '=' in line
+    }
+
+
+# creator -> (args, expected ini keys). Provenance per entry.
+DEDICATED_CREATOR_CONTRACT = {
+    # venv certbot-dns-cloudflare 2.10.0: 'api-token' (token auth path).
+    create_cloudflare_config: (('tok',), {'dns_cloudflare_api_token'}),
+    # venv certbot-dns-digitalocean 2.10.0: var 'token'.
+    create_digitalocean_config: (('tok',), {'dns_digitalocean_token'}),
+    # venv certbot-dns-linode 2.10.0: required 'key'; 'version' is a
+    # documented optional the plugin reads to select API v3/v4.
+    create_linode_config: (('k',), {'dns_linode_key', 'dns_linode_version'}),
+    # venv certbot-dns-gandi 1.6.1: 'token' (personal access token).
+    create_gandi_config: (('tok',), {'dns_gandi_token'}),
+    # venv certbot-dns-ovh 2.10.0 (lexicon): endpoint / application-key /
+    # application-secret / consumer-key.
+    create_ovh_config: (('e', 'ak', 'as', 'ck'),
+                        {'dns_ovh_endpoint', 'dns_ovh_application_key',
+                         'dns_ovh_application_secret', 'dns_ovh_consumer_key'}),
+    # venv certbot-dns-duckdns 1.8.0: var 'token'.
+    create_duckdns_config: (('tok',), {'dns_duckdns_token'}),
+    # venv certbot-dns-arvancloud 0.1.0: var 'api_token' (was drifted:
+    # CertMate wrote dns_arvancloud_api_key, which the plugin never reads).
+    create_arvancloud_config: (('tok',), {'dns_arvancloud_api_token'}),
+    # venv certbot-plugin-edgedns 0.1.0: entry point 'edgedns' (no dns-
+    # prefix), keys client_token / client_secret / access_token / host.
+    create_edgedns_config: (('ct', 'cs', 'at', 'h'),
+                            {'edgedns_client_token', 'edgedns_client_secret',
+                             'edgedns_access_token', 'edgedns_host'}),
+    # certbot-dns-powerdns 0.2.1 (NOT importable here — pinned from its
+    # README): dns_powerdns_api_url / dns_powerdns_api_key.
+    create_powerdns_config: (('https://pdns', 'k'),
+                             {'dns_powerdns_api_url', 'dns_powerdns_api_key'}),
+    # certbot-dns-infomaniak (NOT importable here — pinned from its README):
+    # dns_infomaniak_token.
+    create_infomaniak_config: (('tok',), {'dns_infomaniak_token'}),
+    # certbot-dns-namecheap 1.0.0 (alpha; NOT importable on Python 3.12 —
+    # pinned from its README): dns_namecheap_username / dns_namecheap_api_key.
+    create_namecheap_config: (('u', 'k'),
+                              {'dns_namecheap_username', 'dns_namecheap_api_key'}),
+}
+
+
+@pytest.mark.parametrize(
+    'creator', sorted(DEDICATED_CREATOR_CONTRACT, key=lambda f: f.__name__))
+def test_dedicated_creator_ini_keys_match_plugin_contract(creator, monkeypatch):
+    args, expected_keys = DEDICATED_CREATOR_CONTRACT[creator]
+    generated = _captured_ini_keys(monkeypatch, creator, *args)
+    assert generated == expected_keys, (
+        f"{creator.__name__}: writes {sorted(generated)}, plugin expects "
+        f"{sorted(expected_keys)}"
+    )

--- a/tests/test_renewal_reliability_hardening.py
+++ b/tests/test_renewal_reliability_hardening.py
@@ -473,3 +473,262 @@ def test_renew_reports_renewed_when_certbot_acts(tmp_path):
         res = mgr.renew_certificate(domain)
     assert res['success'] is True
     assert res['renewed'] is True
+
+
+# --------------------------------------------------------------------------
+# No-op renewal detection must be output-independent (fingerprint-based).
+# certbot 2.x under --quiet sends "not yet due for renewal" to /dev/null, so
+# a production no-op renew exits 0 with EMPTY output; the artifact (live
+# cert bytes) is the only signal certbot cannot suppress.
+# --------------------------------------------------------------------------
+
+class _SilentNoOpExecutor(MockShellExecutor):
+    """certbot exits 0 with EMPTY output and touches NO files — the exact
+    production shape of a --quiet no-op renew. produces_artifacts=True marks
+    this as a real execution so the fingerprint comparison is active."""
+    produces_artifacts = True
+
+    def __init__(self):
+        super().__init__()
+        self.set_next_result(returncode=0)
+
+
+class _SilentRenewExecutor(_RenewExecutor):
+    """Real-execution semantics (fingerprint comparison active) AND stages
+    changed live files, with empty output either way."""
+    produces_artifacts = True
+
+
+def _prep_live_cert(tmp_path, domain, content=b'live-cert-v1\n'):
+    live = tmp_path / domain / 'live' / domain
+    live.mkdir(parents=True, exist_ok=True)
+    for cert_file in CERTIFICATE_FILES:
+        (live / cert_file).write_bytes(content)
+    return live
+
+
+def test_renew_noop_detected_with_empty_output(tmp_path):
+    """rc=0 + empty stdout/stderr + unchanged live cert -> renewed=False and
+    renewed_at NOT stamped. The old sentinel-only check reported this as a
+    successful renewal because the sentinel text never appears under --quiet."""
+    domain = 'silent-noop.example.com'
+    _prep_existing_cert(tmp_path, domain, metadata={})
+    _prep_live_cert(tmp_path, domain)
+    mgr = _make_cert_mgr(tmp_path, _SilentNoOpExecutor())
+    with patch.object(CertificateManager, '_write_pfx', return_value=None):
+        res = mgr.renew_certificate(domain)
+    assert res['success'] is True
+    assert res['renewed'] is False
+    meta = json.loads((tmp_path / domain / 'metadata.json').read_text())
+    assert 'renewed_at' not in meta
+
+
+def test_renew_detected_when_cert_bytes_change(tmp_path):
+    """rc=0 + empty output + CHANGED live cert bytes -> renewed=True with
+    renewed_at stamped (a real renewal says nothing under --quiet either)."""
+    domain = 'silent-renew.example.com'
+    _prep_existing_cert(tmp_path, domain, metadata={})
+    _prep_live_cert(tmp_path, domain)  # executor overwrites with new bytes
+    mgr = _make_cert_mgr(tmp_path, _SilentRenewExecutor(tmp_path, domain))
+    with patch.object(CertificateManager, '_write_pfx', return_value=None):
+        res = mgr.renew_certificate(domain)
+    assert res['success'] is True
+    assert res['renewed'] is True
+    meta = json.loads((tmp_path / domain / 'metadata.json').read_text())
+    assert 'renewed_at' in meta
+
+
+def test_renew_detected_when_live_cert_appears(tmp_path):
+    """Missing-before but present-after live cert counts as a renewal."""
+    domain = 'fresh-live.example.com'
+    _prep_existing_cert(tmp_path, domain, metadata={})
+    # No pre-existing live dir: the executor materialises it.
+    mgr = _make_cert_mgr(tmp_path, _SilentRenewExecutor(tmp_path, domain))
+    with patch.object(CertificateManager, '_write_pfx', return_value=None):
+        res = mgr.renew_certificate(domain)
+    assert res['renewed'] is True
+
+
+def test_renew_sentinel_still_detected_for_mock_executors(tmp_path):
+    """Non-artifact-producing doubles keep sentinel-based detection: the
+    fingerprint would always read 'unchanged' for them and falsely no-op."""
+    domain = 'mock-sentinel.example.com'
+    _prep_existing_cert(tmp_path, domain, metadata={})
+    shell = MockShellExecutor()
+    shell.set_next_result(returncode=0, stdout='no renewals were attempted')
+    mgr = _make_cert_mgr(tmp_path, shell)
+    with patch.object(CertificateManager, '_write_pfx', return_value=None):
+        res = mgr.renew_certificate(domain)
+    assert res['renewed'] is False
+
+
+def test_check_renewals_routes_silent_noop_to_skipped_not_due(tmp_path):
+    """A silent no-op renew must be counted as skipped_not_due — never as
+    renewed — and must fire NO deploy hook event and NO success audit."""
+    domain = 'sched-noop.example.com'
+    _prep_existing_cert(tmp_path, domain, metadata={})
+    _prep_live_cert(tmp_path, domain)
+    mgr = _make_cert_mgr(tmp_path, _SilentNoOpExecutor())
+    mgr.settings_manager.load_settings.return_value = {
+        'auto_renew': True, 'domains': [{'domain': domain}],
+    }
+    mgr.settings_manager.migrate_domains_format.side_effect = lambda s: s
+    mgr._publish_renewed_event = MagicMock()
+    mgr._audit_scheduled_renew = MagicMock()
+    with patch.object(CertificateManager, 'get_certificate_info',
+                      return_value={'needs_renewal': True}), \
+         patch.object(CertificateManager, '_write_pfx', return_value=None):
+        summary = mgr.check_renewals()
+    assert summary['skipped_not_due'] == 1
+    assert summary['renewed'] == 0
+    mgr._publish_renewed_event.assert_not_called()
+    mgr._audit_scheduled_renew.assert_not_called()
+
+
+def test_check_renewals_counts_real_renewal_and_fires_hook(tmp_path):
+    domain = 'sched-renew.example.com'
+    _prep_existing_cert(tmp_path, domain, metadata={})
+    _prep_live_cert(tmp_path, domain)
+    mgr = _make_cert_mgr(tmp_path, _SilentRenewExecutor(tmp_path, domain))
+    mgr.settings_manager.load_settings.return_value = {
+        'auto_renew': True, 'domains': [{'domain': domain}],
+    }
+    mgr.settings_manager.migrate_domains_format.side_effect = lambda s: s
+    mgr._publish_renewed_event = MagicMock()
+    mgr._audit_scheduled_renew = MagicMock()
+    with patch.object(CertificateManager, 'get_certificate_info',
+                      return_value={'needs_renewal': True}), \
+         patch.object(CertificateManager, '_write_pfx', return_value=None):
+        summary = mgr.check_renewals()
+    assert summary['renewed'] == 1
+    assert summary['skipped_not_due'] == 0
+    mgr._publish_renewed_event.assert_called_once_with(domain)
+
+
+# --------------------------------------------------------------------------
+# API/web honesty: the renew responses must carry 'renewed' and must not
+# claim (or event-broadcast) a renewal that certbot no-oped.
+# --------------------------------------------------------------------------
+
+def _build_api_app(tmp_path, renew_result):
+    from flask_restx import Api, Namespace
+    from modules.api.models import create_api_models
+    from modules.api.resources import create_api_resources
+
+    auth = MagicMock()
+    auth.require_role = MagicMock(side_effect=_passthrough_decorator)
+    auth.user_can_access_domain.return_value = True
+
+    certs = MagicMock(cert_dir=Path(tmp_path))
+    certs.renew_certificate.return_value = renew_result
+
+    settings = MagicMock()
+    settings.load_settings.return_value = {
+        'email': 'ops@example.com', 'dns_provider': 'cloudflare',
+        'default_ca': 'letsencrypt', 'challenge_type': 'dns-01'}
+
+    managers = {
+        'auth': auth, 'settings': settings, 'certificates': certs,
+        'file_ops': MagicMock(cert_dir=Path(tmp_path)), 'cache': MagicMock(),
+        'dns': MagicMock(), 'audit': None, 'cert_executor': None,
+    }
+
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['EVENT_BUS'] = MagicMock()
+    api = Api(app, prefix='/api')
+    models = create_api_models(api)
+    resources = create_api_resources(api, models, managers)
+    ns = Namespace('certificates', description='certs')
+    api.add_namespace(ns)
+    ns.add_resource(resources['RenewCertificate'], '/<string:domain>/renew')
+
+    @app.before_request
+    def _attach_user():
+        request.current_user = {'username': 'op', 'role': 'operator', 'allowed_domains': None}
+
+    return app
+
+
+def test_api_renew_response_reports_noop_honestly(tmp_path):
+    app = _build_api_app(tmp_path, {
+        'success': True, 'renewed': False, 'domain': 'x.example.com',
+        'message': 'Certificate not yet due for renewal'})
+    r = app.test_client().post('/api/certificates/x.example.com/renew')
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body['renewed'] is False
+    assert 'not yet due' in body['message']
+    assert 'renewed successfully' not in body['message']
+    # Nothing was replaced: deploy hooks must not fire.
+    app.config['EVENT_BUS'].publish.assert_not_called()
+
+
+def test_api_renew_response_reports_real_renewal(tmp_path):
+    app = _build_api_app(tmp_path, {
+        'success': True, 'renewed': True, 'domain': 'x.example.com',
+        'message': 'Certificate renewed successfully'})
+    r = app.test_client().post('/api/certificates/x.example.com/renew')
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body['renewed'] is True
+    assert 'renewed successfully' in body['message']
+    app.config['EVENT_BUS'].publish.assert_called_once_with(
+        'certificate_renewed', {'domain': 'x.example.com'})
+
+
+def test_api_renew_defaults_renewed_true_for_legacy_results(tmp_path):
+    """Frozen compat contract: a manager result without the 'renewed' key
+    (older shape) must keep reporting a successful renewal."""
+    app = _build_api_app(tmp_path, {'success': True, 'domain': 'x.example.com'})
+    r = app.test_client().post('/api/certificates/x.example.com/renew')
+    assert r.status_code == 200
+    assert r.get_json()['renewed'] is True
+
+
+def _build_web_app(tmp_path, renew_result):
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+
+    certificate_manager = MagicMock(cert_dir=Path(tmp_path))
+    certificate_manager.renew_certificate.return_value = renew_result
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough_decorator)
+    auth_manager.domain_matches_scope.return_value = True
+    settings_manager = MagicMock()
+    settings_manager.load_settings.return_value = {'email': 'ops@example.com'}
+
+    register_cert_routes(
+        app, {'audit': MagicMock(), 'cert_service': None}, _passthrough_decorator,
+        auth_manager, certificate_manager,
+        lambda d, cert_dir: (Path(cert_dir) / d, None), MagicMock(cert_dir=Path(tmp_path)),
+        settings_manager, MagicMock(), CERTIFICATE_FILES,
+    )
+
+    @app.before_request
+    def _attach_user():
+        request.current_user = {'username': 'op', 'role': 'operator', 'allowed_domains': None}
+
+    return app
+
+
+def test_web_renew_response_reports_noop_honestly(tmp_path):
+    app = _build_web_app(tmp_path, {
+        'success': True, 'renewed': False, 'domain': 'x.example.com',
+        'message': 'Certificate not yet due for renewal'})
+    r = app.test_client().post('/api/web/certificates/x.example.com/renew')
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body['renewed'] is False
+    assert body['message'] == 'Certificate not yet due for renewal'
+
+
+def test_web_renew_response_reports_real_renewal(tmp_path):
+    app = _build_web_app(tmp_path, {
+        'success': True, 'renewed': True, 'domain': 'x.example.com',
+        'message': 'Certificate renewed successfully'})
+    r = app.test_client().post('/api/web/certificates/x.example.com/renew')
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body['renewed'] is True
+    assert body['message'] == 'Certificate renewed successfully'

--- a/tests/test_reset_admin_password_script.py
+++ b/tests/test_reset_admin_password_script.py
@@ -1,0 +1,90 @@
+"""Regression tests for scripts/reset_admin_password.py (issue #383).
+
+The emergency reset script must actually create the admin user in the
+settings file it claims to have updated — including on a fresh install
+whose settings.json has no "users" key at all, which is precisely the
+state in which an operator reaches for this script.
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "reset_admin_password.py"
+
+PASSWORD = "SuperSecretPassw0rd!"
+
+
+def _run_script(settings_path: Path):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        input=f"{PASSWORD}\n{PASSWORD}\n",
+        capture_output=True,
+        text=True,
+        env={**os.environ, "CERTMATE_SETTINGS_PATH": str(settings_path)},
+        timeout=60,
+    )
+
+
+def _assert_admin_written(settings_path: Path):
+    data = json.loads(settings_path.read_text())
+    assert "users" in data, "script reported success but wrote no users key"
+    admin = data["users"].get("admin")
+    assert admin, "script reported success but the admin user is missing"
+    assert admin["role"] == "admin"
+    assert admin["enabled"] is True
+
+    import bcrypt
+
+    assert bcrypt.checkpw(PASSWORD.encode(), admin["password_hash"].encode())
+
+
+def test_creates_admin_when_users_key_is_absent(tmp_path):
+    """Fresh-install shape: no 'users' key at all (the #383 scenario)."""
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({"domains": [], "email": "a@b.c"}))
+
+    result = _run_script(settings_path)
+
+    assert result.returncode == 0, result.stderr
+    _assert_admin_written(settings_path)
+    # Other keys must be preserved.
+    data = json.loads(settings_path.read_text())
+    assert data["email"] == "a@b.c"
+
+
+def test_creates_admin_when_users_dict_is_empty(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({"users": {}}))
+
+    result = _run_script(settings_path)
+
+    assert result.returncode == 0, result.stderr
+    _assert_admin_written(settings_path)
+
+
+def test_resets_existing_admin_password(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "users": {
+                    "admin": {
+                        "password_hash": "$2b$12$invalidoldhashvalue",
+                        "role": "admin",
+                        "enabled": True,
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                    }
+                }
+            }
+        )
+    )
+
+    result = _run_script(settings_path)
+
+    assert result.returncode == 0, result.stderr
+    _assert_admin_written(settings_path)
+    # created_at must be preserved, not regenerated.
+    data = json.loads(settings_path.read_text())
+    assert data["users"]["admin"]["created_at"] == "2026-01-01T00:00:00+00:00"


### PR DESCRIPTION
## v2.21.1 (Hardening — truth in reporting, across server, clients and CI)

One theme: every path that could report success while silently not doing the thing now tells the truth. Found by a full-project adversarial review (six parallel audit passes over the codebase, the shipped clients, the previously-open P2 tail, GitHub state and CI), and every defect below was hand-verified in code before being fixed.

### Server

- **Renewal no-op detection now works in production.** The v2.20.0 "not yet due" detection matched certbot's notification text, but the renew command ran with `--quiet`, which routes exactly that text to /dev/null in certbot 2.10.0 — so the detection was dead code outside tests: a daily no-op renew stamped `renewed_at`, counted as renewed, audited success and fired deploy hooks. Detection is now artifact-based (the SHA256 of the live `cert.pem` before vs after certbot, with the text sentinel kept as a cross-check), `--quiet` is gone, the renew API and web responses carry a machine-readable `renewed: true/false` field, and the `certificate_renewed` event only fires when something was actually renewed.
- **Audit verify fails closed on unreadable integrity evidence.** An I/O error reading the checkpoint file was treated as "no checkpoints ever existed", so wiping the chain file while making checkpoints unreadable yielded a benign `200 state='absent'`. Checkpoint read errors are now distinct from absence and verify answers `409` ("checkpoint file unreadable"). The absent-vs-tampered decision also moved from reason-string matching to a structured `chain_file_missing` flag.
- **Four DNS providers were silently broken; all fixed and now contract-tested.** Porkbun wrote the wrong credential keys (community fix by @cre8ivejp, #363/#364); the same hunt found Vultr (`dns_vultr_key`), ArvanCloud (`dns_arvancloud_api_token`) and Dynu (wrong plugin name `dns-dynudns` — the plugin registers `dns-dynu` — plus wrong credential key) equally dead. A new contract test pins the credential-file key names CertMate writes, the plugin entry-point names and the flag namespaces against what each pinned certbot plugin actually reads, for every provider — a silently dead provider can no longer pass CI.
- **DNS provider preflight usable from the terminal.** `POST /api/dns/test-provider` with an empty config now falls back to the stored account credentials for that provider (explicit config still wins), which is what a CLI preflight means.
- **`reset_admin_password.py` actually creates the admin user** (#383). On a fresh settings.json with no `users` key, the script printed "reset successfully" while writing a file with no user at all — the operator stayed locked out of a brand-new install. Regression tests now run the script end-to-end against users-less, empty-users and existing-admin settings files.
- **Deploy-hook output is redacted before it is stored.** Hook stdout/stderr flowed verbatim into deploy history, the audit log and the append-only hash chain — any secret a hook echoed became unredactable without breaking the chain. Output now passes the secret-pattern sanitizer at the single choke point that feeds all three.
- **Google service-account keys no longer linger on disk**: the per-operation SA JSON is deleted in the same `finally` that removes the credentials INI (the hourly orphan sweep stays as belt and braces).
- **Group-writable custom DNS hook scripts are rejected**, not just warned about, matching the existing world-writable rule.
- **The edit-certificate drawer is titled "Edit Certificate"** instead of presenting as create (#382).

### Terminal clients 0.1.2 (`certmate-sdk`, `certmate-cli`)

0.1.1 shipped several commands that lied; 0.1.2 makes them honest and is the recommended upgrade for anyone scripting against the API.

- **`audit verify` no longer exits 0 on a tampered chain.** The CLI matched the human reason string, which is identical for "fresh instance" (benign) and "chain file deleted after signed checkpoints" (the tamper case the server answers with 409). Benign is now only the server's explicit `state='absent'`; anything else broken exits 1, and the SDK preserves the HTTP status on the result (`_http_status`) so clients cannot lose the distinction.
- **`cert renew --force` actually forces.** The SDK sent `force` as a query parameter; the server reads the JSON body. It is in the body now.
- **`cert renew` reports the real outcome** — renewed, "not due" with the server's message, or a neutral "server did not report the outcome" against pre-2.21.1 servers. It never fabricates a green "renewed", and the renew call gets a 600s timeout so real DNS-01 renewals stop dying client-side at 30s.
- **`--dry-run` and `dns test` work.** The SDK sent a body shape the server never accepted, so the documented preflight failed on every server, including perfectly configured ones. Paired with the server-side stored-credentials fallback above.
- **No more raw tracebacks.** Transport failures (server down, timeout, keep-alive race) surface as one clean error line via the new `TransportError`; `wait_for_job` tolerates transient poll blips and treats a job evicted after completion as success when the certificate exists.
- **Smaller truths**: `download` format mapping fixed (json/zip/pem/pfx now request what the server actually serves); staging certificates no longer render `CA: True`; SAN parsing drops empty entries; `--token` on argv warns that `CERTMATE_TOKEN` is preferred (thanks @gitcommit90 for #378/#379, folded in).

### CI and supply chain

- **`:latest` now means released.** The Docker Hub `latest` tag is published only by `v*` tag builds — cut after the release gate that includes real-certificate issuance against Let's Encrypt staging. Pushes to main get branch tags only; previously every merge to main shipped `:latest` with zero real-ACME validation.
- **The weekly real-ACME e2e can no longer be silently off.** If the scheduled run fires while its gate is disabled, a guard job fails loudly with wiring instructions instead of skipping green forever.
- **Dependabot stops fighting the pinned ACME stack** (ignore rules for certbot/josepy/acme and plugin majors, referencing #103).
- **The open `cryptography` CVE alerts are documented, not ignored.** Fixing GHSA-537c-gmf6-5ccf requires cryptography >=48.0.1, which requires pyOpenSSL >=26.2.0, which removed an API that acme 3.3.0 imports — every certbot invocation crashes (verified empirically). SECURITY.md now carries the full constraint chain and the exposure analysis: the vulnerable OpenSSL routine (`PKCS7_verify()`) is unreachable from CertMate's code paths. The real fix is the certbot 5.x migration (#103).
- **The clients publish workflow is pinned and gated**: `pypa/gh-action-pypi-publish` moved from a mutable branch ref to a commit SHA, and a version-consistency job refuses to publish when the pushed `clients-v*` tag does not match both package versions.

## Process

Six parallel adversarial audit passes over the repo, the shipped clients, the open P2 tail, GitHub state and CI; every finding hand-verified in code before fixing. Four workstreams executed in isolated worktrees and merged here:

- server hardening (renewal truth, audit fail-closed, dns-test fallback, provider key contract test, #382, #383)
- clients 0.1.2 (all shipped-broken commands fixed; publish workflow SHA-pinned + tag/version gated)
- dependency CVE assessment (bump empirically blocked by acme 3.3.0 - documented in SECURITY.md, evidence on #103)
- CI honesty (:latest only from release tags; weekly e2e gate fails loudly when off; dependabot ignore rules per #103)

Closes #363 (merged fix #364 already on main; contract test here). Closes #378 (via #379, folded into the clients rewrite). Closes #382. Closes #383.

Gates run locally on this branch: flake8 hard subset, bandit medium+ (0), full non-e2e suite **1702 passed / 6 skipped**. Release will follow scripts/release.sh with the mandatory real-cert e2e (issuance pipeline touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)