### PR TITLE
chore(ci): announcements are a manual step, not an automatic one

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -46,11 +46,21 @@ jobs:
         run: |
           set -euo pipefail
 
+          # TAG is a workflow_dispatch input. Validate it before it reaches a
+          # command line or a query string: a value starting with '-' would be
+          # read as a flag by gh, and quotes or a newline would break out of
+          # the GraphQL search string below. `case` compares the whole value —
+          # grep would match line by line and let a newline through.
+          case "$TAG" in
+            "" | -*)               echo "::error::tag must be non-empty and must not start with '-': $TAG" >&2; exit 1 ;;
+            *[!A-Za-z0-9._-]*)     echo "::error::tag may only contain letters, digits, dot, underscore and hyphen: $TAG" >&2; exit 1 ;;
+          esac
+
           # Read the release rather than trusting the event payload, so a
-          # manual re-run announces the same thing an automatic one would.
-          name="$(gh release view "$TAG" --repo "$REPO" --json name -q '.name // ""')"
-          body="$(gh release view "$TAG" --repo "$REPO" --json body -q '.body // ""')"
-          url="$(gh release view "$TAG" --repo "$REPO" --json url -q .url)"
+          # re-run announces exactly what the first run would have.
+          name="$(gh release view --repo "$REPO" --json name -q '.name // ""' -- "$TAG")"
+          body="$(gh release view --repo "$REPO" --json body -q '.body // ""' -- "$TAG")"
+          url="$(gh release view --repo "$REPO" --json url -q .url -- "$TAG")"
           version="${TAG#v}"
 
           # A release is not required to have a name, and an empty title would

--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -4,13 +4,24 @@ name: Announce release
 # Discussion in Announcements is the one surface people can actually subscribe
 # to, and it shows on the repository front page.
 #
-# Automated rather than remembered, for the same reason release.sh bumps the
-# version files: a step that depends on someone remembering it is a step that
-# gets skipped exactly when the release is busiest.
+# MANUAL ON PURPOSE. This does not fire on `release: published`, and that is a
+# deliberate difference from publish-chart.yml.
+#
+# Publishing an artifact is mechanical: it either matches the release or the
+# gate stops it. An announcement is the maintainer's voice on a public forum,
+# and once posted it has been read. Firing it automatically means a wrong
+# release note, a mis-tagged release or a release cut and then withdrawn all
+# become communication before anyone has looked at them — and a Discussion
+# cannot be un-sent the way a tag can be moved.
+#
+# So this is a tool, invoked when the release is known to be good. Run it from
+# the Actions tab, or:
+#
+#   gh workflow run announce-release.yml -f tag=v2.25.0
+#
+# It still refuses to post twice for the same tag, so re-running is safe.
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -30,7 +41,7 @@ jobs:
       - name: Post the release to Discussions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          TAG: ${{ inputs.tag }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Follow-up to #506, on the maintainer's reservation about automatic announcements — which is well placed.

## What changes

`announce-release.yml` no longer triggers on `release: published`. It is `workflow_dispatch` only:

```bash
gh workflow run announce-release.yml -f tag=v2.25.0
```

## Why this one is manual while the chart publish is not

Both were added in the same PR and it is worth being explicit about why they now differ.

**Publishing an artifact is mechanical.** The chart either matches the release tag or the gate refuses to push. Nothing subjective happens, and a wrong push is fixable by pushing a corrected version.

**An announcement is the maintainer's voice on a public forum, and once posted it has been read.** Firing it automatically means a wrong release note, a mis-tagged release, or a release cut and then withdrawn all become communication before anyone has looked at them. A Discussion cannot be un-sent the way a tag can be moved.

The failure modes are not symmetric, so the automation should not be either.

## What is kept

Everything that made it worth writing: the tag-keyed title that survives an unnamed release, the duplicate check so a re-run is safe, and the composed body with the `docker pull` and `helm upgrade` commands and a link back to the notes.

It stops being an automation and becomes a tool — which still solves the original problem (7 watchers, releases nobody hears about), just with a human deciding when.

🤖 Generated with [Claude Code](https://claude.com/claude-code)