### PR TITLE
fix: make four CI gates actually gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,12 @@ jobs:
         # Pinned-Dependencies flags bare, unversioned pip installs).
         pip install flake8==7.3.0
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # Fails the build. E9/F63/F7/F82 are syntax errors and undefined
+        # names; the rest are bug classes that are already clean in this
+        # codebase and must stay that way — F811 (a redefinition that silently
+        # shadows an import), F632 (is-comparison against a literal), E711/E712
+        # (== None / == True), E713/E714 (not ... in / not ... is). #428
+        flake8 . --count --select=E9,F63,F7,F82,F811,F632,E711,E712,E713,E714 --show-source --statistics
         # exit-zero treats all errors as warnings
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
@@ -89,7 +94,12 @@ jobs:
         # Measure the application package (modules/), not the whole repo: a
         # bare --cov=. folds the tests/ and scripts/ trees (which run at ~100%)
         # into the number, inflating it and hiding the real app coverage.
-        pytest -v --tb=short --cov=modules --cov-report=xml --cov-report=html -m "not ui"
+        # --cov-fail-under is a FLOOR, not a target (#428): before it, project
+        # and patch statuses were both informational and fail_ci_if_error was
+        # false, so coverage could fall to zero with CI still green. 65 is
+        # comfortably below the current number; raise it as a ratchet, never
+        # lower it to make a red build pass.
+        pytest -v --tb=short --cov=modules --cov-report=xml --cov-report=html --cov-fail-under=65 -m "not ui"
 
     - name: Upload coverage reports
       if: matrix.python-version == '3.12'

--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -127,6 +127,7 @@ jobs:
         fi
         
     - name: Build and push Docker image
+      id: build
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
       with:
         context: .
@@ -157,7 +158,12 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name != 'pull_request'
+    # Runs on pull requests too (#412). It used to be skipped there, and on
+    # pushes it scanned the floating `:latest` tag — which, on a push to main,
+    # is still the PREVIOUS release's image (see the tag policy above). So a
+    # CRITICAL introduced by the current change was never scanned by anyone.
+    # The image under test is now rebuilt here from the same buildx cache and
+    # loaded locally, so what is scanned is what was just built.
     # Job-level permission override: the workflow default is read-all
     # (set at the top of this file in v2.6.2), but the Trivy SARIF
     # upload step needs to write into the Security > Code scanning
@@ -167,53 +173,51 @@ jobs:
       contents: read
 
     steps:
-    - name: Ensure Trivy is installed
-      # aquasecurity/trivy-action internally invokes setup-trivy, which
-      # on this self-hosted runner reports "Cache restored successfully"
-      # but does not leave a working binary on PATH — the next
-      # entrypoint.sh step fails with `trivy: command not found`
-      # (exit 127, run 26595913239). Install the versioned release
-      # tarball directly into a user-writable PATH entry and tell
-      # trivy-action to skip its own setup. Pin matches the version
-      # setup-trivy was trying to cache.
-      run: |
-        set -euo pipefail
-        if command -v trivy >/dev/null 2>&1; then
-          echo "trivy already on PATH: $(command -v trivy)"
-          exit 0
-        fi
-        TRIVY_VERSION=0.70.0
-        case "$(uname -m)" in
-          x86_64) BIN_ARCH=64bit ;;
-          aarch64|arm64) BIN_ARCH=ARM64 ;;
-          *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
-        esac
-        tmp=$(mktemp -d)
-        trap 'rm -rf "$tmp"' EXIT
-        curl -fsSL \
-          "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${BIN_ARCH}.tar.gz" \
-          -o "$tmp/trivy.tgz"
-        tar -xzf "$tmp/trivy.tgz" -C "$tmp" trivy
-        install -d "$HOME/.local/bin"
-        install -m 0755 "$tmp/trivy" "$HOME/.local/bin/trivy"
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        echo "Installed trivy ${TRIVY_VERSION} at $HOME/.local/bin/trivy"
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-    - name: Run Trivy vulnerability scanner
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+
+    - name: Build the image under test (amd64, loaded locally)
+      # Reuses the buildx cache the build job just populated, so this is a
+      # cache hit rather than a second full build.
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+      with:
+        context: .
+        platforms: linux/amd64
+        load: true
+        push: false
+        tags: certmate:scan
+        cache-from: type=gha
+        build-args: |
+          REQUIREMENTS_FILE=requirements.txt
+
+    - name: Run Trivy vulnerability scanner (report)
       # Pinned to v0.36.0 (was @master — never pin to a mutable branch
       # in CI; upstream HEAD changes silently bring new behaviour or
       # become an attack surface if compromised).
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
       with:
