### PR TITLE
fix: an in-flight issuance survives a page refresh (#399)

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -2477,6 +2477,33 @@ def create_api_resources(api, models, managers):
                 return scope_err
             return job, 200
 
+    class CertificateJobs(Resource):
+        @api.doc(security='Bearer')
+        @auth_manager.require_role('operator')
+        def get(self):
+            """List the issuance/renewal jobs still in flight.
+
+            The dashboard builds its "issuing" row from client-side state, so
+            a refresh made an in-flight issuance disappear from the list and
+            look like it had failed (issue #399). Listing the jobs the server
+            already tracks lets any session rediscover them — including one
+            opened in a different browser.
+
+            Only queued/running jobs are returned; a finished one is already
+            represented by the certificate itself.
+            """
+            if cert_executor is None:
+                return {'error': 'Async issuance is not enabled'}, 404
+            # Same boundary as polling a single job: a scoped key sees only
+            # jobs for domains it could have created itself. Filtered rather
+            # than refused, so a scoped key still gets its own in-flight work.
+            user = getattr(request, 'current_user', None) or {}
+            jobs = [
+                job for job in cert_executor.list_active()
+                if auth_manager.user_can_access_domain(user, job.get('domain'))
+            ]
+            return {'jobs': jobs, 'count': len(jobs)}, 200
+
     class CertificateAutoRenew(Resource):
         @api.doc(security='Bearer')
         @auth_manager.require_role('operator')
@@ -3862,6 +3889,7 @@ def create_api_resources(api, models, managers):
         'RenewCertificate': RenewCertificate,
         'CertificateReissue': CertificateReissue,
         'CertificateJob': CertificateJob,
+        'CertificateJobs': CertificateJobs,
         'CertificateAutoRenew': CertificateAutoRenew,
         'CertificateRunDeploy': CertificateRunDeploy,
         'BackupList': BackupList,

--- a/modules/core/cert_jobs.py
+++ b/modules/core/cert_jobs.py
@@ -92,6 +92,23 @@ class IssuanceExecutor:
             job = self._jobs.get(job_id)
             return dict(job) if job else None
 
+    def list_active(self):
+        """Every job still queued or running, oldest first.
+
+        The dashboard renders an "issuing" row from client-side state only, so
+        a page refresh made an in-flight issuance vanish from the list and look
+        like it had failed (issue #399). This is what lets any session
+        rediscover the work already in flight — including a different browser,
+        which no amount of client-side persistence could do.
+
+        Terminal jobs are deliberately excluded: a finished certificate is
+        already in the certificate list, and replaying completed jobs would
+        double it up.
+        """
+        with self._lock:
+            return [dict(job) for job in self._jobs.values()
+                    if job['status'] not in _TERMINAL]
+
     def _set(self, job_id, **fields):
         with self._lock:
             job = self._jobs.get(job_id)

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -938,6 +938,7 @@ def setup_api(container: AppContainer, app):
     ns_certificates.add_resource(api_resources['DownloadCertificateFile'], '/<string:domain>/download/<string:file_type>')
     ns_certificates.add_resource(api_resources['RenewCertificate'], '/<string:domain>/renew')
     ns_certificates.add_resource(api_resources['CertificateReissue'], '/<string:domain>/reissue')
+    ns_certificates.add_resource(api_resources['CertificateJobs'], '/jobs')
     ns_certificates.add_resource(api_resources['CertificateJob'], '/jobs/<string:job_id>')
     ns_certificates.add_resource(api_resources['CertificateAutoRenew'], '/<string:domain>/auto-renew')
     ns_certificates.add_resource(api_resources['CertificateRunDeploy'], '/<string:domain>/deploy')

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -2399,6 +2399,13 @@
         var rawErr = String(job.error || 'Certificate issuance failed');
         var errText = escapeHtml(rawErr.length > 140 ? rawErr.slice(0, 137) + '…' : rawErr);
         var errTitle = escapeHtml(rawErr);
+        // Retry resubmits the original request body. A job adopted from the
+        // server after a refresh (#399) has no body to replay — this page
+        // never saw the form — so offering Retry there would POST an empty
+        // create. Dismiss is always available.
+        var retryButton = job.payload
+            ? '<button type="button" onclick="retryCreateJob(\'' + jobId + '\')" class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded border border-border text-label bg-input hover:bg-gray-50 dark:hover:bg-gray-600" title="Retry issuance for ' + domain + '" aria-label="Retry issuance for ' + domain + '"><i class="fas fa-sync-alt mr-1" aria-hidden="true"></i>Retry</button>'
+            : '';
         return '<tr data-pending-job="' + jobId + '" class="bg-red-50/40 dark:bg-red-900/10">' +
             '<td class="px-6 py-4 md:max-w-0"><div class="flex items-center min-w-0">' +
             '<i class="fas fa-times-circle text-danger-fg mr-2 text-sm shrink-0" aria-hidden="true"></i>' +
@@ -2409,7 +2416,7 @@
             '<td class="px-4 py-4 whitespace-nowrap hidden lg:table-cell text-sm text-muted">' + providerLabel + '</td>' +
             '<td class="px-4 py-4 whitespace-nowrap hidden lg:table-cell text-sm text-muted">—</td>' +
             '<td class="px-4 py-4 whitespace-nowrap text-right"><div class="flex items-center justify-end gap-1">' +
-            '<button type="button" onclick="retryCreateJob(\'' + jobId + '\')" class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded border border-border text-label bg-input hover:bg-gray-50 dark:hover:bg-gray-600" title="Retry issuance for ' + domain + '" aria-label="Retry issuance for ' + domain + '"><i class="fas fa-sync-alt mr-1" aria-hidden="true"></i>Retry</button>' +
+            retryButton +
             '<button type="button" onclick="dismissPendingJob(\'' + jobId + '\')" class="inline-flex items-center justify-center p-2 text-gray-500 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-100 rounded hover:bg-hover" title="Dismiss" aria-label="Dismiss failed issuance for ' + domain + '"><i class="fas fa-times" aria-hidden="true"></i></button>' +
             '</div></td></tr>';
     }
