### PR TITLE
feat: file logging, rotated by construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1410,6 +1410,11 @@ main "$@"
 | `SECRET_KEY_FILE`       |          | -              | Path to a file containing the Flask secret key (takes precedence over `SECRET_KEY`) |
 | `PORT`             |          | `8000`         | Server port (honoured by the container entrypoint) |
 | `FLASK_ENV`        |          | `production`   | Flask environment. `production` refuses `--debug`  |
+| `CERTMATE_LOG_FILE` |         | -              | Also write logs to this path. Off by default: the container logs to stdout, which is what `docker logs` and log shippers expect. Set it (e.g. `/app/logs/certmate.log`) to keep a file on the mounted volume — it is what the web UI's log stream reads |
+| `CERTMATE_LOG_MAX_BYTES` |    | `10485760`     | Rotate the log file at this size (10 MB). File logging is always rotated — there is no way to configure an unbounded one |
+| `CERTMATE_LOG_BACKUP_COUNT` | | `5`            | How many rotated files to keep (~60 MB ceiling with the default size) |
+| `CERTMATE_LOG_LEVEL` |        | `INFO`         | DEBUG / INFO / WARNING / ERROR |
+| `CERTMATE_LOG_JSON` |         | `true`         | JSON log lines (set `false` for human-readable) |
 
 > **Bind address is not an environment variable.** The container always binds
 > `0.0.0.0` inside its own network namespace; to expose it only on loopback,

--- a/app.py
+++ b/app.py
@@ -9,13 +9,37 @@ from modules import __version__
 
 # Import new modular components
 from modules.core import configure_structured_logging, get_certmate_logger
+from modules.core.structured_logging import (
+    DEFAULT_LOG_BACKUP_COUNT,
+    DEFAULT_LOG_MAX_BYTES,
+)
 from modules.core.factory import create_app
 
-# Configure structured JSON logging
+# Configure structured JSON logging.
+# CERTMATE_LOG_FILE is opt-in (#431): the container logs to stdout, which is
+# what `docker logs` and every shipper expect. Set it to also write a file on
+# the mounted volume — it is rotated by construction, and it is the file the
+# web UI's log stream reads.
 json_logging = os.getenv('CERTMATE_LOG_JSON', 'true').lower() == 'true'
 log_level_name = os.getenv('CERTMATE_LOG_LEVEL', 'INFO').upper()
 log_level = getattr(logging, log_level_name, logging.INFO)
-configure_structured_logging(level=log_level, json_output=json_logging)
+
+
+def _int_env(name, default):
+    try:
+        value = int(os.getenv(name, ''))
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+configure_structured_logging(
+    level=log_level,
+    json_output=json_logging,
+    log_file=os.getenv('CERTMATE_LOG_FILE') or None,
+    max_bytes=_int_env('CERTMATE_LOG_MAX_BYTES', DEFAULT_LOG_MAX_BYTES),
+    backup_count=_int_env('CERTMATE_LOG_BACKUP_COUNT', DEFAULT_LOG_BACKUP_COUNT),
+)
 logger = get_certmate_logger('app')
 
 # Global app instance for WSGI servers

--- a/docs/api.md
+++ b/docs/api.md
@@ -590,8 +590,14 @@ curl -X POST http://localhost:5000/api/certificates/example.com/reissue \
 GET /api/web/logs/stream
 ```
 
-Server-Sent Events tail of `logs/certmate.log`, for watching an issuance or a
-deployment live from a terminal:
+Server-Sent Events tail of the application log file, for watching an issuance
+or a deployment live from a terminal.
+
+**Requires file logging to be on.** By default CertMate logs to stdout only —
+what `docker logs` and every log shipper expect — so this endpoint reports
+"Log file not found" until you set `CERTMATE_LOG_FILE`
+(e.g. `CERTMATE_LOG_FILE=/app/logs/certmate.log`). The file is rotated
+automatically; see the environment table in the README.
 
 ```bash
 curl -N -H "Authorization: Bearer TOKEN" \

--- a/modules/core/structured_logging.py
+++ b/modules/core/structured_logging.py
@@ -31,6 +31,8 @@ import threading
 import os
 import re
 from datetime import datetime
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 from .utils import utc_now
 from typing import Any, Dict, Optional
 from contextvars import ContextVar
@@ -269,18 +271,34 @@ def timed(logger: StructuredLogger, operation: str):
     return decorator
 
 
