### PR TITLE
chore(release): make version drift and the sed bug impossible, not just fixed

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -158,6 +158,21 @@ dh.write_text(
     re.sub(r'("version": ")[0-9]+\.[0-9]+\.[0-9]+(")', rf"\g<1>{v}\g<2>", dh.read_text()),
     encoding="utf-8",
 )
+# Same reasoning for the "Current Version" line on every docs landing page, in
+# every language. These were bumped by hand for v2.24.0 and then AGAIN for
+# v2.24.1 (#483, #487) because the script did not own them. Globbed, so a
+# translation added later is picked up without editing this script;
+# test_version_consistency fails the build if one is ever missed.
+docs = sorted(pathlib.Path("docs").glob("index.md")) + sorted(pathlib.Path("docs").glob("*/index.md"))
+for page in docs:
+    text = page.read_text(encoding="utf-8")
+    bumped = re.sub(
+        r"(?m)^(\*\*[^*]+\*\*\s*:?[ \t]*)[0-9]+\.[0-9]+\.[0-9]+[ \t]*$",
+        rf"\g<1>{v}",
+        text,
+    )
+    if bumped != text:
+        page.write_text(bumped, encoding="utf-8")
 PY
   [ "$("$PY" -c 'import json;from modules import __version__;print(json.load(open("package.json"))["version"]==__version__)')" = "True" ] \
     || die "version files disagree after bump"
@@ -169,7 +184,7 @@ real-cert E2E skipped (non-issuance change): $skip_reason"
   # the commit produced a release PR whose own CI failed on the version-
   # consistency test — a gate the local run cannot catch, because the bump
   # happens after the gates.
-  git add modules/__init__.py package.json README.dockerhub.md
+  git add modules/__init__.py package.json README.dockerhub.md docs/index.md docs/*/index.md
   git commit -q -m "$body
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
@@ -179,7 +194,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 $( [ "$run_real_cert" = 1 ] && echo "Gates: unit+integration, UI, real-cert E2E (LE staging), Docker build - all green locally." \
      || echo "Gates: unit+integration, UI, Docker build - all green locally. Real-cert E2E skipped (non-issuance): $skip_reason." )"
   gh pr create --base main --head "$branch" \
-    --title "v$version - $(notes_section "$version" | head -1 | sed 's/^## v[0-9.]* (\?//; s/)\?$//')" \
+    --title "v$version - $(notes_section "$version" | head -1 | sed -E 's/^## v[0-9.]+ \(?//; s/\)?$//')" \
     --body "$pr_body"
   echo; info "PR opened. When CI is green and it is merged, run: scripts/release.sh publish $version"
 }

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,13 +1,37 @@
-"""Single-source-of-truth guard: package.json, modules.__version__ and the
-version printed in the Docker Hub README's /health example must agree. A drift
-here means a release bumped one and forgot the others."""
+"""Single-source-of-truth guard: every user-facing copy of the version number
+must agree with modules.__version__. A drift here means a release bumped one
+and forgot the others.
+
+The rule these tests encode: a version string that has to be *remembered* is a
+version string that goes stale. Everything listed here is bumped by
+scripts/release.sh, and these tests are what turn a forgotten bump into a red
+CI run instead of a release that quietly misinforms people about what they are
+running."""
 import json
 import pathlib
 import re
 
+import pytest
+
 from modules import __version__
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Globbed, not enumerated: a translation added later is covered the day it
+# lands, without anyone remembering to extend this list. Both v2.24.0 and
+# v2.24.1 shipped with these pages stale (#483, and again in #487) precisely
+# because they were only ever fixed by hand.
+DOCS_LANDING_PAGES = sorted(REPO_ROOT.glob("docs/index.md")) + sorted(
+    REPO_ROOT.glob("docs/*/index.md")
+)
+
+# Matches the localised "current version" line in any language:
+#   **Current Version**: 2.24.1
+#   **Version actuelle** : 2.24.1
+#   **Versione corrente**: 2.24.1
+DOCS_VERSION_LINE = re.compile(
+    r"^\*\*[^*]+\*\*\s*:?[ \t]*([0-9]+\.[0-9]+\.[0-9]+)[ \t]*$", re.M
+)
 
 
 def test_package_json_matches_module_version():
@@ -33,3 +57,43 @@ def test_dockerhub_readme_health_example_matches_module_version():
             f"README.dockerhub.md shows version {found!r} but "
             f"modules.__version__ is {__version__!r}."
         )
