### PR TITLE
fix: the minimal image never started, and nothing ever built it (#514)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,18 @@ jobs:
             exit 1
           fi
           echo "$req -> /health OK"
+
+          # /health says nothing about certbot, and CertMate drives it as a
+          # subprocess. pip's metadata used to refuse any cryptography new
+          # enough to pull a pyOpenSSL that breaks the ACME stack; as of
+          # 2026-08-08 it no longer does, so a bump can install cleanly, boot
+          # cleanly, and fail on the first issuance. Ask the binary directly.
+          if ! docker exec "$cid" certbot --version; then
+            echo "::error::$req built an image whose certbot cannot start — no certificate can be issued. See SECURITY.md 'Known dependency constraint'."
+            docker rm -f "$cid" >/dev/null 2>&1 || true
+            exit 1
+          fi
+
           docker rm -f "$cid" >/dev/null 2>&1 || true
           echo "::endgroup::"
         done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,10 +115,48 @@ jobs:
         name: codecov-umbrella
         fail_ci_if_error: false
 
-    - name: Test Docker build
+    # Build AND boot both requirements sets.
+    #
+    # This step used to run `docker build` alone. A successful build proves the
+    # layers assemble, not that the process starts — and `requirements-minimal
+    # .txt`, which the Dockerfile advertises via REQUIREMENTS_FILE, was never
+    # built by anything at all. It had been missing SQLAlchemy for months:
+    # factory.py imports APScheduler's SQLAlchemyJobStore at module scope, so
+    # gunicorn's worker died on import and the container restart-looped (#514).
+    # It took a user building it to find out.
+    #
+    # So: every advertised requirements file gets built, started, and asked for
+    # /health. A container that cannot answer that has not been tested.
+    - name: Build and boot every advertised image variant
       if: matrix.python-version == '3.12'
       run: |
-        docker build -t certmate:test .
+        set -euo pipefail
+        for req in requirements.txt requirements-minimal.txt; do
+          tag="certmate:test-$(basename "$req" .txt)"
+          echo "::group::build $req"
+          docker build --build-arg REQUIREMENTS_FILE="$req" -t "$tag" .
+          echo "::endgroup::"
+
+          echo "::group::boot $req"
+          cid=$(docker run -d -p 18900:8000 "$tag")
+          ok=0
+          for _ in $(seq 1 30); do
+            if curl -fsS http://localhost:18900/health >/dev/null 2>&1; then ok=1; break; fi
+            # Fail fast if the container is already gone: waiting out the
+            # timeout on a dead container just hides the traceback.
+            if [ "$(docker inspect -f '{{.State.Running}}' "$cid")" != "true" ]; then break; fi
+            sleep 2
+          done
+          if [ "$ok" != 1 ]; then
+            echo "::error::$req produced an image that never served /health"
+            docker logs "$cid" 2>&1 | tail -40
+            docker rm -f "$cid" >/dev/null 2>&1 || true
+            exit 1
+          fi
+          echo "$req -> /health OK"
+          docker rm -f "$cid" >/dev/null 2>&1 || true
+          echo "::endgroup::"
+        done
 
   # The Tailwind bundle (static/css/tailwind.min.css) is committed to the repo
   # and served as-is — there is no build step at deploy time. So a stale bundle

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -139,6 +139,29 @@ metadata and a clean-room install on 2026-07-07:
 In short: every cryptography version that fixes the GHSA requires a
 pyOpenSSL that breaks the pinned ACME stack at import.
 
+**Re-verified 2026-08-08 against `cryptography==50.0.0` (Dependabot #516), and
+the situation has become more dangerous, not less.**
+
+- **pip now accepts the combination.** `pip install certbot==2.10.0
+  josepy==1.13.0 cryptography==50.0.0` resolves and installs cleanly, pulling
+  `pyopenssl==26.4.0`. The dependency metadata no longer refuses it, so the
+  guard rail that used to stop this bump at resolution time is gone. The
+  failure has moved from install time to run time: an image builds green and
+  then dies the first time it tries to issue a certificate.
+- **The failure is now `X509Req`, not `X509Extension`.** pyOpenSSL 26.4.0 has
+  dropped both (`hasattr(OpenSSL.crypto, 'X509Req') == False`), and `X509Req`
+  is the one that breaks first.
+- **`certbot` itself no longer starts.** Not merely `acme.crypto_util`:
+  `certbot --version` raises `AttributeError: module 'OpenSSL.crypto' has no
+  attribute 'X509Req'` from `certbot/_internal/main.py:21`. CertMate drives
+  certbot as a CLI subprocess, so this is the entire issuance path, not a
+  library nicety.
+
+So the pin is now doing more work than it was, not less: nothing upstream
+enforces it any more. Do not relax `cryptography` or `pyopenssl` here without
+re-running that clean-room install and confirming `certbot --version` still
+answers. The real fix remains the certbot 5.x stack migration (#103).
+
 **Mitigation / actual exposure.** The vulnerable code path is
 `PKCS7_verify()` (PKCS#7 / S/MIME signature verification):
 

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -25,3 +25,12 @@ pyopenssl==26.0.0                  # Do not bump to 26.2.0+: removes X509Extensi
 
 # Production server
 gunicorn==23.0.0
+
+# APScheduler's SQLAlchemyJobStore backs the persistent renewal schedule, and
+# modules/core/factory.py imports it at module scope — so this is not optional
+# for the minimal set, it is required to boot at all. Leaving it out made an
+# image built with REQUIREMENTS_FILE=requirements-minimal.txt die during
+# gunicorn's worker import and restart-loop forever (#514). Nothing in CI had
+# ever built this file, which is why an advertised build argument shipped
+# broken; ci.yml now builds and boots it on every run.
+SQLAlchemy>=2.0.0,<3.0.0

--- a/tests/test_requirements_sets.py
+++ b/tests/test_requirements_sets.py
@@ -107,3 +107,43 @@ def test_every_advertised_requirements_file_is_built_by_ci():
         "the image job no longer checks /health — `docker build` proves the "
         "layers assemble, not that the container starts."
     )
+
+
+def test_the_certbot_cli_actually_runs():
+    """CertMate drives certbot as a subprocess. Prove the binary starts.
+
+    Until 2026-08-08 this was defended by accident: pip's own metadata refused
+    to install a cryptography new enough to drag in a pyOpenSSL that breaks the
+    pinned ACME stack. That guard rail is gone — `pip install certbot==2.10.0
+    josepy==1.13.0 cryptography==50.0.0` now resolves cleanly and installs
+    pyopenssl 26.4.0, which has dropped both `X509Req` and `X509Extension`.
+    `certbot --version` then dies in `certbot/_internal/main.py` with an
+    AttributeError, and every issuance with it.
+
+    Nothing else here would notice. The unit suite mocks the shell, /health
+    reports on the scheduler and the cert directory, and the image builds and
+    boots perfectly well — the first certificate request is where it surfaces.
+    So this asks the one question that matters about the pin: does the binary
+    we shell out to still start?
+
+    No network: `--version` prints and exits.
+    """
+    import shutil
+    import subprocess
+
+    certbot = shutil.which("certbot")
+    if certbot is None:
+        pytest.skip("certbot is not on PATH in this environment")
+
+    result = subprocess.run(
+        [certbot, "--version"], capture_output=True, text=True, timeout=60
+    )
+    assert result.returncode == 0, (
+        "`certbot --version` failed — the ACME stack is broken at import and "
+        "no certificate can be issued. Most likely a cryptography/pyopenssl "
+        "bump; see SECURITY.md 'Known dependency constraint'.\n"
+        f"exit={result.returncode}\n{(result.stderr or result.stdout)[-1500:]}"
+    )
+    assert "certbot" in (result.stdout + result.stderr).lower(), (
+        f"`certbot --version` produced no version line: {result.stdout!r}"
+    )

--- a/tests/test_requirements_sets.py
+++ b/tests/test_requirements_sets.py
@@ -1,0 +1,109 @@
+"""Guards on the requirements files the Dockerfile advertises.
+
+`requirements-minimal.txt` is not a convenience copy — the Dockerfile documents
+`REQUIREMENTS_FILE` as a supported build argument, so it is a shipped product
+surface. It had been missing SQLAlchemy for months: `modules/core/factory.py`
+imports APScheduler's `SQLAlchemyJobStore` at module scope, so an image built
+from it died during gunicorn's worker import and restart-looped forever (#514).
+
+Nothing caught it because nothing built it. CI now builds *and boots* every
+advertised variant; these tests are the cheap part of that guard — they run in
+milliseconds and catch the two failure modes a Docker job is slow at proving:
+a boot-critical distribution going missing, and the two files drifting apart on
+a version pin.
+"""
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+FULL = REPO_ROOT / "requirements.txt"
+MINIMAL = REPO_ROOT / "requirements-minimal.txt"
+
+# Distributions whose absence stops the process from starting, because a module
+# on the import path of `app.py` imports them unguarded. Anything optional is
+# deliberately absent from this list: bcrypt, Authlib and prometheus_client are
+# all wrapped in try/except with a working fallback, which is why the minimal
+# image survives without them.
+BOOT_CRITICAL = {
+    "flask",
+    "flask-cors",
+    "flask-restx",
+    "certbot",
+    "cryptography",
+    "requests",
+    "urllib3",
+    "apscheduler",
+    "sqlalchemy",     # via apscheduler.jobstores.sqlalchemy — factory.py:11
+    "gunicorn",
+}
+
+
+def _requirements(path):
+    """Map distribution name (normalised) -> full specifier, comments stripped."""
+    found = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.split("#")[0].strip()
+        if not line or line.startswith("-"):
+            continue
+        name = re.split(r"[=<>!~\[]", line)[0].strip()
+        if name:
+            found[name.lower().replace("_", "-")] = line
+    return found
+
+
+def test_minimal_requirements_can_actually_boot_the_app():
+    """Every distribution needed to reach a running process must be present."""
+    minimal = _requirements(MINIMAL)
+    missing = sorted(BOOT_CRITICAL - set(minimal))
+    assert not missing, (
+        f"requirements-minimal.txt is missing {missing}. The Dockerfile "
+        f"advertises REQUIREMENTS_FILE=requirements-minimal.txt, so an image "
+        f"built from it must start — leaving one of these out produces a "
+        f"container that restart-loops on an ImportError (#514)."
+    )
+
+
+def test_the_full_set_is_a_superset_of_the_minimal_one():
+    """Minimal is the Cloudflare-only subset. It cannot contain a package the
+    full set lacks — that would mean the default image is missing something."""
+    extra = sorted(set(_requirements(MINIMAL)) - set(_requirements(FULL)))
+    assert not extra, (
+        f"requirements-minimal.txt lists {extra}, absent from requirements.txt. "
+        f"Minimal is meant to be a subset; anything here belongs in both."
+    )
+
+
+@pytest.mark.parametrize("name", sorted(BOOT_CRITICAL))
+def test_shared_pins_do_not_drift_between_the_two_files(name):
+    """The same distribution must carry the same specifier in both files.
+
+    A pin that moves in one file and not the other means the two images run
+    different code while claiming the same release — the drift class that
+    test_version_consistency exists to stop for the version string.
+    """
+    full, minimal = _requirements(FULL), _requirements(MINIMAL)
+    if name not in full or name not in minimal:
+        pytest.skip(f"{name} is not in both files")
+    assert full[name] == minimal[name], (
+        f"{name} is pinned differently:\n"
+        f"  requirements.txt         {full[name]}\n"
+        f"  requirements-minimal.txt {minimal[name]}"
+    )
+
+
+def test_every_advertised_requirements_file_is_built_by_ci():
+    """A requirements file the Dockerfile advertises but CI never builds is a
+    product surface with no test. That is exactly how #514 shipped."""
+    workflow = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    for path in (FULL, MINIMAL):
+        assert path.name in workflow, (
+            f"{path.name} is not built anywhere in ci.yml. Either build it or "
+            f"stop advertising it in the Dockerfile."
+        )
+    assert "/health" in workflow, (
+        "the image job no longer checks /health — `docker build` proves the "
+        "layers assemble, not that the container starts."
+    )


### PR DESCRIPTION
Fixes #514. Reported by @mackboylens against `8a15f52`, reproduced exactly.

## What was broken

An image built with `--build-arg REQUIREMENTS_FILE=requirements-minimal.txt` dies during gunicorn's worker import and restart-loops forever:

```
File "/app/modules/core/factory.py", line 11, in <module>
    from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
ImportError: SQLAlchemyJobStore requires SQLAlchemy installed
```

`requirements-minimal.txt` has no SQLAlchemy; `factory.py` imports `SQLAlchemyJobStore` at module scope. The import of `app` cannot complete, so the container never serves anything.

I checked in a container whether anything else was missing: **SQLAlchemy is the only one.** `bcrypt`, `Authlib` and `prometheus_client` are each wrapped in `try/except` with a working fallback, which is precisely why their absence is survivable and this one is not.

## Why it survived for months

The Dockerfile advertises `REQUIREMENTS_FILE` as a supported build argument, so this is a shipped surface. And **nothing in the repository ever built it** — no workflow, no test, no script referenced `requirements-minimal.txt` anywhere. It took a user building it to find out.

The deeper gap: the CI step was

```yaml
- name: Test Docker build
  run: docker build -t certmate:test .
```

and nothing else. A successful build proves the layers assemble. It says nothing about whether the process starts.

## What changed

- **`requirements-minimal.txt`** gets `SQLAlchemy>=2.0.0,<3.0.0`, the same specifier the full set carries.
- **ci.yml** now builds *and boots* every advertised requirements set, requiring each to answer `/health`. It fails fast with logs when the container is already dead, rather than waiting out the timeout on a corpse.
- **`tests/test_requirements_sets.py`** covers the cheap half in milliseconds: a boot-critical distribution going missing, minimal drifting out of subset with the full set, a shared pin diverging between the two files, and ci.yml ceasing to build an advertised variant or to check `/health`.

## Verification

Built and booted both variants locally with Docker:

```
requirements.txt         -> /health OK: {"status":"healthy","scheduler":"running","version":"2.25.1"}
requirements-minimal.txt -> /health OK: {"status":"healthy","scheduler":"running","version":"2.25.1"}
```

`scheduler: running` is exactly what SQLAlchemy makes possible — the persistent renewal job store.

Both new gates were checked to **fail without their fix**: removing SQLAlchemy turns `test_minimal_requirements_can_actually_boot_the_app` red, and removing the `/health` check from ci.yml turns `test_every_advertised_requirements_file_is_built_by_ci` red.

Suite **2356** green.

## Noted, not changed here

The minimal set also omits `bcrypt`, so an image built from it logs `bcrypt not available; using the scrypt KDF fallback` and runs on the non-preferred password KDF. That is a deliberate, working fallback — not a crash — but it means the officially-advertised minimal image has a different security posture from the default one, and nothing documents that. Worth its own decision rather than a silent change inside a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)