### PR TITLE
fix(audit): rotate the human-readable audit log (#443)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1413,6 +1413,8 @@ main "$@"
 | `CERTMATE_LOG_FILE` |         | -              | Also write logs to this path. Off by default: the container logs to stdout, which is what `docker logs` and log shippers expect. Set it (e.g. `/app/logs/certmate.log`) to keep a file on the mounted volume — it is what the web UI's log stream reads |
 | `CERTMATE_LOG_MAX_BYTES` |    | `10485760`     | Rotate the log file at this size (10 MB). File logging is always rotated — there is no way to configure an unbounded one |
 | `CERTMATE_LOG_BACKUP_COUNT` | | `5`            | How many rotated files to keep (~60 MB ceiling with the default size) |
+| `CERTMATE_AUDIT_LOG_MAX_BYTES` | | `10485760`  | Rotate the human-readable audit log (`logs/audit/certificate_audit.log`) at this size. `0` disables rotation. Does **not** apply to the tamper-evident hash chain in `data/audit/`, which is never rotated |
+| `CERTMATE_AUDIT_LOG_BACKUP_COUNT` | | `5`       | How many rotated audit logs to keep. Note the Activity page tails only the active file, so it shows fewer entries immediately after a roll |
 | `CERTMATE_LOG_LEVEL` |        | `INFO`         | DEBUG / INFO / WARNING / ERROR |
 | `CERTMATE_LOG_JSON` |         | `true`         | JSON log lines (set `false` for human-readable) |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -605,7 +605,6 @@ log_certificate_downloaded() # Log downloads
 log_batch_operation() # Log batch operations
 log_api_request() # Log API requests
 get_recent_entries() # Get latest audit entries
-get_entries_by_resource() # Get entries for a resource
 ```
 
 ---

--- a/docs/de/architecture.md
+++ b/docs/de/architecture.md
@@ -582,7 +582,6 @@ log_certificate_downloaded() # Log downloads
 log_batch_operation() # Log batch operations
 log_api_request() # Log API requests
 get_recent_entries() # Get latest audit entries
-get_entries_by_resource() # Get entries for a resource
 ```
 
 ---

--- a/docs/es/architecture.md
+++ b/docs/es/architecture.md
@@ -582,7 +582,6 @@ log_certificate_downloaded() # Registrar las descargas
 log_batch_operation() # Registrar operaciones por lotes
 log_api_request() # Registrar peticiones API
 get_recent_entries() # Obtener las últimas entradas de auditoría
-get_entries_by_resource() # Obtener entradas para un recurso
 ```
 
 ---

--- a/docs/fr/architecture.md
+++ b/docs/fr/architecture.md
@@ -583,7 +583,6 @@ log_certificate_downloaded() # Journaliser les téléchargements
 log_batch_operation() # Journaliser les opérations par lots
 log_api_request() # Journaliser les requêtes API
 get_recent_entries() # Obtenir les dernières entrées d'audit
-get_entries_by_resource() # Obtenir les entrées pour une ressource
 ```
 
 ---

--- a/docs/it/architecture.md
+++ b/docs/it/architecture.md
@@ -583,7 +583,6 @@ log_certificate_downloaded() # Registrare i download
 log_batch_operation() # Registrare le operazioni in batch
 log_api_request() # Registrare le richieste API
 get_recent_entries() # Ottenere le ultime voci di audit
-get_entries_by_resource() # Ottenere le voci per una risorsa
 ```
 
 ---

--- a/modules/core/audit.py
+++ b/modules/core/audit.py
@@ -7,6 +7,7 @@ import os
 import logging
 import json
 import threading
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from datetime import datetime
 from collections import deque
@@ -17,13 +18,39 @@ from typing import Optional, Dict, Any
 
 logger = logging.getLogger(__name__)
 
+# Rotation defaults for the human-readable audit .log (#443). Same shape as the
+# application log's (#431), and deliberately NOT applied to the hash chain:
+# `certificate_audit.chain.jsonl` is append-only and tamper-evident, and naive
+# rotation breaks the property it exists for (see #437).
+DEFAULT_AUDIT_LOG_MAX_BYTES = 10 * 1024 * 1024   # 10 MB per file
+DEFAULT_AUDIT_LOG_BACKUP_COUNT = 5               # ~60 MB ceiling
+
+
+def _int_env(name: str, default: int) -> int:
+    """Read a positive int from the environment, ignoring anything unusable.
+    A typo in a log-rotation setting must not take the application down."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring %s=%r (not an integer); using %d", name, raw, default)
+        return default
+    if value < 0:
+        logger.warning("Ignoring %s=%r (negative); using %d", name, raw, default)
+        return default
+    return value
+
 
 class AuditLogger:
     """Centralized audit logging for certificate operations."""
 
     def __init__(self, audit_log_dir: Path, chain_dir: Optional[Path] = None,
                  enable_chain: bool = True, signer=None,
-                 checkpoint_interval: int = 100):
+                 checkpoint_interval: int = 100,
+                 max_bytes: Optional[int] = None,
+                 backup_count: Optional[int] = None):
         """
         Initialize Audit Logger.
 
@@ -36,23 +63,64 @@ class AuditLogger:
                 under the (backup-excluded) ``logs`` tree.
             enable_chain: write the hash chain (default True). Disable via the
                 ``CERTMATE_AUDIT_CHAIN=0`` environment variable as a kill switch.
+            max_bytes / backup_count: rotation of the human-readable ``.log``
+                (#443). Default to ``CERTMATE_AUDIT_LOG_MAX_BYTES`` /
+                ``CERTMATE_AUDIT_LOG_BACKUP_COUNT``, then to 10 MB × 5.
+                ``max_bytes=0`` disables rotation, which is how ``logging`` spells
+                it and the only way to get an unbounded file back.
         """
         self.audit_log_dir = Path(audit_log_dir)
-        self.audit_log_dir.mkdir(parents=True, exist_ok=True)
         self.audit_log_file = self.audit_log_dir / "certificate_audit.log"
 
-        # Configure audit file handler
-        self.file_handler = logging.FileHandler(self.audit_log_file)
-        self.file_handler.setFormatter(
-            logging.Formatter(
-                '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-                datefmt='%Y-%m-%d %H:%M:%S'
+        if max_bytes is None:
+            max_bytes = _int_env('CERTMATE_AUDIT_LOG_MAX_BYTES',
+                                 DEFAULT_AUDIT_LOG_MAX_BYTES)
+        if backup_count is None:
+            backup_count = _int_env('CERTMATE_AUDIT_LOG_BACKUP_COUNT',
+                                    DEFAULT_AUDIT_LOG_BACKUP_COUNT)
+
+        # Configure the audit file handler. Rotating, not plain (#443): this
+        # file grew without bound, and #431's fix covered only the application
+        # log — this handler is built here and was never reached by it.
+        #
+        # Safe to rotate because it carries no integrity property: it is
+        # human-readable text, not hashed, not chained, and the `logs/` tree is
+        # excluded from backups. The verifiable artifact is the hash chain in
+        # `data/audit/`, which is emphatically NOT rotated (see #437).
+        #
+        # RotatingFileHandler is not multi-process safe; the container runs
+        # gunicorn with `--workers 1 --threads 8`, one process, which is the
+        # same single-writer assumption the hash chain already depends on.
+        self.file_handler = None
+        try:
+            self.audit_log_dir.mkdir(parents=True, exist_ok=True)
+            self.file_handler = RotatingFileHandler(
+                str(self.audit_log_file),
+                maxBytes=max_bytes,
+                backupCount=backup_count,
+                encoding='utf-8',
             )
-        )
+            self.file_handler.setFormatter(
+                logging.Formatter(
+                    '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S'
+                )
+            )
+        except OSError as e:
+            # Previously this raised out of __init__, which the factory calls
+            # unguarded — an unwritable logs directory took the whole
+            # application down over a *log file*. The hash chain below is the
+            # record that matters and is written elsewhere; keep going.
+            logger.error(
+                "Could not open audit log file %s (%s); the human-readable "
+                "audit log is disabled. The tamper-evident chain is unaffected.",
+                self.audit_log_file, e,
+            )
 
         # Create audit logger
         self.audit_logger = logging.getLogger('certmate.audit')
-        self.audit_logger.addHandler(self.file_handler)
+        if self.file_handler is not None:
+            self.audit_logger.addHandler(self.file_handler)
         self.audit_logger.setLevel(logging.INFO)
 
         # Tamper-evident hash chain (Phase 2). One writer, one local file; the
@@ -799,34 +867,9 @@ class AuditLogger:
             logger.error(f"Error reading audit logs: {e}")
             return []
 
-    def get_entries_by_resource(self, resource_id: str) -> list:
-        """
-        Get all audit entries for a specific resource.
-
-        Args:
-            resource_id: Resource identifier
-
-        Returns:
-            List of matching audit entries
-        """
-        try:
-            entries = []
-            if not self.audit_log_file.exists():
-                return entries
-
-            with open(self.audit_log_file, 'r') as f:
-                for line in f:
-                    try:
-                        if ' - INFO - ' in line:
-                            json_str = line.split(' - INFO - ', 1)[1].strip()
-                            entry = json.loads(json_str)
-                            if entry.get('resource_id') == resource_id:
-                                entries.append(entry)
-                    except (json.JSONDecodeError, IndexError):
-                        continue
-
-            return entries
-
-        except Exception as e:
-            logger.error(f"Error reading audit logs: {e}")
-            return []
+    # ``get_entries_by_resource`` was removed with #443. It read the entire
+    # audit log to filter by resource_id and had no callers anywhere in the
+    # codebase. Leaving a whole-file reader behind a rotating handler is how a
+    # "why is the history missing" bug gets born: it would have silently
+    # reported only what survived in the active file. Per-resource history
+    # belongs on the hash chain, which is complete and verifiable.

--- a/modules/core/audit.py
+++ b/modules/core/audit.py
@@ -27,8 +27,9 @@ DEFAULT_AUDIT_LOG_BACKUP_COUNT = 5               # ~60 MB ceiling
 
 
 def _int_env(name: str, default: int) -> int:
-    """Read a positive int from the environment, ignoring anything unusable.
-    A typo in a log-rotation setting must not take the application down."""
+    """Read a non-negative int from the environment, ignoring anything
+    unusable (0 is meaningful: it is how ``logging`` spells "never roll"). A
+    typo in a log-rotation setting must not take the application down."""
     raw = os.environ.get(name)
     if raw is None:
         return default
@@ -117,7 +118,12 @@ class AuditLogger:
                 self.audit_log_file, e,
             )
 
-        # Create audit logger
+        # Create audit logger. `propagate` is deliberately left on: audit lines
+        # also reach the root handlers, i.e. stdout, which is what `docker logs`
+        # and every log shipper read. That is not duplication to be silenced —
+        # it is the reason the unwritable-directory case above is survivable,
+        # and turning it off would remove audit entries from the stream some
+        # operators collect them from.
         self.audit_logger = logging.getLogger('certmate.audit')
         if self.file_handler is not None:
             self.audit_logger.addHandler(self.file_handler)

--- a/tests/test_audit_log_rotation.py
+++ b/tests/test_audit_log_rotation.py
@@ -1,0 +1,176 @@
+"""The human-readable audit log is rotated by construction.
+
+Regression tests for #443. `AuditLogger.__init__` built a plain
+`logging.FileHandler` for `logs/audit/certificate_audit.log`, which grew without
+bound. #431 bounded the *application* log through
+`configure_structured_logging`; this handler is constructed independently and
+was never reached by that fix, so the file was still unbounded in production
+after the fix shipped.
+
+Rotating it is safe precisely because it carries no integrity property: it is
+human-readable text, not hashed, not chained, and the `logs/` tree is excluded
+from backups. The verifiable artifact is the hash chain under `data/audit/`,
+and these tests pin that the chain is left alone — rotating it naively would
+break the property it exists for (#437).
+"""
+
+import json
+import logging
+import os
+
+import pytest
+
+from modules.core import audit_chain
+from modules.core.audit import (
+    DEFAULT_AUDIT_LOG_BACKUP_COUNT,
+    DEFAULT_AUDIT_LOG_MAX_BYTES,
+    AuditLogger,
+)
+
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def make_audit():
+    """Each AuditLogger adds a handler to the shared 'certmate.audit' logger;
+    detach them so one test cannot write into another's file."""
+    created = []
+
+    def _make(log_dir, **kw):
+        a = AuditLogger(log_dir, **kw)
+        created.append(a)
+        return a
+
+    yield _make
+    for a in created:
+        if a.file_handler is not None:
+            a.audit_logger.removeHandler(a.file_handler)
+            a.file_handler.close()
+
+
+def _emit(audit, n, size=0):
+    for i in range(n):
+        audit.log_operation('renew', 'certificate', f'd{i}.example.com', 'success',
+                            details={'pad': 'x' * size} if size else None)
+
+
+def test_the_handler_rotates(make_audit, tmp_path):
+    audit = make_audit(tmp_path / 'logs')
+
+    assert isinstance(audit.file_handler, logging.handlers.RotatingFileHandler)
+    assert audit.file_handler.maxBytes == DEFAULT_AUDIT_LOG_MAX_BYTES
+    assert audit.file_handler.backupCount == DEFAULT_AUDIT_LOG_BACKUP_COUNT
+
+
+def test_it_actually_rolls_and_the_tail_is_capped(make_audit, tmp_path):
+    log_dir = tmp_path / 'logs'
+    audit = make_audit(log_dir, max_bytes=4096, backup_count=2)
+
+    _emit(audit, 200, size=200)
+
+    names = sorted(p.name for p in log_dir.glob('certificate_audit.log*'))
+    assert 'certificate_audit.log' in names
+    assert 'certificate_audit.log.1' in names, "the audit log never rotated"
+    assert 'certificate_audit.log.3' not in names, "backupCount did not cap the tail"
+    for name in names:
+        assert (log_dir / name).stat().st_size < 40_000
+
+
+def test_the_line_format_is_unchanged(make_audit, tmp_path):
+    """get_recent_entries splits on ' - INFO - ' and parses the rest as JSON.
+    Rotation must not disturb that."""
+    audit = make_audit(tmp_path / 'logs')
+
+    audit.log_operation('create', 'certificate', 'example.com', 'success')
+
+    line = audit.audit_log_file.read_text(encoding='utf-8').strip()
+    assert ' - INFO - ' in line
+    entry = json.loads(line.split(' - INFO - ', 1)[1])
+    assert entry['resource_id'] == 'example.com'
+    assert audit.get_recent_entries(limit=10)[0]['resource_id'] == 'example.com'
+
+
+def test_env_overrides_are_honoured(make_audit, tmp_path, monkeypatch):
+    monkeypatch.setenv('CERTMATE_AUDIT_LOG_MAX_BYTES', '2048')
+    monkeypatch.setenv('CERTMATE_AUDIT_LOG_BACKUP_COUNT', '1')
+
+    audit = make_audit(tmp_path / 'logs')
+
+    assert audit.file_handler.maxBytes == 2048
+    assert audit.file_handler.backupCount == 1
+
+
+@pytest.mark.parametrize('bad', ['', 'lots', '-1', '10MB'])
+def test_an_unusable_env_value_falls_back_instead_of_crashing(
+        make_audit, tmp_path, monkeypatch, bad):
+    """A typo in a log-rotation setting must not take a certificate manager
+    down at startup."""
+    monkeypatch.setenv('CERTMATE_AUDIT_LOG_MAX_BYTES', bad)
+
+    audit = make_audit(tmp_path / 'logs')
+
+    assert audit.file_handler.maxBytes == DEFAULT_AUDIT_LOG_MAX_BYTES
+
+
+def test_rotation_can_be_turned_off_explicitly(make_audit, tmp_path):
+    """0 is how `logging` spells 'never roll'; it stays available for an
+    operator who ships the file elsewhere."""
+    audit = make_audit(tmp_path / 'logs', max_bytes=0)
+
+    assert audit.file_handler.maxBytes == 0
+
+
+# --------------------------------------------------------------------------
+# The chain is a different file with different rules
+# --------------------------------------------------------------------------
+
+def test_the_hash_chain_is_not_rotated(make_audit, tmp_path):
+    """The chain must stay a single append-only file: rotating it naively
+    breaks the tamper-evidence it exists for (#437)."""
+    audit = make_audit(tmp_path / 'logs', chain_dir=tmp_path / 'data',
+                       max_bytes=2048, backup_count=2)
+
+    _emit(audit, 200, size=200)
+
+    chain_files = sorted(p.name for p in (tmp_path / 'data').iterdir())
+    assert chain_files == [audit_chain.CHAIN_FILENAME]
+    assert audit.verify_chain()['ok'], "rotating the .log disturbed the chain"
+    assert audit.verify_chain()['count'] == 200
+
+
+# --------------------------------------------------------------------------
+# Failure posture
+# --------------------------------------------------------------------------
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+def test_an_unwritable_log_dir_does_not_stop_the_application(make_audit, tmp_path, caplog):
+    """This previously raised out of __init__, which the factory calls
+    unguarded: an unwritable logs directory took the whole application down
+    over a *log file*."""
+    blocked = tmp_path / 'blocked'
+    blocked.mkdir()
+    blocked.chmod(0o500)
+    try:
+        with caplog.at_level(logging.ERROR):
+            audit = make_audit(blocked / 'logs', chain_dir=tmp_path / 'data')
+
+        assert audit.file_handler is None
+        assert 'Could not open audit log file' in caplog.text
+
+        # And the record that matters is still written and verifiable.
+        _emit(audit, 3)
+        assert audit.verify_chain()['ok']
+        assert audit.verify_chain()['count'] == 3
+        assert audit.get_recent_entries(limit=10) == []
+    finally:
+        blocked.chmod(0o700)
+
+
+def test_the_dead_whole_file_reader_is_gone(make_audit, tmp_path):
+    """get_entries_by_resource read the entire log, had no callers, and behind
+    a rotating handler would have silently returned only what survived in the
+    active file."""
+    audit = make_audit(tmp_path / 'logs')
+
+    assert not hasattr(audit, 'get_entries_by_resource')


### PR DESCRIPTION
Closes #443. First of the three sub-issues from #437 (approach C).

`AuditLogger.__init__` built a plain `logging.FileHandler` for `logs/audit/certificate_audit.log`. It grew without bound. #431's fix bounded the *application* log through `configure_structured_logging`; this handler is constructed independently and was never reached by it — so the file was still unbounded in production **after** the log-rotation fix shipped.

Safe to rotate because it carries no integrity property: human-readable text, not hashed, not chained, and the `logs/` tree is excluded from backups. The verifiable artifact is the hash chain under `data/audit/`, which is emphatically **not** rotated (#437), and a test pins that rolling the `.log` 200 times leaves the chain a single file that still verifies.

## Also in here

- **An unwritable logs directory no longer stops the application.** This raised out of `__init__`, which the factory calls unguarded — a certificate manager refusing to boot over a *log file*. Now it logs the failure, drops the handler, and keeps writing the chain, which is the record that matters. Tested, including that the chain still verifies with no log handler at all.
- `CERTMATE_AUDIT_LOG_MAX_BYTES` / `CERTMATE_AUDIT_LOG_BACKUP_COUNT`, parsed defensively: `''`, `'lots'`, `'-1'`, `'10MB'` all fall back to the default instead of taking startup down. `max_bytes=0` still buys an unbounded file for an operator who ships it elsewhere.
- **Removed `get_entries_by_resource()`** — it read the entire log, had **no callers**, and behind a rotating handler would have silently returned only what survived in the active file. That is how a "why is the history missing" bug gets born. Dropped from the architecture docs in all five languages.

## Known and accepted

`get_recent_entries()` tails only the active file, so the Activity page and the digest show fewer entries immediately after a roll. At 10 MB ≈ 30k entries against a digest that asks for 500, that is not worth building a multi-file reader for. Documented in the README row.

## Tests

`tests/test_audit_log_rotation.py`, 12 tests: the handler type and defaults, that it actually rolls and `backupCount` caps the tail, that the ` - INFO - ` line format `get_recent_entries` parses is unchanged, env overrides and four unusable env values, explicit `max_bytes=0`, that the hash chain is left alone and still verifies, the unwritable-directory posture, and that the dead reader is gone.

Suite: 1893 passed, 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)