### PR TITLE
fix: scrypt password fallback + close login next= open-redirect (code-scan triage)

### DIFF
--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -52,7 +52,8 @@ class AuthManager:
         _timeout_hours = int(os.getenv('SESSION_TIMEOUT_HOURS', '8'))
         self._session_timeout = max(1, _timeout_hours) * 60 * 60
         if not BCRYPT_AVAILABLE:
-            logger.warning("bcrypt not available, falling back to SHA-256 (less secure)")
+            logger.warning("bcrypt not available; using the scrypt KDF fallback. "
+                           "Install bcrypt for the preferred password hashing.")
 
     def set_audit_logger(self, audit_logger):
         """Inject the AuditLogger so authorization denials emit a real audit
@@ -78,33 +79,50 @@ class AuthManager:
         return role if role in ROLE_HIERARCHY else 'viewer'
 
     def _hash_password(self, password, salt=None):
-        """Hash password using bcrypt (preferred) or SHA-256 with salt (fallback)
-        
-        bcrypt is the industry standard for password hashing as it's designed
-        to be slow and resistant to GPU/ASIC attacks.
+        """Hash a password with bcrypt (preferred) or scrypt (fallback).
+
+        bcrypt is the industry standard — slow and GPU/ASIC-resistant. If bcrypt
+        cannot be imported, fall back to scrypt (a slow, memory-hard KDF from the
+        stdlib) rather than a fast hash: a bare SHA-256 of salt+password would be
+        trivially GPU-crackable for low-entropy passwords.
         """
         if BCRYPT_AVAILABLE:
             # bcrypt handles salt internally, rounds=12 provides good security
             return bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=12)).decode()
-        else:
-            # Fallback to SHA-256 with salt (less secure but functional)
-            if salt is None:
-                salt = secrets.token_hex(16)
-            hashed = hashlib.sha256((salt + password).encode()).hexdigest()
-            return f"sha256:{salt}:{hashed}"
-    
+        # bcrypt import failed — scrypt KDF fallback (NOT a fast hash).
+        # Format: "scrypt:<n>:<r>:<p>:<salt_hex>:<hash_hex>".
+        if salt is None:
+            salt = secrets.token_hex(16)
+        n, r, p = 2 ** 14, 8, 1  # ~16 MiB work factor, under scrypt's default maxmem
+        dk = hashlib.scrypt(password.encode(), salt=salt.encode(),
+                            n=n, r=r, p=p, dklen=32)
+        return f"scrypt:{n}:{r}:{p}:{salt}:{dk.hex()}"
+
     def _verify_password(self, password, stored_hash):
-        """Verify password against stored hash (supports bcrypt and legacy SHA-256)"""
+        """Verify a password against a stored hash.
+
+        Supports bcrypt, the scrypt fallback, and the pre-existing legacy
+        SHA-256 formats ("sha256:salt:hash" and bare "salt:hash") so operators
+        hashed under the old fallback can still log in after upgrade.
+        """
         try:
-            # Check if it's a bcrypt hash (starts with $2b$ or $2a$)
+            # bcrypt hash (starts with $2b$ / $2a$)
             if stored_hash.startswith('$2'):
                 if BCRYPT_AVAILABLE:
                     return bcrypt.checkpw(password.encode(), stored_hash.encode())
