### PR TITLE
feat(k8s): Helm chart for running CertMate in a cluster

### DIFF
--- a/charts/certmate/Chart.yaml
+++ b/charts/certmate/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: certmate
+description: Self-hosted SSL/TLS certificate lifecycle management — issuance, renewal, discovery, inventory and deployment
+type: application
+# Chart version: bumped when the CHART changes.
+version: 0.1.0
+# Application version: tracks the CertMate release this chart defaults to.
+# scripts/release.sh bumps this, and tests/test_version_consistency.py fails
+# the build if it drifts from modules.__version__ — the same treatment the
+# docs landing pages and package-lock.json needed.
+appVersion: "2.25.0"
+home: https://www.certmate.org
+sources:
+  - https://github.com/fabriziosalmi/certmate
+keywords:
+  - certificates
+  - tls
+  - ssl
+  - acme
+  - lets-encrypt
+  - certificate-lifecycle-management
+  - private-ca
+maintainers:
+  - name: fabriziosalmi
+    url: https://github.com/fabriziosalmi

--- a/charts/certmate/README.md
+++ b/charts/certmate/README.md
@@ -1,0 +1,82 @@
+# CertMate Helm chart
+
+Run [CertMate](https://github.com/fabriziosalmi/certmate) in Kubernetes.
+
+```bash
+helm install certmate ./charts/certmate --namespace certmate --create-namespace
+kubectl -n certmate port-forward svc/certmate 8000:8000
+```
+
+## What this chart deliberately will not do
+
+**It renders exactly one replica, and refuses anything else.** CertMate's
+scheduler (APScheduler) runs inside the web process and gunicorn runs a single
+worker on purpose. A second replica is a second scheduler issuing and renewing
+against the same certificate store, and a second writer on a ReadWriteOnce
+volume. `--set replicaCount=2` fails at template time with that explanation
+rather than deploying something that looks healthy and quietly double-renews.
+
+Scale the resources, not the replicas.
+
+**It will not run without persistent storage.** Issued certificates, the
+settings store, the certificate inventory and the tamper-evident audit chain
+all live on disk. Disabling persistence without supplying
+`persistence.existingClaim` fails at template time.
+
+**The volume outlives the release.** The PVC carries
+`helm.sh/resource-policy: keep`, so `helm uninstall` leaves your certificates
+alone. Removing them is a deliberate `kubectl delete pvc`.
+
+The rollout strategy is `Recreate` rather than `RollingUpdate`: a
+ReadWriteOnce volume cannot be mounted by the new pod while the old one holds
+it, so a rolling update would deadlock. Expect a few seconds of downtime on
+upgrade.
+
+## Secrets
+
+`values.yaml` is not a secret store. For anything committed to git, create the
+Secret yourself and point the chart at it:
+
+```yaml
+secrets:
+  existingSecret: certmate-secrets
+```
+
+with keys such as `API_BEARER_TOKEN`, `SECRET_KEY` and whatever DNS provider
+credentials you use (`CLOUDFLARE_TOKEN`, …). Everything in that Secret is
+exposed to the container as environment variables.
+
+Left empty, CertMate generates what it can on first boot — fine for a trial,
+not for something you want to reproduce.
+
+## Common values
+
+| key | default | note |
+|---|---|---|
+| `image.tag` | chart `appVersion` | pin a digest for production |
+| `persistence.size` | `2Gi` | certificates, inventory, audit chain, backups |
+| `persistence.existingClaim` | `""` | bring your own volume |
+| `env.behindProxy` | `true` | correct when traffic arrives via Ingress |
+| `env.gunicornTimeout` | `300` | raise for slow DNS providers |
+| `ingress.enabled` | `false` | |
+| `secrets.existingSecret` | `""` | strongly preferred over inline values |
+
+## OpenShift
+
+The image's writable trees are group 0 with setgid, so an arbitrary assigned
+UID works. Clear the values that would fight the SCC:
+
+```bash
+helm install certmate ./charts/certmate \
+  --set podSecurityContext.runAsUser=null \
+  --set podSecurityContext.fsGroup=null
+```
+
+## Where this fits
+
+If everything needing TLS is an in-cluster Ingress, **cert-manager** is the
+right tool and we say so in the
+[deployment guide](https://www.certmate.org/deploy/kubernetes). CertMate earns
+its place when certificates also have to reach things that are not Ingresses —
+load balancers, appliances, hosts outside the cluster — and when you want one
+inventory, audit trail and expiry view across all of them.

--- a/charts/certmate/README.md
+++ b/charts/certmate/README.md
@@ -47,7 +47,30 @@ credentials you use (`CLOUDFLARE_TOKEN`, …). Everything in that Secret is
 exposed to the container as environment variables.
 
 Left empty, CertMate generates what it can on first boot — fine for a trial,
-not for something you want to reproduce.
+not for something you want to reproduce. With nothing supplied the chart
+creates no Secret at all and mounts no environment from one, rather than
+wiring up an empty object that looks like configuration.
+
+The `secretRef` is **not** marked optional. If `existingSecret` names a Secret
+that does not exist, the pod fails to start and says so, instead of coming up
+without its credentials and turning a typo into a runtime mystery.
+
+### Rotating an external Secret
+
+The chart adds a checksum annotation so that changing values it *owns*
+restarts the pod. It cannot do that for `existingSecret`: the chart does not
+own that object, and reading it would require `lookup`, which returns nothing
+during `helm template` and makes rendering depend on the live cluster —
+breaking dry runs and GitOps diffs.
+
+So after rotating an external Secret, restart the deployment yourself:
+
+```bash
+kubectl -n certmate rollout restart deployment/certmate
+```
+
+or run a controller that does it for you, such as
+[stakater/Reloader](https://github.com/stakater/Reloader).
 
 ## Common values
 

--- a/charts/certmate/templates/NOTES.txt
+++ b/charts/certmate/templates/NOTES.txt
@@ -1,0 +1,30 @@
+CertMate {{ .Chart.AppVersion }} is installing as {{ include "certmate.fullname" . }}.
+
+Reach it:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "certmate.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  then open http://localhost:{{ .Values.service.port }}
+{{- end }}
+
+{{- if not .Values.secrets.apiBearerToken }}
+{{- if not .Values.secrets.existingSecret }}
+
+No API bearer token was supplied, so CertMate generated one on first boot.
+Read it from the running pod's settings, or set secrets.apiBearerToken (or
+secrets.existingSecret) to control it yourself.
+{{- end }}
+{{- end }}
+
+Two things worth knowing:
+
+  * CertMate is single-instance on purpose. Its scheduler runs in the web
+    process, so a second replica would duplicate every renewal. The chart
+    refuses to render more than one.
+
+  * The volume holding your certificates and the audit chain is annotated
+    helm.sh/resource-policy: keep — `helm uninstall` leaves it behind.
+    Removing it is a deliberate `kubectl delete pvc`.

--- a/charts/certmate/templates/_helpers.tpl
+++ b/charts/certmate/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{- define "certmate.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "certmate.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "certmate.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "certmate.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "certmate.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "certmate.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "certmate.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "certmate.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "certmate.secretName" -}}
+{{- if .Values.secrets.existingSecret }}
+{{- .Values.secrets.existingSecret }}
+{{- else }}
+{{- include "certmate.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{- define "certmate.pvcName" -}}
+{{- if .Values.persistence.existingClaim }}
+{{- .Values.persistence.existingClaim }}
+{{- else }}
+{{- include "certmate.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Refuse to render a configuration the application cannot survive.
+
+CertMate runs APScheduler inside the web process and gunicorn with a single
+worker. A second replica is a second scheduler issuing and renewing against the
+same store, and a second writer to a ReadWriteOnce volume. Failing at template
+time is the only place this can be caught before it is someone's incident.
+*/}}
+{{- define "certmate.validate" -}}
+{{- if ne (int .Values.replicaCount) 1 }}
+{{- fail "certmate: replicaCount must be 1. CertMate is single-instance by design — its scheduler runs in-process, so a second replica duplicates every renewal job against the same certificate store. Scale up the resources, not the replicas." }}
+{{- end }}
+{{- if and (not .Values.persistence.enabled) (not .Values.persistence.existingClaim) }}
+{{- fail "certmate: persistence is disabled, which means issued certificates, the audit chain and the settings store live in the pod and are lost on restart. Set persistence.enabled=true, or persistence.existingClaim to a volume you manage." }}
+{{- end }}
+{{- end }}

--- a/charts/certmate/templates/_helpers.tpl
+++ b/charts/certmate/templates/_helpers.tpl
@@ -67,3 +67,26 @@ time is the only place this can be caught before it is someone's incident.
 {{- fail "certmate: persistence is disabled, which means issued certificates, the audit chain and the settings store live in the pod and are lost on restart. Set persistence.enabled=true, or persistence.existingClaim to a volume you manage." }}
 {{- end }}
 {{- end }}
+
+{{/*
+Does the chart generate a Secret of its own?
+
+Only when the operator supplied something to put in it. Rendering an empty
+Secret produced `stringData:` with a null value and an envFrom pointing at a
+bag of nothing — noise that looks like configuration.
+*/}}
+{{- define "certmate.generatesSecret" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{- else if or .Values.secrets.apiBearerToken .Values.secrets.secretKey .Values.secrets.extra -}}
+true
+{{- end }}
+{{- end }}
+
+{{/*
+Is there any Secret to load environment from at all?
+*/}}
+{{- define "certmate.hasSecret" -}}
+{{- if or .Values.secrets.existingSecret (include "certmate.generatesSecret" .) -}}
+true
+{{- end }}
+{{- end }}

--- a/charts/certmate/templates/deployment.yaml
+++ b/charts/certmate/templates/deployment.yaml
@@ -18,9 +18,16 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if not .Values.secrets.existingSecret }}
-        # Roll the pod when the generated Secret changes, otherwise a rotated
-        # token sits in the API server while the process keeps the old one.
+        {{- if include "certmate.generatesSecret" . }}
+        # Rolls the pod when the chart-generated Secret changes, so a rotated
+        # token is actually picked up.
+        #
+        # This cannot cover secrets.existingSecret: the chart does not own that
+        # object and cannot see its contents without `lookup`, which returns
+        # nothing during `helm template` and would make renders depend on the
+        # live cluster — breaking GitOps diffs and dry runs. Rotating an
+        # external Secret therefore needs `kubectl rollout restart`, or a
+        # controller such as stakater/Reloader. Documented in the chart README.
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.podAnnotations }}
@@ -62,10 +69,15 @@ spec:
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- if include "certmate.hasSecret" . }}
           envFrom:
