### PR TITLE
security: the audit chain called a double write "a deletion", and could not stop one

### DIFF
--- a/modules/core/audit.py
+++ b/modules/core/audit.py
@@ -42,6 +42,33 @@ def _int_env(name: str, default: int) -> int:
     return value
 
 
+
+def _lock_file(fh) -> None:
+    """Take an exclusive advisory lock on an open file, where the platform has
+    them. POSIX only: the shipped image is Linux and the lock is advisory, so a
+    platform without flock degrades to the previous behaviour rather than
+    refusing to log."""
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - non-POSIX
+        return
+    try:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+    except OSError as e:  # pragma: no cover - e.g. a filesystem without locking
+        logger.debug(f"Audit chain: advisory lock unavailable ({e}); continuing")
+
+
+def _unlock_file(fh) -> None:
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - non-POSIX
+        return
+    try:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    except OSError:  # pragma: no cover
+        pass
+
+
 class AuditLogger:
     """Centralized audit logging for certificate operations."""
 
@@ -131,15 +158,26 @@ class AuditLogger:
             self.audit_logger.addHandler(self.file_handler)
         self.audit_logger.setLevel(logging.INFO)
 
-        # Tamper-evident hash chain (Phase 2). One writer, one local file; the
-        # lock guards the shared next-seq/last-hash state because Flask request
-        # threads and the APScheduler renewal thread share this instance.
+        # Tamper-evident hash chain (Phase 2). The threading lock guards the
+        # shared next-seq/last-hash state across Flask request threads and the
+        # APScheduler renewal thread. It cannot see a SECOND PROCESS: two
+        # instances sharing a data directory each recover the same `_next_seq`
+        # at startup and then both append with it, producing duplicate seqs.
+        # That is not hypothetical — it happened on 2026-06-25, two `migrate`
+        # entries at an identical timestamp, and left the chain permanently
+        # unverifiable. CertMate is single-instance by design (the Helm chart
+        # refuses a second replica), but "by design" is not an enforcement, so
+        # the append also takes an advisory file lock and re-reads the tail
+        # whenever the file has grown underneath it.
         self._chain_enabled = enable_chain and os.environ.get('CERTMATE_AUDIT_CHAIN', '1') != '0'
         self._chain_dir = Path(chain_dir) if chain_dir is not None else self.audit_log_dir
         self.audit_chain_file = self._chain_dir / audit_chain.CHAIN_FILENAME
         self._chain_lock = threading.Lock()
         self._next_seq = 0
         self._last_hash = audit_chain.GENESIS_PREV
+        # Size of the chain file as of our last append. A mismatch under the
+        # file lock means somebody else wrote, so our cached seq/hash are stale.
+        self._chain_size = 0
         if self._chain_enabled:
             self._recover_chain_state()
 
@@ -178,6 +216,10 @@ class AuditLogger:
             if last_good is not None:
                 self._next_seq = last_good['seq'] + 1
                 self._last_hash = last_good['hash']
+            try:
+                self._chain_size = self.audit_chain_file.stat().st_size
+            except OSError:
+                self._chain_size = 0
         except Exception as e:
             # Recovery runs inside AuditLogger.__init__, which the factory calls
             # unguarded — it must NEVER abort app startup (that would take the
@@ -185,6 +227,28 @@ class AuditLogger:
             # rather than fork it from a wrong baseline or raise.
             logger.error(f"Could not recover audit chain state; disabling chain: {e}")
             self._chain_enabled = False