-                else:
-                    logger.error("bcrypt hash found but bcrypt not available")
-                    return False
-            
-            # Legacy SHA-256 format: "sha256:salt:hash" or "salt:hash"
+                logger.error("bcrypt hash found but bcrypt not available")
+                return False
+
+            # scrypt fallback: "scrypt:<n>:<r>:<p>:<salt>:<hash>"
+            if stored_hash.startswith('scrypt:'):
+                _, n, r, p, salt, expected_hash = stored_hash.split(':', 5)
+                dk = hashlib.scrypt(password.encode(), salt=salt.encode(),
+                                    n=int(n), r=int(r), p=int(p),
+                                    dklen=len(expected_hash) // 2)
+                return secrets.compare_digest(dk.hex(), expected_hash)
+
+            # Legacy SHA-256 formats (verify-only, for pre-upgrade hashes):
+            # "sha256:salt:hash" or the older bare "salt:hash".
             if stored_hash.startswith('sha256:'):
                 parts = stored_hash.split(':', 2)
                 if len(parts) == 3:
@@ -112,9 +130,8 @@ class AuthManager:
                 else:
                     return False
             else:
-                # Old format without prefix
                 salt, expected_hash = stored_hash.split(':', 1)
-            
+
             actual_hash = hashlib.sha256((salt + password).encode()).hexdigest()
             return secrets.compare_digest(actual_hash, expected_hash)
         except (ValueError, AttributeError) as e:

--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -115,10 +115,19 @@ class AuthManager:
 
             # scrypt fallback: "scrypt:<n>:<r>:<p>:<salt>:<hash>"
             if stored_hash.startswith('scrypt:'):
-                _, n, r, p, salt, expected_hash = stored_hash.split(':', 5)
+                _, n_s, r_s, p_s, salt, expected_hash = stored_hash.split(':', 5)
+                n, r, p = int(n_s), int(r_s), int(p_s)
+                # Bounds-check the stored KDF params BEFORE the (costly) work so a
+                # corrupted settings.json can't turn each login into an expensive
+                # scrypt run. These bracket what _hash_password writes
+                # (n=2**14, r=8, p=1); scrypt's own maxmem is the hard backstop.
+                if not (2 ** 12 <= n <= 2 ** 17 and (n & (n - 1)) == 0
+                        and 1 <= r <= 16 and 1 <= p <= 8
+                        and 0 < len(expected_hash) <= 256
+                        and all(c in '0123456789abcdefABCDEF' for c in expected_hash)):
+                    return False
                 dk = hashlib.scrypt(password.encode(), salt=salt.encode(),
-                                    n=int(n), r=int(r), p=int(p),
-                                    dklen=len(expected_hash) // 2)
+                                    n=n, r=r, p=p, dklen=len(expected_hash) // 2)
                 return secrets.compare_digest(dk.hex(), expected_hash)
 
             # Legacy SHA-256 formats (verify-only, for pre-upgrade hashes):

--- a/templates/login.html
+++ b/templates/login.html
@@ -155,7 +155,12 @@
             try {
                 var raw = new URLSearchParams(window.location.search).get('next');
                 if (!raw || typeof raw !== 'string') return '/';
-                if (!raw.startsWith('/') || raw.startsWith('//')) return '/';
+                // Must be a same-origin absolute path. Reject protocol-relative
+                // ("//host") AND backslash variants ("/\host", "\\host") that
+                // browsers normalize to "//host" and would bounce the user to an
+                // external origin after login.
+                if (!raw.startsWith('/')) return '/';
+                if (raw.length > 1 && (raw[1] === '/' || raw[1] === '\\')) return '/';
                 return raw;
             } catch (e) { return '/'; }
         }

--- a/tests/test_auth_manager_coverage.py
+++ b/tests/test_auth_manager_coverage.py
@@ -130,6 +130,31 @@ class TestPasswordHashing:
         assert mgr._verify_password('anything', 'not-a-real-hash-at-all') is False
         assert mgr._verify_password('anything', '') is False
 
+    def test_scrypt_fallback_round_trip(self, auth_manager_factory, monkeypatch):
+        """When bcrypt is unavailable, _hash_password must fall back to scrypt
+        (a slow KDF), not raw SHA-256, and the round-trip must still work."""
+        import modules.core.auth as auth_mod
+        monkeypatch.setattr(auth_mod, 'BCRYPT_AVAILABLE', False)
+        mgr, _ = auth_manager_factory()
+        hashed = mgr._hash_password('CorrectHorseBatteryStaple')
+        assert hashed.startswith('scrypt:')
+        assert mgr._verify_password('CorrectHorseBatteryStaple', hashed) is True
+        assert mgr._verify_password('wrong', hashed) is False
+
+    def test_scrypt_fallback_is_not_raw_sha256(self, auth_manager_factory, monkeypatch):
+        """Regression guard for the weak-hashing finding: the fallback digest
+        must NOT equal a bare SHA-256 of salt+password."""
+        import modules.core.auth as auth_mod
+        import hashlib
+        monkeypatch.setattr(auth_mod, 'BCRYPT_AVAILABLE', False)
+        mgr, _ = auth_manager_factory()
+        hashed = mgr._hash_password('pw-12345678!')
+        parts = hashed.split(':')
+        assert parts[0] == 'scrypt'
+        salt = parts[4]
+        raw_sha = hashlib.sha256((salt + 'pw-12345678!').encode()).hexdigest()
+        assert parts[5] != raw_sha
+
 
 # ---------------------------------------------------------------------------
 # _normalize_allowed_domains — input validation for scoped API keys

--- a/tests/test_auth_manager_coverage.py
+++ b/tests/test_auth_manager_coverage.py
@@ -155,6 +155,18 @@ class TestPasswordHashing:
         raw_sha = hashlib.sha256((salt + 'pw-12345678!').encode()).hexdigest()
         assert parts[5] != raw_sha
 
+    def test_scrypt_verify_rejects_out_of_range_params(self, auth_manager_factory):
+        """Defense-in-depth: a corrupted scrypt hash with absurd KDF params is
+        rejected by the bounds check, without launching the costly scrypt work."""
+        mgr, _ = auth_manager_factory()
+        salt, digest = "ab" * 16, "cd" * 32
+        # n far above the cap -> reject before scrypt
+        assert mgr._verify_password('x', f"scrypt:99999999:8:1:{salt}:{digest}") is False
+        # non-power-of-two n
+        assert mgr._verify_password('x', f"scrypt:12345:8:1:{salt}:{digest}") is False
+        # non-hex digest
+        assert mgr._verify_password('x', f"scrypt:16384:8:1:{salt}:zzzz") is False
+
 
 # ---------------------------------------------------------------------------
 # _normalize_allowed_domains — input validation for scoped API keys


### PR DESCRIPTION
The two genuine issues surfaced by triaging the 375 open code-scanning alerts — the remaining 371 are systematic false positives (`path-injection` on validated paths, `clear-text-logging` of non-secrets, `url-substring` in test assertions), accept-by-policy (`log-injection`: JSON formatter escapes CRLF; Scorecard: solo-maintainer), or external container CVEs (146 Trivy → #403).

### 1. Weak password-hashing fallback (`auth.py`, HIGH)
When bcrypt can't be imported, `_hash_password` used raw salted **SHA-256** — a fast, GPU/ASIC-crackable hash for low-entropy passwords. Replaced with **`hashlib.scrypt`** (slow, memory-hard, stdlib). bcrypt stays preferred; `_verify_password` still accepts the legacy `sha256:salt:hash` / `salt:hash` formats so existing operators can log in after upgrade. The stored scrypt params are bounds-checked before use so a corrupted `settings.json` can't force expensive KDF work. (`py/weak-sensitive-data-hashing`)

### 2. Open redirect via backslash (`login.html`, medium)
`safeNextUrl()` rejected `//host` but not `/\host`, which browsers normalize to `//host` → `?next=/\evil.com` bounced users off-site after login. Now rejects any `next` whose second char is `/` or `\`. (`js/client-side-unvalidated-url-redirection`)

### Tests
Python, committed: scrypt fallback round-trip, not-raw-SHA-256 regression guard, scrypt param bounds-check rejection, legacy sha256 verification. Full auth suite green. **Note:** the `safeNextUrl` fix is template-only JS and this repo has no JS test runner — its logic was verified manually against `//`, `/\`, `\\` bypasses, but is not asserted by an automated test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)