### PR TITLE
fix(mcp): the documented job-polling loop could not run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,33 @@ jobs:
   # ships silently whenever input.css / tailwind.config.js change without a
   # rebuild. This job rebuilds from source and fails if the committed output
   # drifts, forcing `npm run css:build` to be part of every CSS-touching PR.
+  # The MCP server ships in the image and is documented as a supported way to
+  # drive CertMate from an assistant, but its two test suites were run by
+  # nothing: no workflow, no Makefile target, not run-tests.sh, not release.sh.
+  # Dependabot DOES update mcp/ dependencies (.github/dependabot.yml), so those
+  # bumps were shipping with a suite that never executed — and the async
+  # regression that made the documented job-polling loop impossible sat there
+  # undetected because nothing asked.
+  mcp:
+    name: MCP server
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+    - name: Set up Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v4
+      with:
+        node-version: '20'
+
+    - name: Install MCP dependencies
+      working-directory: mcp
+      run: npm ci
+
+    - name: Run the MCP suites
+      working-directory: mcp
+      run: npm test
+
   frontend-css:
     runs-on: ubuntu-latest
     steps:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -23,12 +23,37 @@ The CertMate MCP server exposes the following tools to AI assistants:
 
 **Providers**
 12. **`certmate_list_dns_providers`** — DNS providers supported and configured on this instance.
-13. **`certmate_list_dns_accounts`** — Configured DNS provider accounts (credentials masked); use a returned account id as `account_id` when creating a certificate.
+13. **`certmate_list_dns_accounts`** — Configured DNS provider accounts (credentials masked); use a returned account id as `account_id` when creating a certificate. **Requires `admin`.**
+
+**Editing and removing**
+14. **`certmate_update_certificate`** — Changes an existing certificate's coverage in place by reissuing it: replace the SAN set and/or the DNS-01 alias. The primary domain is the certificate's identity and cannot be changed here. Returns a `job_id`.
+15. **`certmate_delete_certificate`** — **Destructive and not reversible.** Removes the certificate files from disk and the domain from settings. **Requires `admin`.**
+16. **`certmate_get_certificate_file`** — Returns one certificate file as raw, pasteable PEM rather than JSON-wrapped. Anything carrying key material needs `operator`.
+
+## Roles
+
+Give the agent the narrowest token that does its job, and note that three tools
+need more than the rest:
+
+| Tool | Minimum role |
+|---|---|
+| everything under Inventory & status, except diagnostics/settings | `viewer` |
+| `certmate_create_certificate`, `certmate_renew_certificate`, `certmate_set_auto_renew`, `certmate_update_certificate`, `certmate_download_certificate`, `certmate_get_certificate_file` | `operator` |
+| `certmate_diagnostics`, `certmate_get_settings` | `admin` |
+| **`certmate_deploy_certificate`** | **`admin`** |
+| **`certmate_list_dns_accounts`** | **`admin`** |
+| **`certmate_delete_certificate`** | **`admin`** |
+
+Deploy and account listing are the surprising ones: both read or act on stored
+credentials, so both are `admin` on the server side even though an agent that
+only renews would otherwise be happy with `operator`. An operator-scoped agent
+asked to "pick an account and issue" will get a 403 on the account lookup — pass
+the `account_id` in the prompt instead, or give it an admin token deliberately.
 
 ## Setup & Configuration
 
 ### Prerequisites
-- Node.js (v18 or higher)
+- Node.js (>= 20 — `mcp/package.json` declares `engines.node: ">=20.0.0"`)
 - npm
 
 ### Installation

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -262,11 +262,18 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           domain: args.domain,
           dns_provider: args.dns_provider,
           account_id: args.account_id,
-          ca_provider: args.ca_provider
+          ca_provider: args.ca_provider,
+          // Without this the server takes the SYNCHRONOUS branch
+          // (`_wants_async`, modules/api/resources.py) and blocks for the whole
+          // ACME exchange — minutes on a slow DNS provider. The MCP client's
+          // own timeout aborts the tool call while certbot keeps going, and no
+          // job_id is ever produced, so certmate_get_job has nothing to poll.
+          // The documented "create, then poll until done" loop could not run.
+          async: true
         });
         break;
       case "certmate_renew_certificate":
