### PR TITLE
docs: bump stale 'Current Version' in doc landing pages to 2.24.0

### DIFF
--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -246,7 +246,7 @@ Siehe LICENSE-Datei im Repository
 
 ## Version
 
-**Aktuelle Version**: 2.3.0
+**Aktuelle Version**: 2.24.0
 **Status**: Produktionsbereit
 
 ---

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -240,7 +240,7 @@ Consulte el archivo LICENSE en el repositorio
 
 ## Versión
 
-**Versión actual**: 2.3.0
+**Versión actual**: 2.24.0
 **Estado**: Listo para producción
 
 ---

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -240,7 +240,7 @@ Voir le fichier LICENSE dans le dépôt
 
 ## Version
 
-**Version actuelle** : 2.3.0
+**Version actuelle** : 2.24.0
 **Statut** : Prêt pour la production
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -247,7 +247,7 @@ See LICENSE file in the repository
 
 ## Version
 
-**Current Version**: 2.3.0
+**Current Version**: 2.24.0
 **Status**: Production Ready
 
 ---

--- a/docs/it/index.md
+++ b/docs/it/index.md
@@ -240,7 +240,7 @@ Vedere il file LICENSE nel repository
 
 ## Versione
 
-**Versione corrente**: 2.3.0
+**Versione corrente**: 2.24.0
 **Stato**: Pronto per la produzione
 
 ---


### PR DESCRIPTION
The `docs/*/index.md` landing pages still stated **Current Version: 2.3.0** (21 releases behind) in all five locales, while `modules/__init__.py`, `package.json`, `README.dockerhub.md` and the marketing site are all on **2.24.0**.

Surfaced by a post-release cross-surface consistency sweep. Docs-only, no code or behavior change.

- `docs/index.md` — Current Version → 2.24.0
- `docs/it/index.md` — Versione corrente → 2.24.0
- `docs/de/index.md` — Aktuelle Version → 2.24.0
- `docs/fr/index.md` — Version actuelle → 2.24.0
- `docs/es/index.md` — Versión actual → 2.24.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)