### PR TITLE
perf(audit): stream chain verification instead of reading the whole file (#444)

### DIFF
--- a/modules/core/audit.py
+++ b/modules/core/audit.py
@@ -269,7 +269,13 @@ class AuditLogger:
         instance fingerprint, public key, seq range and head hash; the signature
         is over the canonical manifest, which (via head_hash) transitively
         commits to every entry. ``bundle_signature`` is None when no signer is
-        wired (the entries + chain are still verifiable, just not attributed)."""
+        wired (the entries + chain are still verifiable, just not attributed).
+
+        This one legitimately holds the slice in memory: the bundle *is* the
+        entries, and the manifest's head_hash is only known after the last of
+        them. ``from_seq`` / ``to_seq`` are how a caller bounds it — an
+        anchored slice verifies on its own (#441), so exporting a large chain
+        in pieces is a supported workflow rather than a workaround."""
         with self._chain_lock:
             records = audit_chain.load_records(self.audit_chain_file, from_seq, to_seq)
         signed = self._signer is not None and getattr(self._signer, 'available', False)
@@ -369,7 +375,9 @@ class AuditLogger:
                 "(key rotated, or checkpoints from another instance)"
             )
             return
-        records = audit_chain.load_records(self.audit_chain_file)
+        # Streamed: cross_check_checkpoint scans for one seq and stops, so the
+        # cross-check costs one record of memory, not the whole chain (#444).
+        records = audit_chain.iter_records(self.audit_chain_file)
         check = audit_chain.cross_check_checkpoint(records, latest)
         result["checkpoint_verified"] = bool(check.get("ok"))
         result["checkpoint_seq"] = latest.get("seq")

--- a/modules/core/audit_chain.py
+++ b/modules/core/audit_chain.py
@@ -65,6 +65,97 @@ def make_line(seq: int, entry: Dict[str, Any], prev_hash: str) -> Dict[str, Any]
     }
 
 
+def _blank_result() -> Dict[str, Any]:
+    """The result dict every verifier entry point returns, in its initial
+    (nothing verified yet) state."""
+    return {
+        "ok": False, "count": 0, "first_seq": None, "last_seq": None,
+        "head_hash": None, "error_seq": None, "reason": None,
+    }
+
+
+class _ChainVerifier:
+    """Incremental verifier: fed one record at a time, holding only the running
+    ``prev_hash`` / ``seq`` / count. Shared by the streaming file verifier and
+    the in-memory record verifier so the two can never drift apart (#444)."""
+
+    def __init__(self, anchor_prev_hash: str = GENESIS_PREV,
+                 anchor_seq: Optional[int] = None):
+        self._prev_hash = anchor_prev_hash
+        self._expected_seq = anchor_seq
+        self._anchor_prev_hash = anchor_prev_hash
+        self._first_seq: Optional[int] = None
+        self._count = 0
+        self._seen = False
+
+    def _fail(self, reason: str, error_seq) -> Dict[str, Any]:
+        result = _blank_result()
+        result["first_seq"] = self._first_seq
+        result["error_seq"] = error_seq
+        result["reason"] = reason
+        return result
+
+    def feed(self, rec, position: int) -> Optional[Dict[str, Any]]:
+        """Verify one record against the running state. Returns a failure
+        result dict, or None if the record was accepted."""
+        if not isinstance(rec, dict):
+            return self._fail(
+                f"malformed (non-object) record at position {position}",
+                self._expected_seq)
+
+        seq = rec.get("seq")
+        entry = rec.get("entry")
+        rec_prev = rec.get("prev_hash")
+        rec_hash = rec.get("hash")
+
+        if not isinstance(seq, int) or entry is None or rec_hash is None:
+            return self._fail(
+                f"malformed record at position {position} (missing fields)",
+                self._expected_seq)
+
+        if not self._seen:
+            self._seen = True
+            self._first_seq = seq
+        if self._expected_seq is None:
+            self._expected_seq = seq
+        elif seq != self._expected_seq:
+            return self._fail(
+                f"sequence break: expected seq {self._expected_seq}, found "
+                f"{seq} (a deletion or reorder)", self._expected_seq)
+
+        if rec_prev != self._prev_hash:
+            return self._fail(
+                f"broken link at seq {seq}: prev_hash does not match the "
+                f"previous record's hash", seq)
+
+        if entry_hash(seq, entry, rec_prev) != rec_hash:
+            return self._fail(
+                f"hash mismatch at seq {seq}: entry was modified", seq)
+
+        self._prev_hash = rec_hash
+        self._expected_seq += 1
+        self._count += 1
+        return None
+
+    def finish(self) -> Dict[str, Any]:
+        result = _blank_result()
+        result["ok"] = True
+        if not self._seen:
+            result["reason"] = "empty chain"
+            # The head of an empty slice is whatever it was anchored to (the
+            # genesis prev_hash for a full chain), matching what build_manifest
+            # records for an empty slice — so an empty signed bundle verifies
+            # consistently.
+            result["head_hash"] = self._anchor_prev_hash
+            return result
+        result["count"] = self._count
+        result["first_seq"] = self._first_seq
+        result["last_seq"] = self._expected_seq - 1
+        result["head_hash"] = self._prev_hash
+        result["reason"] = "intact"
+        return result
+
+
 def verify_chain(path) -> Dict[str, Any]:
     """Verify a chain file end to end.
 
@@ -76,53 +167,84 @@ def verify_chain(path) -> Dict[str, Any]:
     first record, every ``prev_hash`` links to the prior ``hash``, and every
     ``hash`` recomputes. On the first failure, ``ok`` is False and ``reason`` /
     ``error_seq`` localize it.
+
+    Reads the file **one line at a time** (#444): the chain is append-only and
+    never truncated, so it is the one file here that only ever grows, and a
+    verifier that must first fit the whole history in memory puts a ceiling on
+    how much history an instance can keep. Peak memory is now one line,
+    whatever the file's size.
+
+    One consequence of streaming, deliberate: when a file contains more than one
+    fault, the reported one is the **earliest in the file**. The previous
+    implementation parsed every line before checking any structure, so an
+    unparseable line late in the file masked a hash mismatch early in it.
+    Localizing the first fault is the more useful answer.
     """