+
+
+    def _refresh_if_another_writer_appended(self) -> None:
+        """Re-read the chain tail when the file grew since our last append.
+
+        Cheap in the normal case: one stat, and the size matches. When it does
+        not, a second process has appended and our cached ``_next_seq`` /
+        ``_last_hash`` describe a line that is no longer the head — writing
+        from them is exactly how duplicate seqs are produced. Must be called
+        with the advisory file lock held.
+        """
+        try:
+            size = self.audit_chain_file.stat().st_size
+        except OSError:
+            return
+        if size == self._chain_size:
+            return
+        logger.warning(
+            "Audit chain grew from %s to %s bytes underneath this process — "
+            "another writer is appending to the same file. Re-reading the head "
+            "before appending.", self._chain_size, size)
+        self._recover_chain_state()
 
     def _chain_append(self, entry: Dict[str, Any]) -> None:
         """Append one audit entry to the hash chain. Best-effort and isolated:
@@ -195,12 +259,24 @@ class AuditLogger:
             return
         try:
             with self._chain_lock:
-                seq = self._next_seq
-                line = audit_chain.make_line(seq, entry, self._last_hash)
                 with open(self.audit_chain_file, 'a', encoding='utf-8') as f:
-                    f.write(json.dumps(line, ensure_ascii=False) + '\n')
-                    f.flush()
-                    os.fsync(f.fileno())
+                    # Advisory lock FIRST, then look at the file. Another
+                    # process holding it may be mid-append; taking the lock
+                    # before measuring is what makes the staleness check sound.
+                    _lock_file(f)
+                    try:
+                        self._refresh_if_another_writer_appended()
+                        seq = self._next_seq
+                        line = audit_chain.make_line(seq, entry, self._last_hash)
+                        f.write(json.dumps(line, ensure_ascii=False) + '\n')
+                        f.flush()
+                        os.fsync(f.fileno())
+                        try:
+                            self._chain_size = f.tell()
+                        except OSError:
+                            self._chain_size = 0
+                    finally:
+                        _unlock_file(f)
                 # Advance only after the line is durably written.
                 self._next_seq = seq + 1
                 self._last_hash = line['hash']

--- a/modules/core/audit_chain.py
+++ b/modules/core/audit_chain.py
@@ -10,7 +10,10 @@ Each chain line is the canonical JSON of::
 
 where ``hash = sha256(canon({"seq", "entry", "prev_hash"}))`` and ``prev_hash``
 is the previous line's ``hash`` (the genesis line uses ``""``). ``seq`` is a
-gap-free monotonic counter, so a missing ``seq`` proves a deletion.
+gap-free monotonic counter, so a missing ``seq`` proves a deletion and a
+REPEATED ``seq`` proves a double write — two different faults, and the verifier
+says which. A repeat is not tampering: it is what two processes appending to one
+chain file produce, and the append path takes an advisory file lock to stop it.
 
 Honest threat model: the chain proves these N entries are authentic and ordered.
 It detects tampering by anyone WITHOUT the writer's running state, but it does
@@ -132,15 +135,42 @@ class _ChainVerifier:
                 f"malformed record at position {position} (missing fields)",
                 self._expected_seq)
 
-        if not self._seen:
+        first_record = not self._seen
+        if first_record:
             self._seen = True
             self._first_seq = seq
         if self._expected_seq is None:
             self._expected_seq = seq
         elif seq != self._expected_seq:
-            return self._fail(
-                f"sequence break: expected seq {self._expected_seq}, found "
-                f"{seq} (a deletion or reorder)", self._expected_seq)
+            # Name the failure correctly. A seq that went BACKWARDS is not a
+            # deletion — nothing was removed, something was written twice, which
+            # is what two processes sharing a data directory produce. Reporting
+            # that as "a deletion or reorder" tells an operator their
+            # tamper-evident log was tampered with, which is the one thing this
+            # file exists to be trusted about. A seq that jumped FORWARD is the
+            # deletion case.
+            if first_record:
+                # `_expected_seq` came from a caller-supplied anchor, not from
+                # a previous line. The file simply does not start where the
+                # anchor says it does — neither a double write nor a deletion.
+                return self._fail(
+                    f"sequence break: anchor mismatch — the anchor says this slice starts "
+                    f"at seq "
+                    f"{self._expected_seq}, the first record is {seq}",
+                    self._expected_seq)
+            if seq < self._expected_seq:
+                reason = (
+                    f"sequence break: duplicate or out-of-order seq — expected "
+                    f"{self._expected_seq}, "
+                    f"found {seq} (the same seq written more than once — typically "
+                    f"two processes appending to one chain file, not tampering)")
+            else:
+                reason = (
+                    f"sequence break: missing entries — expected seq {self._expected_seq}, found "
+                    f"{seq} ({seq - self._expected_seq} entr"
+                    f"{'y' if seq - self._expected_seq == 1 else 'ies'} absent — "
+                    f"a deletion or truncation)")
+            return self._fail(reason, self._expected_seq)
 
         if rec_prev != self._prev_hash:
             return self._fail(

--- a/tests/test_audit_chain_concurrent_writers.py
+++ b/tests/test_audit_chain_concurrent_writers.py
@@ -1,0 +1,149 @@
+"""The chain must survive a second writer, and must name the fault correctly.
+
+Both halves of this file come from one real incident. On 2026-08-10 the chain on
+a development instance failed verification at seq 45, and the verifier reported
+"a deletion or reorder" — the vocabulary of tampering, on the one file whose
+entire purpose is to be trustworthy evidence.
+
+Nothing had been deleted. Seq 44 and 45 were each written twice, with identical
+timestamps, on 2026-06-25, by two `migrate` operations: two processes started
+against the same data directory, each recovered the same `_next_seq` at startup,
+and each appended with it. The in-process `threading.Lock` cannot see another
+process.
+
+So: the append takes an advisory file lock and re-reads the head when the file
+grew underneath it, and the verifier distinguishes a repeat from a gap.
+"""
+import json
+import multiprocessing
+import os
+import sys
+
+import pytest
+
+from modules.core import audit_chain
+from modules.core.audit import AuditLogger
+
+
+def _read_chain(path):
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _make_logger(tmp_path):
+    return AuditLogger(audit_log_dir=tmp_path / "logs", chain_dir=tmp_path / "chain")
+
+
+# --------------------------------------------------------------------------- #
+# The verifier's diagnosis
+# --------------------------------------------------------------------------- #
+
+def _chain_lines(seqs):
+    """Build chain lines for the given seq order, hashes consistent per line."""
+    out, prev = [], audit_chain.GENESIS_PREV
+    for s in seqs:
+        line = audit_chain.make_line(s, {"operation": "test", "seq_label": s}, prev)
+        out.append(line)
+        prev = line["hash"]
+    return out
+
+
+def test_a_repeated_seq_is_not_reported_as_a_deletion(tmp_path):
+    """The exact shape of the real incident: 0,1,1.
+
+    Reporting this as a deletion tells an operator their audit log was
+    tampered with. It was not — it was written twice.
+    """
+    path = tmp_path / audit_chain.CHAIN_FILENAME
+    path.write_text("".join(json.dumps(l) + "\n" for l in _chain_lines([0, 1, 1])))
+
+    result = audit_chain.verify_chain(str(path))
+    assert result["ok"] is False
+    reason = result["reason"].lower()
+    assert "duplicate" in reason or "written more than once" in reason, reason
+    assert "deletion" not in reason, (
+        f"a double write must not be described as a deletion: {result['reason']}"
+    )
+
+
+def test_a_missing_seq_is_still_reported_as_a_deletion(tmp_path):
+    """The other direction must keep its alarming name. 0,1,3 really is a gap."""
+    lines = _chain_lines([0, 1, 2, 3])
+    del lines[2]                                    # drop seq 2
+    path = tmp_path / audit_chain.CHAIN_FILENAME
+    path.write_text("".join(json.dumps(l) + "\n" for l in lines))
+
+    result = audit_chain.verify_chain(str(path))
+    assert result["ok"] is False
+    reason = result["reason"].lower()
+    assert "deletion" in reason or "missing" in reason, reason
+    assert "duplicate" not in reason, reason
+
+
+def test_an_intact_chain_still_verifies(tmp_path):
+    """The guard must not have made a good chain fail."""
+    path = tmp_path / audit_chain.CHAIN_FILENAME
+    path.write_text("".join(json.dumps(l) + "\n" for l in _chain_lines([0, 1, 2, 3])))
+    assert audit_chain.verify_chain(str(path))["ok"] is True
+
+
+def _writer_process(directory, label, count):
+    """Module level so multiprocessing's spawn context can pickle it."""
+    from modules.core.audit import AuditLogger as _AL
+    from pathlib import Path as _P
+    logger = _AL(audit_log_dir=_P(directory) / "logs",
+                 chain_dir=_P(directory) / "chain")
+    for i in range(count):
+        logger.log_operation(operation=f"{label}{i}", resource_type="test",
+                             resource_id=label, status="success")
+
+
+# --------------------------------------------------------------------------- #
+# The append path
+# --------------------------------------------------------------------------- #
+
+def test_a_second_writer_does_not_produce_a_duplicate_seq(tmp_path):
+    """Two AuditLoggers on one directory — the two-process case, in-process.
+
+    Each recovers its own `_next_seq` at construction, exactly as two processes
+    do at startup. Before the fix the second one appended with a seq the first
+    had already used.
+    """
+    first = _make_logger(tmp_path)
+    second = _make_logger(tmp_path)          # same directory, own cached state
+
+    first.log_operation(operation="a", resource_type="test", resource_id="x", status="success")
+    second.log_operation(operation="b", resource_type="test", resource_id="y", status="success")
+    first.log_operation(operation="c", resource_type="test", resource_id="z", status="success")
+
+    chain = _read_chain(tmp_path / "chain" / audit_chain.CHAIN_FILENAME)
+    seqs = [r["seq"] for r in chain]
+    assert len(seqs) == len(set(seqs)), f"duplicate seq written: {seqs}"
+    assert seqs == sorted(seqs), f"out of order: {seqs}"
+    assert seqs == list(range(seqs[0], seqs[0] + len(seqs))), f"gap: {seqs}"
+
+    result = audit_chain.verify_chain(
+        str(tmp_path / "chain" / audit_chain.CHAIN_FILENAME))
+    assert result["ok"] is True, result["reason"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="advisory locks are POSIX")
+def test_two_real_processes_do_not_corrupt_the_chain(tmp_path):
+    """The actual failure mode, with actual processes.
+
+    A `threading.Lock` is invisible across a fork; only the advisory file lock
+    plus the staleness re-read keeps this chain verifiable.
+    """
+    ctx = multiprocessing.get_context("spawn")
+    procs = [ctx.Process(target=_writer_process, args=(str(tmp_path), label, 5))
+             for label in ("p1", "p2")]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=60)
+        assert p.exitcode == 0, f"writer process failed: {p.exitcode}"
+
+    path = tmp_path / "chain" / audit_chain.CHAIN_FILENAME
+    seqs = [r["seq"] for r in _read_chain(path)]
+    assert len(seqs) == len(set(seqs)), f"duplicate seq across processes: {seqs}"
+    result = audit_chain.verify_chain(str(path))
+    assert result["ok"] is True, f"{result['reason']} (seqs: {seqs})"

