### PR TITLE
fix: unblock first-run on bearer-only deployments without reopening the setup bypass (#397)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,11 @@ cp .env.example .env
 Edit `.env` file with your credentials:
 
 ```bash
-# Required: API Security
+# Recommended for any network-exposed deployment: API Security.
+# Auto-generated if unset, but a not-yet-onboarded instance serves the
+# first-run setup bypass to anyone who can reach it — set this (or bind to
+# localhost) before exposing CertMate. When set, the first-run screen asks
+# you to paste this same token once to create the initial admin.
 API_BEARER_TOKEN=your_super_secure_api_token_here_change_this
 
 # DNS Provider Configuration (choose one or multiple)

--- a/docs/de/docker.md
+++ b/docs/de/docker.md
@@ -98,7 +98,7 @@ docker run -d --name certmate \
 |----------|--------------|--------------|
 | `SECRET_KEY` | Nein | Flask-Secret-Key für Sessions (wird automatisch generiert, wenn nicht gesetzt) |
 | `SECRET_KEY_FILE` | Nein | Pfad zu einer Datei mit dem Flask-Secret-Key (hat Vorrang vor `SECRET_KEY`) |
-| `API_BEARER_TOKEN` | Nein | Authentifizierungs-Token für den API-Zugriff (wird automatisch generiert, wenn nicht gesetzt) |
+| `API_BEARER_TOKEN` | Nein (automatisch generiert) | API-Authentifizierungs-Token. Wird automatisch generiert, wenn nicht gesetzt, aber setzen Sie es, bevor Sie eine noch nicht eingerichtete Instanz im Netzwerk verfügbar machen; wenn gesetzt, fügen Sie es einmal im Erststart-Bildschirm ein, um den Admin zu erstellen |
 | `API_BEARER_TOKEN_FILE` | Nein | Pfad zu einer Datei mit dem API-Bearer-Token (hat Vorrang vor `API_BEARER_TOKEN`) |
 | `LOG_LEVEL` | Nein | `INFO` (Standard), `DEBUG`, `WARNING`, `ERROR` |
 | `CERTMATE_BACKUP_PASSPHRASE` | Nein | Wenn gesetzt, werden einheitliche Backups im Ruhezustand verschlüsselt (`.zip.enc`, PBKDF2-SHA256 + Fernet). Dieselbe Passphrase wird zur Wiederherstellung benötigt. Nicht gesetzt = ältere unverschlüsselte `.zip`-Backups |

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -61,6 +61,10 @@ Create a `.env` file on your host (not in the Docker image):
 ```bash
 SECRET_KEY=your-super-secret-key-here
 # SECRET_KEY_FILE=/run/secrets/secret_key  # Alternative: takes precedence over SECRET_KEY
+# Set API_BEARER_TOKEN before exposing a not-yet-onboarded instance to a
+# network: until the first admin exists, an instance with no token serves the
+# setup bypass to anyone who can reach it. When set, paste it once on the
+# first-run screen to create the admin.
 API_BEARER_TOKEN=your-api-bearer-token-here
 # API_BEARER_TOKEN_FILE=/run/secrets/api_bearer_token  # Alternative: takes precedence over API_BEARER_TOKEN
 CLOUDFLARE_API_TOKEN=your-cloudflare-api-token
@@ -98,7 +102,7 @@ docker run -d --name certmate \
 |----------|----------|-------------|
 | `SECRET_KEY` | No | Flask secret key for sessions (auto-generated if unset) |
 | `SECRET_KEY_FILE` | No | Path to a file containing the Flask secret key (takes precedence over `SECRET_KEY`) |
-| `API_BEARER_TOKEN` | No | Authentication token for API access (auto-generated if unset) |
+| `API_BEARER_TOKEN` | No (auto-generated) | API auth token. Auto-generated if unset, but set it before exposing a not-yet-onboarded instance to a network; when set, paste it once on the first-run screen to create the admin |
 | `API_BEARER_TOKEN_FILE` | No | Path to a file containing the API bearer token (takes precedence over `API_BEARER_TOKEN`) |
 | `LOG_LEVEL` | No | `INFO` (default), `DEBUG`, `WARNING`, `ERROR` |
 | `CERTMATE_BACKUP_PASSPHRASE` | No | When set, unified backups are encrypted at rest (`.zip.enc`, PBKDF2-SHA256 + Fernet). The same passphrase is required to restore them. Unset = legacy cleartext `.zip` backups |

--- a/docs/es/docker.md
+++ b/docs/es/docker.md
@@ -98,7 +98,7 @@ docker run -d --name certmate \
 |----------|-----------|-------------|
 | `SECRET_KEY` | No | Clave secreta de Flask para las sesiones (se genera automáticamente si no se define) |
 | `SECRET_KEY_FILE` | No | Ruta a un archivo que contiene la clave secreta de Flask (tiene prioridad sobre `SECRET_KEY`) |
-| `API_BEARER_TOKEN` | No | Token de autenticación para el acceso a la API (se genera automáticamente si no se define) |
+| `API_BEARER_TOKEN` | No (autogenerado) | Token de autenticación de la API. Se genera automáticamente si no se define, pero defínelo antes de exponer en red una instancia aún sin configurar; cuando está definido, pégalo una vez en la pantalla de primer inicio para crear el admin |
 | `API_BEARER_TOKEN_FILE` | No | Ruta a un archivo que contiene el bearer token de la API (tiene prioridad sobre `API_BEARER_TOKEN`) |
 | `LOG_LEVEL` | No | `INFO` (por defecto), `DEBUG`, `WARNING`, `ERROR` |
 | `CERTMATE_BACKUP_PASSPHRASE` | No | Cuando se define, las copias de seguridad unificadas se cifran en reposo (`.zip.enc`, PBKDF2-SHA256 + Fernet). Se requiere la misma frase de contraseña para restaurarlas. Sin definir = copias de seguridad en texto claro `.zip` (comportamiento heredado) |

--- a/docs/fr/docker.md
+++ b/docs/fr/docker.md
@@ -96,7 +96,7 @@ docker run -d --name certmate \
 |----------|--------|-------------|
 | `SECRET_KEY` | Non | Clé secrète Flask pour les sessions (auto-générée si non définie) |
 | `SECRET_KEY_FILE` | Non | Chemin vers un fichier contenant la clé secrète Flask (prioritaire sur `SECRET_KEY`) |
-| `API_BEARER_TOKEN` | Non | Token d'authentification pour l'accès API (auto-généré si non défini) |
+| `API_BEARER_TOKEN` | Non (auto-généré) | Token d'authentification de l'API. Auto-généré si non défini, mais définissez-le avant d'exposer sur un réseau une instance pas encore configurée ; une fois défini, collez-le une fois sur l'écran de premier démarrage pour créer l'administrateur |
 | `API_BEARER_TOKEN_FILE` | Non | Chemin vers un fichier contenant le token bearer API (prioritaire sur `API_BEARER_TOKEN`) |
 | `LOG_LEVEL` | Non | `INFO` (défaut), `DEBUG`, `WARNING`, `ERROR` |
 | `CERTMATE_BACKUP_PASSPHRASE` | Non | Quand défini, sauvegardes chiffrées au repos (`.zip.enc`, PBKDF2-SHA256 + Fernet) |

--- a/docs/it/docker.md
+++ b/docs/it/docker.md
@@ -98,7 +98,7 @@ docker run -d --name certmate \
 |-----------|-----------|-------------|
 | `SECRET_KEY` | No | Chiave segreta Flask per le sessioni (generata automaticamente se non impostata) |
 | `SECRET_KEY_FILE` | No | Percorso di un file contenente la chiave segreta Flask (ha precedenza su `SECRET_KEY`) |
-| `API_BEARER_TOKEN` | No | Token di autenticazione per l'accesso all'API (generato automaticamente se non impostato) |
+| `API_BEARER_TOKEN` | No (auto-generato) | Token di autenticazione API. Generato automaticamente se non impostato, ma impostalo prima di esporre in rete un'istanza non ancora configurata; quando impostato, incollalo una volta nella schermata di primo avvio per creare l'admin |
 | `API_BEARER_TOKEN_FILE` | No | Percorso di un file contenente il token bearer API (ha precedenza su `API_BEARER_TOKEN`) |
 | `LOG_LEVEL` | No | `INFO` (predefinito), `DEBUG`, `WARNING`, `ERROR` |
 | `CERTMATE_BACKUP_PASSPHRASE` | No | Se impostata, i backup unificati vengono cifrati a riposo (`.zip.enc`, PBKDF2-SHA256 + Fernet). La stessa passphrase è richiesta per il ripristino. Non impostata = backup in chiaro `.zip` (comportamento precedente) |

--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -825,7 +825,8 @@ class AuthManager:
         """RESTRICTED (never world-open) bootstrap signal for the web UI only.
 
         True iff the operator configured an API bearer token but local auth is
-        not yet provisioned (no admin user + local auth enabled). In this state
+        not yet provisioned — local auth is disabled, or no admin user exists
+        yet (the predicate returns False only once BOTH hold). In this state
         ``is_setup_mode()`` is ALREADY False, so ``_authenticate_request()``
         still demands the bearer token on every gated surface — this predicate
         does NOT grant access and is deliberately kept out of the auth gate. It

--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -820,6 +820,33 @@ class AuthManager:
         if self._is_oidc_configured():
             return False
         return not (self.is_local_auth_enabled() and self.has_any_users())
+
+    def needs_credentialed_bootstrap(self):
+        """RESTRICTED (never world-open) bootstrap signal for the web UI only.
+
+        True iff the operator configured an API bearer token but local auth is
+        not yet provisioned (no admin user + local auth enabled). In this state
+        ``is_setup_mode()`` is ALREADY False, so ``_authenticate_request()``
+        still demands the bearer token on every gated surface — this predicate
+        does NOT grant access and is deliberately kept out of the auth gate. It
+        only tells the UI to render the create-admin form instead of a
+        dead-end login page (local auth is off, so ``/api/auth/login`` 403s).
+        The form authenticates its two bootstrap POSTs with the operator's
+        bearer token, so creating the first admin requires proof-of-possession
+        of the token the operator configured — nothing is granted for free.
+
+        Returns False on a fresh no-token install (``has_operator_bearer_token``
+        is False there), keeping it disjoint from genuine setup mode and from
+        OIDC-only deployments. See issue #397."""
+        if self.is_local_auth_enabled() and self.has_any_users():
+            return False
+        # OIDC-capable boxes bootstrap their first user through SSO (JIT
+        # provisioning), not this local-admin form. Mirror is_setup_mode()'s
+        # OIDC branch so the SSO login page stays reachable instead of being
+        # hidden behind the create-admin form on an OIDC+bearer deployment.
+        if self._is_oidc_configured():
+            return False
+        return self.has_operator_bearer_token()
     
     def _authenticate_request(self):
         """Resolve the caller's identity for the current Flask request.

--- a/modules/web/auth_routes.py
+++ b/modules/web/auth_routes.py
@@ -14,10 +14,11 @@ def register_auth_routes(app, managers, require_web_auth, auth_manager,
     @app.route('/login', methods=['GET'])
     def login_page():
         """Login page"""
-        # In setup mode no login is needed (and index is open); bounce there.
-        # Once configured — including a bearer-token-only deployment where the
-        # web UI is locked — render the form instead, so index (now gated) does
-        # not redirect back here in a loop.
+        # Bounce to index in two cases: genuine setup mode (index is open), and
+        # the bearer-only bootstrap state (index re-surfaces the create-admin
+        # form). In both, /login has nothing to show — local auth is off — and
+        # index owns the onboarding UI, so redirecting avoids a loop. A fully
+        # configured deployment falls through and renders the login form below.
         if auth_manager.is_setup_mode() or auth_manager.needs_credentialed_bootstrap():
             return redirect(url_for('index'))
         # If the visitor already has a valid session cookie, skip rendering

--- a/modules/web/auth_routes.py
+++ b/modules/web/auth_routes.py
@@ -18,7 +18,7 @@ def register_auth_routes(app, managers, require_web_auth, auth_manager,
         # Once configured — including a bearer-token-only deployment where the
         # web UI is locked — render the form instead, so index (now gated) does
         # not redirect back here in a loop.
-        if auth_manager.is_setup_mode():
+        if auth_manager.is_setup_mode() or auth_manager.needs_credentialed_bootstrap():
             return redirect(url_for('index'))
         # If the visitor already has a valid session cookie, skip rendering
         # the login form entirely and bounce to the dashboard. Doing this

--- a/modules/web/ui_routes.py
+++ b/modules/web/ui_routes.py
@@ -9,7 +9,15 @@ def register_ui_routes(app, managers, require_web_auth, auth_manager):
     def index():
         """Main dashboard UI"""
         if auth_manager.is_setup_mode():
-            return render_template('setup.html')
+            return render_template('setup.html', bootstrap_requires_token=False)
+        # Bearer-only box: is_setup_mode() is False (the bearer token is
+        # enforced on every gated surface), but local auth is not yet
+        # provisioned, so a login redirect would dead-end at a 403 "Local auth
+        # disabled". Surface the create-admin form instead; its two writes are
+        # still bearer-gated (@require_role('admin')), so this grants nothing
+        # to an anonymous caller. #397
+        if auth_manager.needs_credentialed_bootstrap():
+            return render_template('setup.html', bootstrap_requires_token=True)
 
         session_id = request.cookies.get('certmate_session')
         user_info = auth_manager.validate_session(session_id)

--- a/scripts/reset_admin_password.py
+++ b/scripts/reset_admin_password.py
@@ -96,20 +96,43 @@ def main() -> int:
         import datetime
         admin_user["created_at"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
+    # Without this, login still returns 403 "Local auth disabled" even though
+    # the admin user now exists (issue #397): local_auth_enabled defaults to
+    # False. Enabling it reproduces the exact end-state the setup wizard
+    # reaches. The change is monotonic — writing a user AND local_auth=True
+    # only ever drives is_setup_mode() False, never into the world-open bypass.
+    data["local_auth_enabled"] = True
+
     # Preserve a pre-write backup of the original file
     backup_path = settings_path.with_suffix(".json.reset_backup")
     try:
         backup_path.write_bytes(settings_path.read_bytes())
+        os.chmod(backup_path, 0o600)  # the backup mirrors settings.json's secrets
         print(f"Original settings backed up to: {backup_path}")
     except OSError as exc:
         print(f"WARNING: could not create backup: {exc}")
 
+    # Atomic write: dump to a temp file in the same directory, then os.replace
+    # onto settings.json so an interruption can't leave a truncated/corrupt
+    # file. This path is the recovery escape hatch, so its robustness matters.
+    tmp_path = settings_path.with_suffix(".json.reset_tmp")
     try:
-        with settings_path.open("w", encoding="utf-8") as f:
+        with tmp_path.open("w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
             f.write("\n")
+        # settings.json holds password/token/API-key hashes and DNS creds and
+        # is kept 0600 by the app. os.replace transfers the temp file's mode
+        # onto the target, so tighten the temp to 0600 BEFORE the swap —
+        # otherwise the umask default (typically 0644) would make the reset
+        # file, and every secret in it, world-readable to other local users.
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, settings_path)
     except OSError as exc:
         print(f"ERROR: failed to write settings: {exc}")
+        try:
+            tmp_path.unlink(missing_ok=True)  # don't leave a 0600 partial behind
+        except OSError:
+            pass
         return 1
 
     print(f"Admin password reset successfully in {settings_path}")

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -23,7 +23,7 @@
         </div>
 
         <div class="px-6 py-8 sm:p-10">
-            <form id="setupForm" class="space-y-6">
+            <form id="setupForm" method="post" action="#" class="space-y-6">
                 <div>
                     <label for="username" class="block text-sm font-semibold text-label">
                         Admin Username
@@ -56,6 +56,26 @@
                     </p>
                 </div>
 
+                {% if bootstrap_requires_token %}
+                <div>
+                    <label for="operatorToken" class="block text-sm font-semibold text-label">
+                        API Bearer Token
+                    </label>
+                    <div class="mt-1 relative rounded-md shadow-sm">
+                        <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                            <i class="fas fa-key text-gray-400"></i>
+                        </div>
+                        <input type="password" name="operatorToken" id="operatorToken" required autocomplete="off"
+                            class="block w-full border border-border bg-input text-foreground rounded-lg pl-10 py-3 focus:outline-none focus:ring-2 focus:ring-primary transition-colors duration-200"
+                            placeholder="Paste your API_BEARER_TOKEN">
+                    </div>
+                    <p class="mt-2 text-xs text-muted">
+                        <i class="fas fa-info-circle mr-1"></i>
+                        Paste the <code>API_BEARER_TOKEN</code> you configured, to authorize creating the first admin.
+                    </p>
+                </div>
+                {% endif %}
+
                 <div class="pt-4">
                     <button type="submit"
                         class="w-full flex justify-center py-4 px-4 border border-transparent rounded-xl shadow-lg text-lg font-bold text-white bg-brand-500 hover:bg-brand-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500 btn-press transition-all duration-200">
@@ -80,25 +100,64 @@
         const username = document.getElementById('username').value;
         const password = document.getElementById('password').value;
 
+        // On a bearer-only box the create-admin POSTs are gated by
+        // @require_role('admin'); the operator authorizes them by proving
+        // possession of the API bearer token they configured. In genuine
+        // setup mode no token is needed and the setup-mode bypass authorizes
+        // both calls exactly as before. #397
+        const requiresToken = {{ 'true' if bootstrap_requires_token else 'false' }};
+        const token = requiresToken ? document.getElementById('operatorToken').value.trim() : null;
+        if (requiresToken && !token) { alert('API bearer token is required'); return; }
+        const authHeaders = token ? { 'Authorization': 'Bearer ' + token } : {};
+
         try {
             const response = await fetch('/api/web/settings/users', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: Object.assign({ 'Content-Type': 'application/json' }, authHeaders),
                 body: JSON.stringify({ username, password, role: 'admin' })
             });
 
-            const data = await response.json();
-            if (response.ok) {
-                // Enable local auth automatically if it's the first user
-                await fetch('/api/auth/config', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + btoa(username + ':' + password) },
-                    body: JSON.stringify({ local_auth_enabled: true })
-                });
-                window.location.href = '/login';
-            } else {
-                alert(data.error || 'Setup failed');
+            // Divergent-token lockout: the box enforces the STORED bearer token,
+            // which can differ from the env token if it was added/rotated after
+            // the first start. Point the operator at the recovery script rather
+            // than the generic "invalid token" message. #397
+            if (requiresToken && (response.status === 401 || response.status === 403)) {
+                alert('The pasted API bearer token was not accepted. If you added or '
+                    + 'rotated API_BEARER_TOKEN after the first start, the token this '
+                    + 'instance stored differs — reset with scripts/reset_admin_password.py.');
+                return;
             }
+
+            const created = response.ok;              // 201 Created
+            const alreadyExists = response.status === 409;
+            if (!created && !alreadyExists) {
+                let msg = 'Setup failed';
+                try { msg = (await response.json()).error || msg; } catch (_) { /* non-JSON */ }
+                alert(msg);
+                return;
+            }
+
+            // Enable local auth so the admin can actually log in.
+            const cfg = await fetch('/api/auth/config', {
+                method: 'POST',
+                headers: Object.assign({ 'Content-Type': 'application/json' }, authHeaders),
+                body: JSON.stringify({ local_auth_enabled: true })
+            });
+            if (!cfg.ok) {
+                let msg = 'Admin created, but enabling local login failed';
+                try { msg = (await cfg.json()).error || msg; } catch (_) { /* non-JSON */ }
+                alert(msg + ' — enable local auth from Settings, then sign in.');
+                return;
+            }
+
+            // 409: an admin already existed (half-finished prior run). Local
+            // login is now on; the just-typed password did NOT overwrite the
+            // existing admin, so tell the operator which credentials to use.
+            if (alreadyExists) {
+                alert('An admin already exists; local login is enabled. Sign in with the '
+                    + 'existing admin credentials, or reset with scripts/reset_admin_password.py.');
+            }
+            window.location.href = '/login';
         } catch (err) {
             alert('Network error during setup');
         }

--- a/tests/test_auth_setup_mode.py
+++ b/tests/test_auth_setup_mode.py
@@ -23,7 +23,7 @@ def _valid_token():
     return generate_secure_token(40)
 
 
-def _auth(local_auth=False, users=None, oidc=None):
+def _auth(local_auth=False, users=None, oidc=None, api_bearer_token=None):
     sm = MagicMock()
     settings = {
         'local_auth_enabled': local_auth,
@@ -31,8 +31,17 @@ def _auth(local_auth=False, users=None, oidc=None):
     }
     if oidc is not None:
         settings['oidc'] = oidc
+    if api_bearer_token is not None:
+        settings['api_bearer_token'] = api_bearer_token
     sm.load_settings.return_value = settings
     return AuthManager(sm)
+
+
+def _request_ctx(headers=None):
+    """A bare Flask request context so _authenticate_request() can read
+    request.cookies / request.headers without a running app."""
+    from flask import Flask
+    return Flask(__name__).test_request_context(headers=headers or {})
 
 
 def _clear_token_env(monkeypatch):
@@ -158,3 +167,113 @@ def test_setup_mode_true_when_oidc_enabled_but_incomplete(monkeypatch):
                     {'enabled': False, 'issuer_url': 'https://idp', 'client_id': 'certmate'}):
         a = _auth(local_auth=False, users={}, oidc=partial)
         assert a.is_setup_mode() is True, partial
+
+
+# --- needs_credentialed_bootstrap (issue #397) -----------------------------
+# A bearer-only box (is_setup_mode() False, local auth unprovisioned) must let
+# the UI re-surface the create-admin form WITHOUT reopening the world-open gate.
+
+def test_needs_bootstrap_true_when_bearer_only_unprovisioned(monkeypatch):
+    """Bearer token set but local auth not yet provisioned: credential-gated
+    (is_setup_mode False) yet the UI must surface the create-admin form so the
+    operator is not locked out."""
+    _clear_token_env(monkeypatch)
+    monkeypatch.setenv('API_BEARER_TOKEN', _valid_token())
+    a = _auth(local_auth=False, users={})
+    assert a.is_setup_mode() is False
+    assert a.needs_credentialed_bootstrap() is True
+
+
+def test_needs_bootstrap_false_when_provisioned(monkeypatch):
+    _clear_token_env(monkeypatch)
+    monkeypatch.setenv('API_BEARER_TOKEN', _valid_token())
+    a = _auth(local_auth=True, users={'admin': {'role': 'admin'}})
+    assert a.needs_credentialed_bootstrap() is False
+
+
+def test_needs_bootstrap_false_on_fresh_install(monkeypatch):
+    """Fresh no-token box is handled by the is_setup_mode() branch, not this
+    one — the two predicates are disjoint on a fresh install."""
+    _clear_token_env(monkeypatch)
+    a = _auth(local_auth=False, users={})
+    assert a.is_setup_mode() is True
+    assert a.needs_credentialed_bootstrap() is False
+
+
+def test_needs_bootstrap_false_when_oidc_only(monkeypatch):
+    """OIDC-only (no bearer token): the form is not surfaced, SSO bootstrap is
+    unaffected (has_operator_bearer_token() is False)."""
+    _clear_token_env(monkeypatch)
+    a = _auth(local_auth=False, users={}, oidc=dict(_FULL_OIDC))
+    assert a.needs_credentialed_bootstrap() is False
+
+
+# --- world-open guard at the request layer, bearer-only state --------------
+# Proves the bearer-only bootstrap state is NOT world-open: _authenticate_request
+# is untouched, so it still rejects the anonymous caller and admits only the
+# operator's configured token.
+
+def test_bearer_only_request_layer_rejects_anonymous(monkeypatch):
+    tok = _valid_token()
+    _clear_token_env(monkeypatch)
+    monkeypatch.setenv('API_BEARER_TOKEN', tok)
+    a = _auth(local_auth=False, users={}, api_bearer_token=tok)
+    assert a.is_setup_mode() is False  # bypass is OFF in this state
+    with _request_ctx():
+        user, err = a._authenticate_request()
+    assert user is None
+    assert err is not None and err[1] == 401
+    assert err[0]['code'] == 'AUTH_HEADER_MISSING'
+
+
+def test_bearer_only_request_layer_accepts_operator_token(monkeypatch):
+    """The fresh-install #397 path: the stored token IS the env token
+    (settings.json is templated from API_BEARER_TOKEN on first run), so pasting
+    it resolves to admin even though the setup-mode bypass is off. The divergent
+    case (stored != env) is covered separately below."""
+    tok = _valid_token()
+    _clear_token_env(monkeypatch)
+    monkeypatch.setenv('API_BEARER_TOKEN', tok)
+    a = _auth(local_auth=False, users={}, api_bearer_token=tok)
+    with _request_ctx(headers={'Authorization': 'Bearer ' + tok}):
+        user, err = a._authenticate_request()
+    assert err is None
+    assert user['role'] == 'admin'
+
+
+def test_bearer_only_request_layer_rejects_divergent_token(monkeypatch):
+    """Fail-closed (NOT world-open) when the stored token diverges from the env
+    token — the 'ran first, added/rotated API_BEARER_TOKEN later' sequence. The
+    box enforces the STORED token, so pasting the env token is rejected 401; the
+    setup form warns and points at reset_admin_password.py. #397 review."""
+    env_tok = _valid_token()
+    stored_tok = _valid_token()  # a different value than the env token
+    _clear_token_env(monkeypatch)
+    monkeypatch.setenv('API_BEARER_TOKEN', env_tok)
+    a = _auth(local_auth=False, users={}, api_bearer_token=stored_tok)
+    assert a.is_setup_mode() is False
+    with _request_ctx(headers={'Authorization': 'Bearer ' + env_tok}):
+        user, err = a._authenticate_request()
+    assert user is None
+    assert err is not None and err[1] == 401  # rejected, never a bypass
+
+
+def test_needs_bootstrap_false_when_oidc_and_bearer_both_set(monkeypatch):
+    """OIDC + bearer with no local users yet: the configured SSO login path must
+    stay reachable, so the local-admin form is NOT surfaced (mirrors
+    is_setup_mode's OIDC branch). Regression guard from the #397 review."""
+    _clear_token_env(monkeypatch)
+    monkeypatch.setenv('API_BEARER_TOKEN', _valid_token())
+    a = _auth(local_auth=False, users={}, oidc=dict(_FULL_OIDC))
+    assert a.is_setup_mode() is False
+    assert a.needs_credentialed_bootstrap() is False
+
+
+def test_needs_bootstrap_true_with_token_file(monkeypatch, tmp_path):
+    """The predicate honours API_BEARER_TOKEN_FILE, not only the env var."""
+    _clear_token_env(monkeypatch)
+    f = tmp_path / 'bearer.token'
+    f.write_text(_valid_token() + '\n')
+    monkeypatch.setenv('API_BEARER_TOKEN_FILE', str(f))
+    a = _auth(local_auth=False, users={})
+    assert a.needs_credentialed_bootstrap() is True

--- a/tests/test_reset_admin_password_script.py
+++ b/tests/test_reset_admin_password_script.py
@@ -39,6 +39,12 @@ def _assert_admin_written(settings_path: Path):
 
     assert bcrypt.checkpw(PASSWORD.encode(), admin["password_hash"].encode())
 
+    # The reset must also enable local auth, otherwise login still returns
+    # 403 "Local auth disabled" even though the admin now exists (issue #397).
+    assert data.get("local_auth_enabled") is True, (
+        "reset must enable local auth so the restored admin can actually log in"
+    )
+
 
 def test_creates_admin_when_users_key_is_absent(tmp_path):
     """Fresh-install shape: no 'users' key at all (the #383 scenario)."""
@@ -62,6 +68,24 @@ def test_creates_admin_when_users_dict_is_empty(tmp_path):
 
     assert result.returncode == 0, result.stderr
     _assert_admin_written(settings_path)
+
+
+def test_reset_keeps_settings_file_0600(tmp_path):
+    """The reset must NOT widen settings.json permissions — it holds password,
+    token and API-key hashes plus DNS creds. The atomic temp+replace chmods the
+    temp to 0600 before the swap so os.replace can't transfer a 0644 umask mode."""
+    import stat
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({"users": {}}))
+    settings_path.chmod(0o600)
+
+    result = _run_script(settings_path)
+
+    assert result.returncode == 0, result.stderr
+    mode = stat.S_IMODE(settings_path.stat().st_mode)
+    assert mode == 0o600, f"settings.json mode is {oct(mode)}, expected 0o600"
+    # No temp file left behind after a successful write.
+    assert not (tmp_path / "settings.json.reset_tmp").exists()
 
 
 def test_resets_existing_admin_password(tmp_path):