-    result: Dict[str, Any] = {
-        "ok": False, "count": 0, "first_seq": None, "last_seq": None,
-        "head_hash": None, "error_seq": None, "reason": None,
-    }
+    verifier = _ChainVerifier()
+    # A corrupt or non-object FINAL line is most likely a truncated trailing
+    # write, not tampering, and gets its own wording — so a line is only
+    # judged once the next one proves it was not the last.
+    pending: Optional[str] = None
+    position = -1
 
     try:
         with open(path, "r", encoding="utf-8") as f:
-            raw_lines = f.read().splitlines()
+            for raw in f:
+                raw = raw.strip()
+                if not raw:  # ignore blank lines, including a trailing one
+                    continue
+                if pending is not None:
+                    position += 1
+                    failure = _feed_raw(verifier, pending, position, is_last=False)
+                    if failure is not None:
+                        return failure
+                pending = raw
     except FileNotFoundError:
-        result["reason"] = "chain file does not exist"
-        # Structured flag so callers deciding absent-vs-tampered do not have
-        # to substring-match the human-readable reason.
-        result["chain_file_missing"] = True
+        result: Dict[str, Any] = {
+            "ok": False, "count": 0, "first_seq": None, "last_seq": None,
+            "head_hash": None, "error_seq": None,
+            "reason": "chain file does not exist",
+            # Structured flag so callers deciding absent-vs-tampered do not
+            # have to substring-match the human-readable reason.
+            "chain_file_missing": True,
+        }
         return result
     except OSError as e:
-        result["reason"] = f"cannot read chain file: {e}"
-        return result
+        return {
+            "ok": False, "count": 0, "first_seq": None, "last_seq": None,
+            "head_hash": None, "error_seq": None,
+            "reason": f"cannot read chain file: {e}",
+        }
 
-    # Ignore a trailing blank line; flag a genuinely empty chain as ok/empty.
-    lines = [ln for ln in raw_lines if ln.strip()]
-    if not lines:
-        result["ok"] = True
-        result["reason"] = "empty chain"
-        return result
+    if pending is not None:
+        position += 1
+        failure = _feed_raw(verifier, pending, position, is_last=True)
+        if failure is not None:
+            return failure
 
