### PR TITLE
fix: scope workflow write permissions, and stop SECURITY.md going stale

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -29,14 +29,19 @@ on:
         required: true
         type: string
 
+# Read-only at the top; the write scope sits on the job that posts. Same
+# reason as publish-chart.yml: nothing else in this file should inherit the
+# ability to write to Discussions.
 permissions:
   contents: read
-  discussions: write
 
 jobs:
   announce:
     name: post to Announcements
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      discussions: write
     steps:
       - name: Post the release to Discussions
         env:

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -23,14 +23,19 @@ on:
         type: boolean
         default: true
 
+# Read-only at the top, matching publish-clients.yml and
+# docker-multiplatform.yml. The write scope lives on the one job that pushes,
+# so a step added elsewhere in this file cannot inherit it.
 permissions:
   contents: read
-  packages: write
 
 jobs:
   publish:
     name: package and push
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,16 +7,17 @@ priority class of issue in this project.
 ## Supported versions
 
 Only the latest minor release line receives security fixes. Operators running
-older lines should upgrade to the latest patch on `2.21.x` before reporting —
+older lines should upgrade to the latest patch on `2.25.x` before reporting —
 fixes for retired lines are out of scope.
 
 | Version   | Supported           |
 | --------- | ------------------- |
-| `2.21.x`  | Yes                 |
-| `< 2.21`  | No (please upgrade) |
+| `2.25.x`  | Yes                 |
+| `< 2.25`  | No (please upgrade) |
 
-The supported line moves forward with each `2.x.0` release. With `2.21.0`
-tagged, `2.18.x` and earlier are retired.
+The supported line moves forward with each `2.x.0` release; everything below
+it is retired at that moment. This file is updated by the release tooling, so
+the line above is always the one currently receiving fixes.
 
 ## Reporting a vulnerability
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -190,6 +190,20 @@ dh.write_text(
 # chart versions with the application on purpose (see charts/certmate/Chart.yaml).
 # `version` must move for a publish to be a new artifact rather than a rejected
 # duplicate; `appVersion` is the image tag the chart deploys by default.
+# SECURITY.md names the supported MINOR line, not the full version, so it only
+# actually moves on a x.y.0 — but it moves without anyone remembering, which is
+# the point. It had gone four minor releases stale saying 2.21.x while 2.25.0
+# shipped: a researcher reading that concludes the current version is out of
+# scope, or that the project is abandoned.
+sec = pathlib.Path("SECURITY.md")
+if sec.exists():
+    major, minor, _ = v.split(".")
+    line = f"{major}.{minor}"
+    text = sec.read_text(encoding="utf-8")
+    text = re.sub(r"`[0-9]+\.[0-9]+\.x`", f"`{line}.x`", text)
+    text = re.sub(r"`< [0-9]+\.[0-9]+`", f"`< {line}`", text)
+    sec.write_text(text, encoding="utf-8")
+
 chart = pathlib.Path("charts/certmate/Chart.yaml")
 if chart.exists():
     text = chart.read_text(encoding="utf-8")
@@ -218,7 +232,7 @@ real-cert E2E skipped (non-issuance change): $skip_reason"
   # the commit produced a release PR whose own CI failed on the version-
   # consistency test — a gate the local run cannot catch, because the bump
   # happens after the gates.
-  git add modules/__init__.py package.json package-lock.json README.dockerhub.md charts/certmate/Chart.yaml docs/index.md docs/*/index.md
+  git add modules/__init__.py package.json package-lock.json README.dockerhub.md charts/certmate/Chart.yaml SECURITY.md docs/index.md docs/*/index.md
   git commit -q -m "$body
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -154,3 +154,26 @@ def test_release_script_ignores_client_tags_when_finding_the_last_release():
             "clients-v* tag can be mistaken for the last release and disarm "
             f"the mandatory real-cert gate: {line.strip()}"
         )
+
+
+def test_security_policy_names_the_current_minor_line():
+    """SECURITY.md is what a researcher reads before reporting.
+
+    It said `2.25.x`... no: it said `2.21.x` while 2.25.0 was the release,
+    four minor lines stale. Someone reading that concludes the version they
+    are running is out of scope, or that nobody is home. It names the MINOR
+    line, so it only moves on a x.y.0 — but it moves without being remembered.
+    """
+    major, minor, _ = __version__.split(".")
+    text = (REPO_ROOT / "SECURITY.md").read_text(encoding="utf-8")
+
+    supported = set(re.findall(r"`(\d+\.\d+)\.x`", text))
+    assert supported == {f"{major}.{minor}"}, (
+        f"SECURITY.md declares support for {sorted(supported)} but the current "
+        f"release is {__version__}. scripts/release.sh bumps this file."
+    )
+    retired = set(re.findall(r"`< (\d+\.\d+)`", text))
+    assert retired == {f"{major}.{minor}"}, (
+        f"SECURITY.md retires everything below {sorted(retired)}, which does "
+        f"not match the supported line {major}.{minor}.x"
+    )


### PR DESCRIPTION
Two findings from a pre-release sweep. One is a regression from yesterday's workflows.

## 1. Workflow write permissions (Scorecard `TokenPermissionsID`, high)

`publish-chart.yml` declared `packages: write` at the **top level**:

```
score is 0: topLevel 'packages' permission set to 'write'
```

Every job and every step later added to that file would inherit the ability to push packages. Moved onto the single job that pushes — which is what `publish-clients.yml` and `docker-multiplatform.yml` already do, so this restores the repository's own convention rather than inventing one.

`announce-release.yml` had the identical shape with `discussions: write`, and was not flagged only because Scorecard had not rescanned it yet. Fixed in the same pass rather than waiting for the alert to appear.

## 2. SECURITY.md was four minor releases stale

It declared:

| Version | Supported |
|---|---|
| `2.21.x` | Yes |
| `< 2.21` | No |

while **2.25.0** was the current release. That is the file a security researcher opens before reporting, linked from the GitHub Security tab. It told them the version they are running is out of scope, or that the project is abandoned.

Given the day this repository has had, updating the number was not the fix. `release.sh` now rewrites the supported line and `test_version_consistency` fails the build when it disagrees with `modules.__version__`. It tracks the **minor** line, so it only actually moves on a `x.y.0`.

### The gate earned its keep immediately

It failed on its first run — because the paragraph I had written mentioned the old `2.21.x` as a historical note, and the check read that as a second support claim. It was right to. A security policy should state the policy, not narrate our process failures; the paragraph is trimmed to the policy.

Verified in the other direction too: rolling the file back to `2.24.x` turns the suite red.

## Not fixed, deliberately

The sweep also surfaced a new `py/path-injection` (high) on `modules/api/resources.py:2082`. It is a **false positive** — `_validate_domain_path` rejects `..`, slashes and null bytes, enforces a domain regex, and confirms containment after `resolve()`; CodeQL does not follow that validation through the helper's return value. It is the same category already accepted for `certificates.py`. That is a triage decision, not a code change, and is left for the maintainer to dismiss.

Full suite: **2284 passed**, 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)