### PR TITLE
feat(ci): publish the Helm chart to GHCR and announce releases

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -37,19 +37,34 @@ jobs:
 
           # Read the release rather than trusting the event payload, so a
           # manual re-run announces the same thing an automatic one would.
-          name="$(gh release view "$TAG" --repo "$REPO" --json name -q .name)"
-          body="$(gh release view "$TAG" --repo "$REPO" --json body -q .body)"
+          name="$(gh release view "$TAG" --repo "$REPO" --json name -q '.name // ""')"
+          body="$(gh release view "$TAG" --repo "$REPO" --json body -q '.body // ""')"
           url="$(gh release view "$TAG" --repo "$REPO" --json url -q .url)"
           version="${TAG#v}"
 
+          # A release is not required to have a name, and an empty title would
+          # create an untitled discussion AND break the de-duplication below.
+          # The tag is the one thing always present, so the title is keyed on
+          # it: either it already appears in the name, or it is prefixed.
+          if [ -z "$name" ]; then
+            title="$TAG"
+          else
+            case "$name" in
+              *"$TAG"*) title="$name" ;;
+              *) title="$TAG - $name" ;;
+            esac
+          fi
+
           # Skip if this release was already announced. Re-running the workflow
-          # should be safe: a duplicate announcement is worse than none.
+          # should be safe: a duplicate announcement is worse than none. Keyed
+          # on the tag rather than the full title, which is stable even if the
+          # release is later renamed.
           existing="$(gh api graphql -f query='
             query($q: String!) {
               search(query: $q, type: DISCUSSION, first: 5) {
                 nodes { ... on Discussion { title url } }
               }
-            }' -f q="repo:$REPO in:title \"$name\"" -q '.data.search.nodes | length')"
+            }' -f q="repo:$REPO in:title \"$TAG\"" -q '.data.search.nodes | length')"
           if [ "$existing" != "0" ]; then
             echo "Already announced ($existing matching discussion(s)); nothing to do."
             exit 0
@@ -85,7 +100,7 @@ jobs:
             }' -f owner="${REPO%%/*}" -f name="${REPO##*/}" -q .data.repository.id)"
 
           gh api graphql -F repositoryId="$repo_id" -F categoryId="$category_id" \
-            -F title="$name" -F body=@body.md -f query='
+            -F title="$title" -F body=@body.md -f query='
             mutation($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
               createDiscussion(input: {repositoryId: $repositoryId, categoryId: $categoryId, title: $title, body: $body}) {
                 discussion { url }

--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -1,0 +1,93 @@
+name: Announce release
+
+# 1,240 stars and 7 watchers: shipping a release notifies almost nobody. A
+# Discussion in Announcements is the one surface people can actually subscribe
+# to, and it shows on the repository front page.
+#
+# Automated rather than remembered, for the same reason release.sh bumps the
+# version files: a step that depends on someone remembering it is a step that
+# gets skipped exactly when the release is busiest.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to announce (e.g. v2.25.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  discussions: write
+
+jobs:
+  announce:
+    name: post to Announcements
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post the release to Discussions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Read the release rather than trusting the event payload, so a
+          # manual re-run announces the same thing an automatic one would.
+          name="$(gh release view "$TAG" --repo "$REPO" --json name -q .name)"
+          body="$(gh release view "$TAG" --repo "$REPO" --json body -q .body)"
+          url="$(gh release view "$TAG" --repo "$REPO" --json url -q .url)"
+          version="${TAG#v}"
+
+          # Skip if this release was already announced. Re-running the workflow
+          # should be safe: a duplicate announcement is worse than none.
+          existing="$(gh api graphql -f query='
+            query($q: String!) {
+              search(query: $q, type: DISCUSSION, first: 5) {
+                nodes { ... on Discussion { title url } }
+              }
+            }' -f q="repo:$REPO in:title \"$name\"" -q '.data.search.nodes | length')"
+          if [ "$existing" != "0" ]; then
+            echo "Already announced ($existing matching discussion(s)); nothing to do."
+            exit 0
+          fi
+
+          {
+            printf '%s\n\n' "$body"
+            printf -- '---\n\n'
+            printf '## Upgrade\n\n'
+            printf '```bash\n'
+            printf 'docker pull fabriziosalmi/certmate:%s\n' "$version"
+            printf '```\n\n'
+            printf 'Helm:\n\n'
+            printf '```bash\n'
+            printf 'helm upgrade --install certmate oci://ghcr.io/fabriziosalmi/charts/certmate --version %s\n' "$version"
+            printf '```\n\n'
+            printf 'Full release notes: %s\n\n' "$url"
+            printf 'Found a problem with this release? Open an issue — every fix in the last few releases came from someone who did.\n'
+          } > body.md
+
+          category_id="$(gh api graphql -f query='
+            query($owner: String!, $name: String!) {
+              repository(owner: $owner, name: $name) {
+                discussionCategories(first: 20) { nodes { id name } }
+              }
+            }' -f owner="${REPO%%/*}" -f name="${REPO##*/}" \
+            -q '.data.repository.discussionCategories.nodes[] | select(.name=="Announcements") | .id')"
+          [ -n "$category_id" ] || { echo "::error::no Announcements category found" >&2; exit 1; }
+
+          repo_id="$(gh api graphql -f query='
+            query($owner: String!, $name: String!) {
+              repository(owner: $owner, name: $name) { id }
+            }' -f owner="${REPO%%/*}" -f name="${REPO##*/}" -q .data.repository.id)"
+
+          gh api graphql -F repositoryId="$repo_id" -F categoryId="$category_id" \
+            -F title="$name" -F body=@body.md -f query='
+            mutation($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+              createDiscussion(input: {repositoryId: $repositoryId, categoryId: $categoryId, title: $title, body: $body}) {
+                discussion { url }
+              }
+            }' -q '.data.createDiscussion.discussion.url' | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -47,7 +47,7 @@ jobs:
         # publish workflow applies to pyproject versions.
         run: |
           set -euo pipefail
-          chart_version="$(helm show chart charts/certmate | awk '/^version:/{print $2}')"
+          chart_version="$(helm show chart charts/certmate | awk '/^version:/{gsub(/"/,"",$2); print $2}')"
           app_version="$(helm show chart charts/certmate | awk '/^appVersion:/{gsub(/"/,"",$2); print $2}')"
           echo "chart version=$chart_version appVersion=$app_version"
           if [ "$chart_version" != "$app_version" ]; then