-        result = await makeRequest("POST", `/api/certificates/${encodeURIComponent(args.domain)}/renew`);
+        result = await makeRequest("POST", `/api/certificates/${encodeURIComponent(args.domain)}/renew`, { async: true });
         break;
       case "certmate_deploy_certificate":
         result = await makeRequest("POST", `/api/certificates/${encodeURIComponent(args.domain)}/deploy`);
@@ -306,7 +313,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         result = await makeRequest("DELETE", `/api/certificates/${encodeURIComponent(args.domain)}`);
         break;
       case "certmate_update_certificate": {
-        const body = {};
+        // Same reasoning as create/renew: without `async` the server reissues
+        // inline and the tool call outlives the client's patience.
+        const body = { async: true };
         // Omit san_domains entirely when not provided so the reissue keeps the
         // current SAN set ([] is a deliberate "drop all").
         if (Array.isArray(args.sans)) body.san_domains = args.sans;

--- a/mcp/test-tools.js
+++ b/mcp/test-tools.js
@@ -155,11 +155,6 @@ server.listen(0, "127.0.0.1", () => {
         process.exit(0);
       }, 400);
       return;
-      /* eslint-disable no-unreachable */
-      console.log("PASS");
-      cleanup();
-      process.exit(0);
-      /* eslint-enable no-unreachable */
     }, 300);
   }
 });

--- a/mcp/test-tools.js
+++ b/mcp/test-tools.js
@@ -103,6 +103,13 @@ server.listen(0, "127.0.0.1", () => {
     if (!upd.body || JSON.stringify(upd.body.san_domains) !== JSON.stringify(["www.api.example.com"]) || upd.body.domain_alias !== "alias.example.net") {
       fail(`update sent the wrong reissue body: ${JSON.stringify(upd.body)}`);
     }
+    // Without `async` the server reissues inline (`_wants_async`,
+    // modules/api/resources.py): the call blocks for the whole ACME exchange,
+    // the MCP client's timeout kills it, and no job_id is produced — so the
+    // documented "poll certmate_get_job until done" loop cannot run at all.
+    if (upd.body.async !== true) {
+      fail(`update must request async issuance; sent ${JSON.stringify(upd.body)}`);
+    }
 
     const getf = requests.find((r) => r.method === "GET" && r.url === "/api/certificates/api.example.com/download?file=fullchain.pem");
     if (!getf) fail("get_certificate_file did not GET /api/certificates/api.example.com/download?file=fullchain.pem");
@@ -123,10 +130,36 @@ server.listen(0, "127.0.0.1", () => {
         fail(`update without sans must omit san_domains; sent ${JSON.stringify(upd2.body)}`);
       }
       if (upd2.body.domain_alias !== "") fail("update should pass domain_alias='' to clear the alias");
-      console.log("OK: delete -> DELETE; update -> POST reissue (body, and san_domains omitted when sans absent); get_file -> GET ?file= returning raw PEM");
+      if (upd2.body.async !== true) fail("update must request async issuance even without sans");
+
+      // create and renew take the same branch, and are the two the docs tell
+      // an agent to follow with certmate_get_job.
+      requests.length = 0;
+      call(14, "certmate_create_certificate", { domain: "new.example.com", dns_provider: "cloudflare" });
+      call(15, "certmate_renew_certificate", { domain: "api.example.com" });
+      setTimeout(() => {
+        const cre = requests.find((r) => r.method === "POST" && r.url === "/api/certificates/create");
+        if (!cre) fail("create did not POST /api/certificates/create");
+        if (!cre.body || cre.body.async !== true) {
+          fail(`create must request async issuance; sent ${JSON.stringify(cre.body)}`);
+        }
+        const ren = requests.find((r) => r.method === "POST" && r.url === "/api/certificates/api.example.com/renew");
+        if (!ren) fail("renew did not POST .../renew");
+        if (!ren.body || ren.body.async !== true) {
+          fail(`renew must request async issuance; sent ${JSON.stringify(ren.body)}`);
+        }
+        console.log("OK: create / renew / update all request async issuance (202 + job_id)");
+        console.log("OK: delete -> DELETE; update -> POST reissue (body, and san_domains omitted when sans absent); get_file -> GET ?file= returning raw PEM");
+        console.log("PASS");
+        cleanup();
+        process.exit(0);
+      }, 400);
+      return;
+      /* eslint-disable no-unreachable */
       console.log("PASS");
       cleanup();
       process.exit(0);
+      /* eslint-enable no-unreachable */
     }, 300);
   }
 });

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -241,6 +241,16 @@ def create_api_models(api):
         'elliptic_curve': fields.String(
             description="ECDSA curve — required when key_type='ecdsa'.",
             enum=['secp256r1', 'secp384r1']
+        ),
+        # Declared here because callers already send it and the server already
+        # honours it (`_wants_async`, resources.py). certmate-sdk has sent
+        # `async: True` on every create since 0.1.x; leaving it out of the model
+        # meant the published Swagger contract described a request the shipped
+        # client does not make, and would reject it outright if validation were
+        # ever turned on. ReissueCertificate has always declared it.
+        'async': fields.Boolean(
+            description='Defer issuance to a background job (202 + job id). '
+                        'Poll GET /api/certificates/jobs/<job_id>.'
         )
     })
 