-        # Use the trivy installed by the previous step. setup-trivy's
-        # cache hit on this self-hosted runner was reporting success
-        # without producing a usable binary.
-        skip-setup-trivy: true
-        image-ref: ${{ env.REGISTRY }}/${{ secrets.DOCKERHUB_USER }}/${{ env.IMAGE_NAME }}:latest
+        image-ref: 'certmate:scan'
         format: 'sarif'
         output: 'trivy-results.sarif'
         severity: 'HIGH,CRITICAL'
-        
+
+    - name: Fail on a fixable CRITICAL
+      # The reporting step above deliberately does not gate: the image
+      # carries a long tail of unfixable base-image findings tracked in #403,
+      # and a gate that is always red is a gate nobody reads. This one has
+      # teeth precisely where action is possible — a CRITICAL with a fix
+      # available means a base-image or dependency bump is due.
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+      with:
+        image-ref: 'certmate:scan'
+        format: 'table'
+        severity: 'CRITICAL'
+        ignore-unfixed: true
+        exit-code: '1'
+
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v3
       if: always()

--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -214,6 +214,11 @@ jobs:
       with:
         image-ref: 'certmate:scan'
         format: 'table'
+        # Vulnerabilities only. The secret scanner flags a .pyc inside the
+        # third-party certbot_dns_google package as a GCP service account —
+        # a false positive that would make this gate permanently red. Secret
+        # findings still reach the Security tab via the SARIF above.
+        scanners: 'vuln'
         severity: 'CRITICAL'
         ignore-unfixed: true
         exit-code: '1'

--- a/.github/workflows/lint-emoji.yml
+++ b/.github/workflows/lint-emoji.yml
@@ -6,6 +6,12 @@ name: Lint (emoji)
 # the single self-hosted host.
 
 on:
+  # Also on push (#428): PR-only meant a direct push or an admin merge could
+  # land emoji unchecked, and — since release.sh now gates on the required
+  # workflows having run for the release commit — that the check was simply
+  # absent from every commit on main.
+  push:
+    branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -66,10 +66,18 @@ jobs:
 
     - name: Install Playwright Chromium
       # --with-deps installs the system libraries (libnss3, libasound2, ...)
-      # Chromium needs. Without them chromium.launch() throws, and the suite
-      # used to turn that into a skip — i.e. a green job that ran zero
-      # assertions (#414).
-      run: python -m playwright install --with-deps chromium
+      # Chromium needs, but it shells out to sudo — which this self-hosted
+      # host does not grant passwordlessly. Use it when it is available and
+      # fall back to the plain install otherwise; either way the launch check
+      # below is what decides, so a host missing those libraries fails the
+      # job instead of skipping every test and reporting green (#414).
+      run: |
+        if sudo -n true 2>/dev/null; then
+          python -m playwright install --with-deps chromium
+        else
+          echo "passwordless sudo unavailable; installing browser only"
+          python -m playwright install chromium
+        fi
 
     - name: Verify Chromium actually launches
       # Fail here, loudly and in one line, rather than inside 17 fixtures.

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -65,7 +65,51 @@ jobs:
         pip install -r requirements-test.txt
 
     - name: Install Playwright Chromium
-      run: python -m playwright install chromium
+      # --with-deps installs the system libraries (libnss3, libasound2, ...)
+      # Chromium needs. Without them chromium.launch() throws, and the suite
+      # used to turn that into a skip — i.e. a green job that ran zero
+      # assertions (#414).
+      run: python -m playwright install --with-deps chromium
+
+    - name: Verify Chromium actually launches
+      # Fail here, loudly and in one line, rather than inside 17 fixtures.
+      run: |
+        python - <<'PY'
+        from playwright.sync_api import sync_playwright
+        with sync_playwright() as p:
+            b = p.chromium.launch(headless=True)
+            print("chromium", b.version)
+            b.close()
+        PY
 
     - name: UI tests
