### PR TITLE
M5: certificate operations & integrations (#465, #475, #474)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -252,7 +252,7 @@ Download certificate, private key, or CSR file.
 
 **Parameters**:
 - `identifier` - Certificate ID
-- `type` - File type: `crt`, `key`, or `csr`
+- `type` - File type: `crt`, `key`, `csr`, or `pfx` (encrypted PKCS#12; requires a PFX password set in Settings, operator role)
 
 **Response** (200 OK):
 - Content-Type: `application/octet-stream`

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -36,7 +36,15 @@ operate certificates on a schedule.
   (periodic checkpoints) and `GET /api/audit/export` produces an Ed25519-signed
   bundle. An auditor verifies it off the box, pinning the instance's public key
   (`GET /api/audit/public-key`) out of band — proving both that the record was
-  not edited and which instance produced it.
+  written, not edited, and which instance produced it.
+- **SIEM audit sink (push).** Each audit entry can also be streamed live to an
+  external collector in a standard format — **syslog** (RFC 5424) or **CEF**
+  over UDP/TCP, or **generic HTTP/JSON** — configured under `audit_sink` in
+  settings. Entries pass through the credential/secret sanitizer before they
+  leave the process (a token in a detail field is redacted), and the sink is
+  failure-isolated with a short timeout, like the hash chain: a dead collector
+  never blocks or breaks a certificate operation. Lifecycle coverage includes
+  create / renew / deploy / revoke, plus a scheduled summary digest.
 
 ## Regime mapping
 

--- a/docs/deploy-hooks.md
+++ b/docs/deploy-hooks.md
@@ -277,9 +277,63 @@ Every hook run writes an `operation: deploy_hook` entry to the audit log with st
 
 ---
 
+## Typed deploy targets
+
+A **typed deploy target** is a declarative alternative to a shell hook for a
+common destination, so you don't hand-roll `kubectl` + credentials. Targets live
+under `deploy_hooks.targets` and fire from the same lifecycle points as hooks
+(issuance + every renewal, and manual deploy), with the same failure isolation —
+a target that fails logs, audits, and raises the `deploy_hook_failed` alert, but
+never blocks the certificate operation.
+
+The first typed target is **Kubernetes Secret**: it writes the renewed
+`fullchain.pem` / `privkey.pem` into a `kubernetes.io/tls` Secret via
+Server-Side Apply (one idempotent create-or-update).
+
+```jsonc
+{
+  "deploy_hooks": {
+    "enabled": true,
+    "targets": [
+      {
+        "id": "prod-web-tls",
+        "name": "Publish to prod web Secret",
+        "type": "kubernetes-secret",
+        "enabled": true,
+        "on_events": ["created", "renewed"],
+        "domains": ["example.com"],          // empty/omitted = all managed domains
+        "config": {
+          "secret_name": "example-tls",
+          "namespace": "web",
+          // Option A — talk to the API server directly:
+          "api_server": "https://10.0.0.1:6443",
+          "token": "<service-account bearer token>",
+          "ca_cert": "-----BEGIN CERTIFICATE-----\n…",  // optional; else system CAs
+          "verify_ssl": true
+          // Option B — running inside the cluster: set "in_cluster": true instead,
+          // and the API server, token, CA and default namespace are read from the
+          // mounted service account.
+        }
+      }
+    ]
+  }
+}
+```
+
+Configure it via `POST /api/deploy/config` (the same admin-only endpoint as
+shell hooks). The service-account token used should be scoped to
+`patch`/`create` on Secrets in the target namespace.
+
+> **Security:** the deploy config is admin-only, and — like a secret embedded in
+> a shell hook — the Kubernetes `token` is stored in settings and returned to
+> admins on `GET /api/deploy/config`. Keep the token minimally scoped.
+
+---
+
 ## See also
 
 - [`modules/core/deployer.py`](../modules/core/deployer.py) — implementation
+- [`modules/core/deploy_targets.py`](../modules/core/deploy_targets.py) — typed deploy targets
 - [`modules/web/settings_routes.py`](../modules/web/settings_routes.py) — `/api/deploy/*` endpoints
 - [`templates/partials/settings_deploy.html`](../templates/partials/settings_deploy.html) — UI partial
 - [`static/js/settings-deploy.js`](../static/js/settings-deploy.js) — Alpine component

--- a/docs/index.md
+++ b/docs/index.md
@@ -164,7 +164,7 @@ python -m pytest tests/ -v
 | `POST` | `/api/client-certs/create`               | Create new certificate         |
 | `GET`  | `/api/client-certs`                      | List certificates with filters |
 | `GET`  | `/api/client-certs/<id>`                 | Get certificate metadata       |
-| `GET`  | `/api/client-certs/<id>/download/<type>` | Download cert/key/csr          |
+| `GET`  | `/api/client-certs/<id>/download/<type>` | Download cert/key/csr/pfx      |
 | `POST` | `/api/client-certs/<id>/revoke`          | Revoke certificate             |
 | `POST` | `/api/client-certs/<id>/renew`           | Renew certificate              |
 | `GET`  | `/api/client-certs/stats`                | Get statistics                 |

--- a/modules/api/client_certificates.py
+++ b/modules/api/client_certificates.py
@@ -64,6 +64,7 @@ def create_client_certificate_resources(api, managers):
     ocsp_responder = managers.get('ocsp')
     crl_manager = managers.get('crl')
     settings_manager = managers.get('settings')
+    event_bus = managers.get('events')
 
     if not client_cert_manager:
         logger.error("ClientCertificateManager not available")
@@ -286,6 +287,17 @@ def create_client_certificate_resources(api, managers):
 
                 if not success:
                     abort(400, error)
+
+                # Lifecycle notification (#474): a revocation is worth alerting
+                # on. Best-effort — never turn a successful revoke into a 500.
+                if event_bus is not None:
+                    try:
+                        event_bus.publish('certificate_revoked', {
+                            'domain': identifier, 'reason': reason,
+                            'resource_type': 'client_certificate',
+                        })
+                    except Exception as pub_err:
+                        logger.warning("certificate_revoked publish failed: %s", pub_err)
 
                 return {'message': f'Certificate revoked: {identifier}'}, 200
 

--- a/modules/api/client_certificates.py
+++ b/modules/api/client_certificates.py
@@ -63,6 +63,7 @@ def create_client_certificate_resources(api, managers):
     auth_manager = managers.get('auth')
     ocsp_responder = managers.get('ocsp')
     crl_manager = managers.get('crl')
+    settings_manager = managers.get('settings')
 
     if not client_cert_manager:
         logger.error("ClientCertificateManager not available")
@@ -194,25 +195,45 @@ def create_client_certificate_resources(api, managers):
         # hold operator+ regardless of which Resource entry point they
         # use (path-style or otherwise). Mirrors `_PRIVATE_KEY_FILES` on
         # the TLS cert side (modules/api/resources.py).
-        _PRIVATE_FILE_TYPES = frozenset({'key'})
+        # 'pfx' bundles the private key, so it is gated like 'key'.
+        _PRIVATE_FILE_TYPES = frozenset({'key', 'pfx'})
 
         def get(self, identifier, file_type):
-            """Download certificate, key, or CSR."""
+            """Download certificate, key, CSR, or a PKCS#12 (.pfx) bundle."""
             try:
                 if not _validate_identifier(identifier):
                     abort(400, "Invalid certificate identifier")
-                if file_type not in ['crt', 'key', 'csr']:
-                    abort(400, "Invalid file type. Must be 'crt', 'key', or 'csr'")
+                if file_type not in ['crt', 'key', 'csr', 'pfx']:
+                    abort(400, "Invalid file type. Must be 'crt', 'key', 'csr', or 'pfx'")
 
                 # Per-file role gate: viewer reads public material only;
-                # private key needs operator+. Mirrors the TLS cert
-                # DownloadCertificate / DownloadCertificateFile pattern.
+                # private key (and the key-bearing .pfx) needs operator+.
+                # Mirrors the TLS cert DownloadCertificate pattern.
                 if file_type in self._PRIVATE_FILE_TYPES:
                     user = getattr(request, 'current_user', None) or {}
                     role = user.get('role')
                     from ..core.auth import ROLE_HIERARCHY
                     if ROLE_HIERARCHY.get(role, -1) < ROLE_HIERARCHY.get('operator', 999):
                         abort(403, "operator role required to download client certificate private key")
+
+                # PKCS#12 is generated on demand and encrypted with the
+                # configured PFX password (same setting as the server-side
+                # export). Without a password we refuse rather than emit an
+                # unencrypted private key bundle.
+                if file_type == 'pfx':
+                    settings = settings_manager.load_settings() if settings_manager else {}
+                    password = (settings.get('pfx_password') or '').strip()
+                    if not password:
+                        abort(400, "Set a PFX password in Settings to enable PKCS#12 export")
+                    pfx_bytes = client_cert_manager.build_pfx(identifier, password.encode())
+                    if not pfx_bytes:
+                        abort(404, f"Client certificate not found: {identifier}")
+                    return send_file(
+                        BytesIO(pfx_bytes),
+                        mimetype='application/x-pkcs12',
+                        as_attachment=True,
+                        download_name=f"{identifier}.pfx"
+                    )
 
                 # Get file
                 file_content = client_cert_manager.get_certificate_file(

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -2155,6 +2155,11 @@ def create_api_resources(api, models, managers):
                     CERTIFICATE_FILES if include_private
                     else tuple(f for f in CERTIFICATE_FILES if f not in _PRIVATE_KEY_FILES)
                 )
+                # The encrypted PKCS#12 bundle (only present when a PFX password
+                # is configured, #230/#465) is key-bearing, so it rides only in
+                # the private ZIP. The loop below writes it only if it exists.
+                if include_private:
+                    files_to_zip = files_to_zip + ('cert.pfx',)
                 zip_suffix = 'certificates' if include_private else 'certificates_public'
 
                 # Create temporary ZIP file

--- a/modules/core/audit.py
+++ b/modules/core/audit.py
@@ -49,7 +49,8 @@ class AuditLogger:
                  enable_chain: bool = True, signer=None,
                  checkpoint_interval: int = 100,
                  max_bytes: Optional[int] = None,
-                 backup_count: Optional[int] = None):
+                 backup_count: Optional[int] = None,
+                 audit_sink=None):
         """
         Initialize Audit Logger.
 
@@ -70,6 +71,9 @@ class AuditLogger:
         """
         self.audit_log_dir = Path(audit_log_dir)
         self.audit_log_file = self.audit_log_dir / "certificate_audit.log"
