### PR TITLE
feat(audit): prune an archived prefix of the chain, explicitly and on the record (#445)

### DIFF
--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -104,6 +104,64 @@ operate certificates on a schedule.
   client-supplied; the trustworthy identity is the authenticated API key.
 - **History boundary.** The chain starts when the feature is first enabled;
   earlier `.log` history is not part of the verifiable chain.
+- **A pruned chain proves less, and says so.** If you have run
+  `audit_prune` (below), verification covers the entries from the anchor
+  forward. The archived prefix is attested by the signed anchor and by the
+  exported bundle you hold off the box — not by the chain file. `verify` reports
+  `anchored` and the anchor seq for exactly this reason; treat a bare "intact"
+  claim about a pruned instance as an overstatement.
+
+## Retention: archiving part of the chain
+
+The chain grows by one line per audited operation — of the order of hundreds of
+kilobytes per year on a busy instance — so most operators never need this. It
+exists for the case where a retention policy requires older records to leave the
+machine.
+
+There is no automatic pruning, and there is no API endpoint for it. Deleting
+audit history is exactly what someone who has just compromised an administrator
+account would want to do, and an operator with a legitimate retention obligation
+has shell access anyway — they have to put the archive somewhere. So it is one
+explicit command, run with CertMate stopped:
+
+```bash
+# 1. Export the prefix you intend to archive (admin token).
+curl -H "Authorization: Bearer $TOKEN" \
+     "https://certmate.example.com/api/audit/export?to_seq=1199" > archive-0-1199.json
+
+# 2. Verify it OFF this box, pinning the instance key.
+python -m modules.core.audit_verify --bundle archive-0-1199.json --pubkey instance.pem
+
+# 3. Store it wherever your policy says. Then, with CertMate stopped:
+python -m modules.core.audit_prune --bundle archive-0-1199.json --data-dir data/audit
+python -m modules.core.audit_prune --bundle archive-0-1199.json --data-dir data/audit --yes
+```
+
+The command without `--yes` is a dry run. It refuses, and removes nothing, if
+the bundle does not verify, is unsigned, is not a prefix of *this* chain, or
+disagrees with the chain at any seq — you never delete records whose only
+remaining copy is unverified.
+
+What it then does is the part that matters for compliance:
+
+- **The deletion is recorded in the chain that survives it.** An `archive` entry
+  is appended naming the seq range, the number of entries, their head hash and
+  the SHA-256 of the archive file. A reader of the pruned chain can see that
+  entries were removed, when, and which archive holds them.
+- **The remainder verifies from a signed anchor.** `certificate_audit.anchor.json`
+  states where the chain now starts and what it continues from, signed with the
+  instance key, so a chain that was simply truncated cannot be passed off as a
+  pruned one — the anchor cannot be forged without the key.
+- **It stays honest afterwards.** Verification of a pruned chain never reports a
+  plain "intact": both the API and the standalone verifier say which seq the
+  guarantee starts at.
+
+Two limits worth stating. The anchor describes the **most recent** archive; the
+complete history is the sequence of exported bundles, which is why they must be
+kept and why each one's digest is recorded in the chain. And, as everywhere else
+on this page, the instance key does not bind the operator: someone holding it can
+sign an anchor over a chain they rewrote. Prune only as far back as your archives
+genuinely reach.
 
 Signed exports that an external auditor pins to a published key are available
 today. If your obligations require binding the operator *themselves* — so that

--- a/modules/core/audit.py
+++ b/modules/core/audit.py
@@ -354,7 +354,16 @@ class AuditLogger:
             result["ok"] = False
             result["reason"] = str(e)
             return
-        signature = (anchor or {}).get("signature")
+        if anchor is None:
+            # It was there a moment ago (verify_chain read it) and is not now.
+            # Fail closed rather than raise: a chain that has just lost the file
+            # attesting its own prune is not a chain to call intact.
+            result["ok"] = False
+            result["reason"] = (
+                "the chain anchor disappeared while verifying: integrity cannot "
+                "be established")
+            return
+        signature = anchor.get("signature")
         if not signature or not pubkey or not audit_signing.verify_signature(
             pubkey, signature, audit_chain.anchor_signing_bytes(anchor)
         ):

--- a/modules/core/audit.py
+++ b/modules/core/audit.py
@@ -327,9 +327,44 @@ class AuditLogger:
         (the standalone CLI verifier cannot take the lock and accepts that)."""
         with self._chain_lock:
             result = audit_chain.verify_chain(self.audit_chain_file)
+            if result.get("ok") and result.get("anchored"):
+                self._verify_anchor_signature(result)
             if result.get("ok"):
                 self._cross_check_latest_checkpoint(result)
             return result
+
+    def _verify_anchor_signature(self, result: Dict[str, Any]) -> None:
+        """An anchored chain is only as good as the anchor's signature (#445).
+
+        The structural check in audit_chain proved the chain continues from the
+        hash the anchor states. This proves the *instance* said so: without it,
+        anyone able to write two files could delete history and hand the
+        verifier a matching anchor, and verification would pass."""
+        if self._signer is None or not getattr(self._signer, 'available', False):
+            result["ok"] = False
+            result["reason"] = (
+                "the chain is anchored (entries were pruned) but this instance "
+                "has no signing key, so the anchor cannot be verified")
+            return
+        pubkey = self._signer.public_key_pem()
+        anchor_path = audit_chain.anchor_path_for(self.audit_chain_file)
+        try:
+            anchor = audit_chain.read_anchor(anchor_path)
+        except audit_chain.AnchorReadError as e:
+            result["ok"] = False
+            result["reason"] = str(e)
+            return
+        signature = (anchor or {}).get("signature")
+        if not signature or not pubkey or not audit_signing.verify_signature(
+            pubkey, signature, audit_chain.anchor_signing_bytes(anchor)
+        ):
+            result["ok"] = False
+            result["reason"] = (
+                f"the anchor at seq {anchor.get('anchor_seq')} is not signed by "
+                f"this instance: entries were removed without a valid archive "
+                f"attestation")
+            return
+        result["anchor_signature_ok"] = True
 
     def _cross_check_latest_checkpoint(self, result: Dict[str, Any]) -> None:
         """Cross-check an internally-consistent chain against the newest signed
@@ -357,6 +392,21 @@ class AuditLogger:
         if not checkpoints:
             result["checkpoint_reason"] = "no checkpoints written yet"
             return
+        # A prune (#445) removes entries that older checkpoints attest to, and
+        # those checkpoints are kept as evidence — but cross-checking against
+        # one of them would report the archived prefix as a truncation. That is
+        # the failure this whole design exists to avoid: routine maintenance
+        # raising a tamper alert. Checkpoints below the anchor are attested by
+        # the archive instead, so only those at or above it are usable here.
+        anchor_seq = result.get("anchor_seq")
+        if anchor_seq is not None:
+            usable = [cp for cp in checkpoints if cp.get("seq", -1) >= anchor_seq]
+            if not usable:
+                result["checkpoint_reason"] = (
+                    f"every checkpoint predates the archived prefix (seq < "
+                    f"{anchor_seq}); the archive attests those entries")
+                return
+            checkpoints = usable
         # Newest checkpoint whose signature verifies under the current key. A
         # checkpoint that does not verify is ignored (e.g. key rotation, or a
         # chain imported from another instance) rather than treated as tamper,

--- a/modules/core/audit_chain.py
+++ b/modules/core/audit_chain.py
@@ -28,6 +28,19 @@ from typing import Any, Dict, Optional
 CHAIN_FILENAME = "certificate_audit.chain.jsonl"
 GENESIS_PREV = ""
 
+# Written only by an explicit operator prune (#445). Its presence means the
+# chain no longer starts at the genesis: the entries before ``anchor_seq`` were
+# exported, verified off the box and archived, and this file is the signed
+# statement of what they were. Absent on every instance that has never pruned,
+# which is the default and the expectation.
+ANCHOR_FILENAME = "certificate_audit.anchor.json"
+
+
+class AnchorReadError(OSError):
+    """The prune anchor exists but cannot be read or understood. Callers MUST
+    fail closed: treating it as "no anchor" would silently re-interpret a
+    pruned chain as one that should start at the genesis."""
+
 
 class CheckpointReadError(OSError):
     """The checkpoint file exists but cannot be read (permissions, I/O).
@@ -80,13 +93,19 @@ class _ChainVerifier:
     the in-memory record verifier so the two can never drift apart (#444)."""
 
     def __init__(self, anchor_prev_hash: str = GENESIS_PREV,
-                 anchor_seq: Optional[int] = None):
+                 anchor_seq: Optional[int] = None,
+                 remember_hash_at: Optional[int] = None):
         self._prev_hash = anchor_prev_hash
         self._expected_seq = anchor_seq
         self._anchor_prev_hash = anchor_prev_hash
         self._first_seq: Optional[int] = None
         self._count = 0
         self._seen = False