-    # Parse each line into a record, with file-specific tolerance: a corrupt or
-    # non-object FINAL line is most likely a truncated trailing write, not
-    # tampering. The structural checks are delegated to verify_records.
-    records = []
-    for idx, raw in enumerate(lines):
-        is_last = idx == len(lines) - 1
-        try:
-            rec = json.loads(raw)
-            ok_obj = isinstance(rec, dict)
-        except json.JSONDecodeError:
-            ok_obj = False
-        if not ok_obj:
-            result["error_seq"] = None
-            result["reason"] = (
-                "truncated or unparseable trailing line (likely an interrupted "
-                "write)" if is_last else f"unparseable line at position {idx}"
-            )
-            return result
-        records.append(rec)
+    return verifier.finish()
 
-    return verify_records(records)
+
+def _feed_raw(verifier, raw: str, position: int,
+              is_last: bool) -> Optional[Dict[str, Any]]:
+    """Parse one raw chain line and feed it to *verifier*. Returns a failure
+    result dict, or None if the line was accepted."""
+    try:
+        rec = json.loads(raw)
+        ok_obj = isinstance(rec, dict)
+    except json.JSONDecodeError:
+        ok_obj = False
+    if not ok_obj:
+        # A fresh result, not the verifier's partial state: an unparseable line
+        # says nothing trustworthy about what the prefix contained.
+        failure = _blank_result()
+        failure["error_seq"] = None
+        failure["reason"] = (
+            "truncated or unparseable trailing line (likely an interrupted "
+            "write)" if is_last else f"unparseable line at position {position}"
+        )
+        return failure
+    return verifier.feed(rec, position)
 
 
 def verify_records(records, anchor_prev_hash: str = GENESIS_PREV,
@@ -144,75 +266,12 @@ def verify_records(records, anchor_prev_hash: str = GENESIS_PREV,
     anchor proves the records from the anchor forward are authentic and ordered
     — it proves nothing at all about the prefix, and callers must not report it
     as if it did."""
-    result: Dict[str, Any] = {
-        "ok": False, "count": 0, "first_seq": None, "last_seq": None,
-        "head_hash": None, "error_seq": None, "reason": None,
-    }
-    if not records:
-        result["ok"] = True
-        result["reason"] = "empty chain"
-        # The head of an empty slice is whatever it was anchored to (the
-        # genesis prev_hash for a full chain), matching what build_manifest
-        # records for an empty slice — so an empty signed bundle verifies
-        # consistently.
-        result["head_hash"] = anchor_prev_hash
-        return result
-
-    prev_hash = anchor_prev_hash
-    expected_seq: Optional[int] = anchor_seq
-    count = 0
-
-    for idx, rec in enumerate(records):
-        if not isinstance(rec, dict):
-            result["error_seq"] = expected_seq
-            result["reason"] = f"malformed (non-object) record at position {idx}"
-            return result
-
-        seq = rec.get("seq")
-        entry = rec.get("entry")
-        rec_prev = rec.get("prev_hash")
-        rec_hash = rec.get("hash")
-
-        if not isinstance(seq, int) or entry is None or rec_hash is None:
-            result["error_seq"] = expected_seq
-            result["reason"] = f"malformed record at position {idx} (missing fields)"
-            return result
-
-        if idx == 0:
-            result["first_seq"] = seq
-        if expected_seq is None:
-            expected_seq = seq
-        elif seq != expected_seq:
-            result["error_seq"] = expected_seq
-            result["reason"] = (
-                f"sequence break: expected seq {expected_seq}, found {seq} "
-                f"(a deletion or reorder)"
-            )
-            return result
-
-        if rec_prev != prev_hash:
-            result["error_seq"] = seq
-            result["reason"] = (
-                f"broken link at seq {seq}: prev_hash does not match the "
-                f"previous record's hash"
-            )
-            return result
-
-        if entry_hash(seq, entry, rec_prev) != rec_hash:
-            result["error_seq"] = seq
-            result["reason"] = f"hash mismatch at seq {seq}: entry was modified"
-            return result
-
-        prev_hash = rec_hash
-        expected_seq += 1
-        count += 1
-
-    result["ok"] = True
-    result["count"] = count
-    result["last_seq"] = expected_seq - 1 if expected_seq is not None else None
-    result["head_hash"] = prev_hash
-    result["reason"] = "intact"
-    return result
+    verifier = _ChainVerifier(anchor_prev_hash, anchor_seq)
+    for position, rec in enumerate(records):
+        failure = verifier.feed(rec, position)
+        if failure is not None:
+            return failure
+    return verifier.finish()
 
 
 # --- Phase 3: signed export bundle + checkpoints --------------------------
@@ -230,30 +289,42 @@ ANCHORED_BUNDLE_FORMAT_VERSION = 2
 SUPPORTED_BUNDLE_FORMAT_VERSIONS = (BUNDLE_FORMAT_VERSION, ANCHORED_BUNDLE_FORMAT_VERSION)
 
 
-def load_records(path, from_seq: Optional[int] = None, to_seq: Optional[int] = None):
-    """Read the chain file into a list of valid record dicts (a truncated
-    trailing line is skipped). Optional inclusive ``from_seq`` / ``to_seq``
-    slice. Best-effort: returns [] if the file is missing."""
+def iter_records(path, from_seq: Optional[int] = None,
+                 to_seq: Optional[int] = None):
+    """Yield valid record dicts from the chain file, one line at a time (#444),
+    so a caller that only needs to *scan* the chain — the checkpoint
+    cross-check, for one — never holds more than a single record.
+
+    A truncated trailing line is skipped. Optional inclusive ``from_seq`` /
+    ``to_seq`` slice. Best-effort: yields nothing if the file is missing."""
     try:
-        with open(path, "r", encoding="utf-8") as f:
-            raw_lines = [ln for ln in f.read().splitlines() if ln.strip()]
+        f = open(path, "r", encoding="utf-8")
     except OSError:
-        return []
-    records = []
-    for raw in raw_lines:
-        try:
-            rec = json.loads(raw)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(rec, dict) or not isinstance(rec.get("seq"), int):
-            continue
-        seq = rec["seq"]
-        if from_seq is not None and seq < from_seq:
-            continue
-        if to_seq is not None and seq > to_seq:
-            continue
-        records.append(rec)
-    return records
+        return
+    with f:
+        for raw in f:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                rec = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(rec, dict) or not isinstance(rec.get("seq"), int):
+                continue
+            seq = rec["seq"]
+            if from_seq is not None and seq < from_seq:
+                continue
+            if to_seq is not None and seq > to_seq:
+                continue
+            yield rec
+
+
+def load_records(path, from_seq: Optional[int] = None, to_seq: Optional[int] = None):
+    """Read the chain file into a **list** of valid record dicts. Use
+    :func:`iter_records` unless the whole slice genuinely has to be held at once
+    (building an export bundle does; scanning does not)."""
+    return list(iter_records(path, from_seq, to_seq))
 
 
 def build_manifest(records, *, fingerprint, public_key_pem, exported_at,
@@ -350,7 +421,10 @@ def cross_check_checkpoint(records, checkpoint) -> Dict[str, Any]:
 
     NOTE: does NOT verify the checkpoint signature (the caller does, with
     crypto) and does NOT bind an operator who holds the signing key — full
-    operator binding needs off-box anchoring (see the module docstring)."""
+    operator binding needs off-box anchoring (see the module docstring).
+
+    *records* may be any iterable, including the :func:`iter_records`
+    generator: it is consumed once and only up to the checkpointed seq."""
     cp_seq = checkpoint.get("seq")
     cp_hash = checkpoint.get("hash")
     if not isinstance(cp_seq, int) or not cp_hash:

--- a/modules/core/audit_chain.py
+++ b/modules/core/audit_chain.py
@@ -296,7 +296,14 @@ def iter_records(path, from_seq: Optional[int] = None,
     cross-check, for one — never holds more than a single record.
 
     A truncated trailing line is skipped. Optional inclusive ``from_seq`` /
-    ``to_seq`` slice. Best-effort: yields nothing if the file is missing."""
+    ``to_seq`` slice. Best-effort: yields nothing if the file is missing.
+
+    The slice filters rather than stopping at ``to_seq``, deliberately: this
+    reads a file that may have been tampered with, and monotonic ``seq`` is
+    what the verifier *proves*, not something a reader may presume. Skipping
+    the tail on that assumption would let a reordered chain export as a
+    quietly-shorter slice. The scan it saves is linear over a file that grows
+    in hundreds of KB per year."""
     try:
         f = open(path, "r", encoding="utf-8")
     except OSError:
@@ -429,7 +436,20 @@ def cross_check_checkpoint(records, checkpoint) -> Dict[str, Any]:
     cp_hash = checkpoint.get("hash")
     if not isinstance(cp_seq, int) or not cp_hash:
         return {"ok": True, "reason": "checkpoint has no usable seq/hash"}
-    match = next((r for r in records if r.get("seq") == cp_seq), None)
+    # Close the iterable when we stop early: iter_records holds an open file,
+    # and abandoning a suspended generator leaves that descriptor to whenever
+    # the interpreter gets round to collecting it — immediately on CPython,
+    # not on every implementation.
+    match = None
+    try:
+        for rec in records:
+            if rec.get("seq") == cp_seq:
+                match = rec
+                break
+    finally:
+        close = getattr(records, "close", None)
+        if callable(close):
+            close()
     if match is None:
         return {"ok": False, "reason": (
             f"chain no longer contains seq {cp_seq}, which a signed checkpoint "

--- a/tests/test_audit_chain_streaming.py
+++ b/tests/test_audit_chain_streaming.py
@@ -198,3 +198,30 @@ def test_the_checkpoint_cross_check_accepts_a_generator(tmp_path):
 
     assert ok["ok"]
     assert not diverged["ok"]
+
+
+def test_the_cross_check_closes_the_generator_it_abandons(tmp_path):
+    """It stops at the checkpointed seq; the file handle behind the generator
+    must not be left to whenever the interpreter collects it."""
+    path = tmp_path / "chain.jsonl"
+    records = _write_chain(path, 10)
+    it = audit_chain.iter_records(path)
+
+    audit_chain.cross_check_checkpoint(it, {"seq": 2, "hash": records[2]["hash"]})
+
+    with pytest.raises(StopIteration):
+        next(it)
+
+
+def test_a_reordered_tail_is_not_silently_dropped_from_a_slice(tmp_path):
+    """iter_records filters rather than stopping at to_seq: monotonic seq is
+    what the verifier proves, not what this reader may presume."""
+    path = tmp_path / "chain.jsonl"
+    _write_chain(path, 6)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    lines = [lines[0], lines[5], *lines[1:5]]  # a record from beyond to_seq, early
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    got = [r["seq"] for r in audit_chain.iter_records(path, to_seq=3)]
+
+    assert got == [0, 1, 2, 3], "a record past to_seq truncated the scan"

--- a/tests/test_audit_chain_streaming.py
+++ b/tests/test_audit_chain_streaming.py
@@ -1,0 +1,200 @@
+"""Verifying the chain must not cost as much memory as the chain is big.
+
+Regression tests for #444. `verify_chain()` did `f.read().splitlines()`,
+`load_records()` did the same, and the checkpoint cross-check then read the
+whole file a second time. The chain is append-only and never truncated — it is
+the one file here that only ever grows — so a verifier that must first fit the
+whole history in memory puts a ceiling on how much history an instance can
+keep, and makes "we should rotate it" look like the answer to a problem that is
+really about how it is read (#437).
+
+The behaviour is unchanged; only the memory profile is. The tests below pin
+both halves: identical verdicts, and a peak that does not track the file size.
+"""
+
+import json
+import tracemalloc
+
+import pytest
+
+from modules.core import audit_chain
+from modules.core.audit_chain import make_line
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def _write_chain(path, n, pad=0):
+    """Write a genuine n-entry chain and return its records."""
+    records = []
+    prev = audit_chain.GENESIS_PREV
+    with path.open("w", encoding="utf-8") as f:
+        for seq in range(n):
+            entry = {"operation": "renew", "resource_id": f"d{seq}.example.com"}
+            if pad:
+                entry["pad"] = "x" * pad
+            line = make_line(seq, entry, prev)
+            f.write(json.dumps(line, ensure_ascii=False) + "\n")
+            prev = line["hash"]
+            records.append(line)
+    return records
+
+
+def test_peak_memory_does_not_track_the_file_size(tmp_path):
+    """The property, stated as a number: verifying a ~4 MB chain must not
+    allocate anything like 4 MB."""
+    path = tmp_path / "chain.jsonl"
+    _write_chain(path, 4000, pad=1000)
+    file_size = path.stat().st_size
+    assert file_size > 4_000_000, "the fixture is not big enough to be a test"
+
+    tracemalloc.start()
+    try:
+        result = audit_chain.verify_chain(path)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert result["ok"] and result["count"] == 4000
+    assert peak < file_size / 10, (
+        f"verify_chain peaked at {peak} bytes on a {file_size}-byte chain — "
+        f"it is holding the file, not streaming it")
+
+
+def test_iter_records_is_lazy(tmp_path):
+    path = tmp_path / "chain.jsonl"
+    _write_chain(path, 500)
+
+    it = audit_chain.iter_records(path)
+    first = next(it)
+
+    assert first["seq"] == 0
+    assert hasattr(it, "close"), "iter_records must be a generator, not a list"
+
+
+def test_iter_records_and_load_records_agree(tmp_path):
+    path = tmp_path / "chain.jsonl"
+    _write_chain(path, 20)
+
+    for kwargs in ({}, {"from_seq": 5}, {"to_seq": 4}, {"from_seq": 5, "to_seq": 9},
+                   {"from_seq": 99}):
+        assert (list(audit_chain.iter_records(path, **kwargs))
+                == audit_chain.load_records(path, **kwargs)), kwargs
+
+
+def test_iter_records_on_a_missing_file_yields_nothing(tmp_path):
+    assert list(audit_chain.iter_records(tmp_path / "nope.jsonl")) == []
+
+
+# --------------------------------------------------------------------------
+# Behaviour must be identical to the buffered verifier
+# --------------------------------------------------------------------------
+
+def test_a_streamed_chain_verifies_like_its_records(tmp_path):
+    path = tmp_path / "chain.jsonl"
+    records = _write_chain(path, 50)
+
+    assert audit_chain.verify_chain(path) == audit_chain.verify_records(records)
+
+
+def test_blank_lines_anywhere_are_ignored(tmp_path):
+    """The old implementation filtered blanks out of the whole file at once;
+    streaming must not start treating a blank line as a record boundary."""
+    path = tmp_path / "chain.jsonl"
+    records = _write_chain(path, 5)
+    body = path.read_text(encoding="utf-8").splitlines()
+    path.write_text("\n".join(["", body[0], "", *body[1:], "", ""]), encoding="utf-8")
+
+    result = audit_chain.verify_chain(path)
+
+    assert result["ok"] and result["count"] == 5
+    assert result["head_hash"] == records[-1]["hash"]
+
+
+def test_an_empty_file_is_an_empty_chain(tmp_path):
+    path = tmp_path / "chain.jsonl"
+    path.write_text("\n\n  \n", encoding="utf-8")
+
+    result = audit_chain.verify_chain(path)
+
+    assert result["ok"] and result["reason"] == "empty chain"
+
+
+def test_a_truncated_last_line_is_still_the_tolerant_wording(tmp_path):
+    path = tmp_path / "chain.jsonl"
+    _write_chain(path, 5)
+    with path.open("a", encoding="utf-8") as f:
+        f.write('{"seq": 5, "entry": {"oper')
+
+    result = audit_chain.verify_chain(path)
+
+    assert not result["ok"]
+    assert "interrupted" in result["reason"]
+
+
+def test_an_unparseable_interior_line_is_localized(tmp_path):
+    path = tmp_path / "chain.jsonl"
+    _write_chain(path, 5)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    lines[2] = "{not json"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = audit_chain.verify_chain(path)
+
+    assert not result["ok"]
+    assert "unparseable line at position 2" in result["reason"]
+
+
+def test_the_first_fault_in_the_file_is_the_one_reported(tmp_path):
+    """Deliberate change: the buffered verifier parsed every line before
+    checking any structure, so a bad line late in the file masked a tampered
+    entry early in it. Streaming reports the earliest fault, which is the one
+    an operator needs."""
+    path = tmp_path / "chain.jsonl"
+    _write_chain(path, 6)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    tampered = json.loads(lines[1])
+    tampered["entry"]["resource_id"] = "evil.example.com"
+    lines[1] = json.dumps(tampered)
+    lines[4] = "}{ garbage"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = audit_chain.verify_chain(path)
+
+    assert not result["ok"]
+    assert "hash mismatch at seq 1" in result["reason"]
+    assert result["error_seq"] == 1
+
+
+def test_a_missing_file_still_reports_the_structured_flag(tmp_path):
+    """The absent-vs-tampered decision in /api/audit/verify hangs off this."""
+    result = audit_chain.verify_chain(tmp_path / "nope.jsonl")
+
+    assert not result["ok"]
+    assert result["chain_file_missing"] is True
+
+
+def test_an_unreadable_file_is_not_reported_as_missing(tmp_path):
+    directory = tmp_path / "a_directory"
+    directory.mkdir()
+
+    result = audit_chain.verify_chain(directory)
+
+    assert not result["ok"]
+    assert result["reason"].startswith("cannot read chain file")
+    assert "chain_file_missing" not in result
+
+
+def test_the_checkpoint_cross_check_accepts_a_generator(tmp_path):
+    """It scans for one seq and stops, so it must not need the list."""
+    path = tmp_path / "chain.jsonl"
+    records = _write_chain(path, 10)
+    checkpoint = {"seq": 4, "hash": records[4]["hash"]}
+
+    ok = audit_chain.cross_check_checkpoint(
+        audit_chain.iter_records(path), checkpoint)
+    diverged = audit_chain.cross_check_checkpoint(
+        audit_chain.iter_records(path), {"seq": 4, "hash": "0" * 64})
+
+    assert ok["ok"]
+    assert not diverged["ok"]


### PR DESCRIPTION
Closes #444. Second of the three sub-issues from #437 (approach C).

`verify_chain()` did `f.read().splitlines()`, `load_records()` did the same, and the checkpoint cross-check then read the file a **second** time. The chain is append-only and never truncated — the one file here that only ever grows — so a verifier that must first fit the whole history in memory puts a ceiling on how much history an instance can keep. It is also the reason "we should rotate it" keeps coming up: the pain is in how the file is read, not in the file.

Measured on a 5 MB chain:

```
streaming peak =    25,272 bytes   (0.005 × file size)
buffered  peak = 8,367,501 bytes   (1.673 × file size)
```

## Changes

- `_ChainVerifier` holds the running `prev_hash` / `seq` / count and is fed one record at a time. **Both** the streaming file verifier and the in-memory `verify_records` (used for bundles) run on it, so the two paths cannot drift apart — which matters, because a verifier that disagrees with itself is worse than a slow one.
- `iter_records()` is the lazy form; `load_records()` is now `list(iter_records())` and stays for the one caller that genuinely needs the whole slice at once — building an export bundle, where the bundle *is* the entries and the manifest's `head_hash` is only known after the last of them. `?from_seq`/`?to_seq` is how that one is bounded, and since #441 an anchored slice verifies on its own, so exporting a large chain in pieces is a supported workflow rather than a workaround.
- The checkpoint cross-check scans for one seq and stops, so it takes the generator.

## One deliberate behaviour change

When a file contains more than one fault, the reported one is now the **earliest in the file**. The buffered verifier parsed every line before checking any structure, so an unparseable line late in the file masked a tampered entry early in it. Pinned by a test.

## Tests

`tests/test_audit_chain_streaming.py`, 13 tests. The headline one asserts the property as a number: verifying a ~5 MB chain must peak below a tenth of the file size — it fails loudly against the old implementation (1.67×). The rest pin that behaviour did not move: streamed result identical to `verify_records` on the same records, blank lines anywhere, empty file, truncated last line keeping its tolerant wording, an unparseable interior line still localized by position, the `chain_file_missing` flag that `/api/audit/verify` hangs its absent-vs-tampered decision on, an unreadable path *not* being reported as missing, and the cross-check accepting a generator.

Suite: 1906 passed, 6 skipped. No existing test needed changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)