--- a/tests/test_docs_navigation.py
+++ b/tests/test_docs_navigation.py
@@ -266,3 +266,73 @@ def test_no_markdown_carries_shell_quoting_artifacts():
         f"shell-escape artifacts leaked into prose: {offenders}. "
         f"They render literally."
     )
+
+
+def test_docs_mcp_documents_every_tool_the_server_ships():
+    """`docs/mcp.md` enumerated 13 tools while `mcp/index.js` registered 16.
+
+    The three it omitted were `certmate_update_certificate`,
+    `certmate_get_certificate_file` and `certmate_delete_certificate` — the last
+    of which deletes certificate files from disk and is not reversible. An
+    operator reading the documented surface would not have known the agent could
+    do it.
+
+    The tool-count assertion in the README was already gated; the enumeration
+    here was not, which is how a list can be exhaustive-looking and short.
+    """
+    server = (REPO_ROOT / "mcp" / "index.js").read_text(encoding="utf-8")
+    shipped = set(re.findall(r'name:\s*"(certmate_[a-z_]+)"', server))
+    assert shipped, "no tools found in mcp/index.js — has the shape changed?"
+
+    doc = (REPO_ROOT / "docs" / "mcp.md").read_text(encoding="utf-8")
+    documented = set(re.findall(r"certmate_[a-z_]+", doc))
+
+    missing = sorted(shipped - documented)
+    assert not missing, f"docs/mcp.md does not mention {missing}"
+
+    phantom = sorted(documented - shipped)
+    assert not phantom, f"docs/mcp.md documents tools the server does not ship: {phantom}"
+
+
+def test_mcp_tools_request_async_issuance():
+    """create / renew / reissue must opt into the background job.
+
+    The server only takes the async branch when the caller sends `async`
+    (`_wants_async`, modules/api/resources.py). Without it the request blocks
+    for the whole ACME exchange, the MCP client's timeout aborts the tool call
+    while certbot keeps running, and no `job_id` is ever produced — so the
+    `certmate_get_job` loop that docs/mcp.md tells an agent to follow could not
+    execute at all.
+
+    mcp/test-tools.js asserts this against a recording mock; this is the cheap
+    check that runs in the Python suite too, because the MCP suite is a separate
+    CI job and a reviewer reading only this one should still see the contract.
+    """
+    server = (REPO_ROOT / "mcp" / "index.js").read_text(encoding="utf-8")
+    # Check the whole handler for each tool, not a fixed window around the
+    # call: reissue builds its body several lines ABOVE the makeRequest, and a
+    # forward-only window missed it. Anchoring on the first mention of the path
+    # was worse still — for create that is a comment, so the check would have
+    # been satisfied by prose.
+    for tool in ("certmate_create_certificate",
+                 "certmate_renew_certificate",
+                 "certmate_update_certificate"):
+        m = re.search(rf'case "{tool}":(.*?)\n      case "', server, re.S)
+        assert m, f"could not isolate the {tool} handler in mcp/index.js"
+        assert "async: true" in m.group(1), (
+            f"{tool} does not request async issuance — the server would run it "
+            f"inline and never produce a job_id for certmate_get_job to poll"
+        )
+
+
+def test_the_mcp_suites_are_run_by_ci():
+    """A test suite nothing executes is not a test suite.
+
+    `mcp/test-smoke.js` and `mcp/test-tools.js` were referenced by no workflow,
+    no Makefile target, not run-tests.sh and not release.sh — while Dependabot
+    updated `mcp/` dependencies, so those bumps shipped with a suite that never
+    ran.
+    """
+    ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    assert "working-directory: mcp" in ci, "no CI job runs anything inside mcp/"
+    assert "npm test" in ci, "the mcp job does not run its test suite"

