### PR TITLE
fix: the optional requirements files drifted off the pin, and one had never installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,72 @@ jobs:
           echo "::endgroup::"
         done
 
+    # The optional requirements files are never built above, because no image
+    # ships them — and that is exactly why they rotted unnoticed:
+    #
+    #   * requirements-extended.txt could not be installed at all, in any
+    #     environment. certbot-dns-powerdns==0.2.1 wants dns-lexicon<=3.5.6 and
+    #     certbot-dns-linode wants >=3.14.1: ResolutionImpossible, alone in an
+    #     empty venv or layered either way. Advertised by the Dockerfile as an
+    #     EXTRA_REQUIREMENTS option the whole time.
+    #   * requirements-aws.txt and -gcp.txt pinned plugins above the certbot
+    #     pin. Since extras install in a *separate* pip run, pip upgraded
+    #     certbot off 2.10.0 — measured at 3.3.0 on 3.12 — in a build that
+    #     reported success.
+    #
+    # Resolving is enough to catch both and costs seconds, so every file and
+    # every combination the Dockerfile and docker-compose.yml advertise gets
+    # resolved on every run. `--dry-run` does full dependency resolution
+    # without downloading wheels.
+    - name: Resolve every optional requirements combination
+      if: matrix.python-version == '3.12'
+      run: |
+        set -euo pipefail
+        combos=(
+          "requirements-minimal.txt requirements-extended.txt"
+          "requirements.txt requirements-aws.txt"
+          "requirements.txt requirements-gcp.txt"
+          "requirements.txt requirements-azure.txt"
+          "requirements.txt requirements-aws.txt requirements-gcp.txt"
+        )
+        pinned=$(grep -oE '^certbot==[0-9.]+' requirements.txt | cut -d= -f3)
+        echo "certbot is pinned at $pinned"
+        for combo in "${combos[@]}"; do
+          echo "::group::resolve $combo"
+          args=()
+          for f in $combo; do args+=(-r "$f"); done
+          # Resolved together, not one after another. The Dockerfile installs
+          # extras in a separate pip run, where a plugin requiring a newer
+          # certbot is silently granted it; asking pip to satisfy every file at
+          # once turns that same silent upgrade into ResolutionImpossible,
+          # which is the answer we want on a build machine. Both failure modes
+          # are covered: this catches the conflict, the version check below
+          # catches a drift pip could satisfy.
+          report=$(mktemp)
+          # --ignore-installed is what makes this a check. The job already has
+          # requirements.txt installed, so without it pip reports only the
+          # delta — four packages, certbot not among them — and any assertion
+          # about certbot's resolved version passes without having looked at
+          # one. Verified: the report goes from 4 entries to the full set.
+          if ! python -m pip install --dry-run --ignore-installed --quiet \
+               --report "$report" "${args[@]}"; then
+            echo "::error::$combo does not resolve — this combination is advertised and cannot be installed"
+            exit 1
+          fi
+          # One line on purpose: a multi-line `python -c "..."` inside a YAML
+          # block scalar has to start at column 0 to be valid Python, and that
+          # is not valid YAML. The default is 'ABSENT', never the pinned
+          # version — a resolution that does not mention certbot has not
+          # checked certbot, and must not read as a pass.
+          got=$(python -c "import json; d=json.load(open('$report')); print(next((i.get('metadata',{}).get('version','UNKNOWN') for i in d.get('install',[]) if i.get('metadata',{}).get('name','').lower()=='certbot'), 'ABSENT'))")
+          if [ "$got" != "$pinned" ]; then
+            echo "::error::$combo resolves certbot to $got, not the pinned $pinned. An optional file is dragging the ACME stack off its pin (#103 is still a plan, not a migration)."
+            exit 1
+          fi
+          echo "$combo -> certbot $got"
+          echo "::endgroup::"
+        done
+
   # The Tailwind bundle (static/css/tailwind.min.css) is committed to the repo
   # and served as-is — there is no build step at deploy time. So a stale bundle
   # ships silently whenever input.css / tailwind.config.js change without a

--- a/docs/de/installation.md
+++ b/docs/de/installation.md
@@ -478,42 +478,50 @@ services:
 
 ### Versionskonflikte bei DNS-Plugins
 
-Bei Versionskonflikten verwenden Sie diese spezifischen Versionen:
+Installieren Sie aus der Requirements-Datei, die CertMate mitliefert. Dieser
+Satz wird bei jedem CI-Lauf aufgelöst, gebaut und gestartet; eine von Hand
+zusammengestellte Liste nicht.
 
