### PR TITLE
fix: closing the certificate drawer abandons an in-progress edit (#492)

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -2093,6 +2093,10 @@
     }
 
     function cancelEditReissue() {
+        // No-op outside edit mode, so closing the drawer can call this
+        // unconditionally (#492) without wiping a create form the user was
+        // half-way through filling in.
+        if (!reissueEditingDomain) return;
         reissueEditingDomain = null;
         var domainField = document.getElementById('domain');
         domainField.readOnly = false;

--- a/templates/index.html
+++ b/templates/index.html
@@ -439,6 +439,15 @@
             if (focusTarget) setTimeout(function () { focusTarget.focus(); }, 320);
         }
         function closeCertDrawer() {
+            // Leaving the drawer abandons an in-progress "Edit & reissue"
+            // (#492). The edit state used to survive the close, so the next
+            // "New certificate" silently re-opened the edit form for the
+            // previous certificate, with its domain field read-only and no
+            // obvious way back. Closing a dialog is how people abandon an
+            // edit, so treat it as one. No-op when not editing.
+            if (typeof window.cancelEditReissue === 'function') {
+                window.cancelEditReissue();
+            }
             var d = document.getElementById('createCertFormContainer');
             var s = document.getElementById('certDrawerScrim');
             if (d) d.classList.add('translate-x-full');

--- a/tests/test_frontend_state_regressions.py
+++ b/tests/test_frontend_state_regressions.py
@@ -16,6 +16,7 @@ missing guard — so pinning the line is what actually stops the regression.
   which is undefined over plain HTTP — a silent no-op on a token shown once.
 """
 
+import re
 from pathlib import Path
 
 import pytest
@@ -24,6 +25,29 @@ import pytest
 pytestmark = [pytest.mark.unit]
 
 ROOT = Path(__file__).resolve().parent.parent
+
+
+def _js_function_body(source, name):
+    """Return the body of ``function <name>(...) { ... }`` by matching braces.
+
+    Slicing to a hard-coded closing-brace string (``"\\n    }"``) made these
+    guards depend on the current indentation, so a pure reformat could fail a
+    test whose behaviour was still correct. Counting braces from the function's
+    opening one is indentation-agnostic; only genuinely removing the code the
+    assertions look for turns them red.
+    """
+    match = re.search(r"function\s+%s\s*\([^)]*\)\s*\{" % re.escape(name), source)
+    assert match, f"function {name} not found — was it renamed?"
+    depth, start = 0, match.end() - 1
+    for index in range(start, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start:index + 1]
+    raise AssertionError(f"unbalanced braces while reading {name}")
 
 
 def _read(rel):
@@ -200,12 +224,18 @@ def test_missing_ca_email_does_not_block_saving_unrelated_settings():
     """
     js = _read("static/js/settings.js")
 
-    marker = "Email address is required in the "
-    assert marker in js, "the initial-setup guard disappeared entirely"
+    assert "Email address is required in the " in js, (
+        "the initial-setup guard disappeared entirely"
+    )
 
-    # The throw must be reachable only before setup is complete.
-    guard = js[js.index(marker) - 400:js.index(marker)]
-    assert "setup_completed" in guard, (
+    # The throw must sit inside a setup_completed check. Whitespace-tolerant so
+    # reindenting or rewrapping the block does not fail a still-correct file —
+    # only dropping the condition does.
+    assert re.search(
+        r"if\s*\(\s*!\s*currentSettings\.setup_completed\s*\)\s*\{\s*"
+        r"throw new Error\(\s*'Email address is required in the ",
+        js,
+    ), (
         "the missing-CA-email error is thrown unconditionally again — that is "
         "#491: it blocks saving settings that have nothing to do with the CA"
     )
@@ -215,7 +245,9 @@ def test_missing_ca_email_does_not_block_saving_unrelated_settings():
         "the non-blocking warning was removed; a silently missing CA email "
         "surfaces only as a failed issuance later"
     )
-    assert "showMessage(missingCaEmailWarning, 'warning')" in js
+    assert re.search(
+        r"showMessage\(\s*missingCaEmailWarning\s*,\s*'warning'\s*\)", js
+    )
 
 
 def test_closing_the_cert_drawer_abandons_an_in_progress_reissue_edit():
@@ -230,20 +262,17 @@ def test_closing_the_cert_drawer_abandons_an_in_progress_reissue_edit():
     the mode. cancelEditReissue no-ops outside edit mode, so this cannot wipe
     a create form the user was half-way through.
     """
-    html = _read("templates/index.html")
-    js = _read("static/js/dashboard.js")
-
-    close_fn = html[html.index("function closeCertDrawer"):]
-    close_fn = close_fn[:close_fn.index("\n        }")]
+    close_fn = _js_function_body(_read("templates/index.html"), "closeCertDrawer")
     assert "cancelEditReissue" in close_fn, (
         "closeCertDrawer no longer clears the reissue edit state — that is "
         "#492: the next 'New certificate' re-opens the previous edit"
     )
 
     # The no-op guard is what makes the call above safe to make unconditionally.
-    cancel_fn = js[js.index("function cancelEditReissue"):]
-    cancel_fn = cancel_fn[:cancel_fn.index("\n    }")]
-    assert "if (!reissueEditingDomain) return;" in cancel_fn, (
+    cancel_fn = _js_function_body(_read("static/js/dashboard.js"), "cancelEditReissue")
+    assert re.search(
+        r"if\s*\(\s*!\s*reissueEditingDomain\s*\)\s*\{?\s*return", cancel_fn
+    ), (
         "cancelEditReissue lost its not-editing guard; closing the drawer now "
         "wipes a half-filled create form"
     )

--- a/tests/test_frontend_state_regressions.py
+++ b/tests/test_frontend_state_regressions.py
@@ -216,3 +216,34 @@ def test_missing_ca_email_does_not_block_saving_unrelated_settings():
         "surfaces only as a failed issuance later"
     )
     assert "showMessage(missingCaEmailWarning, 'warning')" in js
+
+
+def test_closing_the_cert_drawer_abandons_an_in_progress_reissue_edit():
+    """#492: the "Edit & reissue" state used to survive closing the drawer.
+
+    Close the edit drawer with the X or by clicking the scrim, then press
+    "New certificate": the drawer re-opened still bound to the previous
+    certificate, domain field read-only, with no obvious way out — the only
+    escape was a small "Cancel edit" button inside the form body.
+
+    Closing a dialog is how people abandon an edit, so closeCertDrawer resets
+    the mode. cancelEditReissue no-ops outside edit mode, so this cannot wipe
+    a create form the user was half-way through.
+    """
+    html = _read("templates/index.html")
+    js = _read("static/js/dashboard.js")
+
+    close_fn = html[html.index("function closeCertDrawer"):]
+    close_fn = close_fn[:close_fn.index("\n        }")]
+    assert "cancelEditReissue" in close_fn, (
+        "closeCertDrawer no longer clears the reissue edit state — that is "
+        "#492: the next 'New certificate' re-opens the previous edit"
+    )
+
+    # The no-op guard is what makes the call above safe to make unconditionally.
+    cancel_fn = js[js.index("function cancelEditReissue"):]
+    cancel_fn = cancel_fn[:cancel_fn.index("\n    }")]
+    assert "if (!reissueEditingDomain) return;" in cancel_fn, (
+        "cancelEditReissue lost its not-editing guard; closing the drawer now "
+        "wipes a half-filled create form"
+    )


### PR DESCRIPTION
Closes #492. Reported by @exterrestris.

## The bug

1. Open a certificate, click **Edit & reissue**
2. Close the drawer with the X, or by clicking outside it
3. Press **New certificate**

The drawer re-opens still bound to the previous certificate — domain field read-only, fields pre-filled — with no obvious way out. As the reporter put it, the only escape was a small "Cancel edit" button inside the form body, which does not even close the drawer.

## Cause

`closeCertDrawer()` hid the drawer and restored focus, but never touched the reissue state, so `reissueEditingDomain` survived the close. The next open inherited it.

## The fix

Closing a dialog is how people abandon an edit, so `closeCertDrawer()` now treats it as one — for every close path, since the X, the scrim and Escape all route through it.

`cancelEditReissue()` gained a not-editing early return. That is what makes the unconditional call safe: closing a half-filled **create** form must not wipe the fields, and only the edit case resets them.

## On the reporter's wider UX point

They also observed that "Cancel edit" sits in the form body rather than next to the submit action, and that using it leaves the drawer open. That is a fair criticism, but it is a layout change rather than a defect, so it is out of scope here — this PR fixes the trap itself: closing the drawer by any normal means now leaves a clean create form behind, which is the stated expected behaviour. Worth a follow-up issue if the button should move or disappear entirely.

## Tests

A source-level guard in `tests/test_frontend_state_regressions.py`, alongside the one added for #491, asserting both halves: `closeCertDrawer` resets the edit mode, and `cancelEditReissue` keeps its not-editing guard.

**Verified it actually fails**: removing the reset call turns it red with

```
AssertionError: closeCertDrawer no longer clears the reissue edit state — that is
#492: the next 'New certificate' re-opens the previous edit
```

Full suite: **2235 passed**, 6 skipped. `theme_codemod --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)