### PR TITLE
ci: run test + frontend-css on GitHub-hosted runners (drop the self-hosted bottleneck)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,19 +22,18 @@ concurrency:
 
 jobs:
   test:
-    # Host-global serialization. The e2e suite (tests/conftest.py) binds a
-    # FIXED-name container (certmate-test-suite) and port (18888) on the
-    # self-hosted host and `docker rm -f`s it on startup, so two test jobs from
-    # DIFFERENT refs/PRs running at once cycle each other's container mid-run
-    # and the HTTP e2e tests fail with connection-refused (observed when two
-    # PRs were opened together). The per-ref group above cannot see across
-    # refs; this single host-wide group makes every test job — regardless of
-    # branch — queue and run one at a time. cancel-in-progress:false so a
-    # waiting PR's tests are queued, never dropped.
-    concurrency:
-      group: certmate-selfhosted-test-container
-      cancel-in-progress: false
-    runs-on: [self-hosted, Linux, X64]
+    # GitHub-hosted, ephemeral VM per job. The e2e suite (tests/conftest.py)
+    # builds and runs a FIXED-name container (certmate-test-suite) on port
+    # 18888; on a shared self-hosted host, two test jobs from different
+    # refs/PRs clobbered each other's container mid-run, which forced a
+    # host-global concurrency group that serialized every test job one at a
+    # time (a single-point bottleneck: a burst of PRs + Dependabot builds
+    # queued for 10-20 min behind one box). On ubuntu-latest every job gets
+    # its own VM and localhost, so there is no cross-ref collision and no need
+    # to serialize. Docker is preinstalled, so the container e2e tests still
+    # run. The per-ref concurrency group at the top of the file still cancels
+    # a branch's own superseded runs.
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         # 3.12 matches the production Dockerfile. Python 3.14 is temporarily
@@ -117,7 +116,7 @@ jobs:
   # rebuild. This job rebuilds from source and fails if the committed output
   # drifts, forcing `npm run css:build` to be part of every CSS-touching PR.
   frontend-css:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4


### PR DESCRIPTION
## Why

Right now `test` and `frontend-css` run on `[self-hosted, Linux, X64]` (your Contabo box), and the `test` job carries a **host-global concurrency group** (`certmate-selfhosted-test-container`, cancel-in-progress:false) that serializes every test job across all refs one at a time. The reason was real — the e2e suite binds a fixed container name (`certmate-test-suite`) + port (18888), so two test jobs on the same host clobber each other.

The cost: the box is a **single point of failure and a queue**. A burst of PRs + Dependabot multi-arch builds waits 10-20 min behind it (observed today: a PR's `test (3.12)` sat 'Waiting for a runner' while 4 runners were all busy). External contributors can't get CI at all unless the box is up.

## What

Move `test` and `frontend-css` to `ubuntu-latest`. Every job gets its own ephemeral VM + localhost, so there's **no cross-ref container collision** and the serialization is no longer needed (removed the host-global concurrency group; the per-ref `ci-${{ github.ref }}` group at the top still cancels a branch's own superseded runs). Docker is preinstalled on ubuntu-latest, so the container e2e tests still run.

**This PR proves itself**: its own `test (3.12)` runs on ubuntu-latest — if it's green, GitHub-hosted works for the full suite (unit + container e2e + docker build).

The multi-arch image build (`Build Multi-Platform Docker Images`) stays self-hosted for now — QEMU multi-arch on GitHub-hosted is slow; can be split (single-arch amd64 on PRs, multi-arch on tags) as a follow-up if you want full independence.

Note: after merge, update the required-status-check names in branch protection if the check contexts change (they shouldn't — job names are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)