### PR TITLE
docs: v2.25.2 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,49 @@
+## v2.25.2 (Things that were never tested, and therefore never worked)
+
+A patch release. Every change here is a fix, and four of them share a shape worth naming: the check that should have caught the bug either did not exist, or existed and could not fail.
+
+### An image variant that could not start
+
+- **`requirements-minimal.txt` produced a container that crash-looped** (#514, reported by @mackboylens). The Dockerfile advertises `REQUIREMENTS_FILE` as a supported build argument, but the minimal set omitted SQLAlchemy while `modules/core/factory.py` imports APScheduler's `SQLAlchemyJobStore` at module scope. Gunicorn's worker died during import, every time.
+
+  It had been broken for months because **nothing in the repository ever built that file** — no workflow, no test, no script referenced it. And the CI step was `docker build` alone, which proves the layers assemble and says nothing about whether the process starts. CI now builds *and boots* every advertised requirements set and requires each to answer `/health`.
+
+  If you build your own image with the default `requirements.txt`, nothing changes: that path was always fine, and the published images are built from it.
+
+### Certificate issuance
+
+- **Four calls to Akamai EdgeDNS had no timeout** (#511). They run inside the certbot authentication hook, on one of the eight threads the process has. `requests` has no default timeout, so a hung connection held that thread indefinitely; enough of them and the interface stops responding. Every other outbound call in that module already set one.
+
+- **A dependency pin was not pinning anything** (#511). `certbot-dns-hetzner==3.0.0` depends on `dns-lexicon-coop`, a third-party fork that ships the same top-level `lexicon/` package as the pinned `dns-lexicon==3.25.1`. pip installed both and let one overwrite the other, so which library the DNS alias mode actually used depended on install order. Held at `certbot-dns-hetzner==2.0.1`, whose four Python files are byte-identical to 3.0.0 — the releases differ only in that dependency line.
+
+### Availability
+
+- **A quadratic blowup in the routine that redacts secrets from logs** (#511). The PEM matcher restarted a forward scan at every `-----BEGIN`, so text that opens blocks it never closes cost time proportional to the square of its length. Measured before the fix: 480 KB of such text burned **21.6 seconds** of CPU on a single worker thread. That routine sanitises deploy-hook output, which is unbounded and frequently carries text from other systems.
+
+  Replaced with a linear scanner, verified equivalent to the old pattern by differential fuzzing. The same 480 KB now takes **36 milliseconds**, and 3.8 MB takes 291.
+
+### Guarding the dependency pins
+
+- **`certbot --version` is now checked, in the test suite and inside both built images.** Until this release the constraint documented in SECURITY.md was enforced by accident: pip'"'"'s own metadata refused any `cryptography` new enough to pull a `pyOpenSSL` that breaks the pinned ACME stack. That is no longer true. As of 2026-08-08 the combination installs cleanly and then `certbot --version` dies with `AttributeError: module '"'"'OpenSSL.crypto'"'"' has no attribute '"'"'X509Req'"'"'` — taking the whole issuance path with it.
+
+  Nothing would have noticed: the unit suite mocks the shell, `/health` reports on the scheduler and the certificate directory, and the image builds and boots perfectly. An operator would have found out on their first certificate request.
+
+### Documentation
+
+- **210 examples pointed at the wrong port.** `api.md` and `guide.md`, in all five languages, used `localhost:5000` — Flask'"'"'s development default, never CertMate'"'"'s 8000. The most copy-pasted thing in the documentation returned connection refused.
+- **The batch import limit was overstated by 300x.** Nine pages promised 30,000 certificates per request against an API that rejects more than 100 with a 400.
+- **Eleven files documented a test command that fails on a clean checkout**, and thirteen relative links in the translations pointed at nothing.
+- The MCP server, present and documented in five languages, was linked from no index at all.
+
+### Notes for operators
+
+- Upgrading is a drop-in. No configuration, data or API changes.
+- Worth upgrading promptly if you use **DNS alias mode with Akamai EdgeDNS**, **deploy hooks that emit large output**, or **the Hetzner DNS plugin**.
+- If you build your own image from `requirements-minimal.txt`, this release is the one that makes it start.
+- The published Docker images were not affected by #514.
+
+---
+
 ## v2.25.1 (A Helm chart, and a security policy that tells the truth)
 
 No application code changed in this release — `modules/` is byte-identical to v2.25.0. What changed is how CertMate is installed, described, and reported to.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,17 +20,17 @@ A patch release. Every change here is a fix, and four of them share a shape wort
 
 - **A quadratic blowup in the routine that redacts secrets from logs** (#511). The PEM matcher restarted a forward scan at every `-----BEGIN`, so text that opens blocks it never closes cost time proportional to the square of its length. Measured before the fix: 480 KB of such text burned **21.6 seconds** of CPU on a single worker thread. That routine sanitises deploy-hook output, which is unbounded and frequently carries text from other systems.
 
-  Replaced with a linear scanner, verified equivalent to the old pattern by differential fuzzing. The same 480 KB now takes **36 milliseconds**, and 3.8 MB takes 291.
+  Replaced with a linear scanner, verified equivalent to the old pattern by differential fuzzing. The same 480 KB now takes **36 milliseconds**, and 3.8 MB takes 291 milliseconds.
 
 ### Guarding the dependency pins
 
-- **`certbot --version` is now checked, in the test suite and inside both built images.** Until this release the constraint documented in SECURITY.md was enforced by accident: pip'"'"'s own metadata refused any `cryptography` new enough to pull a `pyOpenSSL` that breaks the pinned ACME stack. That is no longer true. As of 2026-08-08 the combination installs cleanly and then `certbot --version` dies with `AttributeError: module '"'"'OpenSSL.crypto'"'"' has no attribute '"'"'X509Req'"'"'` — taking the whole issuance path with it.
+- **`certbot --version` is now checked, in the test suite and inside both built images.** Until this release the constraint documented in SECURITY.md was enforced by accident: pip's own metadata refused any `cryptography` new enough to pull a `pyOpenSSL` that breaks the pinned ACME stack. That is no longer true. As of 2026-08-08 the combination installs cleanly and then `certbot --version` dies with `AttributeError: module 'OpenSSL.crypto' has no attribute 'X509Req'` — taking the whole issuance path with it.
 
   Nothing would have noticed: the unit suite mocks the shell, `/health` reports on the scheduler and the certificate directory, and the image builds and boots perfectly. An operator would have found out on their first certificate request.
 
 ### Documentation
 
-- **210 examples pointed at the wrong port.** `api.md` and `guide.md`, in all five languages, used `localhost:5000` — Flask'"'"'s development default, never CertMate'"'"'s 8000. The most copy-pasted thing in the documentation returned connection refused.
+- **210 examples pointed at the wrong port.** `api.md` and `guide.md`, in all five languages, used `localhost:5000` — Flask's development default, never CertMate's 8000. The most copy-pasted thing in the documentation returned connection refused.
 - **The batch import limit was overstated by 300x.** Nine pages promised 30,000 certificates per request against an API that rejects more than 100 with a 400.
 - **Eleven files documented a test command that fails on a clean checkout**, and thirteen relative links in the translations pointed at nothing.
 - The MCP server, present and documented in five languages, was linked from no index at all.

--- a/tests/test_docs_navigation.py
+++ b/tests/test_docs_navigation.py
@@ -244,3 +244,25 @@ def test_docs_use_the_port_the_app_actually_listens_on():
         f"\n  " + "\n  ".join(wrong[:20])
         + (f"\n  ... and {len(wrong) - 20} more" if len(wrong) > 20 else "")
     )
+
+
+def test_no_markdown_carries_shell_quoting_artifacts():
+    """`'"'"'` is how you escape a quote inside a single-quoted shell string.
+
+    It has no business in prose. Seven of them shipped into the v2.25.2 release
+    notes because the notes were written through a heredoc and the escaping
+    leaked verbatim — `pip'"'"'s`, `Flask'"'"'s`, and three inside a quoted
+    Python attribute error. GitHub renders them literally, in the first thing
+    an operator reads about a release.
+    """
+    artifact = "'" + '"' + "'" + '"' + "'"
+    offenders = []
+    for path in ALL_MARKDOWN:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if artifact in text:
+            count = text.count(artifact)
+            offenders.append(f"{path.relative_to(REPO_ROOT)} ({count})")
+    assert not offenders, (
+        f"shell-escape artifacts leaked into prose: {offenders}. "
+        f"They render literally."
+    )


### PR DESCRIPTION
Written before the release rather than after: `scripts/release.sh` refuses to prepare a version `RELEASE_NOTES.md` does not document, so this has to land on `main` first.

The notes name the theme rather than listing changes. Every fix in v2.25.2 shares a shape — **the check that should have caught the bug either did not exist, or existed and could not fail**:

- `requirements-minimal.txt` was never built by any workflow, test or script, so an advertised build argument shipped a container that crash-looped for months (#514).
- The batch-limit test searched for the literal `"30,000"` in two English files that write `"30k"`, while the four files that do write `"30.000"` were not in its list — it could not have failed for any page in any language.
- The `cryptography` pin was enforced only by pip metadata that has since **stopped refusing the combination**, moving the failure from install time to the first certificate request.
- The real-cert release gate could not see the DNS code at all (fixed in #521, so not in these notes).

Numbers were measured today against the shipped code rather than carried over from the PRs that introduced them: the PEM redaction that burned **21.6 s** on 480 KB now takes **36 ms**, and 3.8 MB takes 291 ms.

The operator section says what actually matters: the upgrade is a drop-in, it is worth doing promptly if you use DNS alias mode with Akamai EdgeDNS, deploy hooks with large output, or the Hetzner DNS plugin — and the published Docker images were never affected by #514, which only reached people building the minimal variant themselves.

Verified: `notes_section` extracts the block cleanly (44 lines, terminated at the rule), the emoji scan is clean, and `test_version_consistency` and `test_docs_navigation` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)