### PR TITLE
Fix race condition in tools/list response handling

### DIFF
--- a/mcp/test-smoke.js
+++ b/mcp/test-smoke.js
@@ -42,6 +42,8 @@ const timeout = setTimeout(() => {
   fail("timed out waiting for tools/list response");
 }, 8000);
 
+let initialized = false;
+
 child.stdout.on("data", (d) => {
   buf += d.toString();
   let idx;
@@ -55,6 +57,14 @@ child.stdout.on("data", (d) => {
     } catch (e) {
       continue;
     }
+    // Track successful initialize response
+    if (msg.id === 1 && msg.result) {
+      initialized = true;
+      // Now send notifications/initialized and tools/list only after initialize succeeded
+      child.stdin.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n");
+      child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }) + "\n");
+    }
+    // Handle tools/list response
     if (msg.id === 2 && msg.result && msg.result.tools) {
       clearTimeout(timeout);
       const names = msg.result.tools.map((t) => t.name);
@@ -81,7 +91,3 @@ const init = {
   params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "smoke", version: "0" } },
 };
 child.stdin.write(JSON.stringify(init) + "\n");
-setTimeout(() => {
-  child.stdin.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n");
-  child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }) + "\n");
-}, 400);


### PR DESCRIPTION
### FabGPT — code quality

**File:** `mcp/test-smoke.js`

**Rationale:** The test sends the tools/list request unconditionally after a fixed 400ms delay, but the server may not have responded to the initialize request yet. This creates a race condition where the tools/list request could be sent before the server is ready, causing the response to be missed and the test to time out. The fix waits for the initialize response (id:1) before sending notifications/initialized and tools/list, ensuring the handshake is complete before proceeding. This makes the test robust against startup timing variations without changing any public behavior or adding unnecessary complexity.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `7e3c7edd825908da` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"7e3c7edd825908da","source":"quality","model":"qwen3-coder-next","severity":"INFO","iterations":2,"inference_s":61.82,"prompt_sha":"c59a5944b92e9308","triage":"INFO"} -->