+        # Optional SIEM sink (#474): each audit entry is also streamed to an
+        # external collector. Failure-isolated; may be wired after construction.
+        self.audit_sink = audit_sink
 
         if max_bytes is None:
             max_bytes = _int_env('CERTMATE_AUDIT_LOG_MAX_BYTES',
@@ -505,6 +509,14 @@ class AuditLogger:
             # Mirror into the tamper-evident hash chain. Isolated: a chain
             # failure must never break audit logging or the audited operation.
             self._chain_append(audit_entry)
+            # Stream to the SIEM sink (#474), if configured. The sink is itself
+            # failure-isolated, but guard here too so a sink bug can never break
+            # audit logging.
+            if self.audit_sink is not None:
+                try:
+                    self.audit_sink.send(audit_entry)
+                except Exception as sink_err:  # pragma: no cover - defensive
+                    logger.warning("Audit sink error (isolated): %s", sink_err)
 
         except Exception as e:
             logger.error(f"Failed to write audit log: {e}")

--- a/modules/core/audit_sink.py
+++ b/modules/core/audit_sink.py
@@ -1,0 +1,185 @@
+"""SIEM audit sink (#474).
+
+The tamper-evident audit trail is a signed, hash-chained JSON event stream, but
+until now the only way out was the on-disk file + the signed export bundle.
+SOC/SIEM integration expects a *push* in a standard format. This module streams
+each audit entry to an external collector in one of three formats:
+
+* **syslog** (RFC 5424) over UDP or TCP
+* **CEF** (ArcSight Common Event Format) over UDP or TCP
+* **generic HTTP/JSON** (POST the entry as JSON)
+
+Every entry is run through the existing credential/secret sanitizer
+(:class:`structured_logging.JSONFormatter.sanitize_data` — redacts sensitive
+keys and PEM/key=value secrets) before it leaves the process, so a token in a
+detail field never reaches the collector.
+
+The sink is **failure-isolated**, exactly like the hash chain: any formatting or
+transport error is caught and logged, never raised into the audited operation.
+Sends use a short socket/HTTP timeout so a dead collector can't stall a
+certificate operation.
+"""
+
+import json
+import logging
+import socket
+import urllib.request
+
+from .structured_logging import JSONFormatter
+
+logger = logging.getLogger(__name__)
+
+# One shared sanitizer instance (stateless w.r.t. the entry).
+_SANITIZER = JSONFormatter(include_hostname=False, include_pid=False)
+
+FORMAT_SYSLOG = 'syslog'
+FORMAT_CEF = 'cef'
+FORMAT_JSON = 'json'
+FORMATS = (FORMAT_SYSLOG, FORMAT_CEF, FORMAT_JSON)
+
+DEFAULT_CONFIG = {
+    'enabled': False,
+    'format': FORMAT_SYSLOG,     # syslog | cef | json
+    'protocol': 'udp',           # udp | tcp (syslog/cef transport)
+    'host': '',
+    'port': 514,
+    'url': '',                   # for format=json (HTTP POST)
+    'timeout': 3.0,
+    'facility': 16,              # local0
+    'app_name': 'certmate',
+}
+
+# RFC 5424 severity per audit status (lower = more severe).
+_SEVERITY = {'success': 6, 'failure': 3, 'denied': 4}  # info / error / warning
+# CEF severity 0-10.
+_CEF_SEVERITY = {'success': 3, 'failure': 8, 'denied': 6}
+
+
+def _severity(status):
+    return _SEVERITY.get(status, 5)
+
+
+def format_syslog(entry, config):
+    """Render an audit entry as an RFC 5424 syslog line (JSON in the MSG)."""
+    facility = int(config.get('facility', 16))
+    pri = facility * 8 + _severity(entry.get('status'))
+    ts = entry.get('timestamp') or '-'
+    host = socket.gethostname() or '-'
+    app = config.get('app_name', 'certmate')
+    msgid = (entry.get('operation') or '-')[:32]
+    msg = json.dumps(entry, separators=(',', ':'))
+    # <PRI>VERSION TIMESTAMP HOST APP PROCID MSGID STRUCTURED-DATA MSG
+    return f'<{pri}>1 {ts} {host} {app} - {msgid} - {msg}'
+
+
+def _cef_escape(value):
+    return (str(value).replace('\\', '\\\\').replace('|', '\\|')
+            .replace('\n', ' '))
+
+
+def _cef_ext_escape(value):
+    return str(value).replace('\\', '\\\\').replace('=', '\\=').replace('\n', ' ')
+
+
+def format_cef(entry, config):
+    """Render an audit entry as a CEF line with a syslog header."""
+    facility = int(config.get('facility', 16))
+    pri = facility * 8 + _severity(entry.get('status'))
+    ts = entry.get('timestamp') or '-'
+    host = socket.gethostname() or '-'
+    vendor = 'CertMate'
+    op = entry.get('operation') or 'audit'
+    sev = _CEF_SEVERITY.get(entry.get('status'), 5)
+    ext = {
+        'act': entry.get('operation'),
+        'outcome': entry.get('status'),
+        'suser': entry.get('user'),
+        'src': entry.get('ip_address'),
+        'cs1Label': 'resource', 'cs1': entry.get('resource_id'),
+        'cs2Label': 'resource_type', 'cs2': entry.get('resource_type'),
+    }
+    if entry.get('error'):
+        ext['reason'] = entry['error']
+    ext_str = ' '.join(
+        f'{k}={_cef_ext_escape(v)}' for k, v in ext.items() if v is not None)
+    header = (f'CEF:0|{vendor}|CertMate|1|{_cef_escape(op)}|'
+              f'{_cef_escape(op)}|{sev}|{ext_str}')
+    return f'<{pri}>1 {ts} {host} {config.get("app_name", "certmate")} - - - {header}'
+
+
+def format_json(entry):
+    return json.dumps(entry)
+
+
+class AuditSink:
+    """Streams sanitized audit entries to a configured SIEM collector.
+
+    Config is read from ``settings['audit_sink']`` on each send, so an admin can
+    enable/disable or retune it at runtime. Transports are injectable for tests.
+    """
+
+    def __init__(self, settings_manager, syslog_send=None, http_post=None):
+        self.settings_manager = settings_manager
+        self._syslog_send = syslog_send or _syslog_transport
+        self._http_post = http_post or _http_transport
+
+    def _config(self):
+        config = dict(DEFAULT_CONFIG)
+        try:
+            block = self.settings_manager.load_settings().get('audit_sink')
+        except Exception:  # pragma: no cover - defensive; never break audit
+            block = None
+        if isinstance(block, dict):
+            config.update(block)
+        return config
+
+    def send(self, entry):
+        """Sanitize, format and ship one audit entry. Never raises."""
+        try:
+            config = self._config()
+            if not config.get('enabled'):
+                return
+            sanitized = _SANITIZER.sanitize_data(entry)
+            fmt = config.get('format', FORMAT_SYSLOG)
+            if fmt == FORMAT_JSON:
+                self._http_post(format_json(sanitized), config)
+            elif fmt == FORMAT_CEF:
+                self._syslog_send(format_cef(sanitized, config), config)
+            else:
+                self._syslog_send(format_syslog(sanitized, config), config)
+        except Exception as e:
+            # Isolated like the hash chain: a broken collector must never break
+            # audit logging or the audited certificate operation.
+            logger.warning("Audit sink send failed (isolated): %s", e)
+
+
+def _syslog_transport(line, config):
+    host = config.get('host')
+    if not host:
+        raise ValueError('audit_sink: syslog/cef selected but no host configured')
+    port = int(config.get('port', 514))
+    timeout = float(config.get('timeout', 3.0))
+    data = line.encode('utf-8')
+    if str(config.get('protocol', 'udp')).lower() == 'tcp':
+        with socket.create_connection((host, port), timeout=timeout) as sock:
+            sock.sendall(data + b'\n')
+    else:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            sock.settimeout(timeout)
+            sock.sendto(data, (host, port))
+        finally:
+            sock.close()
+
+
+def _http_transport(payload, config):
+    url = config.get('url')
+    if not url:
+        raise ValueError('audit_sink: json format selected but no url configured')
+    timeout = float(config.get('timeout', 3.0))
+    req = urllib.request.Request(
+        url, data=payload.encode('utf-8'), method='POST',
+        headers={'Content-Type': 'application/json',
+                 'User-Agent': 'CertMate-AuditSink'})
+    with urllib.request.urlopen(req, timeout=timeout):  # nosec B310 - operator-configured URL
+        pass

--- a/modules/core/client_certificates.py
+++ b/modules/core/client_certificates.py
@@ -581,7 +581,9 @@ class ClientCertificateManager:
             crt_path = cert_dir / f"{identifier}.crt"
             key_path = cert_dir / f"{identifier}.key"
             if not (crt_path.exists() and key_path.exists()):
-                return None
+                # A partial / wrong-usage directory: keep looking for a complete
+                # one rather than declaring the whole identifier unexportable.
+                continue
             chain_pem = None
             try:
                 ca_path = getattr(self.private_ca, 'ca_cert_path', None)

--- a/modules/core/client_certificates.py
+++ b/modules/core/client_certificates.py
@@ -565,6 +565,35 @@ class ClientCertificateManager:
             logger.error(f"Error getting certificate file: {str(e)}")
             return None
 
+    def build_pfx(self, identifier: str, password: bytes) -> Optional[bytes]:
+        """Build an encrypted PKCS#12 (.pfx) bundle for a client certificate.
+
+        Bundles the leaf certificate + private key, plus the issuing CA cert as
+        the chain, into a password-encrypted PFX — generated on demand from the
+        on-disk PEMs (client certs, where a .pfx for import into Windows/mobile
+        keystores is most useful, #465). Returns None if the cert or key is
+        missing, or if *password* is empty (an unencrypted PFX carrying a
+        private key is never produced — mirrors the server-side policy).
+        """
+        if not password:
+            return None
+        for cert_dir in self.client_certs_dir.glob(f"*/{identifier}"):
+            crt_path = cert_dir / f"{identifier}.crt"
+            key_path = cert_dir / f"{identifier}.key"
+            if not (crt_path.exists() and key_path.exists()):
+                return None
+            chain_pem = None
+            try:
+                ca_path = getattr(self.private_ca, 'ca_cert_path', None)
+                if ca_path and Path(ca_path).exists():
+                    chain_pem = Path(ca_path).read_bytes()
+            except Exception:  # pragma: no cover - chain is best-effort
+                chain_pem = None
+            from .storage_backends import _build_pfx
+            return _build_pfx(
+                crt_path.read_bytes(), chain_pem, key_path.read_bytes(), password)
+        return None
+
     def check_renewals(self) -> Tuple[int, int, List[str]]:
         """
         Check for certificates that need renewal.

--- a/modules/core/deploy_targets.py
+++ b/modules/core/deploy_targets.py
@@ -1,0 +1,237 @@
+"""Typed deploy targets (#475).
+
+Deploy hooks are raw shell commands. A *typed* deploy target is a small,
+declarative alternative for the common cases where hand-rolling a shell hook
+(with kubectl + credentials) is friction. The first typed target writes a
+renewed certificate straight into a **Kubernetes TLS Secret**.
+
+Targets are configured under ``deploy_hooks.targets`` in settings and fire from
+the same lifecycle points as shell hooks (issuance + every renewal), and are
+equally failure-isolated: a target that fails logs and reports, but never blocks
+the certificate operation.
+
+Scope is deliberately narrow — typed targets only, no agent/fleet delegation.
+Credentials (e.g. a Kubernetes API token) live in settings and are masked by the
+existing secret machinery (the field name ``token`` matches the secret regex).
+"""
+
+import base64
+import logging
+import os
+import tempfile
+
+logger = logging.getLogger(__name__)
+
+# Well-known in-cluster service-account locations (mounted into every pod).
+_SA_DIR = '/var/run/secrets/kubernetes.io/serviceaccount'
+_SA_TOKEN = f'{_SA_DIR}/token'
+_SA_CA = f'{_SA_DIR}/ca.crt'
+_SA_NAMESPACE = f'{_SA_DIR}/namespace'
+
+# Recognised target types.
+TARGET_KUBERNETES_SECRET = 'kubernetes-secret'
+TARGET_TYPES = (TARGET_KUBERNETES_SECRET,)
+
+
+class DeployTargetError(Exception):
+    """A typed deploy target could not be built or executed."""
+
+
+class KubernetesSecretTarget:
+    """Publish a certificate to a Kubernetes ``kubernetes.io/tls`` Secret.
+
+    Uses **Server-Side Apply** (a single idempotent PATCH that creates or
+    updates the Secret), so issuance and every renewal converge the Secret to
+    the current cert without create-vs-update bookkeeping.
+
+    Config keys:
+      - ``secret_name`` (required), ``namespace`` (required unless in-cluster
+        default is used).
+      - ``in_cluster`` (bool): read the API server, token, CA and default
+        namespace from the mounted service account. Otherwise:
+      - ``api_server`` (e.g. ``https://10.0.0.1:6443``), ``token`` (bearer),
+        ``ca_cert`` (PEM string, optional), ``verify_ssl`` (bool, default True).
+    """
+
+    def __init__(self, config, http_patch=None):
+        self.config = config or {}
+        # Injection point for tests; defaults to requests.patch.
+        self._http_patch = http_patch
+
+    # --- connection resolution --------------------------------------------- #
+
+    def _resolve_connection(self):
+        """Return (api_server, token, verify, namespace).
+
+        ``verify`` is either a CA-bundle file path, True (system CAs) or False.
+        Raises DeployTargetError when required pieces are missing.
+        """
+        cfg = self.config
+        if cfg.get('in_cluster'):
+            host = os.getenv('KUBERNETES_SERVICE_HOST')
+            port = os.getenv('KUBERNETES_SERVICE_PORT', '443')
+            if not host:
+                raise DeployTargetError(
+                    'in_cluster set but KUBERNETES_SERVICE_HOST is not present')
+            try:
+                with open(_SA_TOKEN) as f:
+                    token = f.read().strip()
+            except OSError as e:
+                raise DeployTargetError(f'cannot read in-cluster token: {e}')
+            verify = _SA_CA if os.path.exists(_SA_CA) else True
+            namespace = cfg.get('namespace')
+            if not namespace and os.path.exists(_SA_NAMESPACE):
+                with open(_SA_NAMESPACE) as f:
+                    namespace = f.read().strip()
+            return f'https://{host}:{port}', token, verify, namespace
+
+        api_server = (cfg.get('api_server') or '').rstrip('/')
+        token = cfg.get('token')
+        if not api_server or not token:
+            raise DeployTargetError(
+                'kubernetes-secret target needs api_server + token '
+                '(or in_cluster)')
+        verify = self._resolve_verify()
+        return api_server, token, verify, cfg.get('namespace')
+
+    def _resolve_verify(self):
+        """Return a CA path / True / False for TLS verification."""
+        ca_pem = self.config.get('ca_cert')
+        if ca_pem:
+            # requests needs a file path for a custom CA bundle.
+            fd, path = tempfile.mkstemp(suffix='.crt', prefix='certmate-k8s-ca-')
+            with os.fdopen(fd, 'w') as f:
+                f.write(ca_pem)
+            return path
+        if self.config.get('verify_ssl', True) is False:
+            return False
+        return True
+
+    # --- manifest ---------------------------------------------------------- #
+
+    @staticmethod
+    def build_manifest(secret_name, namespace, cert_pem, key_pem):
+        """Return the Secret manifest (dict) for Server-Side Apply."""
+        return {
+            'apiVersion': 'v1',
+            'kind': 'Secret',
+            'metadata': {
+                'name': secret_name,
+                'namespace': namespace,
+                'labels': {'app.kubernetes.io/managed-by': 'certmate'},
+            },
+            'type': 'kubernetes.io/tls',
+            'data': {
+                'tls.crt': base64.b64encode(cert_pem).decode('ascii'),
+                'tls.key': base64.b64encode(key_pem).decode('ascii'),
+            },
+        }
+
+    # --- deploy ------------------------------------------------------------ #
+
+    def deploy(self, cert_pem, key_pem):
+        """Apply the certificate to the configured Secret.
+
+        Returns a result dict ``{success, message, status_code}``. Never raises
+        for an operational failure — the caller (DeployManager) is
+        failure-isolated — but a misconfiguration raises DeployTargetError so
+        it surfaces at save time / manual test.
+        """
+        secret_name = self.config.get('secret_name')
+        if not secret_name:
+            raise DeployTargetError('kubernetes-secret target needs secret_name')
+
+        api_server, token, verify, namespace = self._resolve_connection()
+        if not namespace:
+            raise DeployTargetError('kubernetes-secret target needs a namespace')
+
+        manifest = self.build_manifest(secret_name, namespace, cert_pem, key_pem)
+        url = (f'{api_server}/api/v1/namespaces/{namespace}/secrets/{secret_name}'
+               '?fieldManager=certmate&force=true')
+        headers = {
+            'Authorization': f'Bearer {token}',
+            'Content-Type': 'application/apply-patch+yaml',
+            'Accept': 'application/json',
+        }
+
+        patch = self._http_patch or _default_patch
+        ca_tempfile = verify if isinstance(verify, str) and 'certmate-k8s-ca-' in str(verify) else None
+        try:
+            resp = patch(url, json=manifest, headers=headers, verify=verify, timeout=15)
+        except Exception as e:
+            return {'success': False, 'status_code': None,
+                    'message': f'Kubernetes API request failed: {e}'}
+        finally:
+            if ca_tempfile:
+                try:
+                    os.remove(ca_tempfile)
+                except OSError:
+                    pass
+
+        status = getattr(resp, 'status_code', None)
+        if status is not None and 200 <= status < 300:
+            return {'success': True, 'status_code': status,
+                    'message': f'Applied Secret {namespace}/{secret_name}'}
+        body = _safe_body(resp)
+        return {'success': False, 'status_code': status,
+                'message': f'Kubernetes API returned {status}: {body}'}
+
+
+def _default_patch(url, timeout=15, **kwargs):
+    import requests
+    return requests.patch(url, timeout=timeout, **kwargs)
+
+
+def _safe_body(resp):
+    try:
+        return (resp.text or '')[:300]
+    except Exception:
+        return '<unreadable response>'
+
+
+def build_target(target, http_patch=None):
+    """Instantiate a typed deploy target from its config dict."""
+    ttype = (target or {}).get('type')
+    if ttype == TARGET_KUBERNETES_SECRET:
+        return KubernetesSecretTarget(target.get('config') or {}, http_patch=http_patch)
+    raise DeployTargetError(f'unknown deploy target type: {ttype!r}')
+
+
+def target_applies(target, domain, event_type):
+    """True if *target* is enabled, covers *domain*, and fires on *event_type*.
+
+    ``domains`` empty/absent means "all managed domains". ``on_events`` empty
+    means "created + renewed".
+    """
+    if not target.get('enabled'):
+        return False
+    domains = target.get('domains') or []
+    if domains and domain not in domains:
+        return False
+    on_events = target.get('on_events') or ['created', 'renewed']
+    return event_type in on_events or event_type == 'manual'
+
+
+def run_targets(targets, domain, cert_pem, key_pem, event_type, http_patch=None):
+    """Run every applicable typed target for *domain*, failure-isolated.
+
+    Returns a list of per-target result dicts. A build/deploy error for one
+    target is captured and never aborts the others (or the cert operation).
+    """
+    results = []
+    for target in targets or []:
+        if not target_applies(target, domain, event_type):
+            continue
+        name = target.get('name') or target.get('id') or target.get('type')
+        try:
+            instance = build_target(target, http_patch=http_patch)
+            outcome = instance.deploy(cert_pem, key_pem)
+        except DeployTargetError as e:
+            outcome = {'success': False, 'status_code': None, 'message': str(e)}
+        except Exception as e:  # pragma: no cover - defensive isolation
+            logger.exception('Deploy target %s crashed', name)
+            outcome = {'success': False, 'status_code': None,
+                       'message': f'unexpected error: {e}'}
+        outcome.update({'target': name, 'type': target.get('type'), 'domain': domain})
+        results.append(outcome)
+    return results

--- a/modules/core/deploy_targets.py
+++ b/modules/core/deploy_targets.py
@@ -163,7 +163,7 @@ class KubernetesSecretTarget:
             resp = patch(url, json=manifest, headers=headers, verify=verify, timeout=15)
         except Exception as e:
             return {'success': False, 'status_code': None,
-                    'message': f'Kubernetes API request failed: {e}'}
+                    'message': f'Kubernetes API request failed: {_scrub(str(e), token)}'}
         finally:
             if ca_tempfile:
                 try:
@@ -175,7 +175,7 @@ class KubernetesSecretTarget:
         if status is not None and 200 <= status < 300:
             return {'success': True, 'status_code': status,
                     'message': f'Applied Secret {namespace}/{secret_name}'}
-        body = _safe_body(resp)
+        body = _scrub(_safe_body(resp), token)
         return {'success': False, 'status_code': status,
                 'message': f'Kubernetes API returned {status}: {body}'}
 
@@ -198,6 +198,16 @@ def _materialize_verify(spec):
 def _default_patch(url, timeout=15, **kwargs):
     import requests
     return requests.patch(url, timeout=timeout, **kwargs)
+
+
+def _scrub(text, secret):
+    """Remove *secret* (the bearer token) from a diagnostic string before it is
+    returned/stored. The Kubernetes API never echoes the token, but scrubbing it
+    guarantees a token can never reach the deploy history/audit through an error
+    message or response body (and satisfies clear-text-storage analysis)."""
+    if secret and text:
+        return text.replace(secret, '[REDACTED]')
+    return text
 
 
 def _safe_body(resp):

--- a/modules/core/deploy_targets.py
+++ b/modules/core/deploy_targets.py
@@ -95,14 +95,15 @@ class KubernetesSecretTarget:
         return api_server, token, verify, cfg.get('namespace')
 
     def _resolve_verify(self):
-        """Return a CA path / True / False for TLS verification."""
+        """Return the TLS-verify spec: a CA PEM string, False, or True.
+
+        Returns the PEM *content* (not a temp file). Materialization is deferred
+        to :func:`_materialize_verify`, called only after every config check
+        passes, so a validation error can't leak a temp CA bundle.
+        """
         ca_pem = self.config.get('ca_cert')
         if ca_pem:
-            # requests needs a file path for a custom CA bundle.
-            fd, path = tempfile.mkstemp(suffix='.crt', prefix='certmate-k8s-ca-')
-            with os.fdopen(fd, 'w') as f:
-                f.write(ca_pem)
-            return path
+            return ca_pem
         if self.config.get('verify_ssl', True) is False:
             return False
         return True
@@ -141,7 +142,7 @@ class KubernetesSecretTarget:
         if not secret_name:
             raise DeployTargetError('kubernetes-secret target needs secret_name')
 
-        api_server, token, verify, namespace = self._resolve_connection()
+        api_server, token, verify_spec, namespace = self._resolve_connection()
         if not namespace:
             raise DeployTargetError('kubernetes-secret target needs a namespace')
 
@@ -155,7 +156,9 @@ class KubernetesSecretTarget:
         }
 
         patch = self._http_patch or _default_patch
-        ca_tempfile = verify if isinstance(verify, str) and 'certmate-k8s-ca-' in str(verify) else None
+        # Materialize the CA bundle only now — after every validation above —
+        # inside the try/finally, so a config error can never leak a temp file.
+        verify, ca_tempfile = _materialize_verify(verify_spec)
         try:
             resp = patch(url, json=manifest, headers=headers, verify=verify, timeout=15)
         except Exception as e:
@@ -175,6 +178,21 @@ class KubernetesSecretTarget:
         body = _safe_body(resp)
         return {'success': False, 'status_code': status,
                 'message': f'Kubernetes API returned {status}: {body}'}
+
+
+def _materialize_verify(spec):
+    """Turn a verify spec into a value the HTTP client accepts.
+
+    A CA PEM string is written to a short-lived temp file (its path is returned
+    as the second element so the caller can delete it); a file path (in-cluster
+    SA CA) or a bool passes through with no temp file to clean up.
+    """
+    if isinstance(spec, str) and '-----BEGIN' in spec:
+        fd, path = tempfile.mkstemp(suffix='.crt', prefix='certmate-k8s-ca-')
+        with os.fdopen(fd, 'w') as f:
+            f.write(spec)
+        return path, path
+    return spec, None
 
 
 def _default_patch(url, timeout=15, **kwargs):

--- a/modules/core/deployer.py
+++ b/modules/core/deployer.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .structured_logging import sanitize_text
+from .utils import utc_now_iso
+from .deploy_targets import run_targets, target_applies, TARGET_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -88,18 +90,22 @@ class DeployManager:
             if hook.get('enabled'):
                 hooks.append(hook)
 
-        if not hooks:
+        targets = [t for t in config.get('targets', [])
+                   if target_applies(t, domain, 'manual')]
+
+        if not hooks and not targets:
             return {
                 'ok': False,
                 'total': 0, 'succeeded': 0, 'failed': 0,
                 'results': [],
                 'error': (
-                    f'No enabled hooks configured for {domain}. Add a '
-                    'global or domain-specific hook in Settings → Deploy.'
+                    f'No enabled hooks or deploy targets configured for {domain}. '
+                    'Add a global/domain hook or a typed target in Settings → Deploy.'
                 ),
             }
 
         results = [self._run_hook(h, domain, 'manual') for h in hooks]
+        results.extend(self._execute_targets(domain, 'manual', config))
         succeeded = sum(1 for r in results if r.get('success'))
         failed = len(results) - succeeded
         return {
@@ -130,7 +136,77 @@ class DeployManager:
         for hook in hooks:
             result = self._run_hook(hook, domain, event_type)
             results.append(result)
+        # Typed deploy targets fire from the same lifecycle points (#475).
+        results.extend(self._execute_targets(domain, event_type, config))
         return results
+
+    def _execute_targets(self, domain, event_type, config=None):
+        """Run every applicable typed deploy target for a domain/event.
+
+        Failure-isolated (like shell hooks): reads the current fullchain +
+        private key from disk and applies them via each configured target,
+        recording audit + history per target. Never raises into the caller.
+        """
+        config = config if config is not None else self.get_config()
+        targets = config.get('targets') or []
+        if not any(target_applies(t, domain, event_type) for t in targets):
+            return []
+
+        cert_path = self.cert_dir / domain / 'fullchain.pem'
+        key_path = self.cert_dir / domain / 'privkey.pem'
+        try:
+            cert_pem = cert_path.read_bytes()
+            key_pem = key_path.read_bytes()
+        except OSError as e:
+            logger.error("Deploy targets: cannot read cert files for %s: %s", domain, e)
+            return [{'success': False, 'target': None, 'type': None,
+                     'domain': domain, 'message': f'certificate files unreadable: {e}'}]
+
+        results = run_targets(targets, domain, cert_pem, key_pem, event_type)
+        for result in results:
+            self._record_target(result, domain, event_type)
+        return results
+
+    def _record_target(self, result, domain, event_type):
+        """Audit + history + failure-event for one typed-target result."""
+        status = 'success' if result.get('success') else 'failure'
+        try:
+            self.audit_logger.log_operation(
+                operation='deploy_target',
+                resource_type='certificate',
+                resource_id=domain,
+                status=status,
+                details={
+                    'target': result.get('target'),
+                    'type': result.get('type'),
+                    'event': event_type,
+                    'status_code': result.get('status_code'),
+                    'message': result.get('message') or '',
+                },
+                error=None if result.get('success') else result.get('message'),
+            )
+        except Exception:  # pragma: no cover - audit must never break deploy
+            logger.debug("Audit emit failed for deploy_target on %s", domain)
+
+        if not result.get('success'):
+            # Same "silent deploy" alerting path as a failed shell hook.
+            self.event_bus.publish('deploy_hook_failed', {
+                'hook_name': result.get('target'),
+                'domain': domain,
+                'error': result.get('message'),
+            })
+
+        self._log_history({
+            'kind': 'target',
+            'success': result.get('success'),
+            'target': result.get('target'),
+            'type': result.get('type'),
+            'domain': domain,
+            'event': event_type,
+            'status_code': result.get('status_code'),
+            'message': result.get('message'),
+            'timestamp': utc_now_iso(),
+        })
 
     def _run_hook(self, hook, domain, event_type, dry_run=False):
         """Execute a single deploy hook."""
@@ -374,11 +450,15 @@ class DeployManager:
     def get_config(self):
         """Return deploy_hooks config with defaults."""
         settings = self.settings_manager.load_settings()
-        return settings.get('deploy_hooks', {
+        config = settings.get('deploy_hooks', {
             'enabled': False,
             'global_hooks': [],
             'domain_hooks': {},
         })
+        # Typed deploy targets (#475) live alongside the shell hooks; default to
+        # an empty list so older configs keep working.
+        config.setdefault('targets', [])
+        return config
 
     def save_config(self, config):
         """Validate and save deploy_hooks config.
@@ -405,12 +485,42 @@ class DeployManager:
                 if not ok:
                     return False, f"Hook for domain '{domain}' rejected: {err}"
 
+        if 'targets' in config:
+            if not isinstance(config['targets'], list):
+                return False, "targets must be a list"
+            for target in config['targets']:
+                ok, err = self._validate_target(target)
+                if not ok:
+                    return False, f"Deploy target rejected: {err}"
+
         # Atomic via settings_manager.update so two concurrent admin saves
         # (e.g. one editing deploy hooks, another editing DNS providers)
         # cannot lose each other's changes.
         def _mutate(settings):
             settings['deploy_hooks'] = config
         self.settings_manager.update(_mutate, "deploy_hooks_save")
+        return True, None
+
+    @staticmethod
+    def _validate_target(target):
+        """Validate one typed deploy target. Returns (ok, error|None)."""
+        if not isinstance(target, dict):
+            return False, "target must be an object"
+        ttype = target.get('type')
+        if ttype not in TARGET_TYPES:
+            return False, f"unknown target type {ttype!r} (expected one of {TARGET_TYPES})"
+        cfg = target.get('config') or {}
+        if not isinstance(cfg, dict):
+            return False, "target.config must be an object"
+        if ttype == 'kubernetes-secret':
+            if not cfg.get('secret_name'):
+                return False, "kubernetes-secret needs config.secret_name"
+            if cfg.get('in_cluster'):
+                return True, None
+            if not cfg.get('api_server') or not cfg.get('token'):
+                return False, "kubernetes-secret needs config.api_server + config.token (or in_cluster)"
+            if not cfg.get('namespace'):
+                return False, "kubernetes-secret needs config.namespace"
         return True, None
 
     @staticmethod

--- a/modules/core/deployer.py
+++ b/modules/core/deployer.py
@@ -12,7 +12,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from .structured_logging import sanitize_text
+from .structured_logging import sanitize_text, JSONFormatter
 from .utils import utc_now_iso
 from .deploy_targets import run_targets, target_applies, TARGET_TYPES
 
@@ -21,6 +21,11 @@ logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT = 30
 MAX_TIMEOUT = 300
 MAX_HISTORY_ENTRIES = 500
+
+# Redacts sensitive-keyed fields recursively before a deploy result is persisted
+# to the history JSONL — a deploy hook command / target config can carry a
+# credential, and the history file is not the place for it.
+_HISTORY_SANITIZER = JSONFormatter(include_hostname=False, include_pid=False)
 
 
 class DeployManager:
@@ -167,8 +172,13 @@ class DeployManager:
             key_pem = key_path.read_bytes()
         except OSError as e:
             logger.error("Deploy targets: cannot read cert files for %s: %s", domain, e)
-            return [{'success': False, 'target': None, 'type': None,
-                     'domain': domain, 'message': f'certificate files unreadable: {e}'}]
+            # An unreadable cert is an operational failure that affects deploy —
+            # record it (audit + history + failure alert), don't swallow it.
+            failure = {'success': False, 'target': None, 'type': None,
+                       'domain': domain, 'status_code': None,
+                       'message': f'certificate files unreadable: {e}'}
+            self._record_target(failure, domain, event_type)
+            return [failure]
 
         results = run_targets(targets, domain, cert_pem, key_pem, event_type)
         for result in results:
@@ -357,8 +367,9 @@ class DeployManager:
         """Append a deploy result to the JSONL history file."""
         try:
             self._history_path.parent.mkdir(parents=True, exist_ok=True)
+            safe_result = _HISTORY_SANITIZER.sanitize_data(result)
             with open(self._history_path, 'a') as f:
-                f.write(json.dumps(result) + '\n')
+                f.write(json.dumps(safe_result) + '\n')
             self._truncate_history()
         except OSError as e:
             # Surface write failures at warning level so the "history is

--- a/modules/core/deployer.py
+++ b/modules/core/deployer.py
@@ -52,7 +52,15 @@ class DeployManager:
         if not domain:
             return
         try:
-            self._execute_hooks(domain, event_type)
+            results = self._execute_hooks(domain, event_type)
+            # A successful deploy is a lifecycle event in its own right (#474):
+            # surface it so notifications/SIEM see "the new cert is live",
+            # distinct from the per-hook completion events.
+            succeeded = sum(1 for r in results if r.get('success'))
+            if succeeded:
+                self.event_bus.publish('certificate_deployed', {
+                    'domain': domain, 'event': event_type, 'count': succeeded,
+                })
         except Exception as e:
             logger.error(f"Deploy hooks failed for {domain}: {e}")
 

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -487,7 +487,12 @@ def initialize_managers(container: AppContainer, app):
     # hash chain still works.
     from .audit_signing import AuditSigner
     audit_signer = AuditSigner(container.data_dir)
-    audit_logger = AuditLogger(audit_dir, chain_dir=audit_chain_dir, signer=audit_signer)
+    # SIEM audit sink (#474): stream every audit entry to a configured collector
+    # (syslog/CEF/HTTP), sanitized + failure-isolated. Reads its config live.
+    from .audit_sink import AuditSink
+    audit_sink = AuditSink(settings_manager)
+    audit_logger = AuditLogger(audit_dir, chain_dir=audit_chain_dir,
+                               signer=audit_signer, audit_sink=audit_sink)
     # Let AuthManager emit RBAC + scope denials through the same audit
     # surface the rest of the app uses (2026-05-12 API auth audit, F-2).
     auth_manager.set_audit_logger(audit_logger)
@@ -515,6 +520,8 @@ def initialize_managers(container: AppContainer, app):
             'certificate_created': 'Certificate Created',
             'certificate_renewed': 'Certificate Renewed',
             'certificate_failed': 'Certificate Failed',
+            'certificate_revoked': 'Certificate Revoked',
+            'certificate_deployed': 'Certificate Deployed',
             'deploy_hook_failed': 'Deploy Hook Failed',
         }
         title = event_titles.get(event)

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -50,6 +50,9 @@ PUBLIC_SETTINGS_WRITABLE_KEYS = frozenset({
     # Domains to watch in Certificate Transparency logs (#470). Pure config;
     # the crt.sh poll runs as a scheduled job.
     'ct_monitoring',
+    # SIEM audit sink (#474): collector host/port/format for streaming audit
+    # events. No secrets; the sink reads it live.
+    'audit_sink',
     'setup_completed',
     # Per-install "stop nagging me with the first-run wizard" flag. Distinct
     # from setup_completed, which must stay truthful for recovery/downgrade

--- a/tests/test_audit_sink.py
+++ b/tests/test_audit_sink.py
@@ -1,0 +1,178 @@
+"""SIEM audit sink (#474): formatters, send routing, secret redaction,
+failure isolation, and the AuditLogger integration."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.audit_sink import (
+    AuditSink, format_syslog, format_cef, format_json,
+    _syslog_transport, _http_transport,
+    FORMAT_SYSLOG, FORMAT_CEF, FORMAT_JSON,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def _entry(**over):
+    e = {
+        'timestamp': '2026-07-29T10:00:00+00:00',
+        'operation': 'create', 'resource_type': 'certificate',
+        'resource_id': 'example.com', 'status': 'success',
+        'user': 'alice', 'ip_address': '10.0.0.9', 'details': {}, 'error': None,
+    }
+    e.update(over)
+    return e
+
+
+class _Capture:
+    def __init__(self):
+        self.payloads = []
+
+    def __call__(self, payload, config):
+        self.payloads.append(payload)
+
+
+def _sink(settings, **kw):
+    sm = MagicMock()
+    sm.load_settings.return_value = settings
+    return AuditSink(sm, **kw)
+
+
+# --------------------------------------------------------------------------- #
+# formatters
+# --------------------------------------------------------------------------- #
+
+def test_format_syslog_rfc5424():
+    line = format_syslog(_entry(), {'facility': 16, 'app_name': 'certmate'})
+    # PRI = 16*8 + 6 (info) = 134; version 1; MSGID=operation; JSON in MSG.
+    assert line.startswith('<134>1 2026-07-29T10:00:00+00:00 ')
+    assert ' certmate - create - ' in line
+    payload = line.split(' - ', 1)[1].split(' - ', 1)[1]
+    assert json.loads(payload)['resource_id'] == 'example.com'
+
+
+def test_format_syslog_severity_for_failure():
+    line = format_syslog(_entry(status='failure'), {'facility': 16})
+    # 16*8 + 3 (error) = 131
+    assert line.startswith('<131>1 ')
+
+
+def test_format_cef():
+    line = format_cef(_entry(error='boom', status='failure'), {'facility': 16})
+    assert 'CEF:0|CertMate|CertMate|1|create|create|8|' in line
+    assert 'act=create' in line and 'outcome=failure' in line
+    assert 'suser=alice' in line and 'src=10.0.0.9' in line
+    assert 'reason=boom' in line
+
+
+def test_format_json():
+    assert json.loads(format_json(_entry()))['operation'] == 'create'
+
+
+# --------------------------------------------------------------------------- #
+# AuditSink.send routing
+# --------------------------------------------------------------------------- #
+
+def test_disabled_sink_sends_nothing():
+    syslog, http = _Capture(), _Capture()
+    _sink({'audit_sink': {'enabled': False}}, syslog_send=syslog, http_post=http).send(_entry())
+    assert syslog.payloads == [] and http.payloads == []
+
+
+def test_syslog_format_uses_syslog_transport():
+    syslog, http = _Capture(), _Capture()
+    _sink({'audit_sink': {'enabled': True, 'format': FORMAT_SYSLOG, 'host': 'siem'}},
+          syslog_send=syslog, http_post=http).send(_entry())
+    assert len(syslog.payloads) == 1 and syslog.payloads[0].startswith('<')
+    assert http.payloads == []
+
+
+def test_cef_format_uses_syslog_transport():
+    syslog, http = _Capture(), _Capture()
+    _sink({'audit_sink': {'enabled': True, 'format': FORMAT_CEF, 'host': 'siem'}},
+          syslog_send=syslog, http_post=http).send(_entry())
+    assert 'CEF:0|' in syslog.payloads[0]
+    assert http.payloads == []
+
+
+def test_json_format_uses_http_transport():
+    syslog, http = _Capture(), _Capture()
+    _sink({'audit_sink': {'enabled': True, 'format': FORMAT_JSON, 'url': 'https://x/y'}},
+          syslog_send=syslog, http_post=http).send(_entry())
+    assert len(http.payloads) == 1 and json.loads(http.payloads[0])['operation'] == 'create'
+    assert syslog.payloads == []
+
+
+# --------------------------------------------------------------------------- #
+# secret redaction + isolation
+# --------------------------------------------------------------------------- #
+
+def test_secrets_are_redacted_before_send():
+    http = _Capture()
+    entry = _entry(details={'token': 'super-secret-value', 'note': 'ok',
+                            'blob': 'api_key=leaked123'})
+    _sink({'audit_sink': {'enabled': True, 'format': FORMAT_JSON, 'url': 'https://x'}},
+          http_post=http).send(entry)
+    payload = http.payloads[0]
+    assert 'super-secret-value' not in payload
+    assert 'leaked123' not in payload
+    assert '[REDACTED]' in payload
+    assert 'ok' in payload  # non-secret preserved
+
+
+def test_send_is_failure_isolated():
+    def boom(payload, config):
+        raise ConnectionError('collector down')
+    # Must not raise.
+    _sink({'audit_sink': {'enabled': True, 'format': FORMAT_SYSLOG, 'host': 'h'}},
+          syslog_send=boom).send(_entry())
+
+
+def test_settings_read_failure_isolated():
+    sm = MagicMock()
+    sm.load_settings.side_effect = RuntimeError('settings unavailable')
+    # No enabled config -> disabled; must not raise.
+    AuditSink(sm, syslog_send=_Capture()).send(_entry())
+
+
+# --------------------------------------------------------------------------- #
+# transports (config validation)
+# --------------------------------------------------------------------------- #
+
+def test_syslog_transport_requires_host():
+    with pytest.raises(ValueError):
+        _syslog_transport('msg', {'protocol': 'udp'})
+
+
+def test_http_transport_requires_url():
+    with pytest.raises(ValueError):
+        _http_transport('{}', {})
+
+
+# --------------------------------------------------------------------------- #
+# AuditLogger integration
+# --------------------------------------------------------------------------- #
+
+def test_audit_logger_streams_to_sink(tmp_path):
+    from modules.core.audit import AuditLogger
+    sink = MagicMock()
+    logger = AuditLogger(tmp_path / 'logs', chain_dir=tmp_path / 'chain',
+                         audit_sink=sink)
+    logger.log_operation(operation='revoke', resource_type='certificate',
+                         resource_id='ex.com', status='success', user='bob')
+    assert sink.send.called
+    sent = sink.send.call_args[0][0]
+    assert sent['operation'] == 'revoke' and sent['resource_id'] == 'ex.com'
+
+
+def test_audit_logger_survives_sink_error(tmp_path):
+    from modules.core.audit import AuditLogger
+    sink = MagicMock()
+    sink.send.side_effect = RuntimeError('sink exploded')
+    logger = AuditLogger(tmp_path / 'logs', chain_dir=tmp_path / 'chain',
+                         audit_sink=sink)
+    # Must not raise despite the sink blowing up.
+    logger.log_operation(operation='create', resource_type='certificate',
+                         resource_id='ex.com', status='success')

--- a/tests/test_client_pfx_export.py
+++ b/tests/test_client_pfx_export.py
@@ -1,0 +1,98 @@
+"""Client-certificate PKCS#12 (.pfx) export (#465).
+
+Server certs already produced an on-disk cert.pfx; client certs — where a .pfx
+for import into Windows / mobile keystores is most useful — did not. These
+tests cover the on-demand builder: it bundles leaf + key (+ the CA as chain),
+encrypts with the configured password, and refuses to emit an unencrypted
+key-bearing bundle.
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import pkcs12
+
+from modules.core.client_certificates import ClientCertificateManager
+
+pytestmark = [pytest.mark.unit]
+
+
+def _cert_and_key(cn):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name).issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=90))
+        .sign(key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption())
+    return cert_pem, key_pem
+
+
+@pytest.fixture
+def manager(tmp_path):
+    ca_pem, _ = _cert_and_key('Test Client CA')
+    ca_path = tmp_path / 'ca.crt'
+    ca_path.write_bytes(ca_pem)
+    private_ca = SimpleNamespace(ca_cert_path=ca_path)
+    return ClientCertificateManager(
+        client_certs_dir=tmp_path / 'client-certs', private_ca=private_ca)
+
+
+def _place_cert(manager, identifier, usage='api'):
+    d = manager.client_certs_dir / usage / identifier
+    d.mkdir(parents=True)
+    cert_pem, key_pem = _cert_and_key(identifier)
+    (d / f'{identifier}.crt').write_bytes(cert_pem)
+    (d / f'{identifier}.key').write_bytes(key_pem)
+    return cert_pem
+
+
+def test_build_pfx_is_loadable_with_password(manager):
+    _place_cert(manager, 'alice')
+    blob = manager.build_pfx('alice', b'pw-123')
+    key, cert, chain = pkcs12.load_key_and_certificates(blob, b'pw-123')
+    assert key is not None and cert is not None
+    # The CA cert rides along as the chain.
+    assert chain and any(
+        c.subject.rfc4514_string().endswith('Test Client CA') for c in chain)
+
+
+def test_build_pfx_rejects_wrong_password(manager):
+    _place_cert(manager, 'bob')
+    blob = manager.build_pfx('bob', b'right')
+    with pytest.raises(ValueError):
+        pkcs12.load_key_and_certificates(blob, b'wrong')
+
+
+def test_build_pfx_empty_password_returns_none(manager):
+    _place_cert(manager, 'carol')
+    assert manager.build_pfx('carol', b'') is None
+
+
+def test_build_pfx_unknown_identifier_returns_none(manager):
+    assert manager.build_pfx('nobody', b'pw') is None
+
+
+def test_build_pfx_without_ca_still_works(tmp_path):
+    # No CA cert available -> chain is empty but the PFX still builds.
+    private_ca = SimpleNamespace(ca_cert_path=None)
+    mgr = ClientCertificateManager(
+        client_certs_dir=tmp_path / 'cc', private_ca=private_ca)
+    _place_cert(mgr, 'dave')
+    blob = mgr.build_pfx('dave', b'pw')
+    key, cert, chain = pkcs12.load_key_and_certificates(blob, b'pw')
+    assert key is not None and cert is not None
+    assert not chain

--- a/tests/test_client_pfx_export.py
+++ b/tests/test_client_pfx_export.py
@@ -86,6 +86,17 @@ def test_build_pfx_unknown_identifier_returns_none(manager):
     assert manager.build_pfx('nobody', b'pw') is None
 
 
+def test_build_pfx_skips_incomplete_candidate(manager):
+    # An incomplete dir (crt, no key) under one usage folder must not shadow a
+    # complete cert under another — build_pfx keeps looking.
+    incomplete = manager.client_certs_dir / 'vpn' / 'dup'
+    incomplete.mkdir(parents=True)
+    cert_pem, _ = _cert_and_key('dup')
+    (incomplete / 'dup.crt').write_bytes(cert_pem)   # crt only, no key
+    _place_cert(manager, 'dup', usage='api')          # complete
+    assert manager.build_pfx('dup', b'pw') is not None
+
+
 def test_build_pfx_without_ca_still_works(tmp_path):
     # No CA cert available -> chain is empty but the PFX still builds.
     private_ca = SimpleNamespace(ca_cert_path=None)

--- a/tests/test_deploy_targets.py
+++ b/tests/test_deploy_targets.py
@@ -268,6 +268,26 @@ def test_manual_deploy_with_only_a_target(tmp_path, requests_mock):
     assert m.called
 
 
+def test_certificate_deployed_event_on_success(tmp_path, requests_mock):
+    requests_mock.patch(re.compile(r'/secrets/tls-web'), status_code=200, json={})
+    settings = {'deploy_hooks': {'enabled': True, 'global_hooks': [],
+                                 'domain_hooks': {}, 'targets': [_k8s_target()]}}
+    mgr = _deploy_manager(tmp_path, settings)
+    mgr.on_certificate_event('certificate_renewed', {'domain': 'example.com'})
+    published = [c.args[0] for c in mgr.event_bus.publish.call_args_list]
+    assert 'certificate_deployed' in published
+
+
+def test_no_deployed_event_when_target_fails(tmp_path, requests_mock):
+    requests_mock.patch(re.compile(r'/secrets/tls-web'), status_code=500, json={})
+    settings = {'deploy_hooks': {'enabled': True, 'global_hooks': [],
+                                 'domain_hooks': {}, 'targets': [_k8s_target()]}}
+    mgr = _deploy_manager(tmp_path, settings)
+    mgr.on_certificate_event('certificate_renewed', {'domain': 'example.com'})
+    published = [c.args[0] for c in mgr.event_bus.publish.call_args_list]
+    assert 'certificate_deployed' not in published
+
+
 def test_missing_cert_files_is_isolated(tmp_path):
     settings = {'deploy_hooks': {'enabled': True, 'global_hooks': [],
                                  'domain_hooks': {}, 'targets': [

--- a/tests/test_deploy_targets.py
+++ b/tests/test_deploy_targets.py
@@ -1,0 +1,279 @@
+"""Typed deploy targets — Kubernetes Secret (#475).
+
+Covers the KubernetesSecretTarget (manifest, Server-Side Apply request, auth
+resolution incl. in-cluster, failure handling), the run_targets orchestration
+(applicability + failure isolation), and the DeployManager integration
+(config default/validation, firing on renewal + manual, cert files read from
+disk) — the K8s API is mocked throughout.
+"""
+
+import base64
+import json
+import re
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.deploy_targets import (
+    KubernetesSecretTarget, DeployTargetError, build_target, target_applies,
+    run_targets,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+class _Resp:
+    def __init__(self, status_code=200, text='{}'):
+        self.status_code = status_code
+        self.text = text
+
+
+class _CapturePatch:
+    def __init__(self, status_code=200, text='{}', raises=None):
+        self.status_code = status_code
+        self.text = text
+        self.raises = raises
+        self.calls = []
+
+    def __call__(self, url, json=None, headers=None, verify=None, timeout=None):
+        self.calls.append({'url': url, 'json': json, 'headers': headers,
+                           'verify': verify})
+        if self.raises:
+            raise self.raises
+        return _Resp(self.status_code, self.text)
+
+
+def _cfg(**over):
+    base = {'secret_name': 'tls-web', 'namespace': 'prod',
+            'api_server': 'https://k8s.local:6443', 'token': 'sa-token'}
+    base.update(over)
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# KubernetesSecretTarget
+# --------------------------------------------------------------------------- #
+
+def test_deploy_success_builds_ssa_request():
+    patch = _CapturePatch(200)
+    t = KubernetesSecretTarget(_cfg(), http_patch=patch)
+    out = t.deploy(b'CERT', b'KEY')
+    assert out['success'] is True and out['status_code'] == 200
+
+    call = patch.calls[0]
+    assert call['url'] == (
+        'https://k8s.local:6443/api/v1/namespaces/prod/secrets/tls-web'
+        '?fieldManager=certmate&force=true')
+    assert call['headers']['Authorization'] == 'Bearer sa-token'
+    assert call['headers']['Content-Type'] == 'application/apply-patch+yaml'
+    manifest = call['json']
+    assert manifest['type'] == 'kubernetes.io/tls'
+    assert base64.b64decode(manifest['data']['tls.crt']) == b'CERT'
+    assert base64.b64decode(manifest['data']['tls.key']) == b'KEY'
+    assert manifest['metadata'] == {
+        'name': 'tls-web', 'namespace': 'prod',
+        'labels': {'app.kubernetes.io/managed-by': 'certmate'}}
+
+
+def test_deploy_non_2xx_is_failure():
+    patch = _CapturePatch(403, text='{"message":"forbidden"}')
+    out = KubernetesSecretTarget(_cfg(), http_patch=patch).deploy(b'C', b'K')
+    assert out['success'] is False
+    assert out['status_code'] == 403
+    assert 'forbidden' in out['message']
+
+
+def test_deploy_request_exception_is_failure():
+    patch = _CapturePatch(raises=ConnectionError('no route to host'))
+    out = KubernetesSecretTarget(_cfg(), http_patch=patch).deploy(b'C', b'K')
+    assert out['success'] is False
+    assert 'no route to host' in out['message']
+
+
+def test_missing_secret_name_raises():
+    with pytest.raises(DeployTargetError):
+        KubernetesSecretTarget(_cfg(secret_name=None),
+                               http_patch=_CapturePatch()).deploy(b'C', b'K')
+
+
+def test_missing_api_server_or_token_raises():
+    with pytest.raises(DeployTargetError):
+        KubernetesSecretTarget({'secret_name': 's', 'namespace': 'n'},
+                               http_patch=_CapturePatch()).deploy(b'C', b'K')
+
+
+def test_missing_namespace_raises():
+    cfg = _cfg()
+    cfg.pop('namespace')
+    with pytest.raises(DeployTargetError):
+        KubernetesSecretTarget(cfg, http_patch=_CapturePatch()).deploy(b'C', b'K')
+
+
+def test_ca_cert_written_to_tempfile_and_cleaned_up(tmp_path):
+    patch = _CapturePatch(200)
+    t = KubernetesSecretTarget(_cfg(ca_cert='-----BEGIN CERT-----\nx\n'),
+                               http_patch=patch)
+    out = t.deploy(b'C', b'K')
+    assert out['success'] is True
+    ca_path = patch.calls[0]['verify']
+    assert isinstance(ca_path, str) and 'certmate-k8s-ca-' in ca_path
+    import os
+    assert not os.path.exists(ca_path)  # removed after the request
+
+
+def test_verify_ssl_false_disables_verification():
+    patch = _CapturePatch(200)
+    KubernetesSecretTarget(_cfg(verify_ssl=False), http_patch=patch).deploy(b'C', b'K')
+    assert patch.calls[0]['verify'] is False
+
+
+def test_in_cluster_resolution(tmp_path, monkeypatch):
+    sa = tmp_path / 'sa'
+    sa.mkdir()
+    (sa / 'token').write_text('incluster-token')
+    (sa / 'ca.crt').write_text('CA')
+    (sa / 'namespace').write_text('kube-system')
+    monkeypatch.setattr('modules.core.deploy_targets._SA_TOKEN', str(sa / 'token'))
+    monkeypatch.setattr('modules.core.deploy_targets._SA_CA', str(sa / 'ca.crt'))
+    monkeypatch.setattr('modules.core.deploy_targets._SA_NAMESPACE', str(sa / 'namespace'))
+    monkeypatch.setenv('KUBERNETES_SERVICE_HOST', '10.96.0.1')
+    monkeypatch.setenv('KUBERNETES_SERVICE_PORT', '443')
+
+    patch = _CapturePatch(200)
+    t = KubernetesSecretTarget({'secret_name': 'tls', 'in_cluster': True},
+                               http_patch=patch)
+    out = t.deploy(b'C', b'K')
+    assert out['success'] is True
+    call = patch.calls[0]
+    assert call['url'].startswith('https://10.96.0.1:443/api/v1/namespaces/kube-system/secrets/tls')
+    assert call['headers']['Authorization'] == 'Bearer incluster-token'
+    assert call['verify'] == str(sa / 'ca.crt')
+
+
+# --------------------------------------------------------------------------- #
+# build_target / target_applies / run_targets
+# --------------------------------------------------------------------------- #
+
+def test_build_target_unknown_type_raises():
+    with pytest.raises(DeployTargetError):
+        build_target({'type': 'ftp-upload'})
+
+
+@pytest.mark.parametrize('target,domain,event,expected', [
+    ({'enabled': True, 'domains': ['a.com'], 'on_events': ['renewed']}, 'a.com', 'renewed', True),
+    ({'enabled': False, 'domains': ['a.com']}, 'a.com', 'renewed', False),
+    ({'enabled': True, 'domains': ['a.com']}, 'b.com', 'renewed', False),
+    ({'enabled': True, 'domains': [], 'on_events': ['created']}, 'x.com', 'created', True),
+    ({'enabled': True}, 'x.com', 'created', True),          # defaults: all domains, created+renewed
+    ({'enabled': True, 'on_events': ['created']}, 'x.com', 'renewed', False),
+    ({'enabled': True, 'domains': ['a.com']}, 'a.com', 'manual', True),  # manual always applies
+])
+def test_target_applies(target, domain, event, expected):
+    assert target_applies(target, domain, event) is expected
+
+
+def test_run_targets_failure_isolated():
+    good = {'enabled': True, 'type': 'kubernetes-secret', 'name': 'good',
+            'config': _cfg(secret_name='good')}
+    bad = {'enabled': True, 'type': 'kubernetes-secret', 'name': 'bad',
+           'config': {'namespace': 'n'}}  # missing secret_name+api -> DeployTargetError
+    patch = _CapturePatch(200)
+    results = run_targets([bad, good], 'a.com', b'C', b'K', 'renewed', http_patch=patch)
+    by = {r['target']: r for r in results}
+    assert by['bad']['success'] is False        # errored, isolated
+    assert by['good']['success'] is True        # still ran
+    assert all(r['domain'] == 'a.com' for r in results)
+
+
+def test_run_targets_skips_inapplicable():
+    t = {'enabled': True, 'type': 'kubernetes-secret', 'name': 'x',
+         'domains': ['other.com'], 'config': _cfg()}
+    assert run_targets([t], 'a.com', b'C', b'K', 'renewed') == []
+
+
+# --------------------------------------------------------------------------- #
+# DeployManager integration
+# --------------------------------------------------------------------------- #
+
+def _deploy_manager(tmp_path, settings):
+    from modules.core.deployer import DeployManager
+    sm = MagicMock()
+    sm.load_settings.return_value = settings
+    sm.update.side_effect = lambda mutate, reason=None: mutate(settings)
+    cert_dir = tmp_path / 'certs'
+    (cert_dir / 'example.com').mkdir(parents=True)
+    (cert_dir / 'example.com' / 'fullchain.pem').write_bytes(b'FULLCHAIN')
+    (cert_dir / 'example.com' / 'privkey.pem').write_bytes(b'PRIVKEY')
+    return DeployManager(sm, MagicMock(), MagicMock(), MagicMock(),
+                         cert_dir=cert_dir, data_dir=str(tmp_path / 'data'))
+
+
+def _k8s_target(**cfg_over):
+    return {'id': 't1', 'name': 'prod-secret', 'type': 'kubernetes-secret',
+            'enabled': True, 'on_events': ['created', 'renewed'],
+            'domains': ['example.com'], 'config': _cfg(**cfg_over)}
+
+
+def test_get_config_has_targets_default(tmp_path):
+    mgr = _deploy_manager(tmp_path, {'deploy_hooks': {'enabled': True}})
+    assert mgr.get_config()['targets'] == []
+
+
+def test_save_config_rejects_bad_target(tmp_path):
+    mgr = _deploy_manager(tmp_path, {})
+    ok, err = mgr.save_config({'enabled': True, 'targets': [
+        {'type': 'kubernetes-secret', 'config': {'namespace': 'n'}}]})
+    assert ok is False and 'secret_name' in err
+
+
+def test_save_config_accepts_valid_target(tmp_path):
+    mgr = _deploy_manager(tmp_path, {})
+    ok, err = mgr.save_config({'enabled': True, 'targets': [_k8s_target()]})
+    assert ok is True and err is None
+
+
+def test_renewal_applies_secret(tmp_path, requests_mock):
+    m = requests_mock.patch(
+        re.compile(r'/api/v1/namespaces/prod/secrets/tls-web'),
+        status_code=200, json={})
+    settings = {'deploy_hooks': {'enabled': True, 'global_hooks': [],
+                                 'domain_hooks': {}, 'targets': [_k8s_target()]}}
+    mgr = _deploy_manager(tmp_path, settings)
+
+    mgr.on_certificate_event('certificate_renewed', {'domain': 'example.com'})
+
+    assert m.called
+    sent = json.loads(m.last_request.text)
+    assert base64.b64decode(sent['data']['tls.crt']) == b'FULLCHAIN'
+    assert base64.b64decode(sent['data']['tls.key']) == b'PRIVKEY'
+    assert m.last_request.headers['Authorization'] == 'Bearer sa-token'
+
+
+def test_disabled_deploy_skips_targets(tmp_path, requests_mock):
+    m = requests_mock.patch(re.compile(r'/secrets/'), status_code=200, json={})
+    settings = {'deploy_hooks': {'enabled': False, 'targets': [_k8s_target()]}}
+    mgr = _deploy_manager(tmp_path, settings)
+    mgr.on_certificate_event('certificate_renewed', {'domain': 'example.com'})
+    assert not m.called
+
+
+def test_manual_deploy_with_only_a_target(tmp_path, requests_mock):
+    m = requests_mock.patch(re.compile(r'/secrets/tls-web'), status_code=200, json={})
+    settings = {'deploy_hooks': {'enabled': True, 'global_hooks': [],
+                                 'domain_hooks': {}, 'targets': [_k8s_target()]}}
+    mgr = _deploy_manager(tmp_path, settings)
+    out = mgr.run_manual_deploy('example.com')
+    assert out['ok'] is True
+    assert out['total'] == 1 and out['succeeded'] == 1
+    assert m.called
+
+
+def test_missing_cert_files_is_isolated(tmp_path):
+    settings = {'deploy_hooks': {'enabled': True, 'global_hooks': [],
+                                 'domain_hooks': {}, 'targets': [
+                                     _k8s_target()]}}
+    mgr = _deploy_manager(tmp_path, settings)
+    # A domain with no cert files on disk must not crash the sweep.
+    results = mgr._execute_targets('ghost.example.com', 'renewed', mgr.get_config())
+    # ghost has no target (domains=['example.com']) -> nothing applies
+    assert results == []

--- a/tests/test_deploy_targets.py
+++ b/tests/test_deploy_targets.py
@@ -8,8 +8,11 @@ disk) — the K8s API is mocked throughout.
 """
 
 import base64
+import glob
 import json
+import os
 import re
+import tempfile
 from unittest.mock import MagicMock
 
 import pytest
@@ -119,6 +122,18 @@ def test_ca_cert_written_to_tempfile_and_cleaned_up(tmp_path):
     assert isinstance(ca_path, str) and 'certmate-k8s-ca-' in ca_path
     import os
     assert not os.path.exists(ca_path)  # removed after the request
+
+
+def test_no_temp_ca_leak_on_validation_error():
+    # A validation error (missing namespace) must raise BEFORE the CA temp file
+    # is materialized — no leaked certmate-k8s-ca-* file.
+    pattern = os.path.join(tempfile.gettempdir(), 'certmate-k8s-ca-*')
+    before = set(glob.glob(pattern))
+    cfg = _cfg(ca_cert='-----BEGIN CERTIFICATE-----\nx\n')
+    cfg.pop('namespace')
+    with pytest.raises(DeployTargetError):
+        KubernetesSecretTarget(cfg, http_patch=_CapturePatch()).deploy(b'C', b'K')
+    assert set(glob.glob(pattern)) == before
 
 
 def test_verify_ssl_false_disables_verification():
@@ -286,6 +301,22 @@ def test_no_deployed_event_when_target_fails(tmp_path, requests_mock):
     mgr.on_certificate_event('certificate_renewed', {'domain': 'example.com'})
     published = [c.args[0] for c in mgr.event_bus.publish.call_args_list]
     assert 'certificate_deployed' not in published
+
+
+def test_read_failure_is_recorded(tmp_path):
+    # A target applicable to a domain whose cert files are missing must be
+    # recorded (audit + failure alert), not silently dropped.
+    target = _k8s_target()
+    target['domains'] = ['nofiles.example.com']
+    settings = {'deploy_hooks': {'enabled': True, 'global_hooks': [],
+                                 'domain_hooks': {}, 'targets': [target]}}
+    mgr = _deploy_manager(tmp_path, settings)
+    results = mgr._execute_targets('nofiles.example.com', 'renewed', mgr.get_config())
+    assert results and results[0]['success'] is False
+    assert 'unreadable' in results[0]['message']
+    assert mgr.audit_logger.log_operation.called
+    published = [c.args[0] for c in mgr.event_bus.publish.call_args_list]
+    assert 'deploy_hook_failed' in published
 
 
 def test_missing_cert_files_is_isolated(tmp_path):

--- a/tests/test_deploy_targets.py
+++ b/tests/test_deploy_targets.py
@@ -93,6 +93,21 @@ def test_deploy_request_exception_is_failure():
     assert 'no route to host' in out['message']
 
 
+def test_token_scrubbed_from_error_message():
+    patch = _CapturePatch(raises=ConnectionError('to https://k8s Bearer sa-token failed'))
+    out = KubernetesSecretTarget(_cfg(token='sa-token'), http_patch=patch).deploy(b'C', b'K')
+    assert out['success'] is False
+    assert 'sa-token' not in out['message']
+    assert '[REDACTED]' in out['message']
+
+
+def test_token_scrubbed_from_response_body():
+    patch = _CapturePatch(403, text='denied: token sa-token not allowed')
+    out = KubernetesSecretTarget(_cfg(token='sa-token'), http_patch=patch).deploy(b'C', b'K')
+    assert out['success'] is False
+    assert 'sa-token' not in out['message']
+
+
 def test_missing_secret_name_raises():
     with pytest.raises(DeployTargetError):
         KubernetesSecretTarget(_cfg(secret_name=None),

--- a/tests/test_pfx_download_api.py
+++ b/tests/test_pfx_download_api.py
@@ -1,0 +1,183 @@
+"""API-level coverage for #465: the encrypted PKCS#12 bundle is included in the
+server certificate ZIP, and client certificates gain a gated .pfx download.
+
+In-process (no Docker), mirroring tests/test_issue212_download_path_style.py:
+require_role is bypassed so the handler's own per-file role gate is exercised
+against request.current_user.
+"""
+
+import io
+import zipfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+from flask_restx import Api, Namespace
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import pkcs12
+
+from modules.api.models import create_api_models
+from modules.api.resources import create_api_resources
+from modules.api.client_certificates import create_client_certificate_resources
+from modules.core.client_certificates import ClientCertificateManager
+
+pytestmark = [pytest.mark.unit]
+
+
+def _passthrough(_min_role):
+    def deco(fn):
+        return fn
+    return deco
+
+
+def _cert_and_key(cn):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+    cert = (
+        x509.CertificateBuilder().subject_name(name).issuer_name(name)
+        .public_key(key.public_key()).serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=90))
+        .sign(key, hashes.SHA256()))
+    return (cert.public_bytes(serialization.Encoding.PEM),
+            key.private_bytes(serialization.Encoding.PEM,
+                              serialization.PrivateFormat.PKCS8,
+                              serialization.NoEncryption()))
+
+
+def _attach_user(app, role):
+    @app.before_request
+    def _set_user():
+        from flask import request as _r
+        _r.current_user = {'username': f'u_{role}', 'role': role,
+                           'allowed_domains': None}
+
+
+# --------------------------------------------------------------------------- #
+# Server ZIP includes cert.pfx
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def server_app(tmp_path):
+    dom = tmp_path / 'example.com'
+    dom.mkdir()
+    for f in ('cert.pem', 'chain.pem', 'fullchain.pem', 'privkey.pem'):
+        (dom / f).write_text(f'DATA-{f}')
+    (dom / 'cert.pfx').write_bytes(b'PKCS12-BLOB')
+
+    auth = MagicMock()
+    auth.require_role = MagicMock(side_effect=_passthrough)
+    auth.user_can_access_domain.return_value = True
+    auth.domain_matches_scope.return_value = True
+    settings = MagicMock()
+    settings.load_settings.return_value = {}
+
+    managers = {
+        'auth': auth, 'settings': settings,
+        'certificates': MagicMock(cert_dir=Path(tmp_path)),
+        'file_ops': MagicMock(cert_dir=Path(tmp_path)),
+        'cache': MagicMock(), 'dns': MagicMock(), 'audit': MagicMock(),
+    }
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    api = Api(app, prefix='/api')
+    resources = create_api_resources(api, create_api_models(api), managers)
+    ns = Namespace('certificates', description='certs')
+    api.add_namespace(ns)
+    ns.add_resource(resources['DownloadCertificate'], '/<string:domain>/download')
+    return app
+
+
+def test_private_zip_includes_pfx(server_app):
+    _attach_user(server_app, 'operator')
+    r = server_app.test_client().get('/api/certificates/example.com/download')
+    assert r.status_code == 200, r.data
+    with zipfile.ZipFile(io.BytesIO(r.data)) as zf:
+        assert 'cert.pfx' in zf.namelist()
+        assert zf.read('cert.pfx') == b'PKCS12-BLOB'
+
+
+def test_public_zip_excludes_pfx(server_app):
+    _attach_user(server_app, 'viewer')
+    r = server_app.test_client().get(
+        '/api/certificates/example.com/download?include_private=0')
+    assert r.status_code == 200, r.data
+    with zipfile.ZipFile(io.BytesIO(r.data)) as zf:
+        assert 'cert.pfx' not in zf.namelist()
+        assert 'privkey.pem' not in zf.namelist()
+
+
+# --------------------------------------------------------------------------- #
+# Client certificate .pfx download
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def client_app(tmp_path):
+    ca_pem, _ = _cert_and_key('Client CA')
+    ca_path = tmp_path / 'ca.crt'
+    ca_path.write_bytes(ca_pem)
+    ccm = ClientCertificateManager(
+        client_certs_dir=tmp_path / 'cc',
+        private_ca=SimpleNamespace(ca_cert_path=ca_path))
+    d = ccm.client_certs_dir / 'api' / 'alice'
+    d.mkdir(parents=True)
+    crt, key = _cert_and_key('alice')
+    (d / 'alice.crt').write_bytes(crt)
+    (d / 'alice.key').write_bytes(key)
+
+    auth = MagicMock()
+    auth.require_role = MagicMock(side_effect=_passthrough)
+    settings = MagicMock()
+    settings.load_settings.return_value = {'pfx_password': 'zip-pw'}
+
+    managers = {
+        'client_certificates': ccm, 'auth': auth, 'settings': settings,
+        'ocsp': MagicMock(), 'crl': MagicMock(),
+    }
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    api = Api(app, prefix='/api')
+    resources = create_client_certificate_resources(api, managers)
+    ns = Namespace('client-certs', description='cc')
+    api.add_namespace(ns)
+    ns.add_resource(resources['ClientCertificateDownload'],
+                    '/<string:identifier>/download/<string:file_type>')
+    return app, settings
+
+
+def test_client_pfx_download_operator(client_app):
+    app, _ = client_app
+    _attach_user(app, 'operator')
+    r = app.test_client().get('/api/client-certs/alice/download/pfx')
+    assert r.status_code == 200, r.data
+    assert r.headers['Content-Type'] == 'application/x-pkcs12'
+    key, cert, _chain = pkcs12.load_key_and_certificates(r.data, b'zip-pw')
+    assert key is not None and cert is not None
+
+
+def test_client_pfx_denied_for_viewer(client_app):
+    app, _ = client_app
+    _attach_user(app, 'viewer')
+    r = app.test_client().get('/api/client-certs/alice/download/pfx')
+    assert r.status_code == 403
+
+
+def test_client_pfx_requires_password(client_app):
+    app, settings = client_app
+    settings.load_settings.return_value = {'pfx_password': ''}
+    _attach_user(app, 'operator')
+    r = app.test_client().get('/api/client-certs/alice/download/pfx')
+    assert r.status_code == 400
+
+
+def test_client_pfx_unknown_identifier_404(client_app):
+    app, _ = client_app
+    _attach_user(app, 'operator')
+    r = app.test_client().get('/api/client-certs/nobody/download/pfx')
+    assert r.status_code == 404


### PR DESCRIPTION
Milestone 5 — the operations/integrations batch. **Excludes #476 (ACME server), which ships separately.**

Closes #465, #475, #474.

### #465 — PKCS#12 (.pfx) for client certs + include cert.pfx in the server ZIP
- Server "download all" ZIP now includes the encrypted `cert.pfx` (private ZIP only, operator+).
- Client certs gain a gated `GET /api/client-certs/<id>/download/pfx` — the PKCS#12 is generated on demand from the on-disk PEMs (leaf + key + CA chain), encrypted with the configured PFX password (operator+; refused without a password). Reuses `_build_pfx`, no new deps.

### #475 — Typed deploy target: write to a Kubernetes Secret
- A declarative alternative to shell hooks. `KubernetesSecretTarget` applies the renewed cert to a `kubernetes.io/tls` Secret via Server-Side Apply (idempotent), with configured (api_server + token + CA/verify) or in-cluster auth. tls.crt = fullchain, tls.key = key.
- Lives under `deploy_hooks.targets`, fires from the same lifecycle points as hooks (create/renew/manual), failure-isolated, audited + history-logged. `save_config` validates targets.

### #474 — SIEM audit sink + richer lifecycle events
- Streams every audit entry to an external collector: **syslog (RFC 5424)** or **CEF** over UDP/TCP, or **generic HTTP/JSON**. Config under `audit_sink`, read live.
- Runs entries through the existing credential/secret sanitizer before send; failure-isolated with a short timeout, like the hash chain. Wired into `AuditLogger.log_operation`.
- New lifecycle events: `certificate_deployed` (on a successful deploy) and `certificate_revoked`; the scheduled renewal/expiry digest already exists.

### Quality
- Full unit/integration suite green (2208), +~70 new tests. flake8 hard gate, bandit, theme-codemod all clean locally.
- Docs updated (deploy-hooks, compliance, api).

🤖 Generated with [Claude Code](https://claude.com/claude-code)