### PR TITLE
fix(auth): OIDC-only deployments no longer stay world-open (critical setup-mode bypass)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 ## v2.21.1 (Hardening — truth in reporting, across server, clients and CI)
 
-One theme: every path that could report success while silently not doing the thing now tells the truth. Found by a full-project adversarial review (six parallel audit passes over the codebase, the shipped clients, the previously-open P2 tail, GitHub state and CI), and every defect below was hand-verified in code before being fixed.
+One theme: every path that could report success while silently not doing the thing now tells the truth. Found by a full-project adversarial review (parallel audit passes over the codebase, the shipped clients, the previously-open P2 tail, GitHub state and CI), and every defect below was hand-verified in code before being fixed.
+
+### Security
+
+- **OIDC/SSO-only deployments are no longer world-open (critical, pre-existing).** `is_setup_mode()` decided whether to allow unauthenticated bootstrap access from two operator-credential sources — local-auth-plus-a-user, or an `API_BEARER_TOKEN` — but never consulted OIDC. On an SSO-only box (OIDC enabled, no bearer token, local password auth left disabled) the local-auth branch can never become true (OIDC's just-in-time user provisioning never enables local auth), so the instance stayed in setup mode permanently and served every gated endpoint — read settings, download private keys, issue and delete certificates — to anonymous callers as admin. Setup mode now also turns off when OIDC is fully configured (enabled + issuer_url + client_id), matching how a configured bearer token already behaves; a partially-configured OIDC box still allows bootstrap so the operator can finish setup.
 
 ### Server
 

--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -784,6 +784,22 @@ class AuthManager:
             self._operator_bearer_token = cached
         return cached
 
+    def _is_oidc_configured(self):
+        """True iff the operator fully configured OIDC (enabled + issuer_url +
+        client_id). That is an operator-controlled credential exactly like
+        API_BEARER_TOKEN or local-auth-plus-a-user, so it must turn setup mode
+        OFF. Otherwise an SSO-only deployment (no bearer token, local auth left
+        disabled) stays in setup mode forever and serves every gated endpoint
+        to anonymous callers as admin — local_auth_enabled defaults False and
+        OIDC JIT provisioning never flips it, so the local-auth branch below
+        can never become True on such a box. Mirrors OIDCManager.is_enabled()
+        without importing it (settings is the single source of truth)."""
+        try:
+            cfg = self.settings_manager.load_settings().get('oidc', {}) or {}
+        except (OSError, ValueError, KeyError, AttributeError):
+            return False
+        return bool(cfg.get('enabled') and cfg.get('issuer_url') and cfg.get('client_id'))
+
     def is_setup_mode(self):
         """True on a genuinely unconfigured instance, where unauthenticated
         access is allowed so the operator can bootstrap (reach the UI, create
@@ -791,15 +807,17 @@ class AuthManager:
 
         Becomes False as soon as ANY credential the operator controls exists:
           * local auth is enabled AND at least one user exists, OR
-          * the operator provided an API bearer token (API_BEARER_TOKEN[_FILE]).
+          * the operator provided an API bearer token (API_BEARER_TOKEN[_FILE]), OR
+          * OIDC is fully configured (enabled + issuer_url + client_id).
 
         Once False, every gated surface requires a real credential. This closes
-        the gap where an API-only operator set API_BEARER_TOKEN — which
-        docs/api.md documents as *required on all endpoints* — but the token
-        was never enforced because local auth stayed off, leaving the whole
-        instance world-open. A fresh install with no operator-provided token is
-        unchanged: it stays in setup mode so onboarding works."""
+        the gap where an operator configured auth — API_BEARER_TOKEN, or an
+        OIDC/SSO-only deployment — but the instance stayed world-open because
+        local auth was never enabled. A fresh install with no operator-provided
+        credential is unchanged: it stays in setup mode so onboarding works."""
         if self.has_operator_bearer_token():
+            return False
+        if self._is_oidc_configured():
             return False
         return not (self.is_local_auth_enabled() and self.has_any_users())
     

--- a/tests/test_auth_setup_mode.py
+++ b/tests/test_auth_setup_mode.py
@@ -23,12 +23,15 @@ def _valid_token():
     return generate_secure_token(40)
 
 
-def _auth(local_auth=False, users=None):
+def _auth(local_auth=False, users=None, oidc=None):
     sm = MagicMock()
-    sm.load_settings.return_value = {
+    settings = {
         'local_auth_enabled': local_auth,
         'users': users or {},
     }
+    if oidc is not None:
+        settings['oidc'] = oidc
+    sm.load_settings.return_value = settings
     return AuthManager(sm)
 
 
@@ -114,3 +117,44 @@ def test_generated_token_does_not_force_enforcement(monkeypatch):
     a = _auth(local_auth=False, users={})
     assert a.has_operator_bearer_token() is False
     assert a.is_setup_mode() is True
+
+
+# --- OIDC-only deployments --------------------------------------------------
+
+_FULL_OIDC = {
+    'enabled': True,
+    'issuer_url': 'https://idp.example.com',
+    'client_id': 'certmate',
+}
+
+
+def test_setup_mode_false_when_oidc_fully_configured(monkeypatch):
+    """The fix: an SSO-only deployment (OIDC enabled + issuer + client_id, no
+    bearer token, local auth off) must NOT stay world-open. Before the fix
+    is_setup_mode() ignored OIDC and returned True forever, serving every
+    gated endpoint to anonymous callers as admin."""
+    _clear_token_env(monkeypatch)
+    a = _auth(local_auth=False, users={}, oidc=dict(_FULL_OIDC))
+    assert a.is_setup_mode() is False
+
+
+def test_setup_mode_false_oidc_even_after_jit_users(monkeypatch):
+    """JIT-provisioned OIDC users never flip local_auth_enabled, so the
+    local-auth branch stays False; OIDC being configured is what closes it."""
+    _clear_token_env(monkeypatch)
+    a = _auth(local_auth=False,
+              users={'alice': {'role': 'admin', 'oidc_subject': 'sub-1'}},
+              oidc=dict(_FULL_OIDC))
+    assert a.is_setup_mode() is False
+
+
+def test_setup_mode_true_when_oidc_enabled_but_incomplete(monkeypatch):
+    """enabled=True but issuer/client_id blank is NOT a usable credential, so
+    onboarding must still work (mirrors OIDCManager.is_enabled semantics) —
+    the operator can still reach the box to finish configuring it."""
+    _clear_token_env(monkeypatch)
+    for partial in ({'enabled': True, 'issuer_url': '', 'client_id': 'certmate'},
+                    {'enabled': True, 'issuer_url': 'https://idp', 'client_id': ''},
+                    {'enabled': False, 'issuer_url': 'https://idp', 'client_id': 'certmate'}):
+        a = _auth(local_auth=False, users={}, oidc=partial)
+        assert a.is_setup_mode() is True, partial


### PR DESCRIPTION
## Critical, pre-existing auth bypass — found by the post-v2.21.1 next-layer audit

`is_setup_mode()` (modules/core/auth.py) allowed unauthenticated bootstrap access based on two operator credentials — local-auth-plus-a-user, or an `API_BEARER_TOKEN` — but **never consulted OIDC**.

On an **SSO-only deployment** (OIDC enabled, no bearer token, local password auth left disabled — the natural config for "we only want SSO"), the local-auth branch can never become true: OIDC just-in-time user provisioning writes user rows but never sets `local_auth_enabled`. So `is_setup_mode()` returns True forever, and `_authenticate_request()` short-circuits every `@require_auth`/`@require_role` to `{'username':'setup_user','role':'admin'}`. An unauthenticated attacker can read settings, download private keys, and issue/delete certificates as admin.

### Fix
Setup mode now also turns off when OIDC is fully configured (`enabled + issuer_url + client_id`), mirroring `OIDCManager.is_enabled()` and the existing bearer-token behaviour. A **partially**-configured OIDC box still allows bootstrap, so an operator mid-setup is never locked out.

### Tests
`tests/test_auth_setup_mode.py`: SSO-only bypass now closed; post-JIT-users case; partial-config still bootstraps. Verified the new test fails without the fix. Full `test_auth_setup_mode.py` + related auth/oidc unit tests green.

Folded into the v2.21.1 release (RELEASE_NOTES updated). Ships before the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)