-```txt
-certbot==4.1.1
-certbot-dns-cloudflare==4.1.1
-certbot-dns-route53==4.1.1
-certbot-dns-azure==2.6.1
-certbot-dns-google==4.1.1
-certbot-dns-powerdns==0.2.1
+```bash
+pip install -r requirements.txt            # alle mitgelieferten Provider
+pip install -r requirements-minimal.txt    # nur certbot + Cloudflare
+pip install -r requirements-extended.txt   # weitere Provider, zusätzlich zu minimal
+pip install -r requirements-aws.txt        # Route53, zusätzlich zu einem von beiden
 ```
 
-> Die meisten DNS-Plugins erfordern Certbot 4.1.1. Das Azure-Plugin hat eine eigenständige Versionierung (2.6.1), und PowerDNS ist ein neueres Plugin (0.2.1).
+> Diese Seite veröffentlichte eine eigene Versionsliste, die in allen fünf
+> Sprachen auf `certbot==4.1.1` abgedriftet war, während das Projekt auf
+> `2.10.0` festgelegt ist: die Migration auf 5.x ist weiterhin ein Plan
+> (Issue #103), keine Veröffentlichung.
+>
+> Diese Zahlen zu korrigieren genügt nicht — deshalb wurde die Liste entfernt
+> statt aktualisiert. Was den Stack zusammenhält, sind nicht die
+> Plugin-Versionen, sondern `cryptography`, `pyopenssl`, `josepy` und `acme`,
+> die einander halten: neuere pyOpenSSL-Versionen entfernen
+> `OpenSSL.crypto.X509Extension`, das `acme` beim Import auswertet. Von Hand
+> zusammengestellt stirbt certbot, bevor es irgendetwas ausstellen kann —
+> viermal gemessen, jeweils mit einem Pin mehr. Siehe SECURITY.md, „Known
+> dependency constraint".
+>
+> `certbot-dns-powerdns` braucht eine eigene Umgebung: es benötigt
+> `dns-lexicon<=3.5.6`, während die Plugins Linode, OVH, RFC2136, DNSMadeEasy
+> und NS1 `>=3.14.1` benötigen, und pip kann beides nicht erfüllen.
 
 ### Manuelle Installation von Abhängigkeiten
 
-Falls die automatische Installation fehlschlägt, installieren Sie DNS-Provider einzeln:
+Wenn ein einzelner Provider sich nicht installieren lässt, fügen Sie ihn zu
+einer funktionierenden Basis hinzu, statt eine von Hand zusammenzustellen:
 
 ```bash
-# Kern-certbot
-pip install certbot==4.1.1
-
-# Cloudflare
-pip install certbot-dns-cloudflare==4.1.1
-
-# AWS Route53
-pip install certbot-dns-route53==4.1.1 boto3==1.35.76
-
-# Azure DNS
-pip install certbot-dns-azure==2.6.1 azure-identity==1.19.0 azure-mgmt-dns==8.1.0
-
-# Google Cloud DNS
-pip install certbot-dns-google==4.1.1 google-cloud-dns==0.35.0
-
-# PowerDNS
-pip install certbot-dns-powerdns==0.2.1
+pip install -r requirements-minimal.txt    # zuerst die funktionierende Basis
+pip install -r requirements-aws.txt        # Route53 + boto3
+pip install -r requirements-gcp.txt        # Google Cloud DNS
+pip install -r requirements-azure.txt      # Azure DNS
 ```
+
+Jede Datei trägt die Versionen, die ihr Plugin braucht, und die CI löst bei
+jedem Lauf jede Kombination auf — einschließlich der Prüfung, dass certbot
+seinen Pin nicht verlässt.
 
 ### Validierungsbefehle
 

--- a/docs/es/installation.md
+++ b/docs/es/installation.md
@@ -329,16 +329,33 @@ curl -X POST http://localhost:8000/api/backups/restore \
 
 ### Conflictos de versiones de plugins DNS
 
-Si encuentra conflictos de versiones, use estas versiones específicas:
+Instale desde el archivo requirements que distribuye CertMate. Ese conjunto se
+resuelve, se construye y se arranca en CI en cada ejecución; una lista montada a
+mano no.
 
-```txt
-certbot==4.1.1
-certbot-dns-cloudflare==4.1.1
-certbot-dns-route53==4.1.1
-certbot-dns-azure==2.6.1
-certbot-dns-google==4.1.1
-certbot-dns-powerdns==0.2.1
+```bash
+pip install -r requirements.txt            # todos los proveedores incluidos
+pip install -r requirements-minimal.txt    # solo certbot + Cloudflare
+pip install -r requirements-extended.txt   # más proveedores, sobre minimal
+pip install -r requirements-aws.txt        # Route53, sobre cualquiera de los dos
 ```