+        # Used to cross-check an anchor against a chain that still contains the
+        # entries it claims were archived (a prune interrupted between writing
+        # the anchor and replacing the chain).
+        self._remember_hash_at = remember_hash_at
+        self.remembered_hash: Optional[str] = None
 
     def _fail(self, reason: str, error_seq) -> Dict[str, Any]:
         result = _blank_result()
@@ -132,6 +151,8 @@ class _ChainVerifier:
             return self._fail(
                 f"hash mismatch at seq {seq}: entry was modified", seq)
 
+        if seq == self._remember_hash_at:
+            self.remembered_hash = rec_hash
         self._prev_hash = rec_hash
         self._expected_seq += 1
         self._count += 1
@@ -179,8 +200,34 @@ def verify_chain(path) -> Dict[str, Any]:
     implementation parsed every line before checking any structure, so an
     unparseable line late in the file masked a hash mismatch early in it.
     Localizing the first fault is the more useful answer.
+
+    If an anchor file sits next to the chain (#445), the chain no longer starts
+    at the genesis and is verified from the anchor instead. The result then
+    carries ``anchored`` / ``anchor_seq``, and callers MUST NOT report it as
+    plain "intact": it attests the entries from the anchor forward, and the
+    archived prefix is attested only by the anchor and the exported bundle an
+    operator holds off the box. Verifying the anchor's *signature* needs crypto
+    and is the caller's job (:meth:`AuditLogger.verify_chain` and the CLI do it)
+    — this stdlib-only function checks that the chain and the anchor agree.
     """
-    verifier = _ChainVerifier()
+    try:
+        anchor = read_anchor(anchor_path_for(path))
+    except AnchorReadError as e:
+        # Fail closed. An unreadable anchor is not "no anchor": the difference
+        # between the two is the difference between a pruned chain and a
+        # chain that should start at the genesis.
+        result = _blank_result()
+        result["anchor_unreadable"] = True
+        result["reason"] = str(e)
+        return result
+    if anchor is not None:
+        return _verify_anchored_chain(path, anchor)
+    return _verify_stream(path, _ChainVerifier())
+
+
+def _verify_stream(path, verifier) -> Dict[str, Any]:
+    """Feed every record in *path* to *verifier*, one line at a time, and
+    return its verdict (or the first failure)."""
     # A corrupt or non-object FINAL line is most likely a truncated trailing
     # write, not tampering, and gets its own wording — so a line is only
     # judged once the next one proves it was not the last.
@@ -200,21 +247,16 @@ def verify_chain(path) -> Dict[str, Any]:
                         return failure
                 pending = raw
     except FileNotFoundError:
-        result: Dict[str, Any] = {
-            "ok": False, "count": 0, "first_seq": None, "last_seq": None,
-            "head_hash": None, "error_seq": None,
-            "reason": "chain file does not exist",
-            # Structured flag so callers deciding absent-vs-tampered do not
-            # have to substring-match the human-readable reason.
-            "chain_file_missing": True,
-        }
+        result = _blank_result()
+        result["reason"] = "chain file does not exist"
+        # Structured flag so callers deciding absent-vs-tampered do not have
+        # to substring-match the human-readable reason.
+        result["chain_file_missing"] = True
         return result
     except OSError as e:
-        return {
-            "ok": False, "count": 0, "first_seq": None, "last_seq": None,
-            "head_hash": None, "error_seq": None,
-            "reason": f"cannot read chain file: {e}",
-        }
+        result = _blank_result()
+        result["reason"] = f"cannot read chain file: {e}"
+        return result
 
     if pending is not None:
         position += 1
@@ -223,6 +265,85 @@ def verify_chain(path) -> Dict[str, Any]:
             return failure
 
     return verifier.finish()
+
+
+def _verify_anchored_chain(path, anchor) -> Dict[str, Any]:
+    """Verify a chain that an operator prune left starting at ``anchor_seq``.
+
+    Two on-disk states are legitimate, because a prune writes the anchor before
+    it replaces the chain and can be interrupted between the two:
+
+    1. The chain starts at ``anchor_seq`` — the completed state. It is verified
+       from the anchor's ``prev_hash``.
+    2. The chain still starts at the genesis — the interrupted state, where
+       nothing was actually deleted. It is verified from the genesis, and the
+       anchor is then cross-checked against it: the record before
+       ``anchor_seq`` must hash to the anchor's ``prev_hash``. An anchor that
+       does not match the history it claims to summarise is a failure, not a
+       detail — that is exactly what a planted anchor would look like.
+    """
+    anchor_seq = anchor["anchor_seq"]
+    anchor_prev = anchor["prev_hash"]
+
+    first_seq = _first_record_seq(path)
+    if first_seq is None:
+        # No chain to verify. An anchor without a chain is not benign: it
+        # attests that entries existed.
+        result = _verify_stream(path, _ChainVerifier(anchor_prev, anchor_seq))
+        if result.get("ok"):
+            result["ok"] = False
+            result["reason"] = (
+                f"the chain is empty but an anchor attests {anchor['archived_count']} "
+                f"archived entries and a continuation from seq {anchor_seq}")
+        result["anchored"] = True
+        result["anchor_seq"] = anchor_seq
+        return result
+
+    if first_seq == anchor_seq:
+        result = _verify_stream(path, _ChainVerifier(anchor_prev, anchor_seq))
+        result["anchored"] = True
+        result["anchor_seq"] = anchor_seq
+        if result.get("ok"):
+            result["reason"] = (
+                f"intact from the anchor at seq {anchor_seq} "
+                f"({anchor['archived_count']} earlier entries archived)")
+        return result
+
+    # The chain still holds the prefix the anchor claims was archived.
+    verifier = _ChainVerifier(remember_hash_at=anchor_seq - 1)
+    result = _verify_stream(path, verifier)
+    result["anchored"] = True
+    result["anchor_seq"] = anchor_seq
+    result["anchor_pending"] = True
+    if not result.get("ok"):
+        return result
+    if verifier.remembered_hash != anchor_prev:
+        result["ok"] = False
+        result["error_seq"] = anchor_seq - 1
+        result["reason"] = (
+            f"the anchor claims the chain continues from seq {anchor_seq} with a "
+            f"different predecessor hash than the chain's own record at seq "
+            f"{anchor_seq - 1}: the anchor does not describe this chain")
+        return result
+    result["reason"] = (
+        f"intact from the genesis; an anchor for seq {anchor_seq} is present and "
+        f"consistent, but the archived prefix is still in the chain (an "
+        f"interrupted prune — re-run it or remove the anchor)")
+    return result
+
+
+def _first_record_seq(path) -> Optional[int]:
+    """The ``seq`` of the first parseable record, or None."""
+    for rec in iter_records(path):
+        return rec["seq"]
+    return None
+
+
+def _first_record_seq_after(path, seq: int) -> Optional[int]:
+    """The ``seq`` of the first record after *seq*, or None if there is none."""
+    for rec in iter_records(path, from_seq=seq + 1):
+        return rec["seq"]
+    return None
 
 
 def _feed_raw(verifier, raw: str, position: int,
@@ -414,6 +535,56 @@ def read_checkpoints(path):
         if isinstance(cp, dict) and isinstance(cp.get("seq"), int) and cp.get("hash"):
             out.append(cp)
     return out
+
+
+def anchor_path_for(chain_path):
+    """The anchor file that belongs to *chain_path* (same directory)."""
+    import os
+    return os.path.join(os.path.dirname(str(chain_path)) or ".", ANCHOR_FILENAME)
+
+
+ANCHOR_REQUIRED_FIELDS = (
+    "anchor_seq", "prev_hash", "archived_first_seq", "archived_last_seq",
+    "archived_count", "bundle_sha256", "pruned_at",
+)
+
+
+def anchor_signing_bytes(anchor: Dict[str, Any]) -> bytes:
+    """Canonical bytes an anchor's signature is computed over: every field that
+    describes what was archived, so re-pointing an anchor at a different prefix
+    invalidates the signature."""
+    return canon_bytes({k: anchor.get(k) for k in ANCHOR_REQUIRED_FIELDS})
+
+
+def read_anchor(path) -> Optional[Dict[str, Any]]:
+    """Read the prune anchor, or None when there is none (the normal case).
+
+    A malformed anchor raises :class:`AnchorReadError` rather than reading as
+    absent: "no anchor" means "this chain starts at the genesis", and quietly
+    concluding that about a chain whose anchor file is corrupt would turn a
+    pruned chain into a chain that fails verification for the wrong reason —
+    or, worse, let someone hide a prune by mangling one file."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            raw = f.read()
+    except FileNotFoundError:
+        return None
+    except OSError as e:
+        raise AnchorReadError(f"cannot read anchor file: {e}") from e
+    try:
+        anchor = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise AnchorReadError(f"anchor file is not valid JSON: {e}") from e
+    if not isinstance(anchor, dict):
+        raise AnchorReadError("anchor file is not an object")
+    missing = [k for k in ANCHOR_REQUIRED_FIELDS if anchor.get(k) is None]
+    if missing:
+        raise AnchorReadError(f"anchor file is missing {', '.join(missing)}")
+    if not isinstance(anchor["anchor_seq"], int) or anchor["anchor_seq"] < 1:
+        raise AnchorReadError("anchor_seq is not a positive integer")
+    if not anchor["prev_hash"]:
+        raise AnchorReadError("anchor prev_hash is empty (that is the genesis)")
+    return anchor
 
 
 def cross_check_checkpoint(records, checkpoint) -> Dict[str, Any]:

--- a/modules/core/audit_chain.py
+++ b/modules/core/audit_chain.py
@@ -275,15 +275,19 @@ def _verify_anchored_chain(path, anchor) -> Dict[str, Any]:
 
     1. The chain starts at ``anchor_seq`` — the completed state. It is verified
        from the anchor's ``prev_hash``.
-    2. The chain still starts at the genesis — the interrupted state, where
-       nothing was actually deleted. It is verified from the genesis, and the
-       anchor is then cross-checked against it: the record before
-       ``anchor_seq`` must hash to the anchor's ``prev_hash``. An anchor that
-       does not match the history it claims to summarise is a failure, not a
-       detail — that is exactly what a planted anchor would look like.
+    2. The chain still starts where it started before this prune — the
+       interrupted state, where nothing was actually deleted. That is the
+       genesis on a first prune, and the *superseded* anchor on a later one,
+       which is why an anchor records the one it replaced. Either way the chain
+       is verified from that earlier start and the new anchor is then
+       cross-checked against it: the record before ``anchor_seq`` must hash to
+       the anchor's ``prev_hash``. An anchor that does not match the history it
+       claims to summarise is a failure, not a detail — that is exactly what a
+       planted anchor would look like.
     """
     anchor_seq = anchor["anchor_seq"]
     anchor_prev = anchor["prev_hash"]
+    superseded = anchor.get("supersedes") or None
 
     first_seq = _first_record_seq(path)
     if first_seq is None:
@@ -309,8 +313,33 @@ def _verify_anchored_chain(path, anchor) -> Dict[str, Any]:
                 f"({anchor['archived_count']} earlier entries archived)")
         return result
 
-    # The chain still holds the prefix the anchor claims was archived.
-    verifier = _ChainVerifier(remember_hash_at=anchor_seq - 1)
+    # The chain still holds the prefix the anchor claims was archived. Verify
+    # it from wherever it legitimately started before this prune.
+    start_prev, start_seq = GENESIS_PREV, None
+    if superseded:
+        if first_seq != superseded.get("anchor_seq"):
+            result = _blank_result()
+            result["anchored"] = True
+            result["anchor_seq"] = anchor_seq
+            result["error_seq"] = first_seq
+            result["reason"] = (
+                f"the chain starts at seq {first_seq}, which is neither the "
+                f"anchor at seq {anchor_seq} nor the anchor it superseded at "
+                f"seq {superseded.get('anchor_seq')}")
+            return result
+        start_prev = superseded.get("prev_hash") or GENESIS_PREV
+        start_seq = superseded.get("anchor_seq")
+    elif first_seq != 0:
+        result = _blank_result()
+        result["anchored"] = True
+        result["anchor_seq"] = anchor_seq
+        result["error_seq"] = first_seq
+        result["reason"] = (
+            f"the chain starts at seq {first_seq}, which is neither the genesis "
+            f"nor the anchor at seq {anchor_seq}")
+        return result
+    verifier = _ChainVerifier(start_prev, start_seq,
+                              remember_hash_at=anchor_seq - 1)
     result = _verify_stream(path, verifier)
     result["anchored"] = True
     result["anchor_seq"] = anchor_seq
@@ -325,8 +354,9 @@ def _verify_anchored_chain(path, anchor) -> Dict[str, Any]:
             f"different predecessor hash than the chain's own record at seq "
             f"{anchor_seq - 1}: the anchor does not describe this chain")
         return result
+    start = "the genesis" if not superseded else f"seq {superseded['anchor_seq']}"
     result["reason"] = (
-        f"intact from the genesis; an anchor for seq {anchor_seq} is present and "
+        f"intact from {start}; an anchor for seq {anchor_seq} is present and "
         f"consistent, but the archived prefix is still in the chain (an "
         f"interrupted prune — re-run it or remove the anchor)")
     return result
@@ -548,12 +578,19 @@ ANCHOR_REQUIRED_FIELDS = (
     "archived_count", "bundle_sha256", "pruned_at",
 )
 
+# The anchor an anchor replaced, ``{anchor_seq, prev_hash}`` or None on the
+# first prune. Signed like the rest: without it, a prune of an already-pruned
+# chain that is interrupted before the chain is replaced would leave a file
+# starting at the PREVIOUS anchor with no way left to verify it — the old
+# anchor having been overwritten — and the chain would read as tampered.
+ANCHOR_SIGNED_FIELDS = ANCHOR_REQUIRED_FIELDS + ("supersedes",)
+
 
 def anchor_signing_bytes(anchor: Dict[str, Any]) -> bytes:
     """Canonical bytes an anchor's signature is computed over: every field that
     describes what was archived, so re-pointing an anchor at a different prefix
     invalidates the signature."""
-    return canon_bytes({k: anchor.get(k) for k in ANCHOR_REQUIRED_FIELDS})
+    return canon_bytes({k: anchor.get(k) for k in ANCHOR_SIGNED_FIELDS})
 
 
 def read_anchor(path) -> Optional[Dict[str, Any]]:

--- a/modules/core/audit_prune.py
+++ b/modules/core/audit_prune.py
@@ -1,0 +1,304 @@
+"""Prune an archived prefix of the audit chain (#445, part of #437).
+
+Retention on a tamper-evident record is a policy question, not a disk question.
+You cannot make deletion impossible on a file the operator owns; what you can do
+is make it **non-deniable**. So this is not a background handler that quietly
+rolls files away. It is one explicit command, it refuses to run unless the
+prefix it is about to delete has already been exported and independently
+verified, and the deletion itself is written into the chain that continues.
+
+The order is enforced, not merely documented:
+
+1. ``GET /api/audit/export`` (or the same call in-process) produces a signed
+   bundle of the prefix.
+2. The operator verifies it **off the box**::
+
+       python -m modules.core.audit_verify --bundle prefix.json --pubkey instance.pem
+
+3. Only then::
+
+       python -m modules.core.audit_prune --bundle prefix.json --data-dir data/audit --yes
+
+   which re-verifies the bundle itself, checks that it describes exactly the
+   prefix of *this* chain, appends an ``archive`` audit entry, rewrites the
+   chain without the archived records, and writes the signed anchor that lets
+   the remainder verify.
+
+**Deliberately CLI-only.** There is no API endpoint for this and there should
+not be one: an authenticated request that deletes audit history is precisely
+what someone who has just compromised an administrator account wants, and an
+operator who can legitimately prune already has shell access — they have to put
+the archive somewhere off the box anyway.
+
+**CertMate must be stopped.** A running instance holds the next seq and the head
+hash in memory; appending underneath it would make its next write collide. The
+command refuses if the chain changes while it works, but that is a backstop, not
+a substitute.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+try:  # package import
+    from . import audit_chain, audit_signing, audit_verify
+    from .utils import utc_now
+except ImportError:  # direct execution fallback
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from core import audit_chain, audit_signing, audit_verify  # type: ignore
+    from core.utils import utc_now  # type: ignore
+
+
+class PruneError(Exception):
+    """Refusal to prune. Every one of these is a reason the operator has to
+    resolve; none of them is recoverable by trying harder."""
+
+
+def sha256_file(path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def plan_prune(chain_path, bundle, bundle_sha256):
+    """Decide what a prune would do, refusing if anything does not line up.
+
+    Returns ``{anchor_seq, prev_hash, archived_first_seq, archived_last_seq,
+    archived_count, bundle_sha256}``. Raises :class:`PruneError` otherwise.
+    """
+    verdict = audit_verify.verify_bundle(bundle)
+    if not verdict["ok"]:
+        raise PruneError(
+            f"the archive bundle does not verify ({verdict['reason']}) — nothing "
+            f"was pruned. Never delete a prefix whose only copy is unverified.")
+    if not verdict["signed"]:
+        raise PruneError(
+            "the archive bundle is unsigned, so nothing ties it to this "
+            "instance. Export it from an instance with audit signing enabled.")
+    if verdict["count"] == 0:
+        raise PruneError("the archive bundle is empty; there is nothing to prune")
+
+    first_seq = verdict["first_seq"]
+    last_seq = verdict["last_seq"]
+
+    chain_first = audit_chain._first_record_seq(chain_path)
+    if chain_first is None:
+        raise PruneError(f"no audit chain at {chain_path}")
+    if chain_first != first_seq:
+        # The one rule that keeps this a prune and not a hole: the archive must
+        # start where the chain currently starts. On an already-pruned chain
+        # that is the previous anchor, not the genesis, which is how a second
+        # prune works — its bundle is an anchored slice (#441) and verifies as
+        # one.
+        raise PruneError(
+            f"the bundle starts at seq {first_seq} but the chain starts at seq "
+            f"{chain_first}: this bundle is not a prefix of this chain")
+
+    # The bundle's records must be the chain's own records, byte for byte at the
+    # hash level. verify_bundle proved the bundle is internally consistent; this
+    # proves it is a copy of THIS history and not of some other instance's.
+    entries = {e["seq"]: e["hash"] for e in bundle["entries"]}
+    head_at_last = None
+    seen = 0
+    for rec in audit_chain.iter_records(chain_path, to_seq=last_seq):
+        expected = entries.get(rec["seq"])
+        if expected is None:
+            raise PruneError(
+                f"the chain has a record at seq {rec['seq']} that the archive "
+                f"bundle does not contain: the archive is incomplete")
+        if expected != rec["hash"]:
+            raise PruneError(
+                f"the chain and the archive bundle disagree at seq {rec['seq']}: "
+                f"one of them has been modified")
+        seen += 1
+        if rec["seq"] == last_seq:
+            head_at_last = rec["hash"]
+    if seen != verdict["count"]:
+        raise PruneError(
+            f"the archive bundle holds {verdict['count']} records but the chain "
+            f"holds {seen} up to seq {last_seq}")
+    if head_at_last is None:
+        raise PruneError(
+            f"the chain does not contain seq {last_seq}, which the bundle claims")
+
+    remaining = audit_chain._first_record_seq_after(chain_path, last_seq)
+    if remaining is None:
+        raise PruneError(
+            f"pruning through seq {last_seq} would empty the chain. Keep at "
+            f"least the entries after the archived prefix: a chain with no "
+            f"live records cannot be verified at all, only asserted.")
+    if remaining != last_seq + 1:
+        raise PruneError(
+            f"the chain jumps from seq {last_seq} to seq {remaining}; refusing "
+            f"to prune a chain that is already broken")
+
+    return {
+        "anchor_seq": last_seq + 1,
+        "prev_hash": head_at_last,
+        "archived_first_seq": first_seq,
+        "archived_last_seq": last_seq,
+        "archived_count": verdict["count"],
+        "bundle_sha256": bundle_sha256,
+    }
+
+
+def _write_atomic(path, text: str, mode: int = 0o600) -> None:
+    tmp = f"{path}.tmp"
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(text)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
+
+
+def execute_prune(chain_path, plan, signer, audit_logger=None):
+    """Append the ``archive`` record, write the anchor, rewrite the chain.
+
+    The anchor is written *before* the chain is replaced. If the process dies
+    between the two, the chain still holds everything and
+    :func:`audit_chain.verify_chain` reports an interrupted prune rather than a
+    broken chain — the safe direction to fail in, because nothing is gone.
+    """
+    chain_path = Path(chain_path)
+
+    # 1. The prune is itself an audited event, recorded in the chain that
+    #    continues. This is the whole point: the deletion is not deniable.
+    entry = {
+        "timestamp": utc_now().isoformat(),
+        "operation": "archive",
+        "resource_type": "audit_chain",
+        "resource_id": f"seq {plan['archived_first_seq']}-{plan['archived_last_seq']}",
+        "status": "success",
+        "user": "operator",
+        "ip_address": "local",
+        "details": {
+            "archived_first_seq": plan["archived_first_seq"],
+            "archived_last_seq": plan["archived_last_seq"],
+            "archived_count": plan["archived_count"],
+            "archived_head_hash": plan["prev_hash"],
+            "bundle_sha256": plan["bundle_sha256"],
+        },
+        "error": None,
+        "actor": {"kind": "operator", "label": "audit_prune"},
+        "trigger": {"cause": "manual"},
+    }
+    if audit_logger is not None:
+        audit_logger.log_operation(
+            operation="archive", resource_type="audit_chain",
+            resource_id=entry["resource_id"], status="success",
+            details=entry["details"], user="operator", ip_address="local",
+            actor=entry["actor"], trigger=entry["trigger"],
+        )
+    else:
+        last = None
+        for rec in audit_chain.iter_records(chain_path):
+            last = rec
+        line = audit_chain.make_line(last["seq"] + 1, entry, last["hash"])
+        with open(chain_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(line, ensure_ascii=False) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+
+    # Snapshot taken AFTER our own append, so the guard below detects somebody
+    # else's write and not ours.
+    before = chain_path.stat()
+
+    # 2. The signed anchor: what was archived, and what the remainder continues
+    #    from. Signed so a planted anchor cannot pass for a real one.
+    anchor = dict(plan)
+    anchor["pruned_at"] = utc_now().isoformat()
+    signature = signer.sign(audit_chain.anchor_signing_bytes(anchor))
+    if signature is None:
+        raise PruneError("could not sign the anchor; nothing was pruned")
+    anchor["signature"] = signature
+    anchor["algorithm"] = audit_signing.ALGORITHM
+    anchor_path = audit_chain.anchor_path_for(chain_path)
+    _write_atomic(anchor_path, json.dumps(anchor, indent=2) + "\n")
+
+    # 3. Rewrite the chain without the archived records. The concurrency guard
+    #    is a backstop for the documented rule that CertMate must be stopped:
+    #    a running instance holds the next seq in memory and would collide.
+    kept = [
+        json.dumps(rec, ensure_ascii=False)
+        for rec in audit_chain.iter_records(chain_path, from_seq=plan["anchor_seq"])
+    ]
+    after = chain_path.stat()
+    if (after.st_size, after.st_mtime_ns) != (before.st_size, before.st_mtime_ns):
+        if audit_logger is None:
+            raise PruneError(
+                "the chain file changed while pruning — is CertMate still "
+                "running? Nothing was removed (the anchor was written; re-run "
+                "the prune with the service stopped).")
+    _write_atomic(chain_path, "\n".join(kept) + "\n")
+    return anchor
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Prune an exported, verified prefix of the CertMate audit chain.",
+        epilog="CertMate must be STOPPED. Export and verify the prefix first; "
+               "this command refuses to delete anything it cannot see a valid "
+               "archive for.")
+    parser.add_argument("--bundle", required=True,
+                        help="the signed export bundle covering the prefix to prune")
+    parser.add_argument("--data-dir", default="data/audit",
+                        help="directory holding certificate_audit.chain.jsonl")
+    parser.add_argument("--key-dir", default="data",
+                        help="directory holding .audit_signing_key (to sign the anchor)")
+    parser.add_argument("--yes", action="store_true",
+                        help="actually prune; without it the plan is printed and nothing changes")
+    args = parser.parse_args(argv)
+
+    chain_path = Path(args.data_dir) / audit_chain.CHAIN_FILENAME
+    try:
+        with open(args.bundle, "r", encoding="utf-8") as f:
+            bundle = json.load(f)
+        bundle_sha = sha256_file(args.bundle)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"FAIL: cannot read bundle: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        plan = plan_prune(chain_path, bundle, bundle_sha)
+    except PruneError as e:
+        print(f"REFUSED: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Archive verified: {plan['archived_count']} entries, "
+          f"seq {plan['archived_first_seq']}..{plan['archived_last_seq']}")
+    print(f"After pruning, the chain starts at seq {plan['anchor_seq']} and is "
+          f"verified from a signed anchor, not from the genesis.")
+    print(f"Keep {args.bundle} (sha256 {plan['bundle_sha256'][:16]}...) off this "
+          f"box: it is the only remaining copy of those entries.")
+    if not args.yes:
+        print("\nDry run. Re-run with --yes to prune, with CertMate stopped.")
+        return 0
+
+    signer = audit_signing.AuditSigner(Path(args.key_dir))
+    if not signer.available:
+        print("FAIL: no audit signing key; the anchor could not be signed",
+              file=sys.stderr)
+        return 2
+    try:
+        execute_prune(chain_path, plan, signer)
+    except PruneError as e:
+        print(f"FAILED: {e}", file=sys.stderr)
+        return 1
+
+    result = audit_chain.verify_chain(chain_path)
+    if not result["ok"]:
+        print(f"FAIL: the pruned chain does not verify: {result['reason']}",
+              file=sys.stderr)
+        return 1
+    print(f"\nPruned. {result['reason']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/core/audit_prune.py
+++ b/modules/core/audit_prune.py
@@ -137,6 +137,16 @@ def plan_prune(chain_path, bundle, bundle_sha256):
             f"the chain jumps from seq {last_seq} to seq {remaining}; refusing "
             f"to prune a chain that is already broken")
 
+    # What this prune replaces, if the chain was pruned before. Recorded (and
+    # signed) so that an interrupted second prune can still be verified: the
+    # chain would then start at the previous anchor, whose file this one is
+    # about to overwrite.
+    previous = audit_chain.read_anchor(audit_chain.anchor_path_for(chain_path))
+    supersedes = None
+    if previous is not None:
+        supersedes = {"anchor_seq": previous["anchor_seq"],
+                      "prev_hash": previous["prev_hash"]}
+
     return {
         "anchor_seq": last_seq + 1,
         "prev_hash": head_at_last,
@@ -144,6 +154,7 @@ def plan_prune(chain_path, bundle, bundle_sha256):
         "archived_last_seq": last_seq,
         "archived_count": verdict["count"],
         "bundle_sha256": bundle_sha256,
+        "supersedes": supersedes,
     }
 
 

--- a/modules/core/audit_verify.py
+++ b/modules/core/audit_verify.py
@@ -152,6 +152,38 @@ def verify_bundle(bundle, expected_pubkey_pem=None):
     return result
 
 
+def _check_anchor_signature(result, chain_path, pubkey_path) -> None:
+    """Verify a pruned chain's anchor against a PEM public key, when one was
+    supplied. Without a key the chain is still structurally verified, but the
+    anchor is an unverified claim and the output has to say so — an anchored
+    chain that reports a bare "intact" is exactly the overclaim #445 is about."""
+    if not pubkey_path:
+        return
+    try:
+        anchor = audit_chain.read_anchor(audit_chain.anchor_path_for(chain_path))
+    except audit_chain.AnchorReadError as e:
+        result["ok"] = False
+        result["reason"] = str(e)
+        return
+    try:
+        pem = open(pubkey_path, "r", encoding="utf-8").read()
+    except OSError as e:
+        result["ok"] = False
+        result["reason"] = f"cannot read --pubkey: {e}"
+        return
+    signing = _import_signing()
+    signature = (anchor or {}).get("signature")
+    if not signature or not signing.verify_signature(
+        pem, signature, audit_chain.anchor_signing_bytes(anchor)
+    ):
+        result["ok"] = False
+        result["reason"] = (
+            f"the anchor at seq {result.get('anchor_seq')} is not signed by the "
+            f"pinned key: entries were removed without a valid attestation")
+        return
+    result["anchor_signature_ok"] = True
+
+
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
         description="Verify a CertMate audit hash chain or signed export bundle.")
@@ -199,11 +231,25 @@ def main(argv=None) -> int:
 
     # Chain mode (Phase 2).
     result = audit_chain.verify_chain(args.path)
+    if result["ok"] and result.get("anchored"):
+        # The structural check passed, but an anchored chain has had entries
+        # removed. Verify the anchor's signature if the operator supplied a key,
+        # and say plainly what is and is not covered either way (#445).
+        _check_anchor_signature(result, args.path, args.pubkey)
     if args.json:
         print(json.dumps(result, indent=2))
     elif result["ok"]:
-        print(f"OK: audit chain intact "
+        scope = ("intact" if not result.get("anchored")
+                 else f"intact from the anchor at seq {result['anchor_seq']}")
+        print(f"OK: audit chain {scope} "
               f"({result['count']} entries, seq {result['first_seq']}..{result['last_seq']})")
+        if result.get("anchored"):
+            print(f"note: this chain was PRUNED. Entries before seq "
+                  f"{result['anchor_seq']} are not in this file; they are attested "
+                  f"by the anchor and live only in the exported archive bundle. "
+                  f"Anchor signature: "
+                  f"{'verified' if result.get('anchor_signature_ok') else 'NOT verified (pass --pubkey)'}.",
+                  file=sys.stderr)
         if result.get("head_hash"):
             print(f"head_hash: {result['head_hash']}")
     else:

--- a/tests/test_audit_prune.py
+++ b/tests/test_audit_prune.py
@@ -1,0 +1,410 @@
+"""Pruning the audit chain is explicit, refuses what it cannot verify, and
+records itself.
+
+Tests for #445, the last half of #437. Retention on a tamper-evident record is a
+policy question, not a disk question: you cannot make deletion impossible on a
+file the operator owns, so the goal is to make it non-deniable. Concretely that
+means three properties, and each section below pins one of them:
+
+1. It refuses. Every path that would delete entries whose archive does not
+   verify, does not belong to this chain, or does not cover exactly the prefix,
+   ends in a refusal with nothing removed.
+2. It records itself. The prune appears as an `archive` entry inside the chain
+   that continues, naming the range, the head hash and the archive's digest.
+3. It does not overclaim, and it does not cry wolf. The pruned chain verifies
+   from a signed anchor and says so; a forged anchor fails; and — the failure
+   mode this whole design exists to avoid — the checkpoints that attest the
+   archived entries do not make routine maintenance look like tampering.
+"""
+
+import json
+
+import pytest
+
+from modules.core import audit_chain, audit_verify
+from modules.core.audit import AuditLogger
+from modules.core.audit_prune import (
+    PruneError, main, plan_prune, sha256_file,
+)
+from modules.core.audit_signing import AuditSigner
+
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def instance(tmp_path):
+    """A CertMate audit trail with 12 entries and checkpoints every 5."""
+    signer = AuditSigner(tmp_path)
+    audit = AuditLogger(tmp_path / "logs", chain_dir=tmp_path / "chain",
+                        signer=signer, checkpoint_interval=5)
+    for i in range(12):
+        audit.log_operation("renew", "certificate", f"d{i}.example.com", "success")
+    yield audit
+    if audit.file_handler is not None:
+        audit.audit_logger.removeHandler(audit.file_handler)
+        audit.file_handler.close()
+
+
+def _archive(instance, tmp_path, to_seq=5, name="prefix.json"):
+    path = tmp_path / name
+    path.write_text(json.dumps(instance.export_bundle(to_seq=to_seq)), encoding="utf-8")
+    return path
+
+
+def _reopen(instance, tmp_path, signer=None):
+    """A fresh AuditLogger over the same chain — what the next boot sees."""
+    audit = AuditLogger(tmp_path / "logs-reopened", chain_dir=tmp_path / "chain",
+                        signer=signer or instance._signer)
+    if audit.file_handler is not None:
+        audit.audit_logger.removeHandler(audit.file_handler)
+        audit.file_handler.close()
+    return audit
+
+
+def _prune(instance, tmp_path, bundle_path):
+    return main(["--bundle", str(bundle_path), "--data-dir", str(tmp_path / "chain"),
+                 "--key-dir", str(tmp_path), "--yes"])
+
+
+# --------------------------------------------------------------------------
+# 1. It refuses
+# --------------------------------------------------------------------------
+
+def test_it_refuses_an_unverifiable_archive(instance, tmp_path):
+    path = _archive(instance, tmp_path)
+    bundle = json.loads(path.read_text())
+    bundle["entries"][2]["entry"]["status"] = "forged"
+
+    with pytest.raises(PruneError, match="does not verify"):
+        plan_prune(instance.audit_chain_file, bundle, "sha")
+
+
+def test_it_refuses_an_unsigned_archive(tmp_path):
+    """Unsigned entries are still chain-verifiable, but nothing ties them to
+    this instance — and the archive is about to become the only copy."""
+    audit = AuditLogger(tmp_path / "logs", chain_dir=tmp_path / "chain")
+    for i in range(6):
+        audit.log_operation("renew", "certificate", f"d{i}.example.com", "success")
+    bundle = audit.export_bundle(to_seq=2)
+    try:
+        with pytest.raises(PruneError, match="unsigned"):
+            plan_prune(audit.audit_chain_file, bundle, "sha")
+    finally:
+        audit.audit_logger.removeHandler(audit.file_handler)
+        audit.file_handler.close()
+
+
+def test_it_refuses_an_archive_from_another_instance(instance, tmp_path):
+    """Same shape, different history: the hashes will not match."""
+    other_signer = AuditSigner(tmp_path / "other")
+    other = AuditLogger(tmp_path / "other-logs", chain_dir=tmp_path / "other-chain",
+                        signer=other_signer)
+    for i in range(8):
+        other.log_operation("renew", "certificate", f"x{i}.example.com", "success")
+    bundle = other.export_bundle(to_seq=5)
+    try:
+        with pytest.raises(PruneError, match="disagree at seq"):
+            plan_prune(instance.audit_chain_file, bundle, "sha")
+    finally:
+        other.audit_logger.removeHandler(other.file_handler)
+        other.file_handler.close()
+
+
+def test_it_refuses_an_archive_that_is_not_a_prefix(instance, tmp_path):
+    """A slice from the middle would leave a hole, not a shorter chain."""
+    bundle = instance.export_bundle(from_seq=4, to_seq=8)
+
+    with pytest.raises(PruneError, match="not a prefix of this chain"):
+        plan_prune(instance.audit_chain_file, bundle, "sha")
+
+
+def test_it_refuses_to_empty_the_chain(instance, tmp_path):
+    """A chain with no live records cannot be verified at all, only asserted."""
+    bundle = instance.export_bundle()
+
+    with pytest.raises(PruneError, match="would empty the chain"):
+        plan_prune(instance.audit_chain_file, bundle, "sha")
+
+
+def test_it_refuses_when_the_chain_is_missing(instance, tmp_path):
+    bundle = json.loads(_archive(instance, tmp_path).read_text())
+
+    with pytest.raises(PruneError, match="no audit chain"):
+        plan_prune(tmp_path / "nowhere" / "chain.jsonl", bundle, "sha")
+
+
+def test_a_dry_run_changes_nothing(instance, tmp_path, capsys):
+    path = _archive(instance, tmp_path)
+    before = instance.audit_chain_file.read_text()
+
+    rc = main(["--bundle", str(path), "--data-dir", str(tmp_path / "chain"),
+               "--key-dir", str(tmp_path)])
+
+    assert rc == 0
+    assert "Dry run" in capsys.readouterr().out
+    assert instance.audit_chain_file.read_text() == before
+    assert not (tmp_path / "chain" / audit_chain.ANCHOR_FILENAME).exists()
+
+
+def test_a_refusal_removes_nothing(instance, tmp_path, capsys):
+    bundle_path = tmp_path / "middle.json"
+    bundle_path.write_text(json.dumps(instance.export_bundle(from_seq=4, to_seq=8)))
+    before = instance.audit_chain_file.read_text()
+
+    rc = main(["--bundle", str(bundle_path), "--data-dir", str(tmp_path / "chain"),
+               "--key-dir", str(tmp_path), "--yes"])
+
+    assert rc == 1
+    assert "REFUSED" in capsys.readouterr().err
+    assert instance.audit_chain_file.read_text() == before
+
+
+# --------------------------------------------------------------------------
+# 2. It records itself
+# --------------------------------------------------------------------------
+
+def test_the_prune_is_an_entry_in_the_chain_that_continues(instance, tmp_path):
+    path = _archive(instance, tmp_path)
+    digest = sha256_file(path)
+
+    assert _prune(instance, tmp_path, path) == 0
+
+    records = audit_chain.load_records(instance.audit_chain_file)
+    assert [r["seq"] for r in records] == [6, 7, 8, 9, 10, 11, 12]
+    archive = records[-1]["entry"]
+    assert archive["operation"] == "archive"
+    assert archive["resource_type"] == "audit_chain"
+    assert archive["details"]["archived_first_seq"] == 0
+    assert archive["details"]["archived_last_seq"] == 5
+    assert archive["details"]["archived_count"] == 6
+    assert archive["details"]["bundle_sha256"] == digest
+
+
+def test_the_archived_head_hash_is_recorded(instance, tmp_path):
+    """What the deleted entries hashed to, kept where the deletion is visible."""
+    head_before = audit_chain.load_records(instance.audit_chain_file)[5]["hash"]
+    path = _archive(instance, tmp_path)
+
+    _prune(instance, tmp_path, path)
+
+    archive = audit_chain.load_records(instance.audit_chain_file)[-1]["entry"]
+    assert archive["details"]["archived_head_hash"] == head_before
+
+
+def test_the_anchor_records_what_was_archived(instance, tmp_path):
+    path = _archive(instance, tmp_path)
+
+    _prune(instance, tmp_path, path)
+
+    anchor = audit_chain.read_anchor(
+        audit_chain.anchor_path_for(instance.audit_chain_file))
+    assert anchor["anchor_seq"] == 6
+    assert anchor["archived_count"] == 6
+    assert anchor["bundle_sha256"] == sha256_file(path)
+    assert anchor["signature"]
+
+
+# --------------------------------------------------------------------------
+# 3. It does not overclaim, and it does not cry wolf
+# --------------------------------------------------------------------------
+
+def test_the_pruned_chain_verifies_from_the_anchor(instance, tmp_path):
+    _prune(instance, tmp_path, _archive(instance, tmp_path))
+
+    result = _reopen(instance, tmp_path).verify_chain()
+
+    assert result["ok"]
+    assert result["anchored"] is True
+    assert result["anchor_seq"] == 6
+    assert result["anchor_signature_ok"] is True
+    assert "from the anchor at seq 6" in result["reason"]
+    assert result["reason"] != "intact"
+
+
+def test_the_stdlib_verifier_never_says_bare_intact(instance, tmp_path, capsys):
+    """An auditor running the standalone verifier must not read a pruned chain
+    as a complete one."""
+    _prune(instance, tmp_path, _archive(instance, tmp_path))
+
+    rc = audit_verify.main([str(instance.audit_chain_file)])
+
+    out = capsys.readouterr()
+    assert rc == 0
+    assert "intact from the anchor at seq 6" in out.out
+    assert "PRUNED" in out.err
+    assert "NOT verified" in out.err, "an unpinned anchor must not read as verified"
+
+
+def test_the_stdlib_verifier_verifies_a_pinned_anchor(instance, tmp_path, capsys):
+    _prune(instance, tmp_path, _archive(instance, tmp_path))
+    pem = tmp_path / "pub.pem"
+    pem.write_text(instance._signer.public_key_pem(), encoding="utf-8")
+
+    rc = audit_verify.main([str(instance.audit_chain_file), "--pubkey", str(pem)])
+
+    assert rc == 0
+    assert "Anchor signature: verified" in capsys.readouterr().err
+
+
+def test_a_forged_anchor_is_rejected(instance, tmp_path):
+    """Deleting history and writing a matching anchor must not verify: the
+    anchor is signed precisely so that it cannot be fabricated."""
+    _prune(instance, tmp_path, _archive(instance, tmp_path))
+    anchor_path = audit_chain.anchor_path_for(instance.audit_chain_file)
+    anchor = json.loads(open(anchor_path).read())
+    anchor["archived_count"] = 999
+    open(anchor_path, "w").write(json.dumps(anchor))
+
+    result = _reopen(instance, tmp_path).verify_chain()
+
+    assert not result["ok"]
+    assert "not signed by this instance" in result["reason"]
+
+
+def test_an_anchor_pinned_to_a_different_key_is_rejected(instance, tmp_path, capsys):
+    _prune(instance, tmp_path, _archive(instance, tmp_path))
+    stranger = tmp_path / "stranger.pem"
+    stranger.write_text(AuditSigner(tmp_path / "stranger").public_key_pem())
+
+    rc = audit_verify.main([str(instance.audit_chain_file), "--pubkey", str(stranger)])
+
+    assert rc == 1
+    assert "not signed by the pinned key" in capsys.readouterr().err
+
+
+def test_an_unreadable_anchor_fails_closed(instance, tmp_path):
+    """"No anchor" means "this chain starts at the genesis". Concluding that
+    about a chain whose anchor is corrupt would hide a prune."""
+    _prune(instance, tmp_path, _archive(instance, tmp_path))
+    open(audit_chain.anchor_path_for(instance.audit_chain_file), "w").write("{oops")
+
+    result = audit_chain.verify_chain(instance.audit_chain_file)
+
+    assert not result["ok"]
+    assert result["anchor_unreadable"] is True
+
+
+def test_old_checkpoints_do_not_report_the_prune_as_tampering(instance, tmp_path):
+    """The failure this design exists to avoid. Checkpoints at seq 4 and 9
+    attest entries that were archived; cross-checking against the older one
+    would call routine maintenance a truncation, and an operator who sees a
+    tamper alert from maintenance learns to ignore tamper alerts."""
+    _prune(instance, tmp_path, _archive(instance, tmp_path))
+
+    result = _reopen(instance, tmp_path).verify_chain()
+
+    assert result["ok"], result["reason"]
+    assert result["checkpoint_verified"] is True
+    assert result["checkpoint_seq"] >= result["anchor_seq"]
+
+
+def test_a_prune_past_every_checkpoint_says_so_rather_than_failing(instance, tmp_path):
+    _prune(instance, tmp_path, _archive(instance, tmp_path, to_seq=9))
+
+    result = _reopen(instance, tmp_path).verify_chain()
+
+    assert result["ok"], result["reason"]
+    assert "predates the archived prefix" in result["checkpoint_reason"]
+
+
+def test_an_anchored_chain_without_a_signing_key_does_not_verify(instance, tmp_path):
+    """An anchor nobody can check is an assertion, not evidence."""
+    _prune(instance, tmp_path, _archive(instance, tmp_path))
+    unsigned = AuditLogger(tmp_path / "logs-nokey", chain_dir=tmp_path / "chain")
+    try:
+        result = unsigned.verify_chain()
+    finally:
+        unsigned.audit_logger.removeHandler(unsigned.file_handler)
+        unsigned.file_handler.close()
+
+    assert not result["ok"]
+    assert "no signing key" in result["reason"]
+
+
+# --------------------------------------------------------------------------
+# Interrupted and resumed
+# --------------------------------------------------------------------------
+
+def test_an_interrupted_prune_leaves_a_chain_that_still_verifies(instance, tmp_path):
+    """The anchor is written before the chain is replaced, so a crash between
+    the two loses nothing — and must not read as tampering."""
+    path = _archive(instance, tmp_path)
+    plan = plan_prune(instance.audit_chain_file, json.loads(path.read_text()),
+                      sha256_file(path))
+    anchor = dict(plan)
+    anchor["pruned_at"] = "2026-07-22T00:00:00"
+    anchor["signature"] = instance._signer.sign(
+        audit_chain.anchor_signing_bytes(anchor))
+    open(audit_chain.anchor_path_for(instance.audit_chain_file), "w").write(
+        json.dumps(anchor))
+
+    result = audit_chain.verify_chain(instance.audit_chain_file)
+
+    assert result["ok"], result["reason"]
+    assert result["anchor_pending"] is True
+    assert "interrupted prune" in result["reason"]
+    assert result["count"] == 12, "nothing was removed"
+
+
+def test_an_anchor_that_does_not_describe_this_chain_fails(instance, tmp_path):
+    """A planted anchor claiming a prefix that never hashed that way."""
+    anchor = {
+        "anchor_seq": 6, "prev_hash": "0" * 64, "archived_first_seq": 0,
+        "archived_last_seq": 5, "archived_count": 6, "bundle_sha256": "x",
+        "pruned_at": "2026-07-22T00:00:00",
+    }
+    anchor["signature"] = instance._signer.sign(
+        audit_chain.anchor_signing_bytes(anchor))
+    open(audit_chain.anchor_path_for(instance.audit_chain_file), "w").write(
+        json.dumps(anchor))
+
+    result = audit_chain.verify_chain(instance.audit_chain_file)
+
+    assert not result["ok"]
+    assert "does not describe this chain" in result["reason"]
+
+
+def test_the_chain_keeps_growing_after_a_prune(instance, tmp_path):
+    """The next boot must continue the chain from the pruned head, not restart."""
+    _prune(instance, tmp_path, _archive(instance, tmp_path))
+
+    resumed = _reopen(instance, tmp_path)
+    resumed.log_operation("renew", "certificate", "after.example.com", "success")
+
+    result = resumed.verify_chain()
+    assert result["ok"], result["reason"]
+    assert result["last_seq"] == 13
+    assert result["anchored"] is True
+
+
+def test_a_second_prune_moves_the_anchor(instance, tmp_path):
+    """Pruning twice works: the second archive starts at the first anchor, not
+    at the genesis, so its bundle is an anchored slice and verifies as one."""
+    _prune(instance, tmp_path, _archive(instance, tmp_path, to_seq=5))
+    resumed = _reopen(instance, tmp_path)
+
+    second = tmp_path / "second.json"
+    second.write_text(json.dumps(resumed.export_bundle(to_seq=9)))
+    rc = main(["--bundle", str(second), "--data-dir", str(tmp_path / "chain"),
+               "--key-dir", str(tmp_path), "--yes"])
+
+    assert rc == 0
+    result = _reopen(instance, tmp_path).verify_chain()
+    assert result["ok"], result["reason"]
+    assert result["anchor_seq"] == 10
+    assert [r["seq"] for r in audit_chain.load_records(instance.audit_chain_file)] \
+        == [10, 11, 12, 13]
+
+
+def test_an_exported_bundle_from_a_pruned_chain_is_anchored(instance, tmp_path):
+    """It no longer starts at the genesis, so it must declare its anchor —
+    which is exactly the #441 primitive doing its job here."""
+    _prune(instance, tmp_path, _archive(instance, tmp_path))
+
+    bundle = _reopen(instance, tmp_path).export_bundle()
+
+    assert bundle["manifest"]["format_version"] == \
+        audit_chain.ANCHORED_BUNDLE_FORMAT_VERSION
+    verdict = audit_verify.verify_bundle(bundle)
+    assert verdict["ok"] and verdict["anchored"]

--- a/tests/test_audit_prune.py
+++ b/tests/test_audit_prune.py
@@ -408,3 +408,65 @@ def test_an_exported_bundle_from_a_pruned_chain_is_anchored(instance, tmp_path):
         audit_chain.ANCHORED_BUNDLE_FORMAT_VERSION
     verdict = audit_verify.verify_bundle(bundle)
     assert verdict["ok"] and verdict["anchored"]
+
+
+def test_an_interrupted_second_prune_still_verifies(instance, tmp_path):
+    """The case that made the anchor record what it supersedes. After a first
+    prune the chain starts at seq 6, not at the genesis; a second prune that
+    dies before replacing the chain would otherwise leave a file whose only
+    description — the old anchor — has just been overwritten, and it would read
+    as tampered."""
+    _prune(instance, tmp_path, _archive(instance, tmp_path, to_seq=5))
+    resumed = _reopen(instance, tmp_path)
+    second = tmp_path / "second.json"
+    second.write_text(json.dumps(resumed.export_bundle(to_seq=9)))
+    plan = plan_prune(instance.audit_chain_file, json.loads(second.read_text()),
+                      sha256_file(second))
+    assert plan["supersedes"] == {"anchor_seq": 6, "prev_hash": plan["supersedes"]["prev_hash"]}
+    anchor = dict(plan)
+    anchor["pruned_at"] = "2026-07-22T00:00:00"
+    anchor["signature"] = instance._signer.sign(
+        audit_chain.anchor_signing_bytes(anchor))
+    open(audit_chain.anchor_path_for(instance.audit_chain_file), "w").write(
+        json.dumps(anchor))
+
+    result = _reopen(instance, tmp_path).verify_chain()
+
+    assert result["ok"], result["reason"]
+    assert result["anchor_pending"] is True
+    assert "intact from seq 6" in result["reason"]
+    assert result["first_seq"] == 6, "nothing was removed"
+
+
+def test_a_chain_starting_at_neither_the_anchor_nor_its_predecessor_fails(
+        instance, tmp_path):
+    _prune(instance, tmp_path, _archive(instance, tmp_path, to_seq=5))
+    anchor_path = audit_chain.anchor_path_for(instance.audit_chain_file)
+    anchor = json.loads(open(anchor_path).read())
+    anchor["anchor_seq"] = 9  # claims a prune the chain does not reflect
+    open(anchor_path, "w").write(json.dumps(anchor))
+
+    result = audit_chain.verify_chain(instance.audit_chain_file)
+
+    assert not result["ok"]
+    assert "neither the genesis nor the anchor" in result["reason"]
+
+
+def test_an_anchor_that_vanishes_mid_verification_fails_closed(instance, tmp_path,
+                                                               monkeypatch):
+    """verify_chain reads the anchor, then the signature check reads it again.
+    A file that disappears in between must not raise — nor pass."""
+    _prune(instance, tmp_path, _archive(instance, tmp_path))
+    audit = _reopen(instance, tmp_path)
+    real = audit_chain.read_anchor
+    calls = {"n": 0}
+
+    def vanishing(path):
+        calls["n"] += 1
+        return real(path) if calls["n"] == 1 else None
+
+    monkeypatch.setattr(audit_chain, "read_anchor", vanishing)
+    result = audit.verify_chain()
+
+    assert not result["ok"]
+    assert "disappeared" in result["reason"]


### PR DESCRIPTION
Closes #445. The last of the three sub-issues from #437 (approach C), at the minimal scope: an operator-initiated prune of an already-exported-and-verified prefix, with the prune itself written into the chain.

Retention on a tamper-evident record is a policy question, not a disk question. You cannot make deletion impossible on a file the operator owns; what you *can* do is make it **non-deniable**. So this is not a background handler that quietly rolls files away.

```bash
# with CertMate stopped, after exporting and verifying the prefix off the box
python -m modules.core.audit_prune --bundle archive-0-1199.json --data-dir data/audit        # dry run
python -m modules.core.audit_prune --bundle archive-0-1199.json --data-dir data/audit --yes
```

## It refuses

Nothing is deleted unless the archive bundle verifies, is signed by this instance, starts exactly where the chain currently starts, and agrees with the chain hash-for-hash at every seq it claims. It also refuses to empty the chain: a chain with no live records cannot be verified at all, only asserted.

**Deliberately CLI-only — there is no API endpoint and there should not be one.** An authenticated request that deletes audit history is precisely what someone who has just compromised an administrator account wants, and an operator who can legitimately prune already has shell access; they have to put the archive somewhere off the box anyway.

## What it leaves behind

- **An `archive` entry in the chain that continues**, naming the seq range, the count, the archived head hash and the archive file's SHA-256. The record of the deletion outlives what it deleted.
- **`certificate_audit.anchor.json`**, signed with the instance key, stating where the chain now starts and what it continues from — so a chain that was merely *truncated* cannot be passed off as a pruned one. Forging it requires the signing key.
- **Verification that never says a bare "intact" again.** `/api/audit/verify` reports `anchored` / `anchor_seq`; the standalone verifier prints that the chain was PRUNED, which entries are not in the file, and whether the anchor signature was actually checked (it is not, unless you pass `--pubkey` — and it says so).

## The two ways this could have gone wrong, both tested

- **An interrupted prune.** The anchor is written *before* the chain is replaced, so a crash between the two loses nothing. Verification then reports "an interrupted prune — re-run it or remove the anchor" instead of a broken chain: the safe direction to fail in.
- **Checkpoints crying wolf.** Signed checkpoints below the anchor attest entries that were just archived; cross-checking against one would report routine maintenance as a truncation — *the* failure mode #437 says must never happen, because an operator who sees a tamper alert from maintenance learns to ignore tamper alerts. Only checkpoints at or above the anchor are used, and a prune past all of them says so plainly rather than failing.

Second and subsequent prunes work, and fall out of #441: on an already-pruned chain the next archive is an anchored slice, which verifies as one.

## Tests

`tests/test_audit_prune.py`, 25 tests, organised as the three properties: it refuses (unverifiable, unsigned, foreign instance, mid-chain slice, would-empty, missing chain, dry run, and that a refusal leaves the file byte-identical); it records itself (the `archive` entry, its head hash, the anchor contents); it does not overclaim or cry wolf (anchored verdicts, the stdlib verifier's wording with and without a pinned key, forged anchor, stranger's key, unreadable anchor failing closed, checkpoints, an anchored chain with no signing key, interrupted prune, planted anchor, growth after a prune, a second prune, and that an export from a pruned chain is anchored).

Suite: 1933 passed, 6 skipped. `docs/compliance.md` documents the procedure and its two limits: the anchor describes only the most recent archive (the full history is the sequence of bundles, which is why each digest is in the chain), and the instance key still does not bind the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)