-      run: python -m pytest -v -m ui
+      # CERTMATE_UI_REQUIRE_BROWSER=1 turns "browser unavailable" from a skip
+      # into a failure, so this job can no longer report success without
+      # having driven a browser.
+      env:
+        CERTMATE_UI_REQUIRE_BROWSER: '1'
+      run: python -m pytest -v -m ui --junitxml=ui-results.xml
+
+    - name: Refuse a green run that asserted nothing
+      if: always()
+      # The last line of defence: if every collected UI test skipped (or none
+      # were collected at all), the job fails. A suite that runs zero tests is
+      # not a passing suite.
+      run: |
+        python - <<'PY'
+        import sys, xml.etree.ElementTree as ET
+        try:
+            root = ET.parse("ui-results.xml").getroot()
+        except Exception as e:
+            sys.exit(f"no UI test results to check: {e}")
+        suites = root.iter("testsuite")
+        total = skipped = 0
+        for s in suites:
+            total += int(s.get("tests", 0))
+            skipped += int(s.get("skipped", 0))
+        print(f"collected={total} skipped={skipped}")
+        if total == 0:
+            sys.exit("UI suite collected 0 tests")
+        if skipped == total:
+            sys.exit("every UI test skipped - the suite proved nothing")
+        PY

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ test-integration: $(VENV)/bin/activate
 	$(PYTEST) -v --tb=short -m "integration"
 
 test-coverage: $(VENV)/bin/activate
-	$(PYTEST) -v --tb=short --cov=. --cov-report=html --cov-report=term-missing --cov-report=xml -m "not ui and not e2e"
+	$(PYTEST) -v --tb=short --cov=modules --cov-report=html --cov-report=term-missing --cov-report=xml -m "not ui and not e2e"
 
 test-watch: $(VENV)/bin/activate
 	$(PIP) install -q pytest-watch
@@ -99,7 +99,7 @@ test-watch: $(VENV)/bin/activate
 # ── Code Quality ───────────────────────────────────────────────────────
 
 lint: $(VENV)/bin/activate
-	$(VENV)/bin/flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+	$(VENV)/bin/flake8 . --count --select=E9,F63,F7,F82,F811,F632,E711,E712,E713,E714 --show-source --statistics
 	$(VENV)/bin/flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 format: $(VENV)/bin/activate

