### PR TITLE
fix(audit): make an incremental export slice actually self-verifying (#441)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -779,6 +779,18 @@ The verifier checks the chain structure, that the manifest matches the entries,
 the Ed25519 signature, and that the fingerprint matches the (optionally pinned)
 public key.
 
+**Partial slices.** A full export starts at the genesis and is
+`format_version: 1`. A slice that starts mid-chain (`?from_seq=N` past the first
+entry) is `format_version: 2` and additionally carries `anchor_prev_hash` /
+`anchor_seq` in the manifest — the predecessor hash its first entry continues
+from — so the fragment can be verified even though it has no genesis. The anchor
+is inside the signed manifest, so the signature attests it. The verifier reports
+such a bundle as a **partial slice** and names the anchor seq: it proves the
+entries from the anchor forward are authentic and ordered, and proves nothing
+about what came before. Verifiers older than v2.23.0 report `unsupported bundle
+format_version 2` for an anchored slice; full exports remain byte-compatible
+with them.
+
 > **Threat-model honesty.** The chain + signature detect any interior
 > modification, deletion, or reorder, and tie an export to this instance's
 > public key — for anyone who does not hold the signing key. They do **not**

--- a/modules/core/audit_chain.py
+++ b/modules/core/audit_chain.py
@@ -125,10 +125,25 @@ def verify_chain(path) -> Dict[str, Any]:
     return verify_records(records)
 
 
-def verify_records(records) -> Dict[str, Any]:
+def verify_records(records, anchor_prev_hash: str = GENESIS_PREV,
+                   anchor_seq: Optional[int] = None) -> Dict[str, Any]:
     """Verify a list of parsed chain records ``[{seq, entry, prev_hash, hash}, ...]``.
     Returns the same result dict as :func:`verify_chain`. Shared by the file
-    verifier and the export-bundle verifier."""
+    verifier and the export-bundle verifier.
+
+    By default the records must start at the genesis, i.e. the first record's
+    ``prev_hash`` must be ``""``. That default is load-bearing: it is why
+    removing entries from the *head* of a full chain is detected.
+
+    A **fragment** that legitimately starts mid-chain — an incremental export
+    slice (#441), and the seam of any future segmentation — passes the
+    predecessor hash it continues from as *anchor_prev_hash*, optionally with
+    the ``seq`` that hash is supposed to precede. The caller is responsible for
+    making that anchor trustworthy: in a bundle it lives in the signed manifest,
+    so the instance attests where the slice starts. Verification against an
+    anchor proves the records from the anchor forward are authentic and ordered
+    — it proves nothing at all about the prefix, and callers must not report it
+    as if it did."""
     result: Dict[str, Any] = {
         "ok": False, "count": 0, "first_seq": None, "last_seq": None,
         "head_hash": None, "error_seq": None, "reason": None,
@@ -136,14 +151,15 @@ def verify_records(records) -> Dict[str, Any]:
     if not records:
         result["ok"] = True
         result["reason"] = "empty chain"
-        # The head of an empty chain is the genesis prev_hash, matching what
-        # build_manifest records for an empty slice (so an empty signed bundle
-        # verifies consistently).
-        result["head_hash"] = GENESIS_PREV
+        # The head of an empty slice is whatever it was anchored to (the
+        # genesis prev_hash for a full chain), matching what build_manifest
+        # records for an empty slice — so an empty signed bundle verifies
+        # consistently.
+        result["head_hash"] = anchor_prev_hash
         return result
 
-    prev_hash = GENESIS_PREV
-    expected_seq: Optional[int] = None
+    prev_hash = anchor_prev_hash
+    expected_seq: Optional[int] = anchor_seq
     count = 0
 
     for idx, rec in enumerate(records):
@@ -162,9 +178,10 @@ def verify_records(records) -> Dict[str, Any]:
             result["reason"] = f"malformed record at position {idx} (missing fields)"
             return result
 
+        if idx == 0:
+            result["first_seq"] = seq
         if expected_seq is None:
             expected_seq = seq
-            result["first_seq"] = seq
         elif seq != expected_seq:
             result["error_seq"] = expected_seq
             result["reason"] = (
@@ -201,7 +218,16 @@ def verify_records(records) -> Dict[str, Any]:
 # --- Phase 3: signed export bundle + checkpoints --------------------------
 
 CHECKPOINT_FILENAME = "certificate_audit.checkpoints.jsonl"
+# v1: the slice starts at the genesis (a full export). Byte-identical to what
+#     every previously shipped version produced, so old verifiers keep working.
+# v2: the slice is ANCHORED — it starts mid-chain, and the manifest carries the
+#     predecessor hash it continues from (#441). Deliberately a new version
+#     rather than an optional field on v1: a verifier that does not understand
+#     anchoring must say "unsupported format", never mistake a legitimate
+#     fragment for a broken chain.
 BUNDLE_FORMAT_VERSION = 1
+ANCHORED_BUNDLE_FORMAT_VERSION = 2
+SUPPORTED_BUNDLE_FORMAT_VERSIONS = (BUNDLE_FORMAT_VERSION, ANCHORED_BUNDLE_FORMAT_VERSION)
 
 
 def load_records(path, from_seq: Optional[int] = None, to_seq: Optional[int] = None):
@@ -234,16 +260,27 @@ def build_manifest(records, *, fingerprint, public_key_pem, exported_at,
                    algorithm) -> Dict[str, Any]:
     """Build the export-bundle manifest. The ``head_hash`` transitively commits
     to every record via the chain, so signing the manifest commits to the whole
-    exported slice without per-entry signatures."""
+    exported slice without per-entry signatures.
+
+    A slice that does not start at the genesis is marked as anchored: the
+    manifest records the ``prev_hash`` its first entry continues from, and the
+    signature therefore covers the anchor too (#441). Without that, the entries
+    are internally consistent but the first link has nothing to check against,
+    and the verifier — correctly — rejects them."""
+    anchor_prev_hash = GENESIS_PREV
     if records:
         seq_first = records[0]["seq"]
         seq_last = records[-1]["seq"]
         head_hash = records[-1]["hash"]
+        anchor_prev_hash = records[0].get("prev_hash") or GENESIS_PREV
     else:
         seq_first = seq_last = None
         head_hash = GENESIS_PREV
-    return {
-        "format_version": BUNDLE_FORMAT_VERSION,
+    anchored = anchor_prev_hash != GENESIS_PREV
+    manifest = {
+        "format_version": (
+            ANCHORED_BUNDLE_FORMAT_VERSION if anchored else BUNDLE_FORMAT_VERSION
+        ),
         "algorithm": algorithm,
         "instance_fingerprint": fingerprint,
         "public_key_pem": public_key_pem,
@@ -253,6 +290,10 @@ def build_manifest(records, *, fingerprint, public_key_pem, exported_at,
         "head_hash": head_hash,
         "exported_at": exported_at,
     }
+    if anchored:
+        manifest["anchor_prev_hash"] = anchor_prev_hash
+        manifest["anchor_seq"] = seq_first
+    return manifest
 
 
 def manifest_signing_bytes(manifest: Dict[str, Any]) -> bytes:

--- a/modules/core/audit_verify.py
+++ b/modules/core/audit_verify.py
@@ -46,7 +46,8 @@ def verify_bundle(bundle, expected_pubkey_pem=None):
     result = {
         "ok": False, "reason": None, "signed": False, "signature_ok": False,
         "fingerprint": None, "count": 0, "first_seq": None, "last_seq": None,
-        "head_hash": None, "error_seq": None,
+        "head_hash": None, "error_seq": None, "anchored": False,
+        "anchor_seq": None,
     }
     if not isinstance(bundle, dict) or "manifest" not in bundle or "entries" not in bundle:
         result["reason"] = "not an audit export bundle (missing manifest/entries)"
@@ -56,11 +57,31 @@ def verify_bundle(bundle, expected_pubkey_pem=None):
 
     # 0. Reject a format/algorithm this verifier does not understand, rather
     #    than silently mis-handling a future bundle version.
-    if manifest.get("format_version") != audit_chain.BUNDLE_FORMAT_VERSION:
+    if manifest.get("format_version") not in audit_chain.SUPPORTED_BUNDLE_FORMAT_VERSIONS:
         result["reason"] = f"unsupported bundle format_version {manifest.get('format_version')!r}"
         return result
     if manifest.get("algorithm") not in (None, "ed25519"):
         result["reason"] = f"unsupported signature algorithm {manifest.get('algorithm')!r}"
+        return result
+
+    # 0b. Anchor. A v2 bundle is a fragment that starts mid-chain and MUST
+    #     declare the predecessor hash it continues from; a v1 bundle must not
+    #     declare one, or a fragment could be passed off as a full chain by
+    #     downgrading its version. The anchor is inside the signed manifest, so
+    #     a valid signature attests it.
+    anchored = manifest.get("format_version") == audit_chain.ANCHORED_BUNDLE_FORMAT_VERSION
+    anchor_prev_hash = audit_chain.GENESIS_PREV
+    anchor_seq = None
+    if anchored:
+        anchor_prev_hash = manifest.get("anchor_prev_hash")
+        anchor_seq = manifest.get("anchor_seq")
+        if not anchor_prev_hash or not isinstance(anchor_seq, int):
+            result["reason"] = "anchored bundle without a usable anchor_prev_hash / anchor_seq"
+            return result
+        result["anchored"] = True
+        result["anchor_seq"] = anchor_seq
+    elif manifest.get("anchor_prev_hash") is not None:
+        result["reason"] = "unanchored bundle declares an anchor_prev_hash"
         return result
 
     # A bundle must carry either both a signature and a public key, or neither.
@@ -73,7 +94,8 @@ def verify_bundle(bundle, expected_pubkey_pem=None):
         return result
 
     # 1. Structural chain verification of the entries.
-    chain = audit_chain.verify_records(entries)
+    chain = audit_chain.verify_records(
+        entries, anchor_prev_hash=anchor_prev_hash, anchor_seq=anchor_seq)
     for k in ("count", "first_seq", "last_seq", "head_hash", "error_seq"):
         result[k] = chain.get(k)
     if not chain["ok"]:
@@ -117,6 +139,11 @@ def verify_bundle(bundle, expected_pubkey_pem=None):
 
     result["ok"] = True
     result["reason"] = "intact and signed" if result["signed"] else "intact (unsigned bundle)"
+    if result["anchored"]:
+        # Never let an anchored fragment read as "the whole record is intact".
+        # It attests the entries from the anchor forward; everything before the
+        # anchor is outside this bundle and unproven by it.
+        result["reason"] += f" from the declared anchor at seq {anchor_seq} (partial slice)"
     return result
 
 
@@ -152,6 +179,10 @@ def main(argv=None) -> int:
             tag = f"signed by {result['fingerprint']}" if result["signed"] else "UNSIGNED"
             print(f"OK: audit bundle {result['reason']} "
                   f"({result['count']} entries, seq {result['first_seq']}..{result['last_seq']}; {tag})")
+            if result["anchored"]:
+                print(f"note: this is a PARTIAL slice verified from a declared anchor at seq "
+                      f"{result['anchor_seq']}, not from the start of the chain. Entries before "
+                      f"that seq are not covered by this bundle.", file=sys.stderr)
             if result["signed"] and expected_pem is None:
                 print("note: public key NOT pinned — the fingerprint is self-asserted by the "
                       "bundle. Pin the instance key with --pubkey to bind the attribution.",

--- a/modules/core/audit_verify.py
+++ b/modules/core/audit_verify.py
@@ -80,8 +80,13 @@ def verify_bundle(bundle, expected_pubkey_pem=None):
             return result
         result["anchored"] = True
         result["anchor_seq"] = anchor_seq
-    elif manifest.get("anchor_prev_hash") is not None:
-        result["reason"] = "unanchored bundle declares an anchor_prev_hash"
+    elif any(manifest.get(k) is not None for k in ("anchor_prev_hash", "anchor_seq")):
+        # Reject EVERY anchor field on a v1 bundle, not just anchor_prev_hash:
+        # a v2 slice downgraded by deleting one of the two fields would
+        # otherwise fall through to the link check and be reported as a broken
+        # chain — a tamper verdict on an intact record. Say what is actually
+        # wrong with it.
+        result["reason"] = "unanchored bundle declares anchor fields"
         return result
 
     # A bundle must carry either both a signature and a public key, or neither.

--- a/tests/test_audit_export_slice_anchor.py
+++ b/tests/test_audit_export_slice_anchor.py
@@ -1,0 +1,262 @@
+"""An incremental export slice must verify — and must not overclaim.
+
+Regression tests for #441. `GET /api/audit/export?from_seq=N` was documented as
+producing a "self-verifying" slice and produced a bundle the shipped verifier
+rejected: `verify_records` seeds `prev_hash` with the genesis and requires the
+first record's `prev_hash` to be `""`, so any fragment failed on its very first
+link. Every documented incremental-export workflow was broken, and the failure
+mode was the worst wording available — "broken link ... a deletion or reorder"
+on a perfectly intact record.
+
+The fix is not to relax the genesis requirement: that requirement is why head
+truncation of a *full* chain is detected. It is to let a fragment declare, inside
+the signed manifest, the predecessor hash it continues from.
+
+The second half of these tests is about not overclaiming. A verified fragment
+says nothing about the entries before its anchor, and neither the result dict nor
+the CLI is allowed to imply otherwise.
+"""
+
+import json
+
+import pytest
+
+from modules.core import audit_chain, audit_verify
+from modules.core.audit import AuditLogger
+from modules.core.audit_signing import AuditSigner
+
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def audit(tmp_path):
+    a = AuditLogger(tmp_path / "logs", chain_dir=tmp_path / "chain",
+                    signer=AuditSigner(tmp_path))
+    for i in range(6):
+        a.log_operation("renew", "certificate", f"d{i}.example.com", "success")
+    yield a
+    a.audit_logger.removeHandler(a.file_handler)
+    a.file_handler.close()
+
+
+# --------------------------------------------------------------------------
+# The bug itself
+# --------------------------------------------------------------------------
+
+def test_a_slice_from_the_middle_verifies(audit):
+    bundle = audit.export_bundle(from_seq=3)
+
+    result = audit_verify.verify_bundle(bundle)
+
+    assert result["ok"], result["reason"]
+    assert result["signed"] and result["signature_ok"]
+    assert result["count"] == 3
+    assert result["first_seq"] == 3 and result["last_seq"] == 5
+
+
+def test_a_bounded_slice_verifies(audit):
+    bundle = audit.export_bundle(from_seq=2, to_seq=4)
+
+    result = audit_verify.verify_bundle(bundle)
+
+    assert result["ok"], result["reason"]
+    assert result["first_seq"] == 2 and result["last_seq"] == 4
+
+
+def test_a_full_export_is_unchanged_and_unanchored(audit):
+    """v1 stays byte-compatible: no new manifest keys, so a verifier shipped
+    before this change still accepts every full export."""
+    manifest = audit.export_bundle()["manifest"]
+
+    assert manifest["format_version"] == audit_chain.BUNDLE_FORMAT_VERSION
+    assert "anchor_prev_hash" not in manifest
+    assert "anchor_seq" not in manifest
+
+
+def test_a_slice_starting_at_the_genesis_is_not_anchored(audit):
+    """?from_seq=0 is a full export by another name."""
+    manifest = audit.export_bundle(from_seq=0)["manifest"]
+
+    assert manifest["format_version"] == audit_chain.BUNDLE_FORMAT_VERSION
+
+
+def test_an_empty_slice_still_verifies(audit):
+    """Nothing at or after the requested seq: no entries, no anchor to declare."""
+    bundle = audit.export_bundle(from_seq=99)
+
+    assert bundle["entries"] == []
+    assert bundle["manifest"]["format_version"] == audit_chain.BUNDLE_FORMAT_VERSION
+    assert audit_verify.verify_bundle(bundle)["ok"]
+
+
+# --------------------------------------------------------------------------
+# Anchoring must not become a hole
+# --------------------------------------------------------------------------
+
+def test_tampering_inside_a_slice_is_still_caught(audit):
+    bundle = audit.export_bundle(from_seq=3)
+    bundle["entries"][1]["entry"]["status"] = "forged"
+
+    result = audit_verify.verify_bundle(bundle)
+
+    assert not result["ok"]
+    assert "hash mismatch" in result["reason"]
+
+
+def test_a_forged_anchor_does_not_validate_foreign_entries(audit):
+    """The anchor is checked against the entries, not merely recorded."""
+    bundle = audit.export_bundle(from_seq=3)
+    bundle["manifest"]["anchor_prev_hash"] = "0" * 64
+
+    result = audit_verify.verify_bundle(bundle)
+
+    assert not result["ok"]
+    assert "broken link" in result["reason"]
+
+
+def test_a_wrong_anchor_seq_is_caught(audit):
+    bundle = audit.export_bundle(from_seq=3)
+    bundle["manifest"]["anchor_seq"] = 99
+
+    result = audit_verify.verify_bundle(bundle)
+
+    assert not result["ok"]
+    assert "sequence break" in result["reason"]
+
+
+def test_a_slice_cannot_be_downgraded_to_look_complete(audit):
+    """Stripping the version off a fragment must not turn it into a full chain
+    — nor produce a misleading 'broken chain' verdict."""
+    bundle = audit.export_bundle(from_seq=3)
+    bundle["manifest"]["format_version"] = audit_chain.BUNDLE_FORMAT_VERSION
+
+    result = audit_verify.verify_bundle(bundle)
+
+    assert not result["ok"]
+    assert "declares an anchor" in result["reason"]
+
+
+def test_an_anchored_bundle_without_an_anchor_is_rejected(audit):
+    bundle = audit.export_bundle(from_seq=3)
+    del bundle["manifest"]["anchor_prev_hash"]
+
+    result = audit_verify.verify_bundle(bundle)
+
+    assert not result["ok"]
+    assert "without a usable anchor" in result["reason"]
+
+
+def test_the_signature_covers_the_anchor(audit):
+    """An attacker who rewrites the anchor cannot re-sign it."""
+    bundle = audit.export_bundle(from_seq=3)
+    genuine = bundle["entries"][0]["prev_hash"]
+    bundle["manifest"]["anchor_prev_hash"] = genuine  # unchanged value...
+    assert audit_verify.verify_bundle(bundle)["ok"]
+
+    # ...but any real change breaks the manifest signature as well as the link.
+    bundle["manifest"]["anchor_seq"] = 4
+    assert not audit_verify.verify_bundle(bundle)["ok"]
+
+
+def test_an_unknown_format_version_is_still_rejected(audit):
+    bundle = audit.export_bundle()
+    bundle["manifest"]["format_version"] = 99
+
+    result = audit_verify.verify_bundle(bundle)
+
+    assert not result["ok"]
+    assert "format_version" in result["reason"]
+
+
+# --------------------------------------------------------------------------
+# Not overclaiming
+# --------------------------------------------------------------------------
+
+def test_a_slice_is_reported_as_partial_not_intact(audit):
+    result = audit_verify.verify_bundle(audit.export_bundle(from_seq=3))
+
+    assert result["anchored"] is True
+    assert result["anchor_seq"] == 3
+    assert "partial slice" in result["reason"]
+
+
+def test_a_full_export_is_not_flagged_as_partial(audit):
+    result = audit_verify.verify_bundle(audit.export_bundle())
+
+    assert result["anchored"] is False
+    assert "partial" not in result["reason"]
+
+
+def test_the_cli_says_a_slice_is_partial(audit, tmp_path, capsys):
+    path = tmp_path / "slice.json"
+    path.write_text(json.dumps(audit.export_bundle(from_seq=3)))
+
+    assert audit_verify.main(["--bundle", str(path)]) == 0
+
+    err = capsys.readouterr().err
+    assert "PARTIAL slice" in err
+    assert "seq 3" in err
+
+
+def test_the_cli_does_not_cry_partial_on_a_full_export(audit, tmp_path, capsys):
+    path = tmp_path / "full.json"
+    path.write_text(json.dumps(audit.export_bundle()))
+
+    assert audit_verify.main(["--bundle", str(path)]) == 0
+    assert "PARTIAL" not in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------
+# verify_records: the primitive, directly
+# --------------------------------------------------------------------------
+
+def test_verify_records_still_requires_the_genesis_by_default(audit):
+    """The default is load-bearing: it is what makes head truncation of a full
+    chain detectable. Anchoring is opt-in, never inferred from the records."""
+    records = audit_chain.load_records(audit.audit_chain_file)
+
+    beheaded = audit_chain.verify_records(records[2:])
+
+    assert not beheaded["ok"]
+    assert "broken link" in beheaded["reason"]
+
+
+def test_verify_records_accepts_an_explicit_anchor(audit):
+    records = audit_chain.load_records(audit.audit_chain_file)
+    tail = records[2:]
+
+    result = audit_chain.verify_records(
+        tail, anchor_prev_hash=tail[0]["prev_hash"], anchor_seq=tail[0]["seq"])
+
+    assert result["ok"]
+    assert result["first_seq"] == 2
+    assert result["head_hash"] == records[-1]["hash"]
+
+
+def test_an_empty_anchored_slice_reports_the_anchor_as_its_head(audit):
+    result = audit_chain.verify_records([], anchor_prev_hash="abc", anchor_seq=7)
+
+    assert result["ok"] and result["head_hash"] == "abc"
+
+
+def test_export_endpoint_slice_verifies(audit, tmp_path):
+    """End to end through the HTTP route, since that is where the broken
+    workflow was documented."""
+    from types import SimpleNamespace
+    from flask import Flask
+    from modules.web.misc_routes import register_misc_routes
+
+    def _passthrough(*_a, **_k):
+        return lambda fn: fn
+
+    app = Flask(__name__)
+    register_misc_routes(app, {"audit": audit}, _passthrough,
+                         SimpleNamespace(require_role=_passthrough))
+
+    response = app.test_client().get("/api/audit/export?from_seq=4")
+
+    assert response.status_code == 200
+    body = json.loads(response.data)
+    assert body["manifest"]["format_version"] == audit_chain.ANCHORED_BUNDLE_FORMAT_VERSION
+    assert audit_verify.verify_bundle(body)["ok"]

--- a/tests/test_audit_export_slice_anchor.py
+++ b/tests/test_audit_export_slice_anchor.py
@@ -125,16 +125,22 @@ def test_a_wrong_anchor_seq_is_caught(audit):
     assert "sequence break" in result["reason"]
 
 
-def test_a_slice_cannot_be_downgraded_to_look_complete(audit):
+@pytest.mark.parametrize("dropped", [None, "anchor_prev_hash", "anchor_seq"])
+def test_a_slice_cannot_be_downgraded_to_look_complete(audit, dropped):
     """Stripping the version off a fragment must not turn it into a full chain
-    — nor produce a misleading 'broken chain' verdict."""
+    — nor produce a misleading 'broken chain' verdict. Dropping either anchor
+    field on the way down does not help: every anchor field is rejected on a v1
+    bundle, so the verdict names the real problem instead of blaming the
+    entries."""
     bundle = audit.export_bundle(from_seq=3)
     bundle["manifest"]["format_version"] = audit_chain.BUNDLE_FORMAT_VERSION
+    if dropped:
+        del bundle["manifest"][dropped]
 
     result = audit_verify.verify_bundle(bundle)
 
     assert not result["ok"]
-    assert "declares an anchor" in result["reason"]
+    assert "declares anchor fields" in result["reason"]
 
 
 def test_an_anchored_bundle_without_an_anchor_is_rejected(audit):

--- a/tests/test_audit_phase3.py
+++ b/tests/test_audit_phase3.py
@@ -199,9 +199,10 @@ def test_half_signed_bundle_is_rejected(make_audit, tmp_path):
 
 
 def test_unsupported_format_is_rejected(make_audit, tmp_path):
+    # 2 is the anchored-slice format (#441); 99 is nobody's format.
     bundle, _ = _signed_bundle(make_audit, tmp_path)
     bad = copy.deepcopy(bundle)
-    bad['manifest']['format_version'] = 2
+    bad['manifest']['format_version'] = 99
     r = audit_verify.verify_bundle(bad)
     assert not r['ok'] and 'format_version' in r['reason']
 


### PR DESCRIPTION
Fixes #441.

`GET /api/audit/export?from_seq=N` is documented as producing an "incremental, **self-verifying** slice". It produced a bundle that `python -m modules.core.audit_verify --bundle` — the verifier we hand to auditors — rejected:

```
ok:     false
reason: chain invalid: broken link at seq 3: prev_hash does not match the previous record's hash
```

`verify_records()` seeds `prev_hash` with the genesis and requires the first record's `prev_hash` to be `""`. Any fragment fails on its very first link, and it fails claiming "a deletion or reorder" about a perfectly intact record — a false tamper verdict, which is the one output an integrity tool must never produce carelessly.

## Approach

The genesis requirement is **not** relaxed. It is load-bearing: it is why removing entries from the *head* of a full chain is detected today. What was missing is a way for a fragment to declare where it legitimately starts.

- `verify_records(records, anchor_prev_hash=GENESIS_PREV, anchor_seq=None)`. Opt-in, never inferred from the records — a caller must state the anchor.
- An anchored slice is `format_version: 2` and carries `anchor_prev_hash` / `anchor_seq` in the manifest. A full export stays byte-identical `format_version: 1`, so verifiers shipped before this change keep accepting every full export; meeting a v2 bundle they report "unsupported bundle format_version 2" instead of a false "chain invalid".
- The anchor is inside the **signed** manifest, so the signature attests it, and it is checked against the entries rather than merely recorded. Rewriting it breaks both the link check and the signature.
- Downgrading a v2 slice to v1 (to pass a fragment off as a full chain) is rejected explicitly, as is a v2 bundle with no usable anchor.
- Neither the result dict nor the CLI is allowed to call a fragment "intact". Both say **partial slice** and name the anchor seq: it proves the entries from the anchor forward are authentic and ordered, and proves nothing about what came before.

## Tests

`tests/test_audit_export_slice_anchor.py`, 20 tests: the bug itself (mid-chain slice, bounded slice, empty slice, `?from_seq=0`), that anchoring did not open a hole (tampered entry, forged anchor, wrong anchor seq, version downgrade, missing anchor, unknown version), that a slice is never reported as complete (result dict + CLI stderr, both directions), the `verify_records` primitive directly including that the genesis default still rejects a beheaded chain, and the HTTP route end to end — since the route is where the broken workflow was documented.

Suite: 1879 passed, 6 skipped. `docs/api.md` documents the partial-slice semantics and the version compatibility.

## Relation to #437

Found while analysing #437. The same missing primitive — *verify a chain fragment against a declared, signed starting anchor* — is what any segmentation or compaction design needs at its seam, so this lands independently of whichever shape #437 takes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)