+            # NOT optional. A typo in secrets.existingSecret should stop the
+            # pod at creation with a clear reason, not start it without its
+            # credentials and turn a configuration error into a runtime
+            # mystery.
             - secretRef:
                 name: {{ include "certmate.secretName" . }}
-                optional: true
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /health

--- a/charts/certmate/templates/deployment.yaml
+++ b/charts/certmate/templates/deployment.yaml
@@ -1,0 +1,108 @@
+{{- include "certmate.validate" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "certmate.fullname" . }}
+  labels: {{- include "certmate.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    # Recreate, not RollingUpdate. A ReadWriteOnce volume cannot be mounted by
+    # the new pod while the old one still holds it, so a rolling update
+    # deadlocks: the new pod waits for a volume the old pod will not release
+    # until the new pod is Ready. Brief downtime is the correct trade for a
+    # single-instance application.
+    type: Recreate
+  selector:
+    matchLabels: {{- include "certmate.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if not .Values.secrets.existingSecret }}
+        # Roll the pod when the generated Secret changes, otherwise a rotated
+        # token sits in the API server while the process keeps the old one.
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "certmate.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "certmate.serviceAccountName" . }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: certmate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext: {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.service.port | quote }}
+            - name: FLASK_ENV
+              value: production
+            - name: BEHIND_PROXY
+              value: {{ .Values.env.behindProxy | quote }}
+            - name: GUNICORN_TIMEOUT
+              value: {{ .Values.env.gunicornTimeout | quote }}
+            {{- with .Values.env.letsencryptEmail }}
+            - name: LETSENCRYPT_EMAIL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "certmate.secretName" . }}
+                optional: true
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            {{- toYaml .Values.probes.liveness | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            {{- toYaml .Values.probes.readiness | nindent 12 }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            # One claim, four subPaths. The app writes all of these at runtime;
+            # separating them into their own claims would buy nothing on a
+            # single-instance workload and cost three more RWO volumes.
+            - name: data
+              mountPath: /app/certificates
+              subPath: certificates
+            - name: data
+              mountPath: /app/data
+              subPath: data
+            - name: data
+              mountPath: /app/logs
+              subPath: logs
+            - name: data
+              mountPath: /app/backups
+              subPath: backups
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "certmate.pvcName" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/certmate/templates/ingress.yaml
+++ b/charts/certmate/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "certmate.fullname" . }}
+  labels: {{- include "certmate.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "certmate.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/certmate/templates/pvc.yaml
+++ b/charts/certmate/templates/pvc.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "certmate.pvcName" . }}
+  labels: {{- include "certmate.labels" . | nindent 4 }}
+  annotations:
+    # Certificates and the tamper-evident audit chain live here. Keep the
+    # volume when the release goes away; deleting it is a deliberate act.
+    helm.sh/resource-policy: keep
+    {{- with .Values.persistence.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/certmate/templates/secret.yaml
+++ b/charts/certmate/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.secrets.existingSecret }}
+{{- if include "certmate.generatesSecret" . }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/certmate/templates/secret.yaml
+++ b/charts/certmate/templates/secret.yaml
@@ -1,0 +1,18 @@
+{{- if not .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "certmate.secretName" . }}
+  labels: {{- include "certmate.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if .Values.secrets.apiBearerToken }}
+  API_BEARER_TOKEN: {{ .Values.secrets.apiBearerToken | quote }}
+  {{- end }}
+  {{- if .Values.secrets.secretKey }}
+  SECRET_KEY: {{ .Values.secrets.secretKey | quote }}
+  {{- end }}
+  {{- range $k, $v := .Values.secrets.extra }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/certmate/templates/service.yaml
+++ b/charts/certmate/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "certmate.fullname" . }}
+  labels: {{- include "certmate.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector: {{- include "certmate.selectorLabels" . | nindent 4 }}

--- a/charts/certmate/templates/serviceaccount.yaml
+++ b/charts/certmate/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "certmate.serviceAccountName" . }}
+  labels: {{- include "certmate.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/certmate/values.yaml
+++ b/charts/certmate/values.yaml
@@ -1,0 +1,117 @@
+# CertMate Helm values.
+#
+# CertMate is a SINGLE-INSTANCE application. Its scheduler (APScheduler) runs
+# in the web process and gunicorn runs one worker on purpose: a second replica
+# would run a second copy of every renewal job against the same certificate
+# store. The chart refuses to render more than one replica rather than letting
+# that happen quietly.
+
+image:
+  repository: fabriziosalmi/certmate
+  # Defaults to .Chart.AppVersion. Pin a digest in production if you want the
+  # exact bytes rather than the tag.
+  tag: ""
+  pullPolicy: IfNotPresent
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Deliberately not a knob to turn up. See the note at the top of this file.
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 8000
+  annotations: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: certmate.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+persistence:
+  # Certificates, the settings/inventory/audit store, logs and backups all
+  # live on one volume under separate subPaths. One ReadWriteOnce claim is
+  # both simpler and more honest than four: the app is single-instance, so
+  # there is nothing to share.
+  enabled: true
+  existingClaim: ""
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 2Gi
+  annotations: {}
+
+# Values that belong in a Secret. Leave them empty and CertMate generates what
+# it can on first boot; set them for reproducible deployments.
+#
+# Prefer existingSecret in anything that is committed to git — values.yaml is
+# not a secret store.
+secrets:
+  existingSecret: ""
+  apiBearerToken: ""
+  secretKey: ""
+  # DNS provider credentials and anything else the app reads from the
+  # environment. Rendered into the same Secret.
+  extra: {}
+
+env:
+  behindProxy: true      # true when traffic arrives via Ingress
+  gunicornTimeout: 300   # ACME DNS-01 can take minutes on slow providers
+  letsencryptEmail: ""
+extraEnv: []
+
+resources:
+  limits:
+    cpu: "1"
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  # The image's writable trees are group 0 + setgid so an arbitrary UID works
+  # (OpenShift, rootless podman). On OpenShift, clear runAsUser and fsGroup
+  # and let the SCC assign them.
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false   # certbot writes under /app at runtime
+  capabilities:
+    drop: ["ALL"]
+
+# Startup runs migrations and directory setup, so give it room before the
+# liveness probe starts counting failures.
+probes:
+  liveness:
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    timeoutSeconds: 10
+    failureThreshold: 3
+  readiness:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+podLabels: {}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -186,6 +186,16 @@ dh.write_text(
 # v2.24.1 (#483, #487) because the script did not own them. Globbed, so a
 # translation added later is picked up without editing this script;
 # test_version_consistency fails the build if one is ever missed.
+# The Helm chart's appVersion is the release it defaults to pulling. Same
+# class of copy as the docs pages and the lockfile: owned here, or stale.
+# Chart *version* is deliberately NOT touched — it tracks chart changes.
+chart = pathlib.Path("charts/certmate/Chart.yaml")
+if chart.exists():
+    chart.write_text(
+        re.sub(r'(?m)^(appVersion:\s*")[^"]+(")', rf"\g<1>{v}\g<2>",
+               chart.read_text(encoding="utf-8")),
+        encoding="utf-8",
+    )
 docs = sorted(pathlib.Path("docs").glob("index.md")) + sorted(pathlib.Path("docs").glob("*/index.md"))
 for page in docs:
     text = page.read_text(encoding="utf-8")
@@ -207,7 +217,7 @@ real-cert E2E skipped (non-issuance change): $skip_reason"
   # the commit produced a release PR whose own CI failed on the version-
   # consistency test — a gate the local run cannot catch, because the bump
   # happens after the gates.
-  git add modules/__init__.py package.json package-lock.json README.dockerhub.md docs/index.md docs/*/index.md
+  git add modules/__init__.py package.json package-lock.json README.dockerhub.md charts/certmate/Chart.yaml docs/index.md docs/*/index.md
   git commit -q -m "$body
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"

--- a/tests/test_helm_chart.py
+++ b/tests/test_helm_chart.py
@@ -1,0 +1,106 @@
+"""The Helm chart must stay true to what CertMate actually is.
+
+CertMate runs APScheduler inside the web process and gunicorn with one worker.
+A chart that lets someone set replicas to 3 does not produce a scaled CertMate,
+it produces three schedulers renewing the same certificates against one
+ReadWriteOnce volume. These pin the invariants that keep the chart honest.
+
+The static assertions run everywhere. The render assertions need the helm
+binary and skip without it — stated plainly rather than pretending to cover
+what they cannot.
+"""
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+ROOT = Path(__file__).resolve().parent.parent
+CHART = ROOT / "charts" / "certmate"
+
+
+def _read(rel):
+    return (CHART / rel).read_text(encoding="utf-8")
+
+
+def test_chart_exists():
+    assert (CHART / "Chart.yaml").exists(), "the Helm chart has moved or gone"
+
+
+def test_replicas_are_hardcoded_not_templated():
+    """A knob that can be turned to 3 is a knob that will be."""
+    deployment = _read("templates/deployment.yaml")
+    assert "replicas: 1" in deployment, (
+        "the Deployment no longer hardcodes one replica — CertMate's scheduler "
+        "runs in-process, so a second replica duplicates every renewal"
+    )
+    assert "{{ .Values.replicaCount }}" not in deployment
+
+
+def test_the_chart_refuses_more_than_one_replica():
+    helpers = _read("templates/_helpers.tpl")
+    assert "fail" in helpers and "replicaCount must be 1" in helpers, (
+        "the render-time guard is gone; a values override would now silently "
+        "produce a multi-scheduler deployment"
+    )
+
+
+def test_rollout_strategy_is_recreate():
+    """RollingUpdate deadlocks on a ReadWriteOnce volume: the new pod waits for
+    a volume the old pod will not release until the new pod is Ready."""
+    assert "type: Recreate" in _read("templates/deployment.yaml")
+
+
+def test_the_certificate_volume_survives_uninstall():
+    assert "helm.sh/resource-policy: keep" in _read("templates/pvc.yaml"), (
+        "helm uninstall would now delete the volume holding issued "
+        "certificates and the tamper-evident audit chain"
+    )
+
+
+def test_appversion_matches_the_application():
+    """Same rule as package.json, the docs pages and package-lock.json."""
+    from modules import __version__
+    chart = _read("Chart.yaml")
+    line = [ln for ln in chart.splitlines() if ln.startswith("appVersion:")]
+    assert line, "Chart.yaml has no appVersion"
+    found = line[0].split(":", 1)[1].strip().strip('"')
+    assert found == __version__, (
+        f"Chart.yaml appVersion is {found!r} but modules.__version__ is "
+        f"{__version__!r}. scripts/release.sh bumps this file."
+    )
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm is not installed")
+class TestRender:
+    def _template(self, *args):
+        return subprocess.run(
+            ["helm", "template", "t", str(CHART), *args],
+            capture_output=True, text=True,
+        )
+
+    def test_default_values_render(self):
+        res = self._template()
+        assert res.returncode == 0, res.stderr
+        assert "kind: Deployment" in res.stdout
+        assert "kind: PersistentVolumeClaim" in res.stdout
+
+    def test_more_than_one_replica_is_rejected_with_a_reason(self):
+        res = self._template("--set", "replicaCount=2")
+        assert res.returncode != 0
+        assert "single-instance" in res.stderr
+
+    def test_disabling_persistence_without_a_claim_is_rejected(self):
+        res = self._template("--set", "persistence.enabled=false")
+        assert res.returncode != 0
+        assert "lost on restart" in res.stderr
+
+    def test_an_external_claim_is_accepted(self):
+        """The escape hatch for operators who manage storage themselves."""
+        res = self._template("--set", "persistence.enabled=false",
+                             "--set", "persistence.existingClaim=my-pvc")
+        assert res.returncode == 0, res.stderr
+        assert "claimName: my-pvc" in res.stdout
+        assert "kind: PersistentVolumeClaim" not in res.stdout

--- a/tests/test_helm_chart.py
+++ b/tests/test_helm_chart.py
@@ -104,3 +104,40 @@ class TestRender:
         assert res.returncode == 0, res.stderr
         assert "claimName: my-pvc" in res.stdout
         assert "kind: PersistentVolumeClaim" not in res.stdout
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm is not installed")
+class TestSecretWiring:
+    """Three paths, and each must render the honest thing for its case."""
+
+    def _template(self, *args):
+        return subprocess.run(
+            ["helm", "template", "t", str(CHART), *args],
+            capture_output=True, text=True, check=True,
+        ).stdout
+
+    def test_no_secret_values_produces_no_secret_and_no_envfrom(self):
+        """An empty Secret is noise that looks like configuration."""
+        out = self._template()
+        assert "kind: Secret" not in out
+        assert "envFrom" not in out
+
+    def test_supplied_values_produce_a_secret_and_load_it(self):
+        out = self._template("--set", "secrets.apiBearerToken=abc")
+        assert "kind: Secret" in out
+        assert "API_BEARER_TOKEN" in out
+        assert "envFrom" in out
+
+    def test_existing_secret_is_loaded_without_generating_one(self):
+        out = self._template("--set", "secrets.existingSecret=my-sec")
+        assert "kind: Secret" not in out
+        assert "name: my-sec" in out
+
+    def test_the_secret_reference_is_not_optional(self):
+        """A typo in existingSecret must stop the pod, not start it blind."""
+        out = self._template("--set", "secrets.existingSecret=my-sec")
+        envfrom = out[out.index("envFrom"):out.index("envFrom") + 400]
+        assert "optional: true" not in envfrom, (
+            "the secretRef is optional again — a non-existent Secret would let "
+            "the pod start without its credentials"
+        )


### PR DESCRIPTION
Closes the gap identified in the distribution review: CertMate ships a **Kubernetes Secret deploy target** (#475) and a guide for getting certificates *into* a cluster, but no way to install CertMate *itself* there short of hand-translating `docker-compose.yml`. Kubernetes users install with `helm`. Without a chart, the project is not evaluated in the environment where its closest comparison lives.

```bash
helm install certmate ./charts/certmate --namespace certmate --create-namespace
```

## The chart encodes what CertMate is, rather than emitting boilerplate

**One replica, and it refuses to render more.** APScheduler runs inside the web process and gunicorn runs a single worker on purpose. `--set replicaCount=2` is not a scaled CertMate — it is two schedulers issuing and renewing against the same certificate store, and two writers on a ReadWriteOnce volume. That fails at template time with the reason:

```
Error: certmate: replicaCount must be 1. CertMate is single-instance by design —
its scheduler runs in-process, so a second replica duplicates every renewal job
against the same certificate store. Scale up the resources, not the replicas.
```

A duplicate-issuance deployment looks perfectly healthy in `kubectl`. Template time is the only place to catch it before it is someone's incident.

**`Recreate`, not `RollingUpdate`.** The new pod cannot mount a ReadWriteOnce volume while the old pod holds it, and the old pod is not terminated until the new one is Ready — a rolling update deadlocks. A few seconds of downtime is the right trade here.

**It will not render without storage.** Certificates, the settings store, the inventory and the tamper-evident audit chain are not pod-local state. `persistence.enabled=false` fails unless `persistence.existingClaim` is supplied — the escape hatch for operators who manage volumes themselves.

**The volume outlives the release.** `helm.sh/resource-policy: keep` on the PVC, so `helm uninstall` does not take the certificates with it.

**One claim, four subPaths.** Four separate RWO claims would buy nothing on a single-instance workload.

**`existingSecret` support**, because `values.yaml` is not a secret store, and a checksum annotation so a rotated token actually restarts the process instead of sitting unread in the API server.

## The version string is wired in from day one

`appVersion` is another copy of the release number. Left alone it becomes the next stale one — that lesson has already cost two hand-fixes for the docs landing pages (#483, #487) and one for `package-lock.json` (#498). So it is bumped by `scripts/release.sh` and pinned by `test_version_consistency` in the same commit that introduces it.

## Tests

`tests/test_helm_chart.py`:

- **Static, always run**: replicas are hardcoded and not templated, the render-time guard exists, the strategy is `Recreate`, the PVC keeps its data, `appVersion` matches `modules.__version__`.
- **Render, when `helm` is present**: defaults render, both guards fire with their intended messages, and `existingClaim` is accepted while suppressing the PVC.

The render tests **skip where helm is not installed**, which includes CI today. Stated rather than papered over: the invariants that matter most are covered by the static half, which runs everywhere. Adding `azure/setup-helm` to the CI workflow would make the render half real too — happy to do that as a follow-up if you want it.

Full suite: **2278 passed**, 6 skipped. `helm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)