+
+> Esta página publicaba su propia lista de versiones, que se había desviado
+> hasta `certbot==4.1.1` en los cinco idiomas mientras el proyecto está fijado a
+> `2.10.0`: la migración a 5.x sigue siendo un plan (incidencia #103), no una
+> versión publicada.
+>
+> Corregir esos números no basta, y por eso la lista se ha eliminado en lugar de
+> actualizarse. Lo que mantiene unida la pila no son las versiones de los
+> plugins, sino `cryptography`, `pyopenssl`, `josepy` y `acme` sosteniéndose
+> mutuamente: las versiones nuevas de pyOpenSSL eliminan
+> `OpenSSL.crypto.X509Extension`, que `acme` evalúa al importar. Montado a mano,
+> certbot muere antes de poder emitir nada — medido cuatro veces, añadiendo un
+> pin cada vez. Véase SECURITY.md, "Known dependency constraint".
+>
+> `certbot-dns-powerdns` necesita su propio entorno: requiere
+> `dns-lexicon<=3.5.6` mientras que los plugins de Linode, OVH, RFC2136,
+> DNSMadeEasy y NS1 requieren `>=3.14.1`, y pip no puede satisfacer ambos.
 
 ### Comandos de validación
 
@@ -465,29 +482,19 @@ services:
 
 ### Instalación manual de dependencias
 
-Si la instalación automática falla, instale los proveedores DNS individualmente:
+Si un proveedor concreto no se instala, añádalo sobre una base que funcione en
+lugar de montar una a mano:
 
 ```bash
-# Núcleo de certbot
-pip install certbot==4.1.1
-
-# Cloudflare
-pip install certbot-dns-cloudflare==4.1.1
-
-# AWS Route53
-pip install certbot-dns-route53==4.1.1 boto3==1.35.76
-
-# Azure DNS
-pip install certbot-dns-azure==2.6.1 azure-identity==1.19.0 azure-mgmt-dns==8.1.0
-
-# Google Cloud DNS
-pip install certbot-dns-google==4.1.1 google-cloud-dns==0.35.0
-
-# PowerDNS
-pip install certbot-dns-powerdns==0.2.1
+pip install -r requirements-minimal.txt    # primero la base que funciona
+pip install -r requirements-aws.txt        # Route53 + boto3
+pip install -r requirements-gcp.txt        # Google Cloud DNS
+pip install -r requirements-azure.txt      # Azure DNS
 ```
 
-> La mayoría de los plugins DNS requieren Certbot 4.1.1. El plugin de Azure tiene versionado independiente (2.6.1) y PowerDNS es un plugin más reciente (0.2.1).
+Cada archivo lleva las versiones que su plugin necesita, y CI resuelve todas las
+combinaciones en cada ejecución — incluida la comprobación de que certbot no se
+sale de su pin.
 
 ### Comandos de validación
 

--- a/docs/fr/installation.md
+++ b/docs/fr/installation.md
@@ -329,16 +329,34 @@ curl -X POST http://localhost:8000/api/backups/restore \
 
 ### Conflits de versions de plugins DNS
 
-Si vous rencontrez des conflits de versions, utilisez ces versions spécifiques :
+Installez depuis le fichier requirements livré avec CertMate. Cet ensemble est
+résolu, construit et démarré par la CI à chaque exécution ; une liste assemblée
+à la main, non.
 
-```txt
-certbot==4.1.1
-certbot-dns-cloudflare==4.1.1
-certbot-dns-route53==4.1.1
-certbot-dns-azure==2.6.1
-certbot-dns-google==4.1.1
-certbot-dns-powerdns==0.2.1
+```bash
+pip install -r requirements.txt            # tous les fournisseurs inclus
+pip install -r requirements-minimal.txt    # certbot + Cloudflare uniquement
+pip install -r requirements-extended.txt   # d'autres fournisseurs, par-dessus minimal
+pip install -r requirements-aws.txt        # Route53, par-dessus l'un ou l'autre
 ```
+
+> Cette page publiait sa propre liste de versions, qui avait dérivé jusqu'à
+> `certbot==4.1.1` dans les cinq langues alors que le projet est épinglé à
+> `2.10.0` : la migration vers 5.x reste un plan (ticket #103), pas une version
+> publiée.
+>
+> Corriger ces numéros ne suffit pas, et c'est pourquoi la liste a été supprimée
+> plutôt que mise à jour. Ce qui tient la pile ensemble, ce ne sont pas les
+> versions des plugins mais `cryptography`, `pyopenssl`, `josepy` et `acme` qui
+> se tiennent mutuellement : les versions récentes de pyOpenSSL suppriment
+> `OpenSSL.crypto.X509Extension`, que `acme` évalue à l'import. Assemblé à la
+> main, certbot meurt avant de pouvoir émettre quoi que ce soit — mesuré quatre
+> fois, en ajoutant un pin à la fois. Voir SECURITY.md, « Known dependency
+> constraint ».
+>
+> `certbot-dns-powerdns` demande son propre environnement : il requiert
+> `dns-lexicon<=3.5.6` alors que les plugins Linode, OVH, RFC2136, DNSMadeEasy
+> et NS1 requièrent `>=3.14.1`, et pip ne peut satisfaire les deux.
 
 ### Commandes de validation
 
@@ -465,29 +483,19 @@ services:
 
 ### Installation manuelle des dépendances
 
-Si l'installation automatique échoue, installez les fournisseurs DNS individuellement :
+Si un fournisseur ne s'installe pas, ajoutez-le par-dessus une base qui
+fonctionne plutôt que d'en assembler une à la main :
 
 ```bash
-# Noyau certbot
-pip install certbot==4.1.1
-
-# Cloudflare
-pip install certbot-dns-cloudflare==4.1.1
-
-# AWS Route53
-pip install certbot-dns-route53==4.1.1 boto3==1.35.76
-
-# Azure DNS
-pip install certbot-dns-azure==2.6.1 azure-identity==1.19.0 azure-mgmt-dns==8.1.0
-
-# Google Cloud DNS
-pip install certbot-dns-google==4.1.1 google-cloud-dns==0.35.0
-
-# PowerDNS
-pip install certbot-dns-powerdns==0.2.1
+pip install -r requirements-minimal.txt    # d'abord la base qui fonctionne
+pip install -r requirements-aws.txt        # Route53 + boto3
+pip install -r requirements-gcp.txt        # Google Cloud DNS
+pip install -r requirements-azure.txt      # Azure DNS
 ```
 
-> La plupart des plugins DNS nécessitent Certbot 4.1.1. Le plugin Azure a un versionnement indépendant (2.6.1) et PowerDNS est un plugin plus récent (0.2.1).
+Chaque fichier porte les versions dont son plugin a besoin, et la CI résout
+chaque combinaison à chaque exécution — y compris la vérification que certbot ne
+quitte pas son pin.
 
 ### Commandes de validation
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -466,42 +466,47 @@ services:
 
 ### DNS Plugin Version Conflicts
 
-If you encounter version conflicts, use these specific versions:
+Install from the requirements file CertMate ships. That set is resolved, built
+and booted in CI on every run; a list assembled by hand is not.
 
-```txt
-certbot==4.1.1
-certbot-dns-cloudflare==4.1.1
-certbot-dns-route53==4.1.1
-certbot-dns-azure==2.6.1
-certbot-dns-google==4.1.1
-certbot-dns-powerdns==0.2.1
+```bash
+pip install -r requirements.txt            # every bundled provider
+pip install -r requirements-minimal.txt    # certbot + Cloudflare only
+pip install -r requirements-extended.txt   # more providers, on top of minimal
+pip install -r requirements-aws.txt        # Route53, on top of either
 ```
 
-> Most DNS plugins require Certbot 4.1.1. The Azure plugin has independent versioning (2.6.1) and PowerDNS is a newer plugin (0.2.1).
+> This page used to publish its own pinned list, and it had drifted to
+> `certbot==4.1.1` in all five languages while the project is pinned to
+> `2.10.0` — the 5.x migration is still a plan (issue #103), not a release.
+>
+> Correcting those numbers is not enough, which is why the list is gone rather
+> than fixed. What holds the stack together is not the plugin versions but
+> `cryptography`, `pyopenssl`, `josepy` and `acme` holding each other in place:
+> newer pyOpenSSL drops `OpenSSL.crypto.X509Extension`, which `acme` evaluates
+> at import. Assembled by hand, certbot dies before it can issue anything —
+> measured four times, adding one pin at a time. See SECURITY.md, "Known
+> dependency constraint".
+>
+> `certbot-dns-powerdns` needs its own environment: it requires
+> `dns-lexicon<=3.5.6` while the Linode, OVH, RFC2136, DNSMadeEasy and NS1
+> plugins require `>=3.14.1`, and pip cannot satisfy both.
 
 ### Manual Dependency Installation
 
-If automatic installation fails, install DNS providers individually:
+If one provider fails to install, add it on top of a working base rather than
+assembling one by hand:
 
 ```bash
-# Core certbot
-pip install certbot==4.1.1
-
-# Cloudflare
-pip install certbot-dns-cloudflare==4.1.1
-
-# AWS Route53
-pip install certbot-dns-route53==4.1.1 boto3==1.35.76
-
-# Azure DNS
-pip install certbot-dns-azure==2.6.1 azure-identity==1.19.0 azure-mgmt-dns==8.1.0
-
-# Google Cloud DNS
-pip install certbot-dns-google==4.1.1 google-cloud-dns==0.35.0
-
-# PowerDNS
-pip install certbot-dns-powerdns==0.2.1
+pip install -r requirements-minimal.txt    # the working base, first
+pip install -r requirements-aws.txt        # Route53 + boto3
+pip install -r requirements-gcp.txt        # Google Cloud DNS
+pip install -r requirements-azure.txt      # Azure DNS
 ```
+
+Each file carries the versions its plugin needs, and CI resolves every
+combination on every run — including the check that certbot does not move off
+its pin.
 
 ### Validation Commands
 

--- a/docs/it/installation.md
+++ b/docs/it/installation.md
@@ -329,16 +329,34 @@ curl -X POST http://localhost:8000/api/backups/restore \
 
 ### Conflitti di versioni dei plugin DNS
 
-In caso di conflitti di versioni, utilizzare queste versioni specifiche:
+Installare dal file requirements che CertMate distribuisce. Quell'insieme viene
+risolto, costruito e avviato dalla CI a ogni esecuzione; un elenco assemblato a
+mano no.
 
-```txt
-certbot==4.1.1
-certbot-dns-cloudflare==4.1.1
-certbot-dns-route53==4.1.1
-certbot-dns-azure==2.6.1
-certbot-dns-google==4.1.1
-certbot-dns-powerdns==0.2.1
+```bash
+pip install -r requirements.txt            # tutti i provider inclusi
+pip install -r requirements-minimal.txt    # solo certbot + Cloudflare
+pip install -r requirements-extended.txt   # altri provider, sopra minimal
+pip install -r requirements-aws.txt        # Route53, sopra uno dei due
 ```
+
+> Questa pagina pubblicava un proprio elenco di versioni, andato alla deriva
+> fino a `certbot==4.1.1` in tutte e cinque le lingue mentre il progetto è
+> vincolato a `2.10.0`: la migrazione a 5.x è ancora un piano (issue #103), non
+> una release.
+>
+> Correggere quei numeri non basta, ed è il motivo per cui l'elenco è stato
+> rimosso anziché aggiornato. A tenere insieme lo stack non sono le versioni dei
+> plugin ma `cryptography`, `pyopenssl`, `josepy` e `acme` che si sostengono a
+> vicenda: le versioni recenti di pyOpenSSL rimuovono
+> `OpenSSL.crypto.X509Extension`, che `acme` valuta all'import. Assemblato a
+> mano, certbot muore prima di poter emettere qualsiasi cosa — misurato quattro
+> volte, aggiungendo un pin alla volta. Vedi SECURITY.md, "Known dependency
+> constraint".
+>
+> `certbot-dns-powerdns` richiede un ambiente separato: vuole
+> `dns-lexicon<=3.5.6` mentre i plugin Linode, OVH, RFC2136, DNSMadeEasy e NS1
+> richiedono `>=3.14.1`, e pip non può soddisfare entrambi.
 
 ### Comandi di verifica
 
@@ -465,29 +483,19 @@ services:
 
 ### Installazione manuale delle dipendenze
 
-Se l'installazione automatica non va a buon fine, installare i provider DNS singolarmente:
+Se un singolo provider non si installa, aggiungerlo sopra una base funzionante
+invece di assemblarne una a mano:
 
 ```bash
-# Core certbot
-pip install certbot==4.1.1
-
-# Cloudflare
-pip install certbot-dns-cloudflare==4.1.1
-
-# AWS Route53
-pip install certbot-dns-route53==4.1.1 boto3==1.35.76
-
-# Azure DNS
-pip install certbot-dns-azure==2.6.1 azure-identity==1.19.0 azure-mgmt-dns==8.1.0
-
-# Google Cloud DNS
-pip install certbot-dns-google==4.1.1 google-cloud-dns==0.35.0
-
-# PowerDNS
-pip install certbot-dns-powerdns==0.2.1
+pip install -r requirements-minimal.txt    # prima la base funzionante
+pip install -r requirements-aws.txt        # Route53 + boto3
+pip install -r requirements-gcp.txt        # Google Cloud DNS
+pip install -r requirements-azure.txt      # Azure DNS
 ```
 
-> La maggior parte dei plugin DNS richiede Certbot 4.1.1. Il plugin Azure ha un versioning indipendente (2.6.1) e PowerDNS è un plugin più recente (0.2.1).
+Ogni file porta le versioni di cui il suo plugin ha bisogno, e la CI risolve
+ogni combinazione a ogni esecuzione — compresa la verifica che certbot non si
+sposti dal suo pin.
 
 ### Comandi di verifica
 

--- a/requirements-aws.txt
+++ b/requirements-aws.txt
@@ -2,4 +2,4 @@
 # Install this in addition to requirements-minimal.txt for AWS support
 
 boto3==1.34.144
-certbot-dns-route53==2.11.0
+certbot-dns-route53==2.10.0

--- a/requirements-extended.txt
+++ b/requirements-extended.txt
@@ -2,11 +2,21 @@
 # Install this in addition to requirements-minimal.txt for additional DNS providers
 
 # Self-hosted and enterprise DNS
-certbot-dns-powerdns==0.2.1
-certbot-dns-rfc2136==2.11.0
+# certbot-dns-powerdns is NOT listed here, and this file was unusable until it
+# was removed: 0.2.1 (the latest) requires dns-lexicon<=3.5.6, while
+# certbot-dns-linode below requires dns-lexicon>=3.14.1. pip cannot satisfy
+# both, so `pip install -r requirements-extended.txt` ended in
+# ResolutionImpossible — alone in an empty venv, layered on
+# requirements-minimal.txt as the header suggests, and layered on
+# requirements.txt as the Dockerfile advertises. Every path.
+# requirements.txt had already excluded it for exactly this reason and says
+# "Install separately if needed"; this file reintroduced the conflict it
+# documented avoiding, and nothing built it, so nothing ever said so.
+#   pip install certbot-dns-powerdns==0.2.1   # in its own environment
+certbot-dns-rfc2136==2.10.0
 
 # Popular hosting providers
-certbot-dns-linode==2.11.0
+certbot-dns-linode==2.10.0
 certbot-dns-vultr==1.1.0
 # Held at 2.0.1: 3.0.0 depends on the `dns-lexicon-coop` fork, which collides
 # file-for-file with upstream `dns-lexicon`. Same reasoning (and the same
@@ -16,7 +26,7 @@ certbot-dns-hetzner-cloud==1.0.5
 
 # Domain registrars with DNS
 certbot-dns-gandi==1.6.1
-certbot-dns-ovh==2.11.0
+certbot-dns-ovh==2.10.0
 # certbot-dns-namecheap removed: only v1.0.0 exists on PyPI (alpha,
 # targets Python 2.7-3.8) and is incompatible with certbot 2.x / Python 3.12.
 # Namecheap users should use acme-dns or manual DNS challenge instead.
@@ -24,8 +34,8 @@ certbot-dns-porkbun==0.11.0
 certbot-dns-godaddy==2.8.0
 
 # Specialized DNS services
-certbot-dns-dnsmadeeasy==2.11.0
-certbot-dns-nsone==2.11.0
+certbot-dns-dnsmadeeasy==2.10.0
+certbot-dns-nsone==2.10.0
 certbot-dns-he-ddns==0.1.0
 certbot-dns-dynudns==0.0.6
 

--- a/requirements-gcp.txt
+++ b/requirements-gcp.txt
@@ -2,4 +2,4 @@
 # Install this in addition to requirements-minimal.txt for Google Cloud support
 
 google-cloud-dns==0.35.0
-certbot-dns-google==2.11.0
+certbot-dns-google==2.10.0

--- a/tests/test_documented_pins_match_requirements.py
+++ b/tests/test_documented_pins_match_requirements.py
@@ -1,0 +1,117 @@
+"""Any version a document tells you to install must be a version we ship.
+
+`docs/installation.md` and its four translations published a hand-maintained
+pin list under "DNS Plugin Version Conflicts" — the section you land on when an
+install has already gone wrong. It said `certbot==4.1.1` while the project is
+pinned to `2.10.0`, in all five languages, for long enough that nobody
+remembered writing it. Following it gave you a stack CertMate has never been
+tested against: the 5.x migration is still issue #103, a plan.
+
+Correcting the numbers would not have been enough, and this is the part worth
+remembering. The pins that make certbot start are `cryptography`, `pyopenssl`,
+`josepy` and `acme`, none of which the list mentioned. Adding them back one at
+a time, in a clean virtualenv, `certbot --version` failed four times in a row:
+
+    AttributeError: module 'OpenSSL.crypto' has no attribute 'X509Req'
+    AttributeError: module 'josepy' has no attribute 'ComparableX509'
+    ...
+
+So the lists were replaced by `pip install -r <the file we ship>`, and this
+test keeps any new list honest.
+
+Scope: fenced code blocks only. Prose may name a wrong version — the sections
+above now explain the drift by quoting `certbot==4.1.1`, and a check that could
+not tell the difference would have to be silenced to let that stand.
+"""
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+_SKIP_DIRS = (".venv", "node_modules", ".git", "scratch", ".claude", "backups")
+# History is allowed to quote what it corrected.
+_SKIP_FILES = ("RELEASE_NOTES.md", "CHANGELOG.md")
+
+
+def _requirement_pins():
+    pins = {}
+    for path in sorted(REPO_ROOT.glob("requirements*.txt")):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = re.match(r"^([A-Za-z0-9_.-]+)==([\w.]+)", line.strip())
+            if match:
+                name = re.sub(r"[-_.]+", "-", match.group(1)).lower()
+                pins.setdefault(name, match.group(2))
+    return pins
+
+
+def _documented_pins():
+    """(file, line, package, version) for every pin inside a code fence."""
+    found = []
+    for path in sorted(REPO_ROOT.rglob("*.md")):
+        if any(part in path.parts for part in _SKIP_DIRS):
+            continue
+        if path.name in _SKIP_FILES:
+            continue
+        fenced = False
+        for number, line in enumerate(
+                path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+            if line.lstrip().startswith("```"):
+                fenced = not fenced
+                continue
+            if not fenced:
+                continue
+            for match in re.finditer(r"\b([A-Za-z][A-Za-z0-9_.-]*)==([\w.]+)", line):
+                name = re.sub(r"[-_.]+", "-", match.group(1)).lower()
+                found.append((str(path.relative_to(REPO_ROOT)), number,
+                              name, match.group(2)))
+    return found
+
+
+def test_the_scan_sees_the_documentation():
+    """Guard the guard: an empty scan would make every check below vacuous."""
+    pins = _requirement_pins()
+    assert len(pins) >= 20, f"parsed only {len(pins)} requirement pins"
+    assert "certbot" in pins, "certbot is not pinned in any requirements file"
+    markdown = [p for p in REPO_ROOT.rglob("*.md")
+                if not any(part in p.parts for part in _SKIP_DIRS)]
+    assert len(markdown) >= 20, f"only found {len(markdown)} markdown files"
+
+
+def test_no_document_tells_you_to_install_a_version_we_do_not_ship():
+    known = _requirement_pins()
+    wrong = [
+        f"{path}:{number}: {package}=={version} — we pin {known[package]}"
+        for path, number, package, version in _documented_pins()
+        if package in known and known[package] != version
+    ]
+    assert not wrong, (
+        "documentation tells operators to install versions the project does "
+        "not pin:\n  " + "\n  ".join(wrong)
+        + "\nThese lists drift because nothing installs them. Point at the "
+          "requirements file instead — it is the set CI resolves and boots."
+    )
+
+
+@pytest.mark.parametrize("package", ["certbot", "cryptography", "pyopenssl", "josepy"])
+def test_the_interlocking_pins_are_never_split_across_a_document(package):
+    """certbot cannot be documented without what makes it start.
+
+    A code block naming `certbot==` and nothing else is the shape of the
+    section this test came from: correct in isolation, unusable in practice.
+    """
+    offenders = []
+    for path, number, name, _version in _documented_pins():
+        if name != "certbot":
+            continue
+        text = (REPO_ROOT / path).read_text(encoding="utf-8")
+        if not re.search(r"\b(cryptography|pyopenssl|josepy)\s*==", text):
+            offenders.append(f"{path}:{number}")
+    assert not offenders, (
+        f"these pin certbot without pinning cryptography / pyopenssl / josepy "
+        f"anywhere in the file: {sorted(set(offenders))}. certbot installed "
+        f"that way does not start — it raises AttributeError on "
+        f"OpenSSL.crypto.X509Req before it can issue anything. Tell people to "
+        f"install from requirements.txt."
+    )

--- a/tests/test_documented_pins_match_requirements.py
+++ b/tests/test_documented_pins_match_requirements.py
@@ -8,8 +8,10 @@ remembered writing it. Following it gave you a stack CertMate has never been
 tested against: the 5.x migration is still issue #103, a plan.
 
 Correcting the numbers would not have been enough, and this is the part worth
-remembering. The pins that make certbot start are `cryptography`, `pyopenssl`,
-`josepy` and `acme`, none of which the list mentioned. Adding them back one at
+remembering. The pins that make certbot start are `cryptography`, `pyopenssl` and
+`josepy`, none of which the list mentioned. (`acme` is not pinned here at
+all — it arrives as certbot's own dependency, which is why naming it in an
+earlier draft of this docstring was wrong.) Adding them back one at
 a time, in a clean virtualenv, `certbot --version` failed four times in a row:
 
     AttributeError: module 'OpenSSL.crypto' has no attribute 'X509Req'
@@ -94,12 +96,15 @@ def test_no_document_tells_you_to_install_a_version_we_do_not_ship():
     )
 
 
-@pytest.mark.parametrize("package", ["certbot", "cryptography", "pyopenssl", "josepy"])
-def test_the_interlocking_pins_are_never_split_across_a_document(package):
+def test_the_interlocking_pins_are_never_split_across_a_document():
     """certbot cannot be documented without what makes it start.
 
     A code block naming `certbot==` and nothing else is the shape of the
     section this test came from: correct in isolation, unusable in practice.
+
+    This ran four times over a `package` parameter its body never read — four
+    identical assertions wearing different names (Copilot, #533). The set it
+    checks lives in the regex below, where it is used.
     """
     offenders = []
     for path, number, name, _version in _documented_pins():

--- a/tests/test_requirements_are_consistent.py
+++ b/tests/test_requirements_are_consistent.py
@@ -1,0 +1,136 @@
+"""The requirements files must agree with each other.
+
+Two defects sat here at once, and both were invisible because nothing installs
+these files except the two the image is built from.
+
+**Seven packages were pinned to two different versions.** `requirements.txt`
+held `certbot-dns-route53==2.10.0`; `requirements-aws.txt` held `2.11.0`. The
+Dockerfile installs extras in a *separate* `pip install`, and advertises the
+recipe itself:
+
+    --build-arg EXTRA_REQUIREMENTS="requirements-aws.txt requirements-gcp.txt"
+
+certbot-dns-route53 2.11.0 requires `certbot>=2.11.0`, so pip did the only
+thing it could: it upgraded certbot off the pin the whole stack is held at
+while #103 is still a plan. Measured, not reasoned about — on Python 3.12,
+certbot went 2.10.0 -> 3.3.0, silently, in a build that reported success.
+
+**`requirements-extended.txt` could not be installed at all.** Not layered, not
+alone in an empty virtualenv: `certbot-dns-powerdns==0.2.1` requires
+`dns-lexicon<=3.5.6` and `certbot-dns-linode` requires `>=3.14.1`.
+ResolutionImpossible, every path. `requirements.txt` had already excluded
+powerdns for exactly this reason, in a comment; this file reintroduced the
+conflict that comment describes avoiding.
+
+The check below is the cheap half — one version per package, offline. The
+other half is in CI, which resolves each file for real, because a pin can be
+self-consistent and still not exist.
+"""
+import collections
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _pins():
+    """package -> {filename: version}, for every `name==version` line."""
+    found = collections.defaultdict(dict)
+    for path in sorted(REPO_ROOT.glob("requirements*.txt")):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = re.match(r"^([A-Za-z0-9_.-]+)==([\w.]+)", line.strip())
+            if match:
+                # PEP 503: `certbot_dns_x` and `certbot-dns-x` are one package.
+                name = re.sub(r"[-_.]+", "-", match.group(1)).lower()
+                found[name][path.name] = match.group(2)
+    return found
+
+
+def test_the_requirements_files_are_being_read():
+    """A vacuous pass here would hide every check below it."""
+    files = list(REPO_ROOT.glob("requirements*.txt"))
+    assert len(files) >= 4, f"only found {[f.name for f in files]}"
+    assert len(_pins()) >= 20, (
+        f"parsed {len(_pins())} pinned packages out of {len(files)} files — "
+        f"the line format has changed and nothing below is checking anything."
+    )
+
+
+def test_no_package_is_pinned_to_two_versions():
+    conflicts = {
+        pkg: where for pkg, where in _pins().items()
+        if len(set(where.values())) > 1
+    }
+    assert not conflicts, (
+        "these packages are pinned to different versions in different "
+        "requirements files:\n"
+        + "\n".join(
+            f"  {pkg}: " + ", ".join(f"{v} in {f}" for f, v in sorted(w.items()))
+            for pkg, w in sorted(conflicts.items())
+        )
+        + "\nThe Dockerfile layers extras in a separate `pip install`, so the "
+          "higher pin wins and drags its dependencies with it. That is how "
+          "certbot moved from 2.10.0 to 3.3.0 in a build that said it "
+          "succeeded."
+    )
+
+
+def test_certbot_stays_on_its_pin_everywhere():
+    """Nothing may require a certbot newer than the one that is pinned."""
+    pins = _pins()
+    certbot = pins.get("certbot")
+    assert certbot, "certbot is no longer pinned in any requirements file"
+    versions = set(certbot.values())
+    assert len(versions) == 1, f"certbot pinned to {versions}"
+    pinned = versions.pop()
+
+    # Every certbot-dns-* plugin from the same upstream release train carries
+    # `certbot>={its own version}`. So a plugin pinned above the certbot pin
+    # forces an upgrade, without saying so anywhere.
+    def _key(version):
+        return tuple(int(part) for part in re.findall(r"\d+", version)[:3])
+
+    offenders = []
+    for pkg, where in pins.items():
+        if not pkg.startswith("certbot-dns-"):
+            continue
+        for filename, version in where.items():
+            # Only the plugins that track certbot's own numbering — the others
+            # (vultr 1.1.0, gandi 1.6.1, powerdns 0.2.1) version independently.
+            if _key(version)[:1] == _key(pinned)[:1] and _key(version) > _key(pinned):
+                offenders.append(f"{filename}: {pkg}=={version} > certbot=={pinned}")
+    assert not offenders, (
+        "these plugins are pinned above the certbot pin and require "
+        "`certbot>=` their own version, so installing them upgrades certbot:\n  "
+        + "\n  ".join(sorted(offenders))
+    )
+
+
+@pytest.mark.parametrize("filename", sorted(
+    p.name for p in REPO_ROOT.glob("requirements*.txt")))
+def test_powerdns_is_not_bundled_with_lexicon_hungry_plugins(filename):
+    """The pair that made `requirements-extended.txt` unusable.
+
+    Named explicitly rather than left to the CI resolve step, because this one
+    has now been reintroduced once after being fixed and documented.
+    """
+    text = (REPO_ROOT / filename).read_text(encoding="utf-8")
+    declared = {
+        re.sub(r"[-_.]+", "-", m.group(1)).lower()
+        for m in re.finditer(r"^([A-Za-z0-9_.-]+)==", text, re.M)
+    }
+    if "certbot-dns-powerdns" not in declared:
+        return
+    # dns-lexicon<=3.5.6 (powerdns) against dns-lexicon>=3.14.1 (these).
+    incompatible = sorted(declared & {
+        "certbot-dns-linode", "certbot-dns-ovh", "certbot-dns-rfc2136",
+        "certbot-dns-dnsmadeeasy", "certbot-dns-nsone",
+    })
+    assert not incompatible, (
+        f"{filename} pins certbot-dns-powerdns (dns-lexicon<=3.5.6) alongside "
+        f"{incompatible} (dns-lexicon>=3.14.1). pip cannot satisfy both: the "
+        f"file will not install at all, in any environment. Install powerdns "
+        f"separately, as requirements.txt already says."
+    )

--- a/tests/test_requirements_are_consistent.py
+++ b/tests/test_requirements_are_consistent.py
@@ -92,15 +92,31 @@ def test_certbot_stays_on_its_pin_everywhere():
     def _key(version):
         return tuple(int(part) for part in re.findall(r"\d+", version)[:3])
 
+    # Anything above the pin, regardless of major. The first version of this
+    # check required the majors to match — so `certbot-dns-route53==4.1.1`
+    # against `certbot==2.10.0` was skipped entirely, which is the exact number
+    # the install docs had drifted to and the exact case this test exists for
+    # (Copilot, #533). A guard that steps aside for the biggest version of the
+    # problem is not a guard.
+    #
+    # A handful of plugins version independently (vultr 1.1.0, gandi 1.6.1,
+    # powerdns 0.2.1, hetzner 2.0.1) — all of them below the certbot pin, so
+    # none needs an exception. If one legitimately goes above it, add it here
+    # with the evidence, rather than widening the rule until it stops catching
+    # anything.
+    checked = 0
     offenders = []
     for pkg, where in pins.items():
         if not pkg.startswith("certbot-dns-"):
             continue
         for filename, version in where.items():
-            # Only the plugins that track certbot's own numbering — the others
-            # (vultr 1.1.0, gandi 1.6.1, powerdns 0.2.1) version independently.
-            if _key(version)[:1] == _key(pinned)[:1] and _key(version) > _key(pinned):
+            checked += 1
+            if _key(version) > _key(pinned):
                 offenders.append(f"{filename}: {pkg}=={version} > certbot=={pinned}")
+    assert checked >= 10, (
+        f"only {checked} plugin pins examined — the parser is not seeing the "
+        f"requirements files, so this test would pass over nothing."
+    )
     assert not offenders, (
         "these plugins are pinned above the certbot pin and require "
         "`certbot>=` their own version, so installing them upgrades certbot:\n  "


### PR DESCRIPTION
CertMate holds certbot at 2.10.0 on purpose — the 5.x migration is issue #103,
a plan, not a release. Three surfaces disagreed with that, and none of them was
built by anything.

**Seven packages were pinned to two versions at once.** requirements.txt held
`certbot-dns-route53==2.10.0`; requirements-aws.txt held `2.11.0`, which
requires `certbot>=2.11.0`. The Dockerfile installs extras in a *separate* pip
run and advertises the recipe itself:

    --build-arg EXTRA_REQUIREMENTS="requirements-aws.txt requirements-gcp.txt"

so pip did the only thing it could and upgraded certbot. Measured in a clean
3.12 virtualenv: 2.10.0 -> 3.3.0, in a build that reported success. Same shape
in requirements-gcp.txt and five entries in requirements-extended.txt. All
seven aligned to the base; the recipe now leaves certbot at 2.10.0, verified
the same way.

**requirements-extended.txt could not be installed at all.** Not layered on
minimal as its own header says, not layered on requirements.txt as the
Dockerfile advertises, not alone in an empty virtualenv:
`certbot-dns-powerdns==0.2.1` requires `dns-lexicon<=3.5.6` and
`certbot-dns-linode` requires `>=3.14.1`. ResolutionImpossible, every path.
requirements.txt had already excluded powerdns for exactly this reason, in a
comment; this file reintroduced the conflict that comment describes avoiding.
Removed, with the reasoning written down where the next person will look.

**The install docs published `certbot==4.1.1` in all five languages.**
Under "DNS Plugin Version Conflicts" — the section you reach when an install
has already gone wrong. Correcting the numbers would not have been enough,
which is why the lists are gone rather than fixed: what makes the stack start
is `cryptography`, `pyopenssl`, `josepy` and `acme` holding each other in
place, none of which the lists mentioned. Assembled by hand in a clean venv,
`certbot --version` failed four times running — X509Req, then ComparableX509,
then more — while `pip install -r requirements.txt` works. The sections now say
that, in each language.

Three gates, because these all rotted for the same reason — nothing installed
them:

- `tests/test_requirements_are_consistent.py`: one version per package, and no
  plugin pinned above the certbot pin.
- `tests/test_documented_pins_match_requirements.py`: every pin inside a code
  fence must be a version we ship, and certbot may not be documented without
  what makes it start. Prose is exempt — the new sections explain the drift by
  quoting `certbot==4.1.1`, and a check that could not tell the difference
  would have to be silenced to allow that.
- a CI step resolving all five advertised combinations with
  `--dry-run --ignore-installed`. The flag is the check: without it the job's
  existing install makes pip report four packages, certbot not among them, and
  any assertion about certbot's version passes without looking at one.

Suite 2426 passed / 6 skipped. Every gate negative-verified by reintroducing
the real defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)