### PR TITLE
chore(audit): drop two unused imports in audit.py

### DIFF
--- a/modules/core/audit.py
+++ b/modules/core/audit.py
@@ -9,8 +9,6 @@ import json
 import threading
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from datetime import datetime
-from collections import deque
 from .utils import utc_now
 from . import audit_chain
 from . import audit_signing


### PR DESCRIPTION
Two dead imports (`datetime`, `deque`) flagged by flake8 F401, sitting at the top of `modules/core/audit.py` and never referenced. Pre-existing, internal-only, no behaviour change.

Spotted during a draconian sweep of the audit modules after v2.23.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)