### PR TITLE
fix: the download URL in the README and the help page returns 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ CertMate solves the complexity of SSL certificate management in modern distribut
 - **Activity Timeline** - Chronological view of all certificate and system events
 
 ### **Developer Experience**
-- **One-URL Downloads** - Simple certificate retrieval for automation (`/{domain}/tls`)
+- **One-URL Downloads** - Simple certificate retrieval for automation (`/api/certificates/{domain}/download`)
 - **Individual Component Downloads** - Fetch cert, key, chain, or fullchain separately
 - **Multiple Output Formats** - PEM, ZIP, individual files
 - **SDK Examples** - Python, Bash, Ansible, Terraform examples
@@ -1002,16 +1002,21 @@ Content-Type: application/json
 **Certificate downloads for infrastructure automation:**
 
 ```bash
-# Download certificates via simple URL pattern
-GET /{domain}/tls
+# Download every certificate file as one ZIP
+GET /api/certificates/{domain}/download
 Authorization: Bearer your_token_here
 ```
 
 This endpoint returns a ZIP file containing all certificate files:
 - `cert.pem` - Server certificate
-- `chain.pem` - Intermediate certificate chain 
+- `chain.pem` - Intermediate certificate chain
 - `fullchain.pem` - Full certificate chain (cert + chain)
 - `privkey.pem` - Private key
+
+For a single file, use the path form
+`GET /api/certificates/{domain}/download/{cert|chain|fullchain|privkey|combined}`.
+`privkey` and `combined` require operator; a viewer may pull the public
+material only.
 
 ### Integration Examples
 

--- a/templates/help.html
+++ b/templates/help.html
@@ -153,8 +153,8 @@
                                 <li><span class="text-blue-500">GET</span> /api/certificates</li>
                                 <li><span class="text-green-500">POST</span> /api/certificates/create</li>
                                 <li><span class="text-green-500">POST</span> /api/certificates/{domain}/renew</li>
-                                <li><span class="text-blue-500">GET</span> /{domain}/tls <span class="text-gray-400 not-italic">(ZIP bundle)</span></li>
-                                <li><span class="text-blue-500">GET</span> /{domain}/tls/{cert|key|chain|fullchain}</li>
+                                <li><span class="text-blue-500">GET</span> /api/certificates/{domain}/download <span class="text-gray-400 not-italic">(ZIP bundle)</span></li>
+                                <li><span class="text-blue-500">GET</span> /api/certificates/{domain}/download/{cert|chain|fullchain|privkey|combined}</li>
                                 <li><span class="text-blue-500">GET</span> /api/activity</li>
                                 <li><span class="text-blue-500">GET</span> /api/deploy/history</li>
                             </ul>
@@ -170,7 +170,7 @@ curl -X POST http://localhost:8000/api/certificates/create \
 # Download full bundle as ZIP
 curl -H "Authorization: Bearer $TOKEN" \
   -o example.com.zip \
-  http://localhost:8000/example.com/tls</code></pre>
+  http://localhost:8000/api/certificates/example.com/download</code></pre>
                         </div>
                     </div>
                     <p class="text-sm text-gray-700 dark:text-gray-200 mt-3">

--- a/templates/help.html
+++ b/templates/help.html
@@ -154,7 +154,7 @@
                                 <li><span class="text-green-500">POST</span> /api/certificates/create</li>
                                 <li><span class="text-green-500">POST</span> /api/certificates/{domain}/renew</li>
                                 <li><span class="text-blue-500">GET</span> /api/certificates/{domain}/download <span class="text-gray-400 not-italic">(ZIP bundle)</span></li>
-                                <li><span class="text-blue-500">GET</span> /api/certificates/{domain}/download/{cert|chain|fullchain|privkey|combined}</li>
+                                <li><span class="text-blue-500">GET</span> /api/certificates/{domain}/download/{cert|chain|fullchain|privkey|combined} <span class="text-gray-400 not-italic">(privkey, combined: operator+)</span></li>
                                 <li><span class="text-blue-500">GET</span> /api/activity</li>
                                 <li><span class="text-blue-500">GET</span> /api/deploy/history</li>
                             </ul>