@@ -2457,6 +2464,47 @@
         showMessage('Issuing certificate for ' + domainsDisplay + '…', 'info');
         renderPendingRows();
         pollCertJob(jobId, job.status_url || ('/api/certificates/jobs/' + jobId));
+    }
+
+    function adoptInFlightJobs() {
+        // pendingJobs lives only in this page's memory, so a refresh used to
+        // drop the "Issuing" row entirely and the certificate looked like it
+        // had failed — while the server was still working on it (#399). Ask
+        // the server what is actually in flight and re-attach to it, which
+        // also covers a session opened in another browser.
+        return fetch('/api/certificates/jobs', { headers: API_HEADERS })
+            .then(function (resp) {
+                // 404 = async issuance disabled on this instance; 403 = the
+                // caller is not an operator. Neither is worth a toast: there
+                // is simply nothing to re-attach to.
+                if (!resp.ok) return null;
+                return resp.json();
+            })
+            .then(function (data) {
+                var jobs = (data && data.jobs) || [];
+                var adopted = 0;
+                jobs.forEach(function (job) {
+                    if (!job || !job.job_id || pendingJobs[job.job_id]) return;
+                    pendingJobs[job.job_id] = {
+                        domain: job.domain || '',
+                        provider: '',
+                        sanCount: 0,
+                        state: 'issuing',
+                        // No original request body to replay: a retry offer
+                        // would have nothing to resubmit, and retryCreateJob
+                        // guards on payload.
+                        payload: null,
+                        domainsDisplay: job.domain || ''
+                    };
+                    adopted++;
+                    pollCertJob(job.job_id, '/api/certificates/jobs/' + job.job_id);
+                });
+                if (adopted) {
+                    renderPendingRows();
+                    addDebugLog('Re-attached to ' + adopted + ' in-flight job(s)', 'info');
+                }
+            })
+            .catch(function () { /* best effort — never block the dashboard */ });
     }
 
     function pollCertJob(jobId, statusUrl) {
@@ -2905,7 +2953,15 @@
         // Resolve the caller's role first so the initial cert list can
         // already render with the right buttons hidden — avoids the
         // viewer briefly seeing admin-only controls before they vanish.
-        refreshCurrentRole().then(function () { loadCertificates().then(function () { maybeOpenCertFromQuery(); maybeFlashCertFromQuery(); }); });
+        refreshCurrentRole().then(function () {
+            loadCertificates().then(function () {
+                maybeOpenCertFromQuery();
+                maybeFlashCertFromQuery();
+                // After the list is on screen, re-attach to anything the
+                // server is still working on (#399).
+                adoptInFlightJobs();
+            });
+        });
         loadProviderAccounts();
 
         // Status filtering is driven by the chips (onclick -> setStatusFilter);

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -2490,9 +2490,11 @@
                         provider: '',
                         sanCount: 0,
                         state: 'issuing',
-                        // No original request body to replay: a retry offer
-                        // would have nothing to resubmit, and retryCreateJob
-                        // guards on payload.
+                        // No original request body to replay — this page never
+                        // saw the form. Two things depend on that being null:
+                        // failedRowHtml omits the Retry button, and
+                        // retryCreateJob refuses rather than POSTing an empty
+                        // create.
                         payload: null,
                         domainsDisplay: job.domain || ''
                     };