@@ -102,6 +102,6 @@ jobs:
             echo "### Helm chart"
             echo
             echo '```bash'
-            echo "helm install certmate oci://ghcr.io/${owner}/charts/certmate --version $(helm show chart charts/certmate | awk '/^version:/{print $2}')"
+            echo "helm install certmate oci://ghcr.io/${owner}/charts/certmate --version $(helm show chart charts/certmate | awk '/^version:/{gsub(/"/,"",$2); print $2}')"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -1,0 +1,107 @@
+name: Publish Helm chart (GHCR)
+
+# The chart is published as an OCI artifact to GHCR, not to Docker Hub and not
+# via a gh-pages index.
+#
+# GHCR because: nested repository paths exist there, so the chart lands at
+# ghcr.io/<owner>/charts/certmate and cannot collide with the container image
+# at docker.io/<owner>/certmate — pushing both to one OCI repository would put
+# a chart and an image behind the same tag. And because GITHUB_TOKEN is enough,
+# so this adds no secret to the repository.
+#
+# Fires on a published RELEASE rather than on the tag push, so the chart is
+# only shipped once the release itself exists — the same ordering release.sh
+# enforces by hand.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Package and verify without pushing'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: package and push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112  # v4.3.0
+        with:
+          version: v3.19.0
+
+      - name: Fail unless the chart version equals the release tag
+        # An OCI push is effectively write-once for a given tag: shipping a
+        # chart whose Chart.yaml disagrees with the release it claims to be
+        # would leave the two permanently out of step. Same gate the client
+        # publish workflow applies to pyproject versions.
+        run: |
+          set -euo pipefail
+          chart_version="$(helm show chart charts/certmate | awk '/^version:/{print $2}')"
+          app_version="$(helm show chart charts/certmate | awk '/^appVersion:/{gsub(/"/,"",$2); print $2}')"
+          echo "chart version=$chart_version appVersion=$app_version"
+          if [ "$chart_version" != "$app_version" ]; then
+            echo "::error::Chart.yaml version ($chart_version) != appVersion ($app_version); the chart versions with the app." >&2
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="${GITHUB_REF#refs/tags/}"; tag="${tag#v}"
+            if [ "$chart_version" != "$tag" ]; then
+              echo "::error::Chart version ($chart_version) does not match release tag ($tag)." >&2
+              exit 1
+            fi
+          fi
+
+      - name: Lint
+        run: helm lint charts/certmate
+
+      - name: Render with the defaults, and prove the guards still bite
+        # A chart that lints but refuses to render is useless; a chart that
+        # renders anything at all is dangerous. Both are checked here because
+        # the pytest equivalents skip wherever helm is absent.
+        run: |
+          set -euo pipefail
+          helm template certmate charts/certmate > /dev/null
+          if helm template certmate charts/certmate --set replicaCount=2 >/dev/null 2>&1; then
+            echo "::error::the single-replica guard no longer fails the render" >&2
+            exit 1
+          fi
+          if helm template certmate charts/certmate --set persistence.enabled=false >/dev/null 2>&1; then
+            echo "::error::the persistence guard no longer fails the render" >&2
+            exit 1
+          fi
+
+      - name: Package
+        run: helm package charts/certmate --destination dist
+
+      - name: Log in to GHCR
+        if: github.event_name == 'release' || inputs.dry_run == false
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push
+        if: github.event_name == 'release' || inputs.dry_run == false
+        run: |
+          set -euo pipefail
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          helm push dist/certmate-*.tgz "oci://ghcr.io/${owner}/charts"
+
+      - name: Summary
+        run: |
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          {
+            echo "### Helm chart"
+            echo
+            echo '```bash'
+            echo "helm install certmate oci://ghcr.io/${owner}/charts/certmate --version $(helm show chart charts/certmate | awk '/^version:/{print $2}')"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/charts/certmate/Chart.yaml
+++ b/charts/certmate/Chart.yaml
@@ -2,12 +2,15 @@ apiVersion: v2
 name: certmate
 description: Self-hosted SSL/TLS certificate lifecycle management — issuance, renewal, discovery, inventory and deployment
 type: application
-# Chart version: bumped when the CHART changes.
-version: 0.1.0
-# Application version: tracks the CertMate release this chart defaults to.
-# scripts/release.sh bumps this, and tests/test_version_consistency.py fails
-# the build if it drifts from modules.__version__ — the same treatment the
-# docs landing pages and package-lock.json needed.
+# The chart versions WITH the application, deliberately.
+#
+# A separate chart version is a second number to bump, and every independent
+# copy of a version in this repository has drifted at least once — the docs
+# landing pages twice, package-lock.json two releases behind. The chart lives
+# in the application's repository and only ever ships that application, so it
+# tracks it: one number, bumped by scripts/release.sh, pinned by
+# tests/test_helm_chart.py. A chart-only fix rides the next release.
+version: 2.25.0
 appVersion: "2.25.0"
 home: https://www.certmate.org
 sources:

--- a/charts/certmate/README.md
+++ b/charts/certmate/README.md
@@ -3,9 +3,26 @@
 Run [CertMate](https://github.com/fabriziosalmi/certmate) in Kubernetes.
 
 ```bash
-helm install certmate ./charts/certmate --namespace certmate --create-namespace
+helm install certmate oci://ghcr.io/fabriziosalmi/charts/certmate \
+  --namespace certmate --create-namespace
 kubectl -n certmate port-forward svc/certmate 8000:8000
 ```
+
+The chart is published as an OCI artifact to GHCR on every release, so there
+is no `helm repo add` step — Helm 3.8 and later pull `oci://` URLs directly.
+It lives under `charts/` rather than beside the container image, because a
+chart and an image in one OCI repository would fight over the same tags.
+
+Or from a checkout, which is the same chart:
+
+```bash
+helm install certmate ./charts/certmate --namespace certmate --create-namespace
+```
+
+**The chart version is the CertMate version.** `--version 2.25.0` gets the
+chart that deploys CertMate 2.25.0. There is no second number to reconcile,
+deliberately: every independent version copy in this repository has drifted at
+least once.
 
 ## What this chart deliberately will not do
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -186,9 +186,10 @@ dh.write_text(
 # v2.24.1 (#483, #487) because the script did not own them. Globbed, so a
 # translation added later is picked up without editing this script;
 # test_version_consistency fails the build if one is ever missed.
-# The Helm chart's appVersion is the release it defaults to pulling. Same
-# class of copy as the docs pages and the lockfile: owned here, or stale.
-# Chart *version* is deliberately NOT touched — it tracks chart changes.
+# The Helm chart carries the release number twice, and BOTH are bumped: the
+# chart versions with the application on purpose (see charts/certmate/Chart.yaml).
+# `version` must move for a publish to be a new artifact rather than a rejected
+# duplicate; `appVersion` is the image tag the chart deploys by default.
 chart = pathlib.Path("charts/certmate/Chart.yaml")
 if chart.exists():
     text = chart.read_text(encoding="utf-8")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -191,11 +191,11 @@ dh.write_text(
 # Chart *version* is deliberately NOT touched — it tracks chart changes.
 chart = pathlib.Path("charts/certmate/Chart.yaml")
 if chart.exists():
-    chart.write_text(
-        re.sub(r'(?m)^(appVersion:\s*")[^"]+(")', rf"\g<1>{v}\g<2>",
-               chart.read_text(encoding="utf-8")),
-        encoding="utf-8",
-    )
+    text = chart.read_text(encoding="utf-8")
+    # Both: the chart versions with the application on purpose (see Chart.yaml).
+    text = re.sub(r'(?m)^(appVersion:\s*")[^"]+(")', rf"\g<1>{v}\g<2>", text)
+    text = re.sub(r'(?m)^(version:\s*)[0-9]+\.[0-9]+\.[0-9]+\s*$', rf"\g<1>{v}", text)
+    chart.write_text(text, encoding="utf-8")
 docs = sorted(pathlib.Path("docs").glob("index.md")) + sorted(pathlib.Path("docs").glob("*/index.md"))
 for page in docs:
     text = page.read_text(encoding="utf-8")

--- a/tests/test_helm_chart.py
+++ b/tests/test_helm_chart.py
@@ -60,16 +60,25 @@ def test_the_certificate_volume_survives_uninstall():
     )
 
 
-def test_appversion_matches_the_application():
-    """Same rule as package.json, the docs pages and package-lock.json."""
+@pytest.mark.parametrize("field", ["version", "appVersion"])
+def test_chart_versions_track_the_application(field):
+    """Both fields, not just appVersion.
+
+    The chart versions with the application on purpose: a separate chart
+    version is a second number to bump, and every independent copy of a
+    version in this repository has drifted at least once. `version` also has
+    to move for a publish to be a new artifact rather than a rejected
+    duplicate — a chart whose contents changed under an unchanged version is
+    how a stale chart gets served forever.
+    """
     from modules import __version__
-    chart = _read("Chart.yaml")
-    line = [ln for ln in chart.splitlines() if ln.startswith("appVersion:")]
-    assert line, "Chart.yaml has no appVersion"
-    found = line[0].split(":", 1)[1].strip().strip('"')
+    lines = [ln for ln in _read("Chart.yaml").splitlines()
+             if ln.startswith(f"{field}:")]
+    assert lines, f"Chart.yaml has no {field}"
+    found = lines[0].split(":", 1)[1].strip().strip('"')
     assert found == __version__, (
-        f"Chart.yaml appVersion is {found!r} but modules.__version__ is "
-        f"{__version__!r}. scripts/release.sh bumps this file."
+        f"Chart.yaml {field} is {found!r} but modules.__version__ is "
+        f"{__version__!r}. scripts/release.sh bumps both."
     )
 
 


### PR DESCRIPTION
Two distribution gaps from the review, both automated rather than left to memory.

## 1. The chart is actually published

`helm install ./charts/certmate` only works from a checkout, which is half a chart. On every published release it now goes to GHCR as an OCI artifact:

```bash
helm install certmate oci://ghcr.io/fabriziosalmi/charts/certmate --version 2.25.0
```

**GHCR rather than Docker Hub**, for a concrete reason: the container image is at `docker.io/fabriziosalmi/certmate`, and Docker Hub has no nested namespaces on that account. Pushing the chart there would put a chart and an image in **one OCI repository fighting over the same tags** — `2.25.0` would mean two different artifacts. GHCR supports nested paths, so the chart lands under `charts/` and cannot collide. `GITHUB_TOKEN` also covers it, so this adds no secret.

No `helm repo add`, no `gh-pages` branch, no `index.yaml` to keep in sync — Helm 3.8+ pulls `oci://` directly.

### Gated like the client publish

An OCI push is effectively write-once per tag, so the workflow **refuses to publish a chart whose version disagrees with the release tag**, mirroring `publish-clients.yml`'s check against the pyproject versions.

It also re-runs the two render guards in CI:

```
helm template --set replicaCount=2         -> must FAIL
helm template --set persistence.enabled=false -> must FAIL
```

That is deliberate duplication. The pytest versions skip wherever `helm` is absent, and CI is exactly where it is absent — a guard that only runs on my laptop is not a guard.

## 2. The chart versions with the application

`version` and `appVersion` are both the CertMate version, bumped together by `release.sh`, pinned by tests.

A separate chart version is a second number to bump, and **every independent copy of a version in this repository has drifted at least once**: the docs landing pages twice (#483, #487), `package-lock.json` two releases behind (#498). `version` also *has* to move for a publish to be a new artifact rather than a rejected duplicate — a chart whose contents changed under an unchanged version is how a stale chart gets served forever.

A chart-only fix rides the next release. That is the cost, and it is smaller than the drift.

## 3. Releases are announced

**1,240 stars, 7 watchers.** Shipping a release notifies almost nobody — four versions went out in two days and the people whose bugs were fixed only found out because they were told individually.

A Discussion in Announcements is the one surface people can subscribe to, and it shows on the repository front page. Now posted automatically on release, carrying the notes, the `docker pull` and `helm upgrade` commands, and a link back.

Two details: it reads the release **through the API rather than the event payload**, so a manual re-run announces exactly what an automatic one would; and it **skips when a discussion with that title already exists**, because a duplicate announcement is worse than none.

## Verification

`helm lint` clean, `helm package` produces `certmate-2.25.0.tgz`, both workflow files parse, full suite **2283 passed**.

The publish workflow can be exercised without shipping anything via `workflow_dispatch` with `dry_run: true`, which packages and runs every gate but does not log in or push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)