### PR DESCRIPTION
## What & why

Closes #397. A Docker quick-start that sets `API_BEARER_TOKEN` (the docs marked it **required**) pushed the instance past `is_setup_mode()`, so the setup wizard never ran, no admin could be created via the UI, and local auth stayed off — locking the operator out with *"Local auth disabled"*. Confirmed by two users (incl. a venv install). The v2.21.1 world-open hardening is correct; the **documented onboarding path was incompatible with it**.

## Approach — security-first, gate untouched

The only code path that grants access without a credential is `_authenticate_request()`, gated solely by `is_setup_mode()`. **Neither is modified** (`auth.py` is **+27 / −0**). Instead:

- **New `needs_credentialed_bootstrap()`** — disjoint from `is_setup_mode()`, guarded by `_is_oidc_configured()` (so OIDC+bearer boxes keep routing to SSO). Consumed by exactly two UI surfaces (`index`, `login_page`); it never mints identity.
- On a bearer-only box the UI re-surfaces the **create-admin form**, which authenticates both bootstrap POSTs with the operator's bearer token. Both stay `@require_role('admin')` → an anonymous caller still gets `401`. **Proof-of-possession required; nothing granted for free.**
- `reset_admin_password.py` now also enables local auth (closes the recovery lockout) and writes atomically (`temp + os.replace`, chmod `0600` so the reset never widens `settings.json` permissions).
- Also fixes two pre-existing bugs found along the way: the invalid `btoa()` `Authorization` header in `setup.html`, and a no-JS form submit that could leak the token in the URL.

## Docs

`API_BEARER_TOKEN` re-labeled *"recommended for network-exposed"* instead of *"required"*, with the first-run token-paste explained — `README.md`, `docs/docker.md` and the `it/de/fr/es` copies. Companion PR on `certmate-website` updates `getting-started.html`.

## Testing

`needs_credentialed_bootstrap` predicate matrix (bearer-only / provisioned / fresh / OIDC-only / OIDC+bearer / token-file); **request-layer proof the bearer-only state is NOT world-open** (rejects anonymous → `AUTH_HEADER_MISSING`, accepts the operator token → admin); divergent-token fail-closed; reset enables local auth and keeps `settings.json` at `0600`. All new tests green locally; full auth/web sweep green (only pre-existing `docker`-fixture e2e errors remain, unrelated).

Reviewed across two adversarial passes (world-open · functional · frontend · tests+docs → delta review); every confirmed finding is addressed.

## Follow-up (tracked separately)

The full **env→stored token reconciliation** for the divergent-token edge (instance ran first, `API_BEARER_TOKEN` added/rotated later) is deferred — it changes token-storage semantics. This PR ships the fail-closed message pointing at the reset script; the reconciliation is filed as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