--- a/tests/test_advertised_endpoints_exist.py
+++ b/tests/test_advertised_endpoints_exist.py
@@ -11,27 +11,45 @@ Nothing caught it because the documentation was checked against itself. The
 route table is the only thing that knows what exists, so the check below asks
 the application, not a list someone maintains by hand.
 """
-import os
 import pathlib
 import re
-import sys
 
 import pytest
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
 
-def _url_map():
-    os.environ.setdefault("TESTING", "true")
-    sys.path.insert(0, str(REPO_ROOT))
-    from modules.core.factory import create_app
-    result = create_app()
+@pytest.fixture(scope="session")
+def url_map(tmp_path_factory):
+    """The application's route table, built once, under a temporary root.
+
+    Built once because the first version called `create_app()` inside every
+    parametrised case, and under a temporary root because `setup_directories()`
+    creates `data/`, `certificates/` and `logs/` relative to
+    `modules/core/factory.__file__` — so a test that only wants to read the
+    route table was creating directories in the working tree and would fail on
+    a read-only checkout (Copilot, #534). Anchoring the module's `__file__` to
+    a temp tree is the pattern the rest of the suite already uses; see
+    tests/test_csp_img_src_airgap.py.
+    """
+    root = tmp_path_factory.mktemp("routes") / "certmate"
+    module_dir = root / "modules" / "core"
+    module_dir.mkdir(parents=True)
+    anchor = module_dir / "factory.py"
+    anchor.write_text("# test path anchor\n", encoding="utf-8")
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setenv("TESTING", "true")
+        patch.setenv("FLASK_ENV", "testing")
+        from modules.core.factory import create_app
+        patch.setattr("modules.core.factory.__file__", str(anchor))
+        result = create_app()
     app = result[0] if isinstance(result, tuple) else result
-    rules = {}
-    for rule in app.url_map.iter_rules():
-        methods = {m for m in rule.methods if m not in ("HEAD", "OPTIONS")}
-        rules[_normalise(str(rule))] = methods
-    return rules
+    return {
+        _normalise(str(rule)): {m for m in rule.methods
+                                if m not in ("HEAD", "OPTIONS")}
+        for rule in app.url_map.iter_rules()
+    }
 
 
 def _normalise(path):
@@ -87,15 +105,14 @@ def test_the_help_page_advertises_something():
     )
 
 
-def test_the_route_map_is_populated():
-    routes = _url_map()
-    assert len(routes) > 50, f"only {len(routes)} routes — did the app boot?"
+def test_the_route_map_is_populated(url_map):
+    assert len(url_map) > 50, f"only {len(url_map)} routes — did the app boot?"
 
 
 @pytest.mark.parametrize("source,verb,path", _advertised(),
                          ids=[f"{v} {p}" for _s, v, p in _advertised()])
-def test_every_advertised_endpoint_is_a_real_route(source, verb, path):
-    routes = _url_map()
+def test_every_advertised_endpoint_is_a_real_route(source, verb, path, url_map):
+    routes = url_map
     # `{cert|key|chain}` in a listing stands for one path segment.
     hit = _match(re.sub(r"\{[^}]*\|[^}]*\}", "<X>", path), routes)
     assert hit, (

--- a/tests/test_advertised_endpoints_exist.py
+++ b/tests/test_advertised_endpoints_exist.py
@@ -1,0 +1,134 @@
+"""Every endpoint the product advertises must be a route the app serves.
+
+`GET /{domain}/tls` was in the README's feature list, in the README's
+"Automation-Friendly Download URL" section with a worked example, and in the
+in-product help page — as a listed endpoint *and* as the copy-pasteable curl
+command underneath it. It returns 404. There are 130 routes in the app and not
+one of them contains `/tls`; the real endpoints are
+`/api/certificates/<domain>/download` and `.../download/<file_type>`.
+
+Nothing caught it because the documentation was checked against itself. The
+route table is the only thing that knows what exists, so the check below asks
+the application, not a list someone maintains by hand.
+"""
+import os
+import pathlib
+import re
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _url_map():
+    os.environ.setdefault("TESTING", "true")
+    sys.path.insert(0, str(REPO_ROOT))
+    from modules.core.factory import create_app
+    result = create_app()
+    app = result[0] if isinstance(result, tuple) else result
+    rules = {}
+    for rule in app.url_map.iter_rules():
+        methods = {m for m in rule.methods if m not in ("HEAD", "OPTIONS")}
+        rules[_normalise(str(rule))] = methods
+    return rules
+
+
+def _normalise(path):
+    """`/api/x/<string:domain>/y` and `/api/x/{domain}/y` are the same route."""
+    path = re.sub(r"<[^>]+>", "<X>", path)
+    path = re.sub(r"\{[^}]+\}", "<X>", path)
+    return path.rstrip("/") or "/"
+
+
+def _match(path, routes):
+    """Find the route a documented path would reach, or None.
+
+    Segment-wise, because documentation writes worked examples with real
+    values: `/api/certificates/example.com/download` must resolve against
+    `/api/certificates/<X>/download`. A `<X>` in the route matches exactly one
+    literal segment — never several, or `/example.com/tls` would be absorbed by
+    some unrelated two-segment rule and this file would prove nothing.
+    """
+    wanted = _normalise(path).strip("/").split("/")
+    for candidate, methods in routes.items():
+        parts = candidate.strip("/").split("/")
+        if len(parts) != len(wanted):
+            continue
+        if all(p == "<X>" or p == w for p, w in zip(parts, wanted)):
+            return candidate, methods
+    return None
+
+
+def _advertised():
+    """(source, verb, path) for every endpoint the help page lists."""
+    html = (REPO_ROOT / "templates" / "help.html").read_text(encoding="utf-8")
+    found = []
+    for match in re.finditer(
+            r'<span class="text-\w+-500">(GET|POST|PUT|PATCH|DELETE)</span>\s*'
+            r'([^\s<]+)', html):
+        found.append(("templates/help.html", match.group(1), match.group(2)))
+    # The curl examples underneath. These are the ones people actually run, so
+    # the verb comes from the command's own -X flag rather than being assumed.
+    for block in re.finditer(r'curl\b(.*?)(?:</code>|\n\n)', html, re.S):
+        text = block.group(1)
+        verb = (re.search(r"-X\s+([A-Z]+)", text) or [None, "GET"])[1]
+        for url in re.finditer(r'http://localhost:8000(/[^\s<\\"\']+)', text):
+            found.append(("templates/help.html (curl)", verb, url.group(1)))
+    return found
+
+
+def test_the_help_page_advertises_something():
+    """Otherwise the parametrised checks below pass over an empty list."""
+    listed = _advertised()
+    assert len(listed) >= 5, (
+        f"parsed {len(listed)} endpoints out of templates/help.html — the "
+        f"markup changed and this file is no longer checking the help page."
+    )
+
+
+def test_the_route_map_is_populated():
+    routes = _url_map()
+    assert len(routes) > 50, f"only {len(routes)} routes — did the app boot?"
+
+
+@pytest.mark.parametrize("source,verb,path", _advertised(),
+                         ids=[f"{v} {p}" for _s, v, p in _advertised()])
+def test_every_advertised_endpoint_is_a_real_route(source, verb, path):
+    routes = _url_map()
+    # `{cert|key|chain}` in a listing stands for one path segment.
+    hit = _match(re.sub(r"\{[^}]*\|[^}]*\}", "<X>", path), routes)
+    assert hit, (
+        f"{source} advertises `{verb} {path}`, which is not a route this "
+        f"application serves. It returns 404 to anyone who copies it."
+    )
+    route, methods = hit
+    assert verb in methods, (
+        f"{source} advertises `{verb} {path}`, but {route} accepts "
+        f"{sorted(methods)}."
+    )
+
+
+def test_the_readme_does_not_advertise_the_phantom_download_url():
+    """The specific claim, in the file most people read first.
+
+    Kept as its own check because the README's prose is not machine-readable
+    the way the help page's markup is, and this endpoint appeared there three
+    times — a feature bullet, a request block, and a worked example.
+    """
+    for name in ("README.md", "README.dockerhub.md"):
+        path = REPO_ROOT / name
+        if not path.exists():
+            continue
+        offenders = [
+            f"{name}:{number}: {line.strip()}"
+            for number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), 1)
+            if re.search(r"(?<!kubernetes\.io)/\{domain\}/tls|localhost:8000/[\w.]+/tls",
+                         line)
+        ]
+        assert not offenders, (
+            "the README advertises `/{domain}/tls`, which no route serves:\n  "
+            + "\n  ".join(offenders)
+            + "\nUse /api/certificates/{domain}/download."
+        )


### PR DESCRIPTION
`GET /{domain}/tls` is advertised in three places — the README's feature list,
the README's "Automation-Friendly Download URL" section with a worked request,
and the in-product help page, both as a listed endpoint and as the curl command
printed underneath it. No such route exists. The application serves 130 routes
and not one of them contains `/tls`; the real ones are
`/api/certificates/<domain>/download` for the ZIP and
`.../download/<cert|chain|fullchain|privkey|combined>` for a single file.

That is the shortest path from "reads the docs" to "gets a 404" in the project,
and it sits in the help page a user opens *because* something is not working.

Corrected in all three places, with the role gating the path form actually
applies (privkey and combined need operator; a viewer gets the public material).

`tests/test_advertised_endpoints_exist.py` asks the Flask url_map rather than a
list someone maintains by hand — checking documentation against documentation
is how this survived. It parses the help page's own markup, takes each curl
example's verb from its `-X` flag instead of assuming GET, and resolves paths
segment-wise so a worked example with a real domain matches its parameterised
route. A `<X>` matches exactly one segment: allowing more would let
`/example.com/tls` be absorbed by some unrelated two-segment rule, and the file
would prove nothing.

Negative-verified four ways — the phantom endpoint in the listing, the phantom
endpoint in the curl example, a wrong verb on a route that does exist, and the
README claim. Suite 2417 passed / 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)