### PR TITLE
fix: acme-dns issuance never worked — drive it with the native hook (#466)

### DIFF
--- a/docs/de/dns-providers.md
+++ b/docs/de/dns-providers.md
@@ -29,7 +29,7 @@ CertMate unterstützt eine breite Palette von DNS-Anbietern für Let's Encrypt D
 | **Infomaniak** | `certbot-dns-infomaniak` | API-Token | Regional |
 | **ArvanCloud** | `certbot-dns-arvancloud` | API-Schlüssel | Regional |
 | **RFC2136** | `certbot-dns-rfc2136` | Nameserver, TSIG-Schlüssel | Standardprotokoll |
-| **ACME-DNS** | `certbot-acme-dns` | API-URL, Benutzername, Passwort | Spezialisiert |
+| **ACME-DNS** | _integriert_ (kein Plugin) | API-URL, Benutzername, Passwort, Subdomain | Spezialisiert |
 | **Hurricane Electric** | `certbot-dns-he-ddns` | Benutzername, Passwort | Kostenloses DNS |
 | **Dynu** | `certbot-dns-dynudns` | API-Token | Dynamisches DNS |
 | **DuckDNS** | `certbot-dns-duckdns` | Konto-Token | Kostenloses DDNS (ohne eigene Domain) |

--- a/docs/dns-providers.md
+++ b/docs/dns-providers.md
@@ -30,7 +30,7 @@ CertMate supports a wide range of DNS providers for Let's Encrypt DNS-01 challen
 | **Infomaniak** | `certbot-dns-infomaniak` | API Token | Regional |
 | **ArvanCloud** | `certbot-dns-arvancloud` | API Key | Regional |
 | **RFC2136** | `certbot-dns-rfc2136` | Nameserver, TSIG Key | Standard Protocol |
-| **ACME-DNS** | `certbot-acme-dns` | API URL, Username, Password | Specialized |
+| **ACME-DNS** | _built-in_ (no plugin) | API URL, Username, Password, Subdomain | Specialized |
 | **Hurricane Electric** | `certbot-dns-he-ddns` | Username, Password | Free DNS |
 | **Dynu** | `certbot-dns-dynudns` | API Token | Dynamic DNS |
 | **DuckDNS** | `certbot-dns-duckdns` | Account Token | Free DDNS (no domain required) |

--- a/docs/es/dns-providers.md
+++ b/docs/es/dns-providers.md
@@ -29,7 +29,7 @@ CertMate soporta una amplia gama de proveedores DNS para los desafíos Let's Enc
 | **Infomaniak** | `certbot-dns-infomaniak` | Token API | Regional |
 | **ArvanCloud** | `certbot-dns-arvancloud` | Clave API | Regional |
 | **RFC2136** | `certbot-dns-rfc2136` | Servidor DNS, Clave TSIG | Protocolo estándar |
-| **ACME-DNS** | `certbot-acme-dns` | URL API, Nombre de usuario, Contraseña | Especializado |
+| **ACME-DNS** | _integrado_ (sin plugin) | URL API, Nombre de usuario, Contraseña, Subdominio | Especializado |
 | **Hurricane Electric** | `certbot-dns-he-ddns` | Nombre de usuario, Contraseña | DNS gratuito |
 | **Dynu** | `certbot-dns-dynudns` | Token API | DNS dinámico |
 | **DuckDNS** | `certbot-dns-duckdns` | Token de cuenta | DDNS gratuito (sin dominio propio) |

--- a/docs/fr/dns-providers.md
+++ b/docs/fr/dns-providers.md
@@ -29,7 +29,7 @@ CertMate supporte une large gamme de fournisseurs DNS pour les défis Let's Encr
 | **Infomaniak** | `certbot-dns-infomaniak` | Jeton API | Régional |
 | **ArvanCloud** | `certbot-dns-arvancloud` | Clé API | Régional |
 | **RFC2136** | `certbot-dns-rfc2136` | Serveur DNS, Clé TSIG | Protocole standard |
-| **ACME-DNS** | `certbot-acme-dns` | URL API, Nom d'utilisateur, Mot de passe | Spécialisé |
+| **ACME-DNS** | _intégré_ (aucun plugin) | URL API, Nom d'utilisateur, Mot de passe, Sous-domaine | Spécialisé |
 | **Hurricane Electric** | `certbot-dns-he-ddns` | Nom d'utilisateur, Mot de passe | DNS gratuit |
 | **Dynu** | `certbot-dns-dynudns` | Jeton API | DNS dynamique |
 | **DuckDNS** | `certbot-dns-duckdns` | Jeton de compte | DDNS gratuit (sans domaine) |

--- a/docs/it/dns-providers.md
+++ b/docs/it/dns-providers.md
@@ -29,7 +29,7 @@ CertMate supporta un'ampia gamma di provider DNS per le challenge DNS-01 di Let'
 | **Infomaniak** | `certbot-dns-infomaniak` | API Token | Regionale |
 | **ArvanCloud** | `certbot-dns-arvancloud` | Chiave API | Regionale |
 | **RFC2136** | `certbot-dns-rfc2136` | Server DNS, Chiave TSIG | Protocollo standard |
-| **ACME-DNS** | `certbot-acme-dns` | URL API, Nome utente, Password | Specializzato |
+| **ACME-DNS** | _integrato_ (nessun plugin) | URL API, Nome utente, Password, Sottodominio | Specializzato |
 | **Hurricane Electric** | `certbot-dns-he-ddns` | Nome utente, Password | DNS gratuito |
 | **Dynu** | `certbot-dns-dynudns` | API Token | DNS dinamico |
 | **DuckDNS** | `certbot-dns-duckdns` | Token account | DDNS gratuito (senza dominio) |

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -614,10 +614,22 @@ class CertificateManager:
 
         Returns '' for every other provider, so callers can use it as a plain
         "should this take the native path?" switch.
+
+        Raises ValueError when an acme-dns account has no subdomain. Returning
+        '' there would silently drop the request back onto the plugin path,
+        where AcmeDNSStrategy raises a "bug in the caller" RuntimeError — a
+        misleading message for what is really a missing settings field.
         """
         if dns_provider != 'acme-dns':
             return ''
-        return str((dns_config or {}).get('subdomain') or '').strip().rstrip('.')
+        subdomain = str((dns_config or {}).get('subdomain') or '').strip().rstrip('.')
+        if not subdomain:
+            raise ValueError(
+                "The acme-dns account is missing its Subdomain. Set it to the "
+                "subdomain acme-dns returned when the account was registered — "
+                "the same value the _acme-challenge CNAME points at."
+            )
+        return subdomain
 
     @staticmethod
     def _create_dns_alias_hook_config(dns_provider, dns_config, domain_alias, propagation_seconds):
@@ -1745,7 +1757,10 @@ class CertificateManager:
                         max(1, min(3600, renew_propagation)),
                     )
                     self._configure_dns_alias_arguments(cmd, alias_hook_config)
-                    logger.info(f"Renewing {domain} with the native acme-dns hook.")
+                    # Strip CR/LF so a crafted domain cannot forge log entries
+                    # (CodeQL py/log-injection), matching modules/web/cert_routes.py.
+                    safe_domain = str(domain).replace('\r', ' ').replace('\n', ' ')
+                    logger.info(f"Renewing {safe_domain} with the native acme-dns hook.")
                 elif dns_config:
                     strategy = DNSStrategyFactory.get_strategy(dns_provider)
                     strategy.prepare_environment(process_env, dns_config)

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -591,6 +591,35 @@ class CertificateManager:
         return {**dns_config, '_zone_domain': zone_domain}
 
     @staticmethod
+    def _acme_dns_native_alias(dns_provider, dns_config):
+        """Return the acme-dns subdomain to drive CertMate's native hook with.
+
+        acme-dns has no usable certbot authenticator. The published
+        ``certbot-acme-dns`` package registers fine but exposes only
+        ``--acme-dns-server`` / ``--acme-dns-propagation-seconds`` /
+        ``--acme-dns-is-trusted`` — it never implements a credentials-file
+        option, so the ``--acme-dns-credentials`` CertMate used to pass was
+        rejected by certbot's own argument parser and acme-dns issuance could
+        never succeed (issue #466). That plugin also expects to register the
+        account itself through interactive zope prompts, which is the opposite
+        of CertMate's model (the account already exists in settings).
+
+        Publishing an acme-dns TXT record is a single authenticated POST, which
+        ``dns_alias_hook._acme_dns_change`` already performs. So every acme-dns
+        issuance is routed through that hook instead of through certbot. The
+        alias target is inherently the configured subdomain: acme-dns *is*
+        CNAME-based delegation, so the user's CNAME already points the
+        challenge name at that subdomain whether or not alias mode was asked
+        for explicitly.
+
+        Returns '' for every other provider, so callers can use it as a plain
+        "should this take the native path?" switch.
+        """
+        if dns_provider != 'acme-dns':
+            return ''
+        return str((dns_config or {}).get('subdomain') or '').strip().rstrip('.')
+
+    @staticmethod
     def _create_dns_alias_hook_config(dns_provider, dns_config, domain_alias, propagation_seconds):
         """Write temporary config consumed by the DNS alias hook."""
         if dns_provider not in DNS_ALIAS_SUPPORTED_PROVIDERS:
@@ -1175,8 +1204,11 @@ class CertificateManager:
                 # provider certbot authenticator, so the plugin is only needed
                 # for the normal non-alias DNS-01 flow. 'manual' is a certbot
                 # core feature (custom-script provider), never an installable
-                # plugin — skip the preflight for it.
-                if not domain_alias and strategy.plugin_name != 'manual':
+                # plugin — skip the preflight for it. acme-dns always takes the
+                # native hook (see _acme_dns_native_alias) and has no certbot
+                # plugin to check for either.
+                if (not domain_alias and strategy.plugin_name != 'manual'
+                        and dns_provider != 'acme-dns'):
                     plugin = strategy.plugin_name
                     if not check_certbot_plugin_installed(plugin):
                         pkg = f"certbot-{plugin}"
@@ -1346,9 +1378,15 @@ class CertificateManager:
                     process_env.setdefault('CERTMATE_DNS_PROPAGATION_SECONDS', str(propagation_time))
 
             alias_hook_provider = alias_dns_provider or dns_provider
+            # acme-dns is always driven by the native hook, with the configured
+            # subdomain standing in as the alias target when the caller did not
+            # ask for alias mode explicitly (issue #466).
+            effective_domain_alias = domain_alias or self._acme_dns_native_alias(
+                dns_provider, dns_config
+            )
             use_dns_alias_hook = (
                 challenge_type != 'http-01'
-                and domain_alias
+                and effective_domain_alias
                 and alias_hook_provider in DNS_ALIAS_SUPPORTED_PROVIDERS
             )
 
@@ -1364,11 +1402,12 @@ class CertificateManager:
                             f"Alias DNS provider '{alias_hook_provider}' is not configured"
                         )
                 logger.info(
-                    f"DNS alias '{domain_alias}' requested for {domain}; "
+                    f"DNS alias '{effective_domain_alias}' requested for {domain}; "
                     f"using {alias_hook_provider} manual hook to create TXT records on the alias zone."
                 )
                 credentials_file = self._create_dns_alias_hook_config(
-                    alias_hook_provider, alias_hook_config, domain_alias, propagation_time or strategy.default_propagation_seconds
+                    alias_hook_provider, alias_hook_config, effective_domain_alias,
+                    propagation_time or strategy.default_propagation_seconds
                 )
                 self._configure_dns_alias_arguments(certbot_cmd, credentials_file)
             else:
@@ -1683,7 +1722,31 @@ class CertificateManager:
                     metadata.get('account_id'),
                     settings,
                 )
-                if dns_config:
+                acme_dns_alias = self._acme_dns_native_alias(dns_provider, dns_config)
+                if dns_config and acme_dns_alias:
+                    # Mirror the create path: acme-dns renews through CertMate's
+                    # native hook, never through a certbot plugin (issue #466).
+                    # Certs issued before this fix carry no domain_alias in
+                    # metadata, so they land here rather than in the alias
+                    # branch above — routing on the provider keeps them renewable
+                    # without a metadata migration.
+                    strategy = DNSStrategyFactory.get_strategy(dns_provider)
+                    strategy.prepare_environment(process_env, dns_config)
+                    propagation_map = settings.get('dns_propagation_seconds', {}) or {}
+                    try:
+                        renew_propagation = int(propagation_map.get(
+                            dns_provider, strategy.default_propagation_seconds))
+                    except (ValueError, TypeError):
+                        renew_propagation = strategy.default_propagation_seconds
+                    alias_hook_config = self._create_dns_alias_hook_config(
+                        dns_provider,
+                        dns_config,
+                        acme_dns_alias,
+                        max(1, min(3600, renew_propagation)),
+                    )
+                    self._configure_dns_alias_arguments(cmd, alias_hook_config)
+                    logger.info(f"Renewing {domain} with the native acme-dns hook.")
+                elif dns_config:
                     strategy = DNSStrategyFactory.get_strategy(dns_provider)
                     strategy.prepare_environment(process_env, dns_config)
                     # Create credentials file for providers that need one.

--- a/modules/core/dns_strategies.py
+++ b/modules/core/dns_strategies.py
@@ -435,15 +435,21 @@ class AcmeDNSStrategy(DNSProviderStrategy):
         return 30
 
     def configure_certbot_arguments(self, cmd: list, credentials_file: Optional[Path], domain_alias: Optional[str] = None) -> None:
-        cmd.extend(['--authenticator', 'acme-dns'])
-        if credentials_file:
-            cmd.extend(['--acme-dns-credentials', str(credentials_file)])
-
-        if domain_alias:
-            logger.info(
-                f"DNS alias '{domain_alias}' requested for ACME-DNS — ensure a CNAME "
-                f"from _acme-challenge.<domain> to _acme-challenge.{domain_alias} exists."
-            )
+        # Unreachable by design. There is no working certbot authenticator for
+        # acme-dns: the published ``certbot-acme-dns`` package exposes only
+        # --acme-dns-server / --acme-dns-propagation-seconds / --acme-dns-is-trusted
+        # and never implements a credentials-file option, so the
+        # ``--acme-dns-credentials`` this method used to emit was rejected by
+        # certbot's argument parser and acme-dns issuance always failed
+        # (issue #466). CertificateManager routes acme-dns through the native
+        # hook instead — see CertificateManager._acme_dns_native_alias. Failing
+        # loudly here keeps a future refactor from silently restoring the
+        # broken flags.
+        raise RuntimeError(
+            "acme-dns does not use a certbot authenticator; it is driven by "
+            "CertMate's native DNS hook. This is a bug in the caller: issuance "
+            "and renewal must route through _acme_dns_native_alias."
+        )
 
 class DuckDNSStrategy(DNSProviderStrategy):
     """DuckDNS free DDNS provider via certbot-dns-duckdns plugin.

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,13 @@ certbot-dns-hetzner-cloud==1.0.5
 certbot-dns-porkbun==0.11.0
 certbot-dns-godaddy==2.8.0
 certbot-dns-arvancloud==0.1.0
-certbot-acme-dns==0.3.1
+# acme-dns needs NO certbot plugin. certbot-acme-dns==0.3.1 was pinned here
+# until v2.24.0 but never worked: it exposes no --acme-dns-credentials option,
+# so certbot rejected the command line CertMate built and every acme-dns
+# issuance failed (issue #466). It also drags in zope.component/zope.interface
+# and drives interactive registration prompts, neither of which fits a
+# headless subprocess. CertMate now publishes acme-dns TXT records itself via
+# modules/core/dns_alias_hook.py (a single authenticated POST).
 # DuckDNS: free DDNS subdomain provider. Enables "no-domain" cert issuance
 # for homelabs / self-hosted services via *.duckdns.org.
 certbot-dns-duckdns==1.8.0

--- a/tests/test_acme_dns_native_hook.py
+++ b/tests/test_acme_dns_native_hook.py
@@ -147,10 +147,42 @@ def test_acme_dns_native_alias_only_applies_to_acme_dns():
         'acme-dns', _provider_config('acme-dns')) == ACME_DNS_SUBDOMAIN
     assert CertificateManager._acme_dns_native_alias(
         'cloudflare', _provider_config('cloudflare')) == ''
-    # Trailing dots are normalised; a missing/blank subdomain yields no alias,
-    # so the caller reports the usual "not configured" error instead of
-    # silently building a hook payload with an empty target.
+    # Trailing dots are normalised.
     assert CertificateManager._acme_dns_native_alias(
         'acme-dns', {'subdomain': 'sub.example.net.'}) == 'sub.example.net'
-    assert CertificateManager._acme_dns_native_alias('acme-dns', {}) == ''
-    assert CertificateManager._acme_dns_native_alias('acme-dns', None) == ''
+
+
+@pytest.mark.parametrize('config', [{}, None, {'subdomain': '   '}])
+def test_acme_dns_without_a_subdomain_reports_a_config_error(config):
+    """A blank subdomain is a settings problem, and must say so.
+
+    Returning '' here would drop the request back onto the plugin path, where
+    AcmeDNSStrategy raises "this is a bug in the caller" — true of the code
+    path, useless to the person who just left a field empty.
+    """
+    with pytest.raises(ValueError, match='missing its Subdomain'):
+        CertificateManager._acme_dns_native_alias('acme-dns', config)
+
+
+def test_acme_dns_missing_subdomain_surfaces_through_create(tmp_path):
+    """Issuance fails with the config error, not with "bug in the caller".
+
+    ValueError is how create_certificate reports every other validation
+    problem (bad SAN, unknown provider); the API layer turns it into a 4xx.
+    """
+    mgr, shell = _manager(tmp_path, provider='acme-dns')
+    mgr.dns_manager.get_dns_provider_account_config.return_value = (
+        {'api_url': 'https://auth.acme-dns.io', 'username': 'u', 'password': 'p'},
+        'production',
+    )
+
+    with pytest.raises(ValueError, match='missing its Subdomain'):
+        mgr.create_certificate(
+            domain='app.certmate.example',
+            email='test@example.com',
+            dns_provider='acme-dns',
+            staging=True,
+        )
+
+    # It must fail before certbot is ever invoked.
+    assert shell.commands_executed == []

--- a/tests/test_acme_dns_native_hook.py
+++ b/tests/test_acme_dns_native_hook.py
@@ -1,0 +1,156 @@
+"""Regression tests for issue #466 — acme-dns must never touch certbot plugins.
+
+The published ``certbot-acme-dns`` package registers as an authenticator but
+implements no credentials-file option, so the ``--acme-dns-credentials`` flag
+CertMate used to emit was rejected by certbot's own argument parser
+("unrecognized arguments") and acme-dns issuance could never succeed. acme-dns
+is now driven end to end by CertMate's native DNS hook, both on issuance and on
+renewal — including for certificates issued before the fix, whose metadata
+carries no ``domain_alias``.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from modules.core.certificates import CertificateManager
+from modules.core.dns_strategies import AcmeDNSStrategy
+
+# Reuse the fixtures the DNS-alias suite already maintains so the acme-dns
+# account shape stays defined in exactly one place.
+from tests.test_domain_alias import _manager, _provider_config
+
+ACME_DNS_SUBDOMAIN = 'certmate-validation.example.net'
+
+
+def _cmd(shell):
+    return shell.commands_executed[0].split()
+
+
+def test_acme_dns_issuance_uses_native_hook_not_certbot_plugin(tmp_path):
+    """The exact scenario from #466: plain acme-dns issuance, no alias mode."""
+    mgr, shell = _manager(tmp_path, provider='acme-dns')
+
+    result = mgr.create_certificate(
+        domain='app.certmate.example',
+        email='test@example.com',
+        dns_provider='acme-dns',
+        staging=True,
+    )
+
+    assert result['success'] is True
+    cmd = _cmd(shell)
+    assert '--manual' in cmd
+    assert '--manual-auth-hook' in cmd
+    assert '--manual-cleanup-hook' in cmd
+    # The flags that made certbot bail out with "unrecognized arguments".
+    assert '--acme-dns-credentials' not in cmd
+    assert '--acme-dns-propagation-seconds' not in cmd
+    assert '--authenticator' not in cmd
+
+
+def test_acme_dns_issuance_does_not_require_a_certbot_plugin(tmp_path):
+    """No plugin preflight: there is no acme-dns plugin worth checking for."""
+    mgr, _shell = _manager(tmp_path, provider='acme-dns')
+
+    with patch('modules.core.certificates.check_certbot_plugin_installed') as plugin_check:
+        result = mgr.create_certificate(
+            domain='app.certmate.example',
+            email='test@example.com',
+            dns_provider='acme-dns',
+            staging=True,
+        )
+
+    assert result['success'] is True
+    plugin_check.assert_not_called()
+
+
+def test_acme_dns_hook_config_carries_account_and_subdomain(tmp_path):
+    """The hook needs the acme-dns credentials, and must clean them up after."""
+    mgr, _shell = _manager(tmp_path, provider='acme-dns')
+    captured = {}
+    original = CertificateManager._configure_dns_alias_arguments
+
+    def capture_config(cmd, hook_config):
+        captured['path'] = Path(hook_config)
+        captured['content'] = json.loads(captured['path'].read_text())
+        original(cmd, hook_config)
+
+    with patch.object(CertificateManager, '_configure_dns_alias_arguments', side_effect=capture_config):
+        result = mgr.create_certificate(
+            domain='app.certmate.example',
+            email='test@example.com',
+            dns_provider='acme-dns',
+            staging=True,
+        )
+
+    assert result['success'] is True
+    payload = captured['content']
+    assert payload['provider'] == 'acme-dns'
+    # The alias target is the configured subdomain even though the caller
+    # never passed domain_alias — acme-dns is CNAME delegation by nature.
+    assert payload['domain_alias'] == ACME_DNS_SUBDOMAIN
+    assert payload['config']['api_url'] == 'https://auth.acme-dns.io'
+    assert payload['config']['username'] == 'acme-user'
+    assert payload['config']['subdomain'] == ACME_DNS_SUBDOMAIN
+    # Credentials must not outlive the certbot run.
+    assert not captured['path'].exists()
+
+
+def test_acme_dns_renewal_without_metadata_alias_uses_native_hook(tmp_path):
+    """Certificates issued before the fix have no domain_alias in metadata.
+
+    They must still renew through the hook rather than falling back to the
+    broken plugin path, without requiring a metadata migration.
+    """
+    mgr, shell = _manager(tmp_path, provider='acme-dns')
+    domain_dir = tmp_path / 'app.certmate.example'
+    domain_dir.mkdir()
+    (domain_dir / 'cert.pem').write_text('fake certificate content')
+    (domain_dir / 'metadata.json').write_text(json.dumps({
+        'domain': 'app.certmate.example',
+        'dns_provider': 'acme-dns',
+        'account_id': 'production',
+        # deliberately no domain_alias / alias_dns_provider
+    }))
+
+    captured = {}
+    original = CertificateManager._configure_dns_alias_arguments
+
+    def capture_config(cmd, hook_config):
+        captured['content'] = json.loads(Path(hook_config).read_text())
+        original(cmd, hook_config)
+
+    with patch.object(CertificateManager, '_configure_dns_alias_arguments', side_effect=capture_config):
+        result = mgr.renew_certificate('app.certmate.example')
+
+    assert result['success'] is True
+    cmd = _cmd(shell)
+    assert '--manual' in cmd
+    assert '--manual-auth-hook' in cmd
+    assert '--acme-dns-credentials' not in cmd
+    assert captured['content']['provider'] == 'acme-dns'
+    assert captured['content']['domain_alias'] == ACME_DNS_SUBDOMAIN
+
+
+def test_acme_dns_strategy_refuses_to_build_certbot_arguments():
+    """Guard rail: restoring the plugin flags must fail loudly, not silently."""
+    with pytest.raises(RuntimeError, match='native DNS hook'):
+        AcmeDNSStrategy().configure_certbot_arguments([], Path('/tmp/creds.json'))
+
+
+def test_acme_dns_native_alias_only_applies_to_acme_dns():
+    """The routing switch must not divert any other provider to the hook."""
+    assert CertificateManager._acme_dns_native_alias(
+        'acme-dns', _provider_config('acme-dns')) == ACME_DNS_SUBDOMAIN
+    assert CertificateManager._acme_dns_native_alias(
+        'cloudflare', _provider_config('cloudflare')) == ''
+    # Trailing dots are normalised; a missing/blank subdomain yields no alias,
+    # so the caller reports the usual "not configured" error instead of
+    # silently building a hook payload with an empty target.
+    assert CertificateManager._acme_dns_native_alias(
+        'acme-dns', {'subdomain': 'sub.example.net.'}) == 'sub.example.net'
+    assert CertificateManager._acme_dns_native_alias('acme-dns', {}) == ''
+    assert CertificateManager._acme_dns_native_alias('acme-dns', None) == ''


### PR DESCRIPTION
Closes #466.

## The bug

Every acme-dns certificate request failed with:

```
certbot: error: unrecognized arguments: --acme-dns-credentials <credential file>
```

## Root cause

The pinned `certbot-acme-dns==0.3.1` **does** register with certbot — `certbot plugins` lists it — but it exposes only:

- `--acme-dns-server`
- `--acme-dns-propagation-seconds`
- `--acme-dns-is-trusted`

It implements **no credentials-file option at all**, so the command line `AcmeDNSStrategy` built could never parse. acme-dns issuance has been broken for as long as this strategy has existed; it is not a recent regression.

Reproduced against this repo's exact pins (certbot 2.10.0, cryptography 46.0.7, pyopenssl 26.0.0, josepy 1.13.0):

```
$ certbot --help acme-dns
acme-dns:
  Obtains certificates using an ACME DNS server.
  --acme-dns-propagation-seconds ACME_DNS_PROPAGATION_SECONDS
  --acme-dns-server ACME_DNS_SERVER
  --acme-dns-is-trusted

$ certbot certonly --authenticator acme-dns --acme-dns-credentials /tmp/x.json -d example.com --dry-run
certbot: error: unrecognized arguments: --acme-dns-credentials /tmp/x.json
```

That plugin is also simply the wrong shape for CertMate: it registers the acme-dns account *itself*, through interactive `zope.component` display prompts, whereas CertMate stores an already-registered account (`api_url` + `username` + `password` + `subdomain`) in settings and runs certbot headless in a subprocess.

## The fix

Publishing an acme-dns TXT record is a single authenticated POST — and CertMate **already** implements it, in `dns_alias_hook._acme_dns_change`. It was just gated behind explicit DNS-alias mode. This PR routes *every* acme-dns issuance and renewal through that hook.

The alias target is inherently the configured subdomain: acme-dns *is* CNAME delegation, so the user's `_acme-challenge.<domain>` CNAME already points at that subdomain whether or not alias mode was requested.

- **`certificates.py`** — new `_acme_dns_native_alias()` routing switch, used on the create path, on renewal, and to skip the certbot-plugin preflight. Renewal routes on the **provider**, not on metadata, so certificates issued before this fix keep renewing with no metadata migration.
- **`dns_strategies.py`** — `AcmeDNSStrategy.configure_certbot_arguments` now raises instead of emitting flags certbot rejects, so a future refactor cannot silently restore them.
- **`requirements.txt`** — drop `certbot-acme-dns` entirely. It never worked, and it dragged `zope.component`/`zope.interface` into the image for nothing.
- **docs (en/it/de/fr/es)** — acme-dns needs no plugin; also documents the required Subdomain field, which the table omitted.

## Tests

New `tests/test_acme_dns_native_hook.py` (6 tests), each of which fails on `main`:

- plain acme-dns issuance uses `--manual-auth-hook` and emits no `--acme-dns-credentials`
- no certbot-plugin preflight runs for acme-dns
- the hook payload carries the account + subdomain and is deleted afterwards
- **renewal of a pre-fix certificate** (no `domain_alias` in metadata) still takes the hook
- `configure_certbot_arguments` raises
- the routing switch diverts acme-dns only, and normalises/rejects blank subdomains

Full suite: **2220 passed**, 8 skipped, 2 xfailed. `flake8` gate clean, `bandit --severity-level medium` clean.

## Note for reviewers

I could not exercise a live acme-dns server end to end. The certbot argument rejection, the plugin's real option set, and the hook routing are all verified; the actual TXT publish path is the pre-existing `_acme_dns_change` code, unchanged by this PR and already covered by `tests/test_domain_alias.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)