--- a/tests/test_audit_chain_concurrent_writers.py
+++ b/tests/test_audit_chain_concurrent_writers.py
@@ -16,7 +16,6 @@ grew underneath it, and the verifier distinguishes a repeat from a gap.
 """
 import json
 import multiprocessing
-import os
 import sys
 
 import pytest


### PR DESCRIPTION
Found while verifying artefacts a review pass had left on a development
instance: the tamper-evident chain there fails verification at seq 45, and the
verifier said "a deletion or reorder" — the vocabulary of tampering, on the one
file whose entire purpose is to be trustworthy evidence.

Nothing had been deleted. Seq 44 and 45 were each written twice, with identical
timestamps, on 2026-06-25, by two `migrate` operations. Two processes had
started against the same data directory: each ran `_recover_chain_state()`,
each cached the same `_next_seq`, and each appended with it. The
`threading.Lock` guarding the append cannot see another process.

**The diagnosis was wrong, which is the part that matters.** A seq that goes
backwards proves the opposite of a deletion: nothing was removed, something was
written twice. An operator reading "a deletion or reorder" concludes their audit
log was tampered with, and acts accordingly. `verify_chain` now separates three
cases it used to collapse into one:

- seq repeated / backwards -> "duplicate or out-of-order seq (the same seq
  written more than once - typically two processes appending to one chain file,
  not tampering)"
- seq jumped forward -> "missing entries (N entries absent - a deletion or
  truncation)"
- the first record disagreeing with a caller-supplied anchor -> "anchor
  mismatch", which is neither.

That third case was not in the original fix. An existing test caught it:
`test_a_wrong_anchor_seq_is_caught` passes an anchor of 99 against a file
starting at 3, and my first version called that "written more than once", which
is false. The suite did its job on me.

`sequence break: ` is kept as the leading phrase on all three, because two tests
and any operator tooling grep for it. The message is more specific, not
differently shaped.

**And the fault is now prevented, not just described.** `_chain_append` takes an
advisory `flock` on the chain file and, under it, re-reads the head when the
file has grown since our last write — a stale cached `_next_seq` is exactly how
the duplicate is produced, and a lock alone would not fix that. Cost in the
normal case is one `stat`. `fcntl` is imported defensively so a platform without
it degrades to the previous behaviour rather than refusing to log.

CertMate is single-instance by design and the Helm chart refuses a second
replica, but "by design" is not an enforcement, and this instance proves it.

Five tests. Three fail against main, including one that spawns two real
processes and reproduces the incident exactly: without the fix the chain comes
back `[0, 0, 1, 1, 2, 2, ...]`. The other two are controls — an intact chain
still verifies, and a genuine gap is still called a deletion.

Suite 2410 green, flake8 gate 0, bandit medium+ 0.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)