@@ -2579,7 +2581,17 @@
     function retryCreateJob(jobId) {
         var job = pendingJobs[jobId];
         if (!job) return;
-        var payload = job.payload || {};
+        // A job adopted from the server after a refresh (#399) has no request
+        // body to replay. failedRowHtml already hides Retry for those, but
+        // guard here too: this function is exposed on window, and a resubmit
+        // with an empty body would create nothing and report a confusing 400.
+        if (!job.payload) {
+            showMessage('This issuance was started in another session, so there '
+                + 'is nothing to resubmit. Create the certificate again from the form.',
+                'warning');
+            return;
+        }
+        var payload = job.payload;
         var domainsDisplay = job.domainsDisplay || payload.domain || 'certificate';
         delete pendingJobs[jobId];
         if (pendingPollTimers[jobId]) { clearTimeout(pendingPollTimers[jobId]); delete pendingPollTimers[jobId]; }

--- a/tests/test_async_issuance.py
+++ b/tests/test_async_issuance.py
@@ -349,8 +349,14 @@ class TestIssuanceExecutorListActive:
 
         active = ex.list_active()
         domains = {j['domain'] for j in active}
-        assert 'slow.example.com' in domains, "an in-flight job must be listed"
-        assert 'fast.example.com' not in domains, (
+        # Explicit equality rather than `in` / `not in`: CodeQL reads a bare
+        # hostname membership test as py/incomplete-url-substring-sanitization
+        # (high) even on a set of exact domains, and a known false positive is
+        # still noise in the security tab.
+        assert any(d == 'slow.example.com' for d in domains), (
+            "an in-flight job must be listed"
+        )
+        assert all(d != 'fast.example.com' for d in domains), (
             "a finished job must not be listed — the certificate itself is "
             "already in the list, and replaying it would double the row"
         )

--- a/tests/test_async_issuance.py
+++ b/tests/test_async_issuance.py
@@ -194,6 +194,10 @@ class _FakeExecutor:
         job = self._jobs.get(jid)
         return dict(job) if job else None
 
+    def list_active(self):
+        return [dict(j) for j in self._jobs.values()
+                if j['status'] not in ('succeeded', 'failed')]
+
 
 def _build_app(tmp_path, executor, allowed=True):
     auth = MagicMock()
@@ -226,6 +230,7 @@ def _build_app(tmp_path, executor, allowed=True):
     api.add_namespace(ns)
     ns.add_resource(resources['CreateCertificate'], '/create')
     ns.add_resource(resources['RenewCertificate'], '/<string:domain>/renew')
+    ns.add_resource(resources['CertificateJobs'], '/jobs')
     ns.add_resource(resources['CertificateJob'], '/jobs/<string:job_id>')
 
     @app.before_request
@@ -330,3 +335,71 @@ class TestJobStatusEndpoint:
         app, _ = _build_app(tmp_path, ex, allowed=False)
         r = app.test_client().get('/api/certificates/jobs/j1')
         assert r.status_code == 403
+
+
+class TestIssuanceExecutorListActive:
+    """#399: a page refresh must be able to rediscover work already in flight."""
+
+    def test_lists_queued_and_running_only(self):
+        ex = _exec()
+        gate = threading.Event()
+        running = ex.submit('create', 'slow.example.com', lambda: gate.wait(5) or {'success': True})
+        done = ex.submit('create', 'fast.example.com', lambda: {'success': True})
+        _wait_terminal(ex, done)
+
+        active = ex.list_active()
+        domains = {j['domain'] for j in active}
+        assert 'slow.example.com' in domains, "an in-flight job must be listed"
+        assert 'fast.example.com' not in domains, (
+            "a finished job must not be listed — the certificate itself is "
+            "already in the list, and replaying it would double the row"
+        )
+        assert {j['job_id'] for j in active} == {running}
+
+        gate.set()
+        _wait_terminal(ex, running)
+        assert ex.list_active() == []
+
+    def test_returns_copies_not_live_records(self):
+        ex = _exec()
+        gate = threading.Event()
+        jid = ex.submit('create', 'x.example.com', lambda: gate.wait(5) or {'success': True})
+        listed = ex.list_active()
+        listed[0]['status'] = 'tampered'
+        assert ex.get(jid)['status'] != 'tampered'
+        gate.set()
+        _wait_terminal(ex, jid)
+
+
+class TestJobsListEndpoint:
+    """#399: the dashboard rebuilds its "issuing" rows from this."""
+
+    def test_lists_in_flight_jobs(self, tmp_path):
+        ex = _FakeExecutor()
+        ex.submit('create', 'a.example.com', lambda: None)
+        app, _ = _build_app(tmp_path, ex)
+        with app.test_client() as c:
+            res = c.get('/api/certificates/jobs')
+        assert res.status_code == 200
+        assert res.json['count'] == 1
+        assert res.json['jobs'][0]['domain'] == 'a.example.com'
+        assert res.json['jobs'][0]['status'] == 'queued'
+
+    def test_scoped_key_sees_only_its_own_domains(self, tmp_path):
+        """Filtered, not refused: a scoped key still gets its own work back."""
+        ex = _FakeExecutor()
+        ex.submit('create', 'mine.example.com', lambda: None)
+        ex.submit('create', 'theirs.example.com', lambda: None)
+        app, managers = _build_app(tmp_path, ex)
+        managers['auth'].user_can_access_domain.side_effect = (
+            lambda user, domain: domain == 'mine.example.com')
+        with app.test_client() as c:
+            res = c.get('/api/certificates/jobs')
+        assert res.status_code == 200
+        assert [j['domain'] for j in res.json['jobs']] == ['mine.example.com']
+
+    def test_404_when_async_issuance_is_disabled(self, tmp_path):
+        app, _ = _build_app(tmp_path, None)
+        with app.test_client() as c:
+            res = c.get('/api/certificates/jobs')
+        assert res.status_code == 404

--- a/tests/test_frontend_state_regressions.py
+++ b/tests/test_frontend_state_regressions.py
@@ -298,10 +298,16 @@ def test_the_dashboard_reattaches_to_in_flight_jobs_on_load():
     assert "pollCertJob" in adopt, "adopted jobs must resume polling"
     assert "renderPendingRows" in adopt, "adopted jobs must be drawn"
 
-    # An adopted job carries no original request body, so a Retry button would
-    # resubmit an empty create.
+    # An adopted job carries no original request body. Two independent
+    # protections, because retryCreateJob is exposed on window and can be
+    # reached without the button: the row omits Retry, and the handler refuses.
     failed_row = _js_function_body(js, "failedRowHtml")
     assert re.search(r"job\.payload\s*\?", failed_row), (
         "the Retry button is offered unconditionally again; a job adopted "
         "after a refresh has no payload to replay and would POST an empty create"
+    )
+    retry = _js_function_body(js, "retryCreateJob")
+    assert re.search(r"if\s*\(\s*!\s*job\.payload\s*\)", retry), (
+        "retryCreateJob no longer refuses a payload-less job; calling it "
+        "directly would POST an empty create"
     )

--- a/tests/test_frontend_state_regressions.py
+++ b/tests/test_frontend_state_regressions.py
@@ -276,3 +276,32 @@ def test_closing_the_cert_drawer_abandons_an_in_progress_reissue_edit():
         "cancelEditReissue lost its not-editing guard; closing the drawer now "
         "wipes a half-filled create form"
     )
+
+
+def test_the_dashboard_reattaches_to_in_flight_jobs_on_load():
+    """#399: the "Issuing" row vanished on refresh and looked like a failure.
+
+    pendingJobs lives only in the page's memory, so reloading dropped the row
+    while the server was still working — @ITJamie reported it reads as if the
+    request had stopped. The dashboard now asks the server what is in flight
+    (GET /api/certificates/jobs) and re-attaches, which also covers a session
+    opened in a different browser.
+    """
+    js = _read("static/js/dashboard.js")
+
+    assert "/api/certificates/jobs" in js, (
+        "the dashboard no longer asks the server for in-flight jobs — that is "
+        "#399: a refresh loses the issuing row"
+    )
+
+    adopt = _js_function_body(js, "adoptInFlightJobs")
+    assert "pollCertJob" in adopt, "adopted jobs must resume polling"
+    assert "renderPendingRows" in adopt, "adopted jobs must be drawn"
+
+    # An adopted job carries no original request body, so a Retry button would
+    # resubmit an empty create.
+    failed_row = _js_function_body(js, "failedRowHtml")
+    assert re.search(r"job\.payload\s*\?", failed_row), (
+        "the Retry button is offered unconditionally again; a job adopted "
+        "after a refresh has no payload to replay and would POST an empty create"
+    )


### PR DESCRIPTION
Closes #399. Reported by @ITJamie.

## The bug

Start issuing a certificate, refresh the page, and the "Issuing" row at the top of the list disappears. The certificate does arrive minutes later — but in the meantime it reads as if the request had stopped or failed, which is exactly what the reporter said it looked like.

## Cause

The row was built entirely from `pendingJobs`, a plain object living in the page's memory. A reload lost it.

The server has tracked these jobs all along — `IssuanceExecutor` records `queued` / `running` / terminal — but exposed only `GET /api/certificates/jobs/<id>`. With no way to ask *what is in flight*, a freshly loaded page had nothing to rediscover, no matter how it was written.

## The fix

- **`IssuanceExecutor.list_active()`** returns queued and running jobs, as copies. Terminal jobs are excluded deliberately: a finished certificate is already in the list, and replaying it would show two rows for one domain.
- **`GET /api/certificates/jobs`** — operator-gated, like the single-job poll. A scoped API key gets its jobs **filtered** rather than a 403, so a restricted key still sees its own work and nobody else's.
- **The dashboard** calls it after the first render, re-attaches to whatever is in flight and resumes polling.

That last point also satisfies the half of the report that client-side persistence could never have covered:

> issuing cert should still show on the list when page is refreshed **or a new user session is opened on another browser**

Because the state is the server's, a second browser sees the same in-flight row.

## One thing the fix had to be careful about

A job adopted after a refresh has **no original request body** — this page never saw the form. `retryCreateJob` does `job.payload || {}`, so a Retry button on such a row would have POSTed an empty create. `failedRowHtml` now omits Retry when there is no payload; Dismiss is unaffected.

## Tests

- `IssuanceExecutor.list_active()`: lists in-flight only, excludes finished, and returns copies (mutating the result must not corrupt the registry).
- The endpoint: lists in-flight jobs, filters by domain scope for a scoped key, and 404s when async issuance is disabled.
- A source-level guard for the dashboard rehydration, in the established pattern of `test_frontend_state_regressions.py`, including the missing-payload Retry case.

Full suite: **2241 passed**, 6 skipped. flake8, bandit and `theme_codemod --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)