--- a/tests/test_docs_navigation.py
+++ b/tests/test_docs_navigation.py
@@ -314,11 +314,23 @@ def test_mcp_tools_request_async_issuance():
     # forward-only window missed it. Anchoring on the first mention of the path
     # was worse still — for create that is a comment, so the check would have
     # been satisfied by prose.
+    #
+    # The handler ends at the next `case`/`default`, or at end of file. The
+    # first version required a literal `\n      case "`, which tied the test to
+    # one indentation and would have failed outright on the last case in the
+    # switch — a red build with nothing broken (Copilot, #531).
+    boundary = r'(?=\n\s*(?:case\s+["\']|default\s*:)|\Z)'
     for tool in ("certmate_create_certificate",
                  "certmate_renew_certificate",
                  "certmate_update_certificate"):
-        m = re.search(rf'case "{tool}":(.*?)\n      case "', server, re.S)
+        m = re.search(rf'case "{tool}":(.*?)' + boundary, server, re.S)
         assert m, f"could not isolate the {tool} handler in mcp/index.js"
+        # Over-capturing would let one tool's `async: true` vouch for another.
+        assert m.group(1).count('makeRequest') <= 2, (
+            f"the {tool} handler capture spilled into the next case "
+            f"({m.group(1).count('makeRequest')} makeRequest calls) — the "
+            f"boundary pattern is matching too late to isolate anything"
+        )
         assert "async: true" in m.group(1), (
             f"{tool} does not request async issuance — the server would run it "
             f"inline and never produce a job_id for certmate_get_job to poll"


### PR DESCRIPTION
docs/mcp.md tells an agent to create or renew a certificate and then poll
`certmate_get_job` until it reports done. That loop was impossible.

The server only takes the background-job branch when the caller opts in —
`_wants_async` (modules/api/resources.py) looks for an `async` flag in the body
or `?async=` in the query. The MCP server sent neither: create sent four fields
and no flag, renew sent no body at all, reissue sent only the SAN/alias changes.

So every one of them took the synchronous certbot path. The tool call blocked
for the whole ACME exchange — minutes on a slow DNS provider — and `fetch` is
called without a timeout, so the MCP client's own timeout aborted the call while
certbot kept working. No `job_id` was ever produced, leaving
`certmate_get_job` correct, wired to the right endpoint, and unreachable.

All three now request async issuance.

**The server's contract did not declare the flag either.** `create_cert_model`
has no `async` field, while `ReissueCertificate` has always had one — yet
certmate-sdk has sent `async: True` on every create since 0.1.x. It worked only
because flask-restx validation is off: the published Swagger described a request
the shipped client does not make, and would have rejected it the day validation
was turned on. Declared.

**docs/mcp.md documented 13 of the 16 tools.** The three missing were
`certmate_update_certificate`, `certmate_get_certificate_file`, and
`certmate_delete_certificate` — which removes certificate files from disk and is
not reversible. An operator reading the documented surface would not have known
an agent could do it.

**And the role guidance was wrong in a way that produces a 403.** The docs said
`operator` for renew/deploy and told the reader to have the agent call
`certmate_list_dns_accounts` to pick an account id. Both `CertificateRunDeploy`
and `DNSAccounts` are `require_role('admin')` on the server, as is certificate
deletion. There is now a role table, with the three surprises called out and the
reason: they read or act on stored credentials.

Node.js "v18 or higher" corrected to ">= 20", which is what
`mcp/package.json` has always declared.

**The mcp/ suites were run by nothing.** No workflow, no Makefile target, not
run-tests.sh, not release.sh — while Dependabot updates mcp/ dependencies, so
those bumps shipped with a suite that never executed. That is why this
regression sat undetected. ci.yml now has an `mcp` job that runs them.

Gates, each checked to fail without its fix: the MCP suite asserts create/renew/
update send the flag, and three Python tests cover the tool enumeration, the
async contract and the CI wiring. The async test anchors on each tool's `case`
handler — my first two attempts looked at a fixed window around the call and
were satisfied by a comment in one direction and missed reissue's body in the
other.

Suite 2408 green, flake8 gate 0, both MCP suites pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)