+# File-logging defaults (#431). Rotation is not optional: the only way to
+# enable a log file is through this function, and it always rotates. An
+# unbounded log on a mounted volume is a slow outage — and the audit chain,
+# which must NOT be rotated naively, lives in the same directory, so the app
+# log filling the volume takes the tamper-evident record down with it.
+DEFAULT_LOG_MAX_BYTES = 10 * 1024 * 1024   # 10 MB per file
+DEFAULT_LOG_BACKUP_COUNT = 5               # ~60 MB ceiling for the app log
+
+
 def configure_structured_logging(
     level: int = logging.INFO,
     json_output: bool = True,
-    log_file: Optional[str] = None
+    log_file: Optional[str] = None,
+    max_bytes: int = DEFAULT_LOG_MAX_BYTES,
+    backup_count: int = DEFAULT_LOG_BACKUP_COUNT,
 ):
     """
     Configure structured logging for the application.
-    
+
     Args:
         level: Logging level (default: INFO)
         json_output: Use JSON format (default: True)
-        log_file: Optional file path for log output
+        log_file: Optional file path for log output. Off by default: the
+            container logs to stdout, which is what `docker logs` and every
+            log shipper expect. Set it when you want a file on the mounted
+            volume as well — the web UI's log stream reads it.
+        max_bytes: Rotate once the active file reaches this size (#431).
+        backup_count: How many rotated files to keep.
     """
     root_logger = logging.getLogger()
     root_logger.setLevel(level)
