### PR TITLE
feat(cli): certmate cert download, so a host can pull what it deploys (#490)

### DIFF
--- a/clients/certmate-cli/README.md
+++ b/clients/certmate-cli/README.md
@@ -16,6 +16,30 @@ certmate cert create app.example.com --dns cloudflare --dry-run
 certmate audit verify
 ```
 
+## Pulling certificates onto a host
+
+`cert download` fetches one file at a time, so a target server can pull
+exactly what it deploys instead of the certificate manager pushing to it:
+
+```bash
+certmate cert download app.example.com --file fullchain -o /etc/ssl/certs/app.pem
+certmate cert download app.example.com --file privkey   -o /etc/ssl/private/app.key
+```
+
+Files are created **0600**, with the mode set at creation rather than after
+the write, so the key is never briefly world-readable.
+
+This is worth preferring over pushing when the manager would otherwise need
+credentials on every target host. Give each host an API key scoped to its own
+domain and run the pull on a timer: the host needs no inbound access, and the
+manager holds no credentials for it. `cert`, `chain` and `fullchain` are
+readable by a viewer-role key; `privkey`, `combined` and `pfx` need operator.
+
+`--file privkey --key-format pkcs1` serves the legacy
+`BEGIN RSA PRIVATE KEY` form for stacks that reject certbot's PKCS#8.
+`--bundle zip` or `--bundle json` fetch the whole certificate instead, and
+`-o -` writes to stdout.
+
 Connection comes from `--url`/`--token` or `CERTMATE_URL`/`CERTMATE_TOKEN`.
 Prefer the `CERTMATE_TOKEN` environment variable over `--token`: command-line
 arguments are visible to other local processes (`ps`) and shell history.

--- a/clients/certmate-cli/certmate_cli/main.py
+++ b/clients/certmate-cli/certmate_cli/main.py
@@ -9,8 +9,12 @@ Connection comes from --url/--token or CERTMATE_URL/CERTMATE_TOKEN.
 """
 from __future__ import annotations
 
+import json
+import os
 import re
+import stat
 import sys
+from pathlib import Path
 from typing import List, Optional
 
 import typer
@@ -262,6 +266,83 @@ def cert_rm(ctx: typer.Context, domain: str,
         typer.confirm(f"Delete certificate {domain}?", abort=True)
     _run(lambda: _client(ctx).delete_certificate(domain))
     out.print(f"[green]deleted[/] {domain}.")
+
+
+_FILE_DEFAULT_NAME = {
+    "cert": "cert.pem",
+    "chain": "chain.pem",
+    "fullchain": "fullchain.pem",
+    "privkey": "privkey.pem",
+    "combined": "combined.pem",
+    "pfx": "cert.pfx",
+}
+# Anything that can carry key material is written owner-only. The public
+# files get the same treatment: a deploy script that later relaxes them is
+# an explicit act, whereas a private key written 0644 is a silent one.
+_DOWNLOAD_MODE = 0o600
+
+
+@cert_app.command("download")
+def cert_download(
+    ctx: typer.Context,
+    domain: str,
+    file: str = typer.Option(
+        "fullchain", "--file", "-f",
+        help="Which file: cert, chain, fullchain, privkey, combined, pfx. "
+             "Use --bundle for a whole-certificate archive instead."),
+    output: Optional[str] = typer.Option(
+        None, "--output", "-o",
+        help="Where to write it. Defaults to the file's usual name in the "
+             "current directory; '-' writes to stdout."),
+    key_format: Optional[str] = typer.Option(
+        None, "--key-format",
+        help="pkcs1 or pkcs8, for --file privkey. certbot writes pkcs8; "
+             "pkcs1 is the legacy 'BEGIN RSA PRIVATE KEY' form."),
+    bundle: Optional[str] = typer.Option(
+        None, "--bundle",
+        help="Download a bundle instead of a single file: zip or json."),
+):
+    """Download a certificate file, so a host can pull what it needs.
+
+    Pulling beats pushing when the certificate manager would otherwise need
+    credentials on every target host: give each host an API key scoped to its
+    own domain and let it fetch on a timer.
+
+        certmate cert download example.com --file fullchain -o /etc/ssl/certs/x.pem
+        certmate cert download example.com --file privkey   -o /etc/ssl/private/x.key
+    """
+    if bundle is not None and bundle not in ("zip", "json"):
+        _die("--bundle must be zip or json")
+    if bundle and key_format:
+        _die("--key-format applies to --file privkey, not to a bundle")
+
+    if bundle:
+        data = _run(lambda: _client(ctx).download_certificate(domain, fmt=bundle))
+        default_name = f"{domain}.zip" if bundle == "zip" else f"{domain}.json"
+        payload = json.dumps(data, indent=2).encode() if bundle == "json" else data
+    else:
+        if file not in _FILE_DEFAULT_NAME:
+            _die(f"unknown --file {file!r}; use one of "
+                 f"{', '.join(sorted(_FILE_DEFAULT_NAME))}")
+        payload = _run(lambda: _client(ctx).download_certificate_file(
+            domain, file, key_format=key_format))
+        default_name = _FILE_DEFAULT_NAME[file]
+
+    if output == "-":
+        # Binary-safe: .pfx and .zip are not text.
+        sys.stdout.buffer.write(payload)
+        return
+
+    target = Path(output or default_name)
+    # Create with the restrictive mode rather than chmod-ing after: between
+    # an open() and a chmod() the key is readable by anyone on the box.
+    fd = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _DOWNLOAD_MODE)
+    with os.fdopen(fd, "wb") as fh:
+        fh.write(payload)
+    # An existing file keeps its old mode through O_CREAT, so state what was
+    # actually written rather than claiming 0600 unconditionally.
+    mode = stat.S_IMODE(os.stat(target).st_mode)
+    out.print(f"[green]wrote[/] {target} ({len(payload)} bytes, mode {mode:04o})")
 
 
 @cert_app.command("reissue")

--- a/clients/certmate-cli/certmate_cli/main.py
+++ b/clients/certmate-cli/certmate_cli/main.py
@@ -311,10 +311,18 @@ def cert_download(
         certmate cert download example.com --file fullchain -o /etc/ssl/certs/x.pem
         certmate cert download example.com --file privkey   -o /etc/ssl/private/x.key
     """
+    # Every one of these is checked before a request goes out: being told
+    # "invalid key_format" by the server after a round trip is a worse error
+    # than being told here, and it costs an authenticated call to learn it.
     if bundle is not None and bundle not in ("zip", "json"):
         _die("--bundle must be zip or json")
     if bundle and key_format:
         _die("--key-format applies to --file privkey, not to a bundle")
+    if key_format is not None:
+        if key_format not in ("pkcs1", "pkcs8"):
+            _die(f"unknown --key-format {key_format!r}; use pkcs1 or pkcs8")
+        if not bundle and file != "privkey":
+            _die(f"--key-format applies to --file privkey, not to {file!r}")
 
     if bundle:
         data = _run(lambda: _client(ctx).download_certificate(domain, fmt=bundle))

--- a/clients/certmate-cli/pyproject.toml
+++ b/clients/certmate-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "certmate-cli"
-version = "0.1.2"
+version = "0.1.3"
 description = "CertMate command-line interface — the SSL certificate lifecycle from your terminal"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -33,7 +33,7 @@ classifiers = [
 # The SDK floor tracks the CLI release: 0.1.2 needs TransportError and the
 # renew/audit semantics introduced in certmate-sdk 0.1.2.
 dependencies = [
-    "certmate-sdk>=0.1.2",
+    "certmate-sdk>=0.1.3",
     "typer>=0.9",
     "rich>=13",
 ]

--- a/clients/certmate-sdk/certmate/client.py
+++ b/clients/certmate-sdk/certmate/client.py
@@ -214,6 +214,17 @@ class Client:
             raise ValueError(
                 f"unknown certificate file {name!r}; use one of "
                 f"{'/'.join(sorted(self.CERT_FILES))}")
+        # Enforce the contract this docstring states instead of deferring to
+        # the server: a round trip to be told "invalid key_format" is a worse
+        # error than one raised here, and the same check already guards
+        # `name` above.
+        if key_format is not None:
+            if key_format not in ("pkcs1", "pkcs8"):
+                raise ValueError(
+                    f"unknown key_format {key_format!r}; use pkcs1 or pkcs8")
+            if name != "privkey":
+                raise ValueError(
+                    f"key_format applies to the private key, not to {name!r}")
         params = {"file": self.CERT_FILES[name]}
         if key_format:
             params["key_format"] = key_format

--- a/clients/certmate-sdk/certmate/client.py
+++ b/clients/certmate-sdk/certmate/client.py
@@ -181,6 +181,45 @@ class Client:
         return self._request("GET", f"/api/certificates/{domain}/download",
                              params=params_by_fmt[fmt])
 
+    #: Short name -> on-disk filename, matching the server's own mapping.
+    CERT_FILES: Dict[str, str] = {
+        "cert": "cert.pem",
+        "chain": "chain.pem",
+        "fullchain": "fullchain.pem",
+        "privkey": "privkey.pem",
+        "combined": "combined.pem",
+        "pfx": "cert.pfx",
+    }
+
+    def download_certificate_file(self, domain: str, name: str,
+                                  key_format: Optional[str] = None) -> bytes:
+        """Download ONE certificate file by short name, as bytes.
+
+        This is the shape a deploy script wants: fetch exactly the file that
+        goes into a given path, rather than a bundle it has to unpack.
+
+        Sent as ``?file=<filename>`` rather than the path-style
+        ``/download/<name>`` route: both exist server-side, but only the
+        query-string form accepts ``key_format``, so this one can also serve
+        the legacy PKCS#1/SEC1 key.
+
+        ``key_format`` is ``pkcs1`` or ``pkcs8`` and applies to ``privkey``
+        only; the server rejects it on any other file.
+
+        Role note: ``privkey``, ``combined`` and ``pfx`` expose private-key
+        material and require operator role, while ``cert``, ``chain`` and
+        ``fullchain`` are readable by a viewer.
+        """
+        if name not in self.CERT_FILES:
+            raise ValueError(
+                f"unknown certificate file {name!r}; use one of "
+                f"{'/'.join(sorted(self.CERT_FILES))}")
+        params = {"file": self.CERT_FILES[name]}
+        if key_format:
+            params["key_format"] = key_format
+        return self._request("GET", f"/api/certificates/{domain}/download",
+                             params=params)
+
     def set_auto_renew(self, domain: str, enabled: bool) -> Dict[str, Any]:
         return self._request("PUT", f"/api/certificates/{domain}/auto-renew",
                              json={"enabled": bool(enabled)}) or {}

--- a/clients/certmate-sdk/pyproject.toml
+++ b/clients/certmate-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "certmate-sdk"
-version = "0.1.2"
+version = "0.1.3"
 description = "Thin Python client for the CertMate REST API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_clients_cli_unit.py
+++ b/tests/test_clients_cli_unit.py
@@ -274,3 +274,17 @@ def test_download_bundle_json_is_written_as_json(tmp_path):
     import json as _json
     assert _json.loads(target.read_text())["domain"] == "app.example.com"
     client.download_certificate.assert_called_once_with("app.example.com", fmt="json")
+
+
+@pytest.mark.parametrize("args,expected", [
+    (["--file", "privkey", "--key-format", "der"], "unknown --key-format"),
+    (["--file", "fullchain", "--key-format", "pkcs1"], "--key-format applies to"),
+])
+def test_download_rejects_bad_key_format_without_calling_the_server(args, expected):
+    """Fail fast: learning this from the server costs an authenticated call."""
+    patcher, client = _cli_client()
+    with patcher:
+        result = runner.invoke(app, ["cert", "download", "app.example.com", *args])
+    assert result.exit_code != 0
+    assert expected in _all_output(result)
+    client.download_certificate_file.assert_not_called()

--- a/tests/test_clients_cli_unit.py
+++ b/tests/test_clients_cli_unit.py
@@ -192,3 +192,85 @@ def test_token_flag_stays_quiet_when_not_interactive(monkeypatch):
         result, _ = _invoke_with_client(["--token", "sekrit", "cert", "ls"],
                                         list_certificates=[])
     assert "warning" not in _all_output(result)
+
+
+# --------------------------------------------------------------------------
+# #490 — `cert download`: a host pulls what it deploys, and the file it
+# lands in is not world-readable.
+# --------------------------------------------------------------------------
+
+def _cli_client(**attrs):
+    """Patch certmate_cli.main.Client so the command runs against a stub."""
+    client = MagicMock(**attrs)
+    return patch("certmate_cli.main.Client", return_value=client), client
+
+
+def test_download_writes_the_requested_file_0600(tmp_path):
+    patcher, client = _cli_client()
+    client.download_certificate_file.return_value = b"KEYBYTES"
+    target = tmp_path / "x.key"
+    with patcher:
+        result = runner.invoke(app, ["cert", "download", "app.example.com",
+                                     "--file", "privkey", "-o", str(target)])
+    assert result.exit_code == 0, _all_output(result)
+    assert target.read_bytes() == b"KEYBYTES"
+    # The whole point of pulling onto a host: the key must not land 0644.
+    import stat as _stat
+    assert _stat.S_IMODE(target.stat().st_mode) == 0o600
+    client.download_certificate_file.assert_called_once_with(
+        "app.example.com", "privkey", key_format=None)
+
+
+def test_download_defaults_to_fullchain(tmp_path, monkeypatch):
+    patcher, client = _cli_client()
+    client.download_certificate_file.return_value = b"CHAIN"
+    monkeypatch.chdir(tmp_path)
+    with patcher:
+        result = runner.invoke(app, ["cert", "download", "app.example.com"])
+    assert result.exit_code == 0, _all_output(result)
+    assert (tmp_path / "fullchain.pem").read_bytes() == b"CHAIN"
+
+
+def test_download_forwards_key_format(tmp_path):
+    patcher, client = _cli_client()
+    client.download_certificate_file.return_value = b"LEGACY"
+    with patcher:
+        result = runner.invoke(app, ["cert", "download", "app.example.com",
+                                     "--file", "privkey", "--key-format", "pkcs1",
+                                     "-o", str(tmp_path / "k.pem")])
+    assert result.exit_code == 0, _all_output(result)
+    client.download_certificate_file.assert_called_once_with(
+        "app.example.com", "privkey", key_format="pkcs1")
+
+
+def test_download_rejects_unknown_file_without_calling_the_server():
+    patcher, client = _cli_client()
+    with patcher:
+        result = runner.invoke(app, ["cert", "download", "app.example.com",
+                                     "--file", "id_rsa"])
+    assert result.exit_code != 0
+    assert "unknown --file" in _all_output(result)
+    client.download_certificate_file.assert_not_called()
+
+
+def test_download_rejects_key_format_on_a_bundle():
+    patcher, client = _cli_client()
+    with patcher:
+        result = runner.invoke(app, ["cert", "download", "app.example.com",
+                                     "--bundle", "zip", "--key-format", "pkcs1"])
+    assert result.exit_code != 0
+    assert "--key-format applies to" in _all_output(result)
+    client.download_certificate.assert_not_called()
+
+
+def test_download_bundle_json_is_written_as_json(tmp_path):
+    patcher, client = _cli_client()
+    client.download_certificate.return_value = {"domain": "app.example.com"}
+    target = tmp_path / "b.json"
+    with patcher:
+        result = runner.invoke(app, ["cert", "download", "app.example.com",
+                                     "--bundle", "json", "-o", str(target)])
+    assert result.exit_code == 0, _all_output(result)
+    import json as _json
+    assert _json.loads(target.read_text())["domain"] == "app.example.com"
+    client.download_certificate.assert_called_once_with("app.example.com", fmt="json")

--- a/tests/test_clients_sdk_unit.py
+++ b/tests/test_clients_sdk_unit.py
@@ -406,3 +406,17 @@ def test_download_certificate_file_unknown_name_raises_before_any_request():
     with _mock_client(handler) as c:
         with pytest.raises(ValueError):
             c.download_certificate_file("app.example.com", "id_rsa")
+
+
+@pytest.mark.parametrize("name,key_format", [
+    ("privkey", "der"),        # not a format the server accepts
+    ("fullchain", "pkcs1"),    # key_format has no meaning for a public file
+])
+def test_download_certificate_file_validates_key_format_before_requesting(name, key_format):
+    """The docstring's contract is enforced here, not by a round trip."""
+    def handler(request):  # pragma: no cover - must never be reached
+        raise AssertionError("no request may be sent for an invalid key_format")
+
+    with _mock_client(handler) as c:
+        with pytest.raises(ValueError):
+            c.download_certificate_file("app.example.com", name, key_format=key_format)

--- a/tests/test_clients_sdk_unit.py
+++ b/tests/test_clients_sdk_unit.py
@@ -354,3 +354,55 @@ def test_certificate_explicit_ca_provider_wins_over_staging():
 def test_certificate_without_ca_or_staging_has_no_ca():
     c = Certificate.from_dict({"domain": "a.example.com", "staging": False})
     assert c.ca_provider is None
+
+
+# --------------------------------------------------------------------------
+# #490 — one file at a time, so a host can pull exactly what it deploys
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name,expected_file", [
+    ("cert", "cert.pem"),
+    ("chain", "chain.pem"),
+    ("fullchain", "fullchain.pem"),
+    ("privkey", "privkey.pem"),
+    ("combined", "combined.pem"),
+    ("pfx", "cert.pfx"),
+])
+def test_download_certificate_file_maps_short_name_to_file_param(name, expected_file):
+    seen = {}
+
+    def handler(request):
+        seen["path"] = request.url.path
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, content=b"BYTES",
+                              headers={"content-type": "application/octet-stream"})
+
+    with _mock_client(handler) as c:
+        res = c.download_certificate_file("app.example.com", name)
+    # The query-string form, not the path-style route: only this one accepts
+    # key_format, so the same call can also serve the legacy key.
+    assert seen["path"] == "/api/certificates/app.example.com/download"
+    assert seen["params"] == {"file": expected_file}
+    assert res == b"BYTES"
+
+
+def test_download_certificate_file_forwards_key_format():
+    seen = {}
+
+    def handler(request):
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, content=b"KEY",
+                              headers={"content-type": "application/octet-stream"})
+
+    with _mock_client(handler) as c:
+        c.download_certificate_file("app.example.com", "privkey", key_format="pkcs1")
+    assert seen["params"] == {"file": "privkey.pem", "key_format": "pkcs1"}
+
+
+def test_download_certificate_file_unknown_name_raises_before_any_request():
+    def handler(request):  # pragma: no cover - must never be reached
+        raise AssertionError("no request may be sent for an unknown file name")
+
+    with _mock_client(handler) as c:
+        with pytest.raises(ValueError):
+            c.download_certificate_file("app.example.com", "id_rsa")


### PR DESCRIPTION
Closes #490. Requested by @exterrestris.

## The argument for it

Straight from the request, and it is the right one: pushing means the certificate manager holds credentials for **every** target host; pulling means each host holds **one** credential, for itself.

## The gap was narrower than it looked

Every layer had this except the one you would actually use:

| layer | before |
|---|---|
| server API | `?file=`, `?format=json`, path-style `/download/<name>` — all present |
| `certmate-sdk` | `download_certificate()` for json/pem/zip/pfx |
| `certmate-cli` | **no download command at all** |

## Per-file first

```bash
certmate cert download example.com --file fullchain -o /etc/ssl/certs/x.pem
certmate cert download example.com --file privkey   -o /etc/ssl/private/x.key
```

with `--bundle zip|json` for whole-certificate shapes and `-o -` for stdout.

Combined with scoped API keys, each host gets a key limited to its own domain and pulls on a timer: no inbound access to the host, no credentials for it on the manager. The role split already on the endpoint fits — `cert`/`chain`/`fullchain` are viewer-readable, `privkey`/`combined`/`pfx` need operator.

## Details that matter more than the command

- **Files are created 0600 via `os.open` with the mode**, not `chmod`-ed after writing. Between an `open()` and a `chmod()` a private key is readable by anyone on the box — a small window, but this is the one file where it matters.
- **The success line reports the mode actually on disk.** `O_CREAT` leaves an existing file's mode alone, so printing `0600` unconditionally would sometimes be false.
- **The SDK sends `?file=<name>`**, not the path-style `/download/<name>`. Both exist server-side, but only the query-string form accepts `key_format` — so `--file privkey --key-format pkcs1` also serves the legacy key (#398, #233) through the same call.
- **An unknown `--file` fails before any request is sent.**

## Versioning

Clients bumped to **0.1.3**, and the CLI's floor on `certmate-sdk` raised to `>=0.1.3`. Left at `>=0.1.2`, installing the new CLI could resolve SDK 0.1.2 and fail at runtime on the missing method — the sort of thing that only shows up for the user, never in CI.

Publishing is a separate cycle (`clients-v*` tag), so this PR only prepares it.

## Tests

- **SDK**: short name → `?file=` mapping for all six files, `key_format` forwarding, and an unknown name raising before any request.
- **CLI**: writes the requested file, asserts the resulting mode is **0600**, defaults to `fullchain`, forwards `--key-format`, rejects an unknown `--file` without calling the server, rejects `--key-format` on a bundle, and writes a JSON bundle as JSON.

Full suite: **2263 passed**, 6 skipped. CLI README documents the pull-based pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)