### PR TITLE
fix(docker): upgrade the runtime stage's bundled pip (#403)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,10 +58,19 @@ WORKDIR /app
 # routinely start with `#!/bin/bash` — without bash the kernel cannot resolve
 # the shebang and the script returns exit 127 (issue #207).
 # apt-get upgrade pulls security patches for glibc, zlib, etc.
+#
+# The pip upgrade is this stage's, not the builder's. The builder already runs
+# `pip install -U pip`, but that only patches the BUILDER's interpreter — the
+# runtime stage starts from the same base image with its own bundled pip under
+# /usr/local/lib/python3.12/site-packages, which nothing touched. That stale
+# copy is what the Trivy scan keeps reporting (CVE-2026-8643, CVE-2026-6357,
+# CVE-2026-3219 against pip 25.0.1); the app itself runs from /opt/venv and
+# never uses it. See issue #403.
 RUN apt-get update && \
     apt-get upgrade -y -o Acquire::Retries=3 && \
     apt-get install -y -o Acquire::Retries=3 bash curl tini && \
     rm -rf /var/lib/apt/lists/* && \
+    pip install --no-cache-dir --upgrade pip && \
     useradd --create-home --shell /bin/bash certmate
 
 # Copy virtual environment from builder stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,11 +66,17 @@ WORKDIR /app
 # copy is what the Trivy scan keeps reporting (CVE-2026-8643, CVE-2026-6357,
 # CVE-2026-3219 against pip 25.0.1); the app itself runs from /opt/venv and
 # never uses it. See issue #403.
+#
+# Pinned, for the same reason the base image is pinned by digest a few lines
+# up: an unpinned `--upgrade pip` would make the runtime stage's contents
+# depend on whatever PyPI happens to serve at build time, so two builds of the
+# same commit could differ. Bump this deliberately when a pip CVE lands.
+ARG PIP_VERSION=26.1.2
 RUN apt-get update && \
     apt-get upgrade -y -o Acquire::Retries=3 && \
     apt-get install -y -o Acquire::Retries=3 bash curl tini && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir "pip==${PIP_VERSION}" && \
     useradd --create-home --shell /bin/bash certmate
 
 # Copy virtual environment from builder stage


### PR DESCRIPTION
Partial fix for #403.

## What

Trivy reports `pip` 25.0.1 in the published image — CVE-2026-8643, CVE-2026-6357, CVE-2026-3219 — even though the builder stage already runs `pip install -U pip`.

That upgrade only ever touched the **builder's** interpreter. The runtime stage starts `FROM` the same base image with its own bundled pip under `/usr/local/lib/python3.12/site-packages`, and nothing upgraded it. That stale copy is what ships, and what Trivy scans:

```
usr/local/lib/python3.12/site-packages/pip-25.0.1.dist-info/METADATA
```

## How

One command added to the runtime stage's existing `apt-get` layer, so the image gains no extra layer.

The application runs from `/opt/venv` and never invokes this pip, so the change is invisible at runtime. It exists so we stop shipping a known-vulnerable copy to anyone who execs into the container and runs `pip`.

## Scope

This is the only Trivy finding in #403 that we can actually close. Of the 247 open Trivy alerts, the **4 CRITICALs are all `perl-base` 5.40.1-6 with an empty `Fixed Version`** — no patched package exists upstream yet, so no rebuild moves them. The rest are OS-layer packages inherited from the base image.

Not touched here, deliberately: `cryptography` 46.0.7 (GHSA-537c-gmf6-5ccf, HIGH) stays pinned. 48.0.1 requires pyopenssl>=26.2.0, which removes `OpenSSL.crypto.X509Extension`, which `acme==3.3.0` evaluates at import time — certbot then crashes on startup. Documented in SECURITY.md; it unblocks with the certbot 5.x epic (#103).

## Verification

I have no Docker daemon on this machine, so the image build and the Trivy delta are verified by this PR's own `build` and `security-scan` jobs rather than locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)