@@ -303,11 +321,28 @@ def configure_structured_logging(
     console_handler.setFormatter(formatter)
     root_logger.addHandler(console_handler)
     
-    # File handler (optional)
+    # File handler (optional) — always rotating, never plain (#431).
     if log_file:
-        file_handler = logging.FileHandler(log_file)
-        file_handler.setFormatter(formatter)
-        root_logger.addHandler(file_handler)
+        path = Path(log_file)
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            file_handler = RotatingFileHandler(
+                str(path),
+                maxBytes=max_bytes,
+                backupCount=backup_count,
+                encoding='utf-8',
+            )
+            file_handler.setFormatter(formatter)
+            root_logger.addHandler(file_handler)
+        except OSError as e:
+            # Never let an unwritable log path stop the application from
+            # starting: stdout logging is already configured above, and a
+            # certificate manager that refuses to boot because it cannot
+            # write a *log* has failed at the wrong thing.
+            root_logger.warning(
+                "Could not open log file %s (%s); continuing with console "
+                "logging only", log_file, e,
+            )
     
     # Reduce noise from third-party libraries
     logging.getLogger('werkzeug').setLevel(logging.WARNING)

--- a/tests/test_log_file_rotation.py
+++ b/tests/test_log_file_rotation.py
@@ -1,0 +1,149 @@
+"""File logging, when enabled, is rotated by construction.
+
+Regression tests for #431 (the application-log half; rotating the
+tamper-evident audit chain is a separate design and a separate issue).
+
+The audit found "no log rotation anywhere". Looking at it, the situation was
+one step stranger: `configure_structured_logging` accepted a `log_file` and
+nothing ever passed one, so the application never wrote a log file at all —
+`logs/certmate.log`, which the web UI's log stream tails, was never created by
+anything. So the fix is not "add rotation to the file handler", it is "make
+the file handler exist, and make it impossible to have one without rotation".
+
+Console logging remains the default: the container logs to stdout, which is
+what `docker logs` and every shipper expect.
+"""
+
+import logging
+import os
+
+import pytest
+
+from modules.core.structured_logging import (
+    DEFAULT_LOG_BACKUP_COUNT,
+    DEFAULT_LOG_MAX_BYTES,
+    configure_structured_logging,
+)
+
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture(autouse=True)
+def _restore_root_logger():
+    """configure_structured_logging replaces the root handlers; put them back
+    so this module cannot silence the rest of the suite."""
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    yield
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+    for h in saved_handlers:
+        root.addHandler(h)
+    root.setLevel(saved_level)
+
+
+def _file_handlers():
+    return [
+        h for h in logging.getLogger().handlers
+        if isinstance(h, logging.FileHandler)
+    ]
+
+
+def test_no_file_handler_by_default():
+    """stdout only, unless an operator asks for a file."""
+    configure_structured_logging(json_output=False)
+    assert _file_handlers() == []
+
+
+def test_enabling_a_log_file_always_gives_a_rotating_handler(tmp_path):
+    log_file = tmp_path / "certmate.log"
+
+    configure_structured_logging(json_output=False, log_file=str(log_file))
+
+    handlers = _file_handlers()
+    assert len(handlers) == 1
+    handler = handlers[0]
+    # The point of the issue: a plain FileHandler grows without bound.
+    assert isinstance(handler, logging.handlers.RotatingFileHandler)
+    assert handler.maxBytes == DEFAULT_LOG_MAX_BYTES
+    assert handler.backupCount == DEFAULT_LOG_BACKUP_COUNT
+
+
+def test_the_file_is_actually_written(tmp_path):
+    log_file = tmp_path / "certmate.log"
+    configure_structured_logging(json_output=False, log_file=str(log_file))
+
+    logging.getLogger("test").warning("hello from the test")
+
+    assert log_file.exists()
+    assert "hello from the test" in log_file.read_text()
+
+
+def test_it_rotates_at_the_configured_size(tmp_path):
+    log_file = tmp_path / "certmate.log"
+    configure_structured_logging(
+        json_output=False, log_file=str(log_file), max_bytes=2048, backup_count=2,
+    )
+    logger = logging.getLogger("rotation-test")
+
+    for i in range(200):
+        logger.warning("x" * 100 + f" line {i}")
+
+    rotated = sorted(p.name for p in tmp_path.glob("certmate.log*"))
+    assert "certmate.log" in rotated
+    assert "certmate.log.1" in rotated, "the log never rotated"
+    # backupCount caps the tail: no .3 survives.
+    assert "certmate.log.3" not in rotated
+    for name in rotated:
+        assert (tmp_path / name).stat().st_size < 20_000
+
+
+def test_the_parent_directory_is_created(tmp_path):
+    log_file = tmp_path / "nested" / "dir" / "certmate.log"
+
+    configure_structured_logging(json_output=False, log_file=str(log_file))
+    logging.getLogger("test").warning("creates its own directory")
+
+    assert log_file.exists()
+
+
+def test_an_unwritable_path_does_not_stop_the_application(tmp_path, caplog):
+    """A certificate manager that refuses to boot because it cannot write a
+    *log* has failed at the wrong thing."""
+    blocked = tmp_path / "blocked"
+    blocked.mkdir()
+    blocked.chmod(0o500)  # no write permission
+    try:
+        configure_structured_logging(
+            json_output=False, log_file=str(blocked / "certmate.log"),
+        )
+        # Console logging still works, and nothing raised.
+        assert _file_handlers() == []
+        logging.getLogger("test").warning("still alive")
+    finally:
+        blocked.chmod(0o700)
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+def test_the_unwritable_case_is_reported(tmp_path, capsys):
+    """Silence here would leave an operator thinking a log file exists.
+
+    Captured from stderr rather than with caplog: configure_structured_logging
+    removes every root handler, including the one caplog installs, so the only
+    place the warning can be observed is the console handler it then adds.
+    """
+    blocked = tmp_path / "blocked"
+    blocked.mkdir()
+    blocked.chmod(0o500)
+    try:
+        configure_structured_logging(
+            json_output=False, log_file=str(blocked / "certmate.log"),
+        )
+    finally:
+        blocked.chmod(0o700)
+
+    err = capsys.readouterr().err
+    assert "Could not open log file" in err
+    assert "console logging only" in err


### PR DESCRIPTION
Closes #431. The audit-chain half is split out into #437 with its design questions written down.

### The issue was subtly wrong, and the truth is more interesting

The finding was "no log rotation anywhere: logs and the audit chain grow without bound". Looking at it: `configure_structured_logging` accepted a `log_file` parameter and **nothing ever passed one**. CertMate has never written an application log file. `logs/certmate.log` — the path the issue worried about, and the path the web UI's log stream tails — was created by nothing, so `/api/web/logs/stream` has been answering "Log file not found" in every default deployment, including the one I documented yesterday.

So this is not "add rotation to the file handler". It is: make the file handler exist, and make it impossible to have one without rotation.

- `CERTMATE_LOG_FILE` is **opt-in**. stdout stays the default because it is the right one for a container — `docker logs` and every shipper expect it.
- When set, the handler is always a `RotatingFileHandler` (10 MB × 5, both tunable). There is no code path that yields an unbounded log file.
- An unwritable path warns and continues on console logging. A certificate manager that refuses to boot because it cannot write a *log* has failed at the wrong thing.

### Why the audit chain is not in here

It is append-only and tamper-evident: every entry chains to the previous by hash. A rotating handler renames the file and starts an empty one, so the new file's first entry has no predecessor and `audit verify` either fails at the seam or trusts an unverifiable start. The failure mode is the worst kind — routine maintenance making the tool cry tamper, which teaches an operator to ignore tamper alerts.

#437 writes down what a design has to answer: the seam (signed checkpoint at the roll + head-hash anchoring), verification across files, what deletion means on a record whose point is that deletion is detectable, whether compaction is the better shape, and migration for existing single-file chains. Practical urgency is low — the chain grows one line per audited operation, and the log that actually grows fast is now bounded.

### Documentation

The README env table gains `CERTMATE_LOG_FILE`, `CERTMATE_LOG_MAX_BYTES`, `CERTMATE_LOG_BACKUP_COUNT`, plus `CERTMATE_LOG_LEVEL` and `CERTMATE_LOG_JSON` which were already read but undocumented. `docs/api.md`'s log-stream section now says the endpoint needs file logging enabled — it was describing a tail of a file nothing wrote.

### Verification

`1974 passed` locally with Docker on PATH (7 new tests), flake8 clean on the failing set. The rotation test writes 200 lines against a 2 KB limit and asserts the roll actually happened and that `backupCount` caps the tail — a test that asserts only "a RotatingFileHandler was installed" would pass against a handler that never rotates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)