### PR TITLE
fix: a CA without an email no longer blocks saving unrelated settings (#491)

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -160,6 +160,11 @@
 
         addDebugLog('Saving main settings...', 'info');
 
+        // Set when the selected CA has no email but the save is allowed
+        // through anyway (#491); surfaced after the save succeeds so it does
+        // not read as a failure.
+        var missingCaEmailWarning = null;
+
         try {
             var formData = new FormData(form);
             var caProviders = collectCAProviderSettings();
@@ -229,7 +234,21 @@
                 settings.pfx_password = pfxPasswordField.value;
             }
 
-            // Validate required fields - email comes from the selected CA provider
+            // The email belongs to the selected CA provider. It is needed to
+            // register an ACME account when a certificate is issued — NOT to
+            // save settings: validate_settings_post never looks at it, so this
+            // was a client-side block on a value the backend does not require.
+            //
+            // Blocking here made every unrelated change unsaveable — a DNS
+            // provider, a storage backend, a regenerated bearer token — for
+            // anyone whose selected CA had no email yet, including right after
+            // switching the default CA. See issue #491.
+            //
+            // It is still enforced to finish initial setup, mirroring how the
+            // API bearer token check below is scoped to setup_completed. After
+            // that it degrades to a warning shown once the save succeeds:
+            // create_certificate still raises "Domain and email are required"
+            // if it is genuinely missing at issuance time.
             if (!settings.email) {
                 var caDisplayName = defaultCA === 'letsencrypt' ? "Let's Encrypt" :
                     defaultCA === 'letsencrypt_staging' ? "Let's Encrypt (Staging)" :
@@ -239,7 +258,10 @@
                     defaultCA === 'sslcom' ? 'SSL.com' :
                     defaultCA === 'digicert' ? 'DigiCert' :
                     defaultCA === 'private_ca' ? 'Private CA' : defaultCA;
-                throw new Error('Email address is required in the ' + caDisplayName + ' configuration section');
+                if (!currentSettings.setup_completed) {
+                    throw new Error('Email address is required in the ' + caDisplayName + ' configuration section');
+                }
+                missingCaEmailWarning = caDisplayName + ' has no email address, so issuing with it will fail until you add one';
             }
 
             if (settings.challenge_type !== 'http-01' && !settings.dns_provider) {
@@ -323,6 +345,9 @@
                 .then(function (result) {
                     addDebugLog('Settings saved successfully', 'info');
                     showMessage('Settings saved successfully', 'success');
+                    if (missingCaEmailWarning) {
+                        showMessage(missingCaEmailWarning, 'warning');
+                    }
 
                     // Reload settings to refresh the UI
                     return loadSettings();

--- a/tests/test_frontend_state_regressions.py
+++ b/tests/test_frontend_state_regressions.py
@@ -183,3 +183,36 @@ def test_no_file_under_tests_is_silently_gitignored():
     out = result.stdout.split()
     swallowed = [f for f in out if f.endswith(".py")]
     assert not swallowed, f"gitignore is hiding test files: {swallowed}"
+
+
+def test_missing_ca_email_does_not_block_saving_unrelated_settings():
+    """#491: a CA without an email must not make the Settings page unsaveable.
+
+    The email registers an ACME account at issuance time. The backend never
+    required it to *save* settings — `validate_settings_post` does not look at
+    it — but settings.js threw unconditionally when the selected CA had no
+    email, so a DNS provider change, a storage backend change or a regenerated
+    bearer token could not be saved at all. Switching the default CA hit it
+    immediately, since the new CA's email field starts empty.
+
+    The guard is kept for initial setup only, mirroring the API-bearer-token
+    check a few lines below it, and degrades to a warning afterwards.
+    """
+    js = _read("static/js/settings.js")
+
+    marker = "Email address is required in the "
+    assert marker in js, "the initial-setup guard disappeared entirely"
+
+    # The throw must be reachable only before setup is complete.
+    guard = js[js.index(marker) - 400:js.index(marker)]
+    assert "setup_completed" in guard, (
+        "the missing-CA-email error is thrown unconditionally again — that is "
+        "#491: it blocks saving settings that have nothing to do with the CA"
+    )
+
+    # And the post-setup path must still tell the user, without failing.
+    assert "missingCaEmailWarning" in js, (
+        "the non-blocking warning was removed; a silently missing CA email "
+        "surfaces only as a failed issuance later"
+    )
+    assert "showMessage(missingCaEmailWarning, 'warning')" in js


### PR DESCRIPTION
Closes #491. Reported by @exterrestris.

## The bug

Open Settings, change anything, click Save:

> Error saving settings: Email address is required in the Let's Encrypt configuration section

A DNS provider change, a storage backend, a freshly generated bearer token — none of it could be saved. As the reporter noted, switching the default CA hits it immediately, because the newly selected CA's email field starts empty.

## Why it was wrong

The email registers an ACME account **when a certificate is issued**. It was never required to *save* settings — `validate_settings_post` in `modules/core/settings.py` does not look at it. The block was purely client-side, on a value the backend does not ask for, and it gated the entire form on one unrelated field.

## The fix

`settings.js` keeps the guard for **initial setup only**, mirroring the API-bearer-token check a few lines below it, which is already scoped to `setup_completed`. That precedent is what the shape of this fix follows.

After setup, the save goes through and a warning toast reports that issuing with that CA will fail until an email is added. Nothing becomes silently broken: `create_certificate` still raises `"Domain and email are required"` if it is genuinely missing at issuance time.

## Tests

A source-level guard in `tests/test_frontend_state_regressions.py`, the established pattern in this repo for frontend defects that a green CI cannot see (the Playwright suite needs a running container).

It asserts the throw is reachable only before `setup_completed`, and that the non-blocking warning path still exists. **Verified it actually fails**: restoring the unconditional throw turns it red with

```
AssertionError: the missing-CA-email error is thrown unconditionally again — that is
#491: it blocks saving settings that have nothing to do with the CA
```

Full suite: **2234 passed**, 6 skipped. `theme_codemod --check` clean, flake8 and bandit clean. No template or CSS change, so no bundle rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)