+
+
+def test_there_are_docs_landing_pages_to_check():
+    """Guard the guard: an empty glob would make the test below vacuously pass."""
+    assert DOCS_LANDING_PAGES, "no docs/**/index.md found - has the layout moved?"
+
+
+@pytest.mark.parametrize(
+    "path", DOCS_LANDING_PAGES, ids=lambda p: str(p.relative_to(REPO_ROOT))
+)
+def test_docs_landing_page_version_matches_module_version(path):
+    """The "Current Version" line on every docs landing page, in every language."""
+    found = DOCS_VERSION_LINE.findall(path.read_text(encoding="utf-8"))
+    rel = path.relative_to(REPO_ROOT)
+    assert found, (
+        f"{rel} has no '**Current Version**: X.Y.Z' line. If the line was "
+        f"renamed or removed, update DOCS_VERSION_LINE - do not delete this "
+        f"test, or the page can drift unnoticed."
+    )
+    for version in found:
+        assert version == __version__, (
+            f"{rel} advertises version {version!r} but modules.__version__ is "
+            f"{__version__!r}. scripts/release.sh bumps this file; if you are "
+            f"seeing this outside a release, it was edited by hand."
+        )
+
+
+def test_release_notes_document_the_current_version():
+    """No version may ship without a section describing it.
+
+    scripts/release.sh refuses to prepare a release whose notes are missing,
+    but that check only runs on the machine cutting the release. This makes the
+    same rule hold in CI, for any path that reaches main.
+    """
+    text = (REPO_ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
+    assert re.search(rf"^## v{re.escape(__version__)}\b", text, re.M), (
+        f"RELEASE_NOTES.md has no '## v{__version__}' section. Every released "
+        f"version needs one - scripts/release.sh builds the GitHub release body "
+        f"from it."
+    )

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -61,7 +61,9 @@ def test_dockerhub_readme_health_example_matches_module_version():
 
 def test_there_are_docs_landing_pages_to_check():
     """Guard the guard: an empty glob would make the test below vacuously pass."""
-    assert DOCS_LANDING_PAGES, "no docs/**/index.md found - has the layout moved?"
+    assert DOCS_LANDING_PAGES, (
+        "neither docs/index.md nor docs/*/index.md matched - has the layout moved?"
+    )
 
 
 @pytest.mark.parametrize(
@@ -92,8 +94,14 @@ def test_release_notes_document_the_current_version():
     same rule hold in CI, for any path that reaches main.
     """
     text = (REPO_ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
-    assert re.search(rf"^## v{re.escape(__version__)}\b", text, re.M), (
-        f"RELEASE_NOTES.md has no '## v{__version__}' section. Every released "
-        f"version needs one - scripts/release.sh builds the GitHub release body "
-        f"from it."
+    # The trailing space is part of the contract, not sloppiness: notes_section()
+    # in scripts/release.sh matches with `awk -v v="## v$1 "` and index($0,v)==1,
+    # so a bare "## v2.24.1" heading with no title extracts an EMPTY section and
+    # the release dies there. Asserting the looser form would let CI go green on
+    # notes the release script cannot read.
+    assert re.search(rf"^## v{re.escape(__version__)} \S", text, re.M), (
+        f"RELEASE_NOTES.md has no '## v{__version__} <title>' section. Every "
+        f"released version needs one, and the heading must carry a title after "
+        f"the version - scripts/release.sh extracts the GitHub release body by "
+        f"matching the literal prefix '## v{__version__} '."
     )


### PR DESCRIPTION
Follow-up to the v2.24.1 release. Two defects surfaced while cutting it, and both had already happened before and been patched by hand.

## What broke

**1. Docs landing pages drift.** The five `docs/**/index.md` pages carry a hand-written "Current Version" line that `scripts/release.sh` did not own. It went stale for v2.24.0 (fixed by hand in #483) and again for v2.24.1 (#487).

**2. The PR-title `sed` is not portable.** It used GNU's `\?`, which BSD sed on macOS treats as a *literal* `?`. No substitution happened, so v2.24.1's release PR opened with the title `v2.24.1 - ## v2.24.1 (ACME-DNS, which had never worked)`.

## Why the script fix alone is not enough

Both bugs are the same failure: a release step that has to be **remembered**. `release.sh` already encodes the counter-argument, in its own comment about `README.dockerhub.md` — *"an example that has to be remembered is an example that goes stale"*. The docs pages were simply never given the same treatment.

So this PR fixes the script **and** adds the gate:

- `release.sh` bumps every `docs/**/index.md`, **globbed** — a translation added later is covered the day it lands, with no edit to the script.
- `sed -E`, which behaves identically on BSD and GNU.
- `test_version_consistency` now pins every docs landing page (also globbed), with a `test_there_are_docs_landing_pages_to_check` guard so an empty glob cannot make the parametrised test vacuously pass — the exact "green no-op gate" this repo's CI hardening set out to eliminate.
- A new test asserts `RELEASE_NOTES.md` contains a section for the current version. `release.sh` refuses to prepare a release without one, but that check only ever runs on the machine cutting the release; this makes the rule hold in CI for any path reaching main.

## Verification

The gate was confirmed to actually fail, not just pass:

```
$ sed -i '' 's/2.24.1/2.24.0/' docs/it/index.md && pytest tests/test_version_consistency.py
AssertionError: docs/it/index.md advertises version '2.24.0' but
modules.__version__ is '2.24.1'. scripts/release.sh bumps this file; if you
are seeing this outside a release, it was edited by hand.
1 failed, 8 passed
```

The title `sed` and the docs-bump regex were both exercised against the real files before committing. `bash -n scripts/release.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)