### PR TITLE
fix(release): the gate that demands a real certificate could not see the DNS code

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -32,7 +32,33 @@ if ! command -v docker >/dev/null 2>&1 && [ -x /Applications/Docker.app/Contents
 fi
 
 # Paths whose change makes the real-cert E2E MANDATORY (issuance pipeline).
-SENSITIVE_RE='^(modules/(core/(certificate|client_cert|deployer|acme|storage)|dns|api/(certificate|resources|client_cert))|requirements.*\.txt|Dockerfile|tests/(e2e_support|test_cert_lifecycle|test_async_issuance|test_health_ready))'
+#
+# FAIL-CLOSED BY DESIGN. This used to be an allowlist of prefixes —
+# `modules/core/(certificate|client_cert|deployer|acme|storage)|modules/dns|...`
+# — and it had rotted badly by 2026-08-08:
+#
+#   * `modules/dns` matched nothing at all. There is no such directory; the DNS
+#     code lives at modules/core/dns_*.py. The branch was dead, so a change to
+#     dns_providers.py, dns_strategies.py, dns_alias_hook.py or
+#     dns_zone_discovery.py did NOT make the real cert mandatory — in the gate
+#     written precisely because two DNS providers had each shipped in a state
+#     where they had never worked in any release.
+#   * Sixteen issuance-critical files were uncovered in total, including
+#     modules/core/shell.py, which is how certbot is invoked at all.
+#
+# The lesson is not "add the missing prefixes" — the next rename breaks it
+# again, silently, and nobody reads a regex this long closely enough to notice.
+# So the rule is inverted: everything that can reach a certificate is sensitive,
+# and the escape hatch exists only for changes that provably cannot (docs, CI,
+# the site, static assets, tests other than the issuance ones).
+#
+# The asymmetry justifies it. A false positive costs one Let's Encrypt staging
+# issuance, about four minutes, which is already the default behaviour. A false
+# negative ships a DNS provider that cannot issue.
+#
+# tests/test_release_gate.py asserts every branch below matches a real path, so
+# a dead branch fails the suite instead of silently disarming the gate.
+SENSITIVE_RE='^(modules/|app\.py$|requirements.*\.txt|Dockerfile|docker-compose\.yml|charts/|tests/(e2e_support|test_cert_lifecycle|test_async_issuance|test_health_ready))'
 
 die()  { echo "ERROR: $*" >&2; exit 1; }
 info() { echo ">>> $*"; }

--- a/tests/test_release_gate.py
+++ b/tests/test_release_gate.py
@@ -1,0 +1,226 @@
+"""Guards on the gate that decides whether a release needs a real certificate.
+
+`scripts/release.sh` runs an end-to-end issuance against Let's Encrypt staging
+before cutting a release. `SENSITIVE_RE` decides whether that run is MANDATORY
+— i.e. whether `--skip-real-cert` is refused. It is the safety catch on the
+escape hatch, and until 2026-08-08 it had a hole big enough to drive the whole
+DNS subsystem through:
+
+    modules/(core/(certificate|client_cert|deployer|acme|storage)|dns|...)
+                                                                 ^^^
+`modules/dns` matches nothing. There is no such directory — the DNS code lives
+at `modules/core/dns_*.py`. So a change to `dns_providers.py`,
+`dns_strategies.py`, `dns_alias_hook.py` or `dns_zone_discovery.py` did not make
+the real certificate mandatory, in the gate written *because* two DNS providers
+had each shipped never having worked in any release. Sixteen issuance-critical
+files were uncovered in all, `modules/core/shell.py` — how certbot is invoked —
+among them.
+
+Nobody spotted it because nobody reads a regex that long closely enough. So the
+tests below check two different things:
+
+  * the specific files that must be covered, and
+  * that **every branch of the pattern matches something real**, which is the
+    check that would have caught a dead `modules/dns` on the day it was written.
+"""
+import pathlib
+import re
+import subprocess
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+RELEASE_SH = REPO_ROOT / "scripts" / "release.sh"
+
+
+def _sensitive_re():
+    """The live pattern, read from the script rather than duplicated here.
+
+    Duplicating it would make these tests pass against a copy while the script
+    shipped something else — the failure mode they exist to prevent.
+    """
+    match = re.search(r"^SENSITIVE_RE='([^']+)'", RELEASE_SH.read_text(encoding="utf-8"),
+                      re.M)
+    assert match, "scripts/release.sh no longer defines SENSITIVE_RE"
+    return match.group(1)
+
+
+def _tracked_files():
+    out = subprocess.run(["git", "ls-files"], cwd=REPO_ROOT,
+                         capture_output=True, text=True, timeout=60)
+    assert out.returncode == 0, "git ls-files failed"
+    return out.stdout.splitlines()
+
+
+def _expand(pattern):
+    """Expand a restricted regex into its alternative branches.
+
+    Handles exactly the constructs the pattern uses: literals and `(a|b|c)`
+    groups, nested one level. Anything else raises rather than being silently
+    ignored — a branch this cannot understand must not be reported as covered.
+    """
+    depth, start, branches, current = 0, None, [], ""
+    i = 0
+    while i < len(pattern):
+        ch = pattern[i]
+        if ch == "\\":                      # escaped char, take both
+            # Only when outside a group: inside one, the characters belong to
+            # the branch being collected by the recursive call, not to the
+            # prefix. Getting this wrong prepended the escapes of every inner
+            # branch to every expansion.
+            if depth == 0:
+                current += pattern[i:i + 2]
+            i += 2
+            continue
+        if ch == "(":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                inner = pattern[start + 1:i]
+                head = current
+                tail = pattern[i + 1:]
+                out = []
+                for alt in _split_top_level(inner):
+                    for rest in _expand(tail):
+                        out.append(head + alt + rest)
+                return out
+        elif depth == 0:
+            current += ch
+        i += 1
+    assert depth == 0, f"unbalanced parentheses in {pattern!r}"
+    return [current]
+
+
+def _split_top_level(pattern):
+    """Split on `|` that is not inside a group."""
+    depth, parts, current = 0, [], ""
+    i = 0
+    while i < len(pattern):
+        ch = pattern[i]
+        if ch == "\\":
+            current += pattern[i:i + 2]
+            i += 2
+            continue
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        if ch == "|" and depth == 0:
+            parts.append(current)
+            current = ""
+        else:
+            current += ch
+        i += 1
+    parts.append(current)
+    return parts
+
+
+# Files that must make the real-cert run mandatory. Every one of these can
+# break certificate issuance in a way only a real issuance would reveal.
+MUST_BE_COVERED = [
+    # the orchestration
+    "modules/core/certificates.py",
+    "modules/core/cert_service.py",
+    "modules/core/cert_jobs.py",
+    # the DNS-01 challenge — the branch that used to be dead
+    "modules/core/dns_providers.py",
+    "modules/core/dns_strategies.py",
+    "modules/core/dns_alias_hook.py",
+    "modules/core/dns_zone_discovery.py",
+    # how certbot is actually invoked
+    "modules/core/shell.py",
+    # the private CA issuance path
+    "modules/core/private_ca.py",
+    "modules/core/ca_manager.py",
+    "modules/core/csr_handler.py",
+    "modules/core/ocsp_crl.py",
+    "modules/core/client_certificates.py",
+    # where certificates are written and sent
+    "modules/core/storage_backends.py",
+    "modules/core/deployer.py",
+    "modules/core/deploy_targets.py",
+    # provider configuration and credential files
+    "modules/core/settings.py",
+    "modules/core/utils.py",
+    # the API and web entry points
+    "modules/api/resources.py",
+    "modules/api/models.py",
+    "modules/api/client_certificates.py",
+    "modules/web/cert_routes.py",
+    # what the image is built from
+    "requirements.txt",
+    "requirements-minimal.txt",
+    "requirements-extended.txt",
+    "Dockerfile",
+]
+
+# Changes that must NOT force a real issuance, or the escape hatch is useless
+# and a docs-only release becomes a four-minute ceremony.
+MUST_NOT_BE_COVERED = [
+    "README.md",
+    "RELEASE_NOTES.md",
+    "SECURITY.md",
+    "docs/api.md",
+    "docs/it/guide.md",
+    ".github/workflows/ci.yml",
+    "static/css/tailwind.min.css",
+    "templates/help.html",
+    "tests/test_docs_navigation.py",
+]
+
+
+@pytest.mark.parametrize("path", MUST_BE_COVERED)
+def test_issuance_critical_paths_make_the_real_cert_mandatory(path):
+    assert (REPO_ROOT / path).exists(), (
+        f"{path} no longer exists — update this list to match the code, do not "
+        f"delete the entry to make the test pass."
+    )
+    assert re.search(_sensitive_re(), path), (
+        f"{path} does not match SENSITIVE_RE, so a release changing only that "
+        f"file would accept --skip-real-cert. This is the hole that let the "
+        f"whole DNS subsystem through."
+    )
+
+
+@pytest.mark.parametrize("path", MUST_NOT_BE_COVERED)
+def test_non_issuance_paths_keep_the_escape_hatch(path):
+    assert not re.search(_sensitive_re(), path), (
+        f"{path} matches SENSITIVE_RE. If every change forces a real "
+        f"certificate, the skip flag is dead and a docs release costs four "
+        f"minutes of Let's Encrypt staging for nothing."
+    )
+
+
+def test_no_branch_of_the_pattern_is_dead():
+    """Every alternative must match at least one tracked file.
+
+    This is the test that was missing. `modules/dns` sat in the pattern for
+    months matching a directory that has never existed, and nothing said so
+    because nothing ever asked whether the branches described real paths.
+    """
+    tracked = _tracked_files()
+    dead = []
+    for branch in _expand(_sensitive_re()):
+        # Drop the anchors so a branch can be matched as a prefix.
+        probe = branch.lstrip("^").rstrip("$")
+        if not any(re.match(probe, f) for f in tracked):
+            dead.append(branch)
+    assert not dead, (
+        f"these branches of SENSITIVE_RE match no file in the repository: "
+        f"{dead}. A dead branch silently disarms the gate for whatever it was "
+        f"meant to cover."
+    )
+
+
+def test_the_gate_is_still_wired_to_the_skip_flag():
+    """The pattern only matters if refusing --skip-real-cert still depends on it."""
+    script = RELEASE_SH.read_text(encoding="utf-8")
+    assert "--skip-real-cert is not allowed here" in script, (
+        "release.sh no longer refuses --skip-real-cert; SENSITIVE_RE is decorative"
+    )
+    assert 'grep -Eq "$SENSITIVE_RE"' in script, (
+        "release.sh no longer tests changed paths against SENSITIVE_RE"
+    )

--- a/tests/test_release_gate.py
+++ b/tests/test_release_gate.py
@@ -83,9 +83,16 @@ def _expand(pattern):
                 head = current
                 tail = pattern[i + 1:]
                 out = []
+                # Each alternative is expanded in turn, not taken whole: a
+                # nested group like `tests/(a|b|c)` must yield one expansion
+                # per option, or a dead option inside it would still match via
+                # its siblings and be reported as live — the same blind spot,
+                # one level down, as the `modules/dns` branch this file exists
+                # to catch.
                 for alt in _split_top_level(inner):
-                    for rest in _expand(tail):
-                        out.append(head + alt + rest)
+                    for alt_expanded in _expand(alt):
+                        for rest in _expand(tail):
+                            out.append(head + alt_expanded + rest)
                 return out
         elif depth == 0:
             current += ch


### PR DESCRIPTION
`scripts/release.sh` runs an end-to-end issuance against Let's Encrypt staging before cutting a release. `SENSITIVE_RE` decides whether that run is **mandatory** — whether `--skip-real-cert` is refused. It had rotted:

```
modules/(core/(certificate|client_cert|deployer|acme|storage)|dns|api/(...))
                                                             ^^^
```

**`modules/dns` matches nothing.** There is no such directory — the DNS code lives at `modules/core/dns_*.py`. So a release changing only `dns_providers.py`, `dns_strategies.py`, `dns_alias_hook.py` or `dns_zone_discovery.py` would have accepted `--skip-real-cert` — in the gate that exists *because* two DNS providers had each shipped in a state where they had never worked in any release.

Sixteen issuance-critical files were uncovered in total:

| | |
|---|---|
| orchestration | `cert_service.py`, `cert_jobs.py` |
| the DNS-01 challenge | `dns_providers.py`, `dns_strategies.py`, `dns_alias_hook.py`, `dns_zone_discovery.py` |
| **how certbot is invoked** | `shell.py` |
| private CA issuance | `private_ca.py`, `ca_manager.py`, `csr_handler.py`, `ocsp_crl.py` |
| delivery & config | `deploy_targets.py`, `settings.py`, `utils.py` |
| entry points | `api/models.py`, `web/cert_routes.py` |

## Why not just add the missing prefixes

Because the next rename breaks it again, silently, and nobody reads a regex that long closely enough to notice — which is exactly how `modules/dns` survived.

So the rule is **inverted to fail closed**: everything under `modules/`, plus what the image is built from, is sensitive. The escape hatch survives only for changes that provably cannot reach a certificate — docs, CI, static assets, templates, non-issuance tests.

The asymmetry justifies it. A false positive costs one Let's Encrypt staging issuance, about four minutes, **which is already the default behaviour**. A false negative ships a DNS provider that cannot issue.

## The test that was missing

`tests/test_release_gate.py` reads the live pattern out of the script rather than duplicating it — a copy would let these tests pass while the script shipped something else. It asserts:

1. every issuance-critical path is covered;
2. docs-only paths still are **not**, so a documentation release does not cost four minutes for nothing;
3. **every branch of the pattern matches at least one real file.**

That third one is the check that was missing. Nothing ever asked whether the branches described real paths, so `modules/dns` sat there for months.

## Verification

- Restoring the **old** pattern turns the DNS and `shell.py` cases red.
- Injecting a **fresh** dead branch (`modules/nonexistent/`) turns the dead-branch test red.
- Behavioural check against the real evaluation `release.sh` performs:

```
modules/core/dns_providers.py     MANDATORY      README.md                 skippable
modules/core/shell.py             MANDATORY      docs/it/guide.md          skippable
modules/core/dns_alias_hook.py    MANDATORY      .github/workflows/ci.yml  skippable
charts/certmate/values.yaml       MANDATORY
```

- The release currently pending (`v2.25.1..main`) is correctly judged **MANDATORY**.

Suite **2394** green, flake8 gate 0, bandit medium+ 0.

While writing the branch expander for test 3 I got it wrong first — it prepended inner escapes to every expansion — and the test failed rather than passing vacuously. Worth saying, since a silently-broken checker is the thing this PR is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)