--- a/modules/core/storage_backends.py
+++ b/modules/core/storage_backends.py
@@ -216,7 +216,6 @@ class LocalFileSystemBackend(CertificateStorageBackend):
         chmod, briefly exposing the private key. mkstemp creates at 0600; the
         rename is atomic so readers see either the old file or the whole new
         one, never a partial write."""
-        import tempfile
         fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix='.tmp-', suffix=path.name)
         try:
             os.chmod(tmp_name, mode)

--- a/modules/web/settings_routes.py
+++ b/modules/web/settings_routes.py
@@ -208,7 +208,6 @@ def register_settings_routes(app, managers, require_web_auth, auth_manager,
         # Password policy: 12 chars minimum with at least one digit and one
         # non-alphanumeric character. Aligns with the OWASP ASVS L1 guidance
         # for shared-credential apps.
-        import re
         if (len(password) < 12
                 or not re.search(r'\d', password)
                 or not re.search(r'[^A-Za-z0-9]', password)):
@@ -275,7 +274,6 @@ def register_settings_routes(app, managers, require_web_auth, auth_manager,
         if password is not None:
             if len(password) > 256:
                 return jsonify({'error': 'Password must be ≤ 256 chars'}), 400
-            import re
             if (len(password) < 12
                     or not re.search(r'\d', password)
                     or not re.search(r'[^A-Za-z0-9]', password)):

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,7 +21,10 @@ filterwarnings =
 
 [coverage:run]
 branch = True
-source = .
+# modules/ only, matching `--cov=modules` in ci.yml and the Makefile: a bare
+# `source = .` folds the tests/ and scripts/ trees (which run at ~100%) into
+# the number and hides the real application coverage (#428).
+source = modules
 omit = 
     tests/*
     venv/*

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -196,7 +196,11 @@ cmd_publish() {
   # is what publishes :latest.
   info "CI status on the release commit"
   local sha; sha="$(git rev-parse HEAD)"
-  local runs; runs="$(gh run list --commit "$sha" --json name,conclusion,status,workflowName 2>/dev/null || echo '')"
+  # --limit 100: the default page size is 20, and reruns plus the
+  # non-required workflows can push a required one off the first page —
+  # which would read as MISSING and block a perfectly good release.
+  local runs; runs="$(gh run list --commit "$sha" --limit 100 \
+    --json name,conclusion,status,workflowName,createdAt 2>/dev/null || echo '')"
   [ -n "$runs" ] || die "could not read CI status for $sha (is gh authenticated?)"
   local verdict; verdict="$(printf '%s' "$runs" | "$PY" -c '
 import json, sys
@@ -207,6 +211,14 @@ import json, sys
 # forever, and a release must not hang on it. They are still reported.
 REQUIRED = {"CI", "Build Multi-Platform Docker Images", "CodeQL", "Lint (emoji)"}
 runs = json.load(sys.stdin)
+
+# Keep only the most recent run per workflow: a rerun creates a second run,
+# and judging the older attempt would fail a release whose rerun is green.
+latest = {}
+for r in sorted(runs, key=lambda r: r.get("createdAt") or ""):
+    latest[r.get("workflowName")] = r
+runs = list(latest.values())
+
 pending, bad, other = set(), set(), []
 for r in runs:
     name = r.get("workflowName", "?")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -118,7 +118,7 @@ $(echo "$changed" | grep -E "$SENSITIVE_RE" | sed 's/^/  /')"
   export FLASK_ENV=testing TESTING=true
 
   gate "flake8 (syntax / undefined names)" bash -c '
-    "'"$PY"'" -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics'
+    "'"$PY"'" -m flake8 . --count --select=E9,F63,F7,F82,F811,F632,E711,E712,E713,E714 --show-source --statistics'
   gate "bandit (medium+)" bash -c '"'"$PY"'" -m bandit -r modules/ app.py --severity-level medium -q'
   gate "unit + integration suite (incl. version + marker-coverage guards)" \
     "$PY" -m pytest -q -m "not ui and not e2e" -p no:cacheprovider
@@ -188,6 +188,55 @@ cmd_publish() {
   local notes; notes="$(notes_section "$version")"
   [ -n "$notes" ] || die "no RELEASE_NOTES section for v$version"
   local title; title="$(echo "$notes" | head -1 | sed 's/^## //')"
+
+  # CI status on the exact commit being released (#413). Every other gate
+  # here checks the *contents* of the release; none checked whether main
+  # actually builds. A Dependabot bump landing between `prepare` and
+  # `publish` was enough to tag and push a broken tree — and the tag push
+  # is what publishes :latest.
+  info "CI status on the release commit"
+  local sha; sha="$(git rev-parse HEAD)"
+  local runs; runs="$(gh run list --commit "$sha" --json name,conclusion,status,workflowName 2>/dev/null || echo '')"
+  [ -n "$runs" ] || die "could not read CI status for $sha (is gh authenticated?)"
+  local verdict; verdict="$(printf '%s' "$runs" | "$PY" -c '
+import json, sys
+
+# Only the workflows behind the REQUIRED branch-protection checks gate the
+# release. UI tests and E2E (staging) run on the self-hosted runner and are
+# deliberately not required: if that box is offline their runs sit queued
+# forever, and a release must not hang on it. They are still reported.
+REQUIRED = {"CI", "Build Multi-Platform Docker Images", "CodeQL", "Lint (emoji)"}
+runs = json.load(sys.stdin)
+pending, bad, other = set(), set(), []
+for r in runs:
+    name = r.get("workflowName", "?")
+    state = r.get("conclusion") or r.get("status")
+    if name not in REQUIRED:
+        other.append(name + "=" + str(state))
+        continue
+    if r.get("status") != "completed":
+        pending.add(name)
+    # cancelled counts as failed: a cancelled required check is exactly how
+    # a broken build slipped through before (see the v2.21.4 release).
+    elif r.get("conclusion") not in ("success", "skipped", "neutral"):
+        bad.add(name + "=" + str(r.get("conclusion")))
+missing = REQUIRED - {r.get("workflowName") for r in runs}
+if pending:
+    print("PENDING " + ", ".join(sorted(pending)))
+elif bad:
+    print("FAILED " + ", ".join(sorted(bad)))
+elif missing:
+    print("MISSING " + ", ".join(sorted(missing)))
+else:
+    print("OK " + ("; not-required: " + ", ".join(sorted(other)) if other else ""))')"
+  case "$verdict" in
+    OK*)      info "  ${verdict}" ;;
+    PENDING*) die "CI still running on $sha (${verdict#PENDING }) - wait for it" ;;
+    FAILED*)  die "CI is not green on $sha: ${verdict#FAILED }" ;;
+    MISSING*) die "no CI run found on $sha for: ${verdict#MISSING } - push the commit and let CI run" ;;
+    *)        die "could not interpret CI status for $sha: $verdict" ;;
+  esac
+
   info "Tag + push v$version"
   git tag -a "v$version" -m "$title" HEAD
   git push origin "v$version" --quiet

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -16,8 +16,31 @@ import os
 import re
 import pytest
 
-# Skip entire module if playwright is not installed
-pytest.importorskip("playwright")
+# Skip the module if playwright is not installed — unless the environment
+# declares that a browser MUST be available (#414). CI sets
+# CERTMATE_UI_REQUIRE_BROWSER=1, so a runner missing playwright or its system
+# libraries fails the job instead of skipping every test and reporting green.
+_REQUIRE_BROWSER = os.environ.get("CERTMATE_UI_REQUIRE_BROWSER") == "1"
+
+
+def _no_browser(reason):
+    """Fail when a browser is mandatory, skip when it is merely unavailable."""
+    if _REQUIRE_BROWSER:
+        pytest.fail(
+            f"{reason} — CERTMATE_UI_REQUIRE_BROWSER=1 means this must not be "
+            "skipped (install with `playwright install --with-deps chromium`)"
+        )
+    pytest.skip(reason)
+
+
+if _REQUIRE_BROWSER:
+    import importlib.util
+    if importlib.util.find_spec("playwright") is None:
+        raise RuntimeError(
+            "playwright is not installed but CERTMATE_UI_REQUIRE_BROWSER=1"
+        )
+else:
+    pytest.importorskip("playwright")
 
 from playwright.sync_api import Page, expect
 
@@ -66,7 +89,7 @@ def browser_page(docker_container):
         browser = pw.chromium.launch(headless=True)
     except Exception as e:
         pw.stop()
-        pytest.skip(f"Chromium not available: {e}")
+        _no_browser(f"Chromium not available: {e}")
     context = browser.new_context(ignore_https_errors=True)
 
     # Inject session cookie into Playwright browser context


### PR DESCRIPTION
Closes #412, closes #413, closes #414, closes #428.

The second theme from the 360° audit: **gates that report success without checking anything**. Individually small, collectively the reason a green board could not be trusted.

| Gate | Why it could not fail | Now |
|---|---|---|
| Trivy container scan | no `exit-code`, scanned the floating `:latest` (= the *previous* release on a push to main), skipped on PRs entirely | scans the image just built (loaded locally from the buildx cache), runs on PRs, fails on a **fixable** CRITICAL |
| `release.sh publish` | never queried CI | refuses unless the required workflows are green on the exact release commit |
| UI tests | any Chromium failure became a skip; `playwright install` without `--with-deps` | `--with-deps`, an explicit launch check, skip-is-failure via env, and a job that fails if every test skipped |
| flake8 | `--exit-zero` in CI, Makefile and release.sh | a curated failing set; three real F811s surfaced and fixed |
| coverage | `informational: true` + `fail_ci_if_error: false` + no `--cov-fail-under` | a floor at 65% (current is ~72% locally) |

### Judgement calls worth reviewing

- **The Trivy gate is deliberately narrow.** Failing on every HIGH would make CI permanently red against the unfixable base-image tail tracked in #403, and a permanently red gate is worse than none. Failing on `severity: CRITICAL` + `ignore-unfixed: true` means the build breaks exactly when a base-image or dependency bump is *possible*. If this PR's own run is red, that is the gate working — the fix is the bump, not a lower bar.
- **`release.sh` gates only on the required workflows** (`CI`, `Build Multi-Platform Docker Images`, `CodeQL`, `Lint (emoji)`). `UI tests` and `E2E (staging)` run on the self-hosted host and are reported but never block: if that box is offline their runs queue forever and would hang every release.
- **`Lint (emoji)` now also runs on push.** It was PR-only, which meant the check was absent from every commit on main — so the new release gate would have reported it MISSING on every release. Verified against the real run list for current `main`.
- **The coverage floor is a floor, not a target.** 65 is below today's number so it cannot go red on merge; raise it as a ratchet, never lower it to make a build pass.
- **`pytest.ini` measured `source = .`** while CI measured `--cov=modules`, so the local and CI numbers were never comparable. Aligned to `modules/`.

### Verification

`1770 passed` locally with `--cov-fail-under=65` satisfied; the curated flake8 set is clean at 0 after fixing the three F811s. The `release.sh` gate logic was exercised against the real run list for `main` plus simulated failed / cancelled / self-hosted-queued cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)