### PR TITLE
fix: a provider status column that said the same thing about all 29 rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,21 +217,21 @@ CertMate solves the complexity of SSL certificate management in modern distribut
 
 CertMate supports a wide range of DNS providers through Let's Encrypt DNS-01 challenge via individual certbot plugins that provide reliable, well-tested DNS challenge support. The complete list is in the table below. **Multi-account support** is available for major providers, enabling enterprise-grade deployments with separate accounts for production, staging, and disaster recovery.
 
-| Provider               | Credentials Required          | Multi-Account | Use Case                        | Status     |
-| ---------------------- | ----------------------------- | ------------- | ------------------------------- | ---------- |
+| Provider               | Credentials Required          | Multi-Account | Use Case                        | Availability |
+| ---------------------- | ----------------------------- | ------------- | ------------------------------- | ------------ |
 | **Cloudflare**         | API Token                     | **Yes**       | Global CDN, Free tier available | **Stable** |
 | **AWS Route53**        | Access Key, Secret Key        | **Yes**       | AWS infrastructure, Enterprise  | **Stable** |
 | **Azure DNS**          | Service Principal credentials | **Yes**       | Microsoft ecosystem             | **Stable** |
 | **Google Cloud DNS**   | Service Account JSON          | **Yes**       | Google Cloud Platform           | **Stable** |
 | **DigitalOcean**       | API Token                     | **Yes**       | Cloud infrastructure            | **Stable** |
-| **PowerDNS**           | API URL, API Key              | **Yes**       | Self-hosted, On-premises        | **Stable** |
+| **PowerDNS**           | API URL, API Key              | **Yes**       | Self-hosted, On-premises        | **Extended image** |
 | **EfficientIP SOLIDserver** | Host, API Credentials     | **Yes**       | Enterprise DDI / Smart Architecture | **Stable** |
 | **RFC2136**            | Nameserver, TSIG Key/Secret   | **Yes**       | Standard DNS update protocol    | **Stable** |
 | **Linode** (Akamai Connected Cloud) | API Key             | Single        | Cloud hosting                   | **Stable** |
 | **Akamai Edge DNS**    | EdgeGrid (.edgerc) credentials| Single        | Enterprise managed DNS          | **Stable** |
 | **Gandi**              | API Token                     | Single        | Domain registrar                | **Stable** |
 | **OVH**                | API Credentials               | Single        | European hosting                | **Stable** |
-| **Namecheap**          | Username, API Key             | Single        | Domain registrar                | **Stable** |
+| **Namecheap**          | Username, API Key             | Single        | Domain registrar                | **Unavailable** |
 | **Vultr**              | API Key                       | Single        | Global cloud infrastructure     | **Stable** |
 | **DNS Made Easy**      | API Key, Secret Key           | Single        | Enterprise DNS management       | **Stable** |
 | **NS1**                | API Key                       | Single        | Intelligent DNS platform        | **Stable** |
@@ -239,15 +239,34 @@ CertMate supports a wide range of DNS providers through Let's Encrypt DNS-01 cha
 | **Hetzner Cloud**      | API Token                     | Single        | Hetzner Cloud DNS (hcloud)      | **Stable** |
 | **Porkbun**            | API Key, Secret Key           | Single        | Domain registrar with DNS       | **Stable** |
 | **GoDaddy**            | API Key, Secret               | Single        | Popular domain registrar        | **Stable** |
-| **Hurricane Electric** | Username, Password            | Single        | Free DNS hosting                | **Stable** |
-| **Dynu**               | API Token                     | Single        | Dynamic DNS service             | **Stable** |
+| **Hurricane Electric** | Username, Password            | Single        | Free DNS hosting                | **Extended image** |
+| **Dynu**               | API Token                     | Single        | Dynamic DNS service             | **Extended image** |
 | **ArvanCloud**         | API Key                       | Single        | Iranian cloud provider          | **Stable** |
 | **Infomaniak**         | API Token                     | Single        | Swiss ISP & cloud provider      | **Stable** |
 | **ACME-DNS**           | JSON Config                   | Single        | Generic ACME-DNS server         | **Stable** |
-| **Scaleway**           | API Token (secret key)        | Single        | European cloud (EU-sovereign)   | **Stable** |
+| **Scaleway**           | API Token (secret key)        | Single        | European cloud (EU-sovereign)   | **Separate install** |
 | **deSEC**              | API Token                     | Single        | Free, non-profit DNSSEC DNS     | **Stable** |
 | **DuckDNS**            | Token                         | Single        | Free dynamic DNS                | **Stable** |
 | **Custom Script**      | User-provided hook scripts    | Single        | Any provider via custom hooks   | **Stable** |
+
+**What the availability column means.** Until now it said `Stable` on all
+twenty-nine rows, which is not a status — a column with one value cannot be
+wrong about any particular provider, and four of them were wrong:
+
+| Value | Meaning |
+| ----- | ------- |
+| **Stable** | The plugin is pinned in `requirements.txt`, so it is in the default image. |
+| **Extended image** | Pinned in `requirements-extended.txt`. Build with `--build-arg EXTRA_REQUIREMENTS=requirements-extended.txt`. |
+| **Separate install** | Not shipped in any image. `pip install` it yourself, in its own environment where noted. |
+| **Unavailable** | No usable plugin exists for the supported stack. CertMate can be configured for it, but issuance will fail. |
+
+`Namecheap` is the **Unavailable** one: the only release on PyPI is
+`certbot-dns-namecheap` 1.0.0, an alpha targeting Python 2.7-3.8, incompatible
+with certbot 2.x on Python 3.12 — as `NamecheapStrategy`'s own docstring has
+said all along. Use ACME-DNS or the custom-script hook for Namecheap domains.
+`Scaleway` is alpha (0.0.7, declares Python 2.7 support) and `PowerDNS` pulls
+`dns-lexicon<=3.5.6`, which conflicts with the rest of the extended set — hence
+its own environment.
 
 ### Provider Categories
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ CertMate supports a wide range of DNS providers through Let's Encrypt DNS-01 cha
 | **Azure DNS**          | Service Principal credentials | **Yes**       | Microsoft ecosystem             | **Stable** |
 | **Google Cloud DNS**   | Service Account JSON          | **Yes**       | Google Cloud Platform           | **Stable** |
 | **DigitalOcean**       | API Token                     | **Yes**       | Cloud infrastructure            | **Stable** |
-| **PowerDNS**           | API URL, API Key              | **Yes**       | Self-hosted, On-premises        | **Extended image** |
+| **PowerDNS**           | API URL, API Key              | **Yes**       | Self-hosted, On-premises        | **Separate install** |
 | **EfficientIP SOLIDserver** | Host, API Credentials     | **Yes**       | Enterprise DDI / Smart Architecture | **Stable** |
 | **RFC2136**            | Nameserver, TSIG Key/Secret   | **Yes**       | Standard DNS update protocol    | **Stable** |
 | **Linode** (Akamai Connected Cloud) | API Key             | Single        | Cloud hosting                   | **Stable** |

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,14 @@ certbot-dns-hetzner-cloud==1.0.5
 certbot-dns-porkbun==0.11.0
 certbot-dns-godaddy==2.8.0
 certbot-dns-arvancloud==0.1.0
+# Infomaniak: Swiss ISP and cloud provider. CertMate has shipped an
+# InfomaniakStrategy, a credentials-file writer and a README row for it since
+# the provider was added — and never the plugin, so `certbot --dns-infomaniak`
+# failed with "unrecognized arguments" in every image ever published. 0.2.4
+# requires only certbot>=0.31.0 and Python>=3.9; verified in a clean venv on
+# top of requirements-minimal.txt: certbot stays at 2.10.0, the entry point
+# registers, `pip check` is clean.
+certbot-dns-infomaniak==0.2.4
 # acme-dns needs NO certbot plugin. certbot-acme-dns==0.3.1 was pinned here
 # until v2.24.0 but never worked: it exposes no --acme-dns-credentials option,
 # so certbot rejected the command line CertMate built and every acme-dns

--- a/tests/test_provider_availability_is_truthful.py
+++ b/tests/test_provider_availability_is_truthful.py
@@ -1,0 +1,153 @@
+"""The provider table's availability column must match what we actually ship.
+
+It said `Stable` on all twenty-nine rows. A column with one value is not a
+status — it cannot be wrong about any particular provider, which is why four
+wrong entries sat in the most-read table in the README:
+
+  * **Namecheap** — the only release on PyPI is 1.0.0, an alpha targeting
+    Python 2.7-3.8, incompatible with certbot 2.x on Python 3.12. Not a
+    judgement call: `NamecheapStrategy`'s own docstring says exactly that, and
+    requirements.txt records the removal in a comment. The README called it
+    Stable anyway.
+  * **Scaleway** — 0.0.7, alpha, still declaring Python 2.7 support. A comment
+    in requirements.txt, never a pin.
+  * **PowerDNS** — pulls `dns-lexicon<=3.5.6`, which conflicts with the rest of
+    the extended set. Not in the default image.
+  * **Infomaniak** — pinned in no requirements file at all.
+
+The check below reads the requirements files, which are the only thing that
+decides what is in an image, and compares them with what the table claims.
+"""
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+# provider display name (as written in the README) -> PyPI distribution.
+# Derived from the plugin, with the cases where the two names differ. Every
+# entry is checked below against the requirements files: a name nothing
+# mentions is a name nobody can verify.
+DISTRIBUTIONS = {
+    "Cloudflare": "certbot-dns-cloudflare",
+    "AWS Route53": "certbot-dns-route53",
+    "Azure DNS": "certbot-dns-azure",
+    "Google Cloud DNS": "certbot-dns-google",
+    "DigitalOcean": "certbot-dns-digitalocean",
+    "PowerDNS": "certbot-dns-powerdns",
+    "RFC2136": "certbot-dns-rfc2136",
+    "Linode": "certbot-dns-linode",
+    "Akamai Edge DNS": "certbot-plugin-edgedns",
+    "Gandi": "certbot-dns-gandi",
+    "OVH": "certbot-dns-ovh",
+    "Namecheap": "certbot-dns-namecheap",
+    "Vultr": "certbot-dns-vultr",
+    "DNS Made Easy": "certbot-dns-dnsmadeeasy",
+    "NS1": "certbot-dns-nsone",              # entry point dns-ns1
+    "Hetzner": "certbot-dns-hetzner",
+    "Hetzner Cloud": "certbot-dns-hetzner-cloud",
+    "Porkbun": "certbot-dns-porkbun",
+    "GoDaddy": "certbot-dns-godaddy",
+    "Hurricane Electric": "certbot-dns-he-ddns",
+    "Dynu": "certbot-dns-dynudns",           # entry point dns-dynu
+    "ArvanCloud": "certbot-dns-arvancloud",
+    "Infomaniak": "certbot-dns-infomaniak",
+    "Scaleway": "certbot-dns-scaleway",
+    "deSEC": "certbot-dns-desec",
+    "DuckDNS": "certbot-dns-duckdns",
+}
+
+# Providers CertMate implements itself, with no certbot plugin involved.
+NATIVE = {"EfficientIP SOLIDserver", "ACME-DNS", "Custom Script"}
+
+
+def _requirements(name):
+    path = REPO_ROOT / name
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _is_pinned(text, distribution):
+    return bool(re.search(rf"^{re.escape(distribution)}==", text, re.M))
+
+
+def _is_only_a_comment(text, distribution):
+    return (not _is_pinned(text, distribution)
+            and bool(re.search(rf"^#.*{re.escape(distribution)}", text, re.M)))
+
+
+def _expected(distribution):
+    """What the availability column should say, from the requirements alone."""
+    base = _requirements("requirements.txt")
+    extended = _requirements("requirements-extended.txt")
+    optional = "".join(_requirements(p.name) for p in REPO_ROOT.glob("requirements-*.txt"))
+    if _is_pinned(base, distribution):
+        return "Stable"
+    if _is_pinned(extended, distribution):
+        return "Extended image"
+    if _is_pinned(optional, distribution):
+        return "Stable"          # per-cloud extras (aws/gcp/azure) are supported
+    if _is_only_a_comment(base + extended, distribution):
+        return {"Separate install", "Unavailable"}
+    return {"Separate install", "Unavailable"}
+
+
+def _table_rows():
+    """(display name, availability) for every row of the provider table."""
+    rows = []
+    for line in README.read_text(encoding="utf-8").splitlines():
+        match = re.match(r"^\|\s*\*\*(.+?)\*\*[^|]*\|.*\|\s*\*\*([\w ]+)\*\*\s*\|\s*$",
+                         line)
+        if match and "Credentials" not in line:
+            name = re.sub(r"\s*\(.*?\)", "", match.group(1)).strip()
+            rows.append((name, match.group(2).strip()))
+    return rows
+
+
+def test_the_table_is_being_parsed():
+    rows = _table_rows()
+    assert len(rows) >= 25, (
+        f"parsed {len(rows)} provider rows out of README.md — the table format "
+        f"changed and every check below would pass over nothing."
+    )
+    values = {status for _name, status in rows}
+    assert len(values) > 1, (
+        f"every row says {values}. A column with one value is decoration, not "
+        f"a status: that is how four wrong entries survived in it."
+    )
+
+
+@pytest.mark.parametrize("distribution", sorted(set(DISTRIBUTIONS.values())))
+def test_every_distribution_name_is_one_the_requirements_know(distribution):
+    """The table above must describe real packages, or it proves nothing."""
+    everything = "".join(
+        _requirements(p.name) for p in REPO_ROOT.glob("requirements*.txt"))
+    assert distribution in everything, (
+        f"{distribution} is named in this test's mapping but appears in no "
+        f"requirements file, pinned or commented. Either the name is wrong or "
+        f"the provider is gone."
+    )
+
+
+@pytest.mark.parametrize("name,claimed", _table_rows(),
+                         ids=[n for n, _s in _table_rows()])
+def test_the_availability_column_matches_the_requirements(name, claimed):
+    if name in NATIVE:
+        assert claimed == "Stable", (
+            f"{name} is implemented natively by CertMate, with no plugin to "
+            f"install — it cannot be anything but Stable."
+        )
+        return
+    distribution = DISTRIBUTIONS.get(name)
+    assert distribution, (
+        f"README lists a provider this test does not know: {name!r}. Add it to "
+        f"DISTRIBUTIONS (or NATIVE) rather than leaving it unchecked."
+    )
+    expected = _expected(distribution)
+    allowed = {expected} if isinstance(expected, str) else expected
+    assert claimed in allowed, (
+        f"README says {name} is '{claimed}', but {distribution} is "
+        f"{'pinned in ' + ', '.join(p.name for p in REPO_ROOT.glob('requirements*.txt') if _is_pinned(_requirements(p.name), distribution)) if any(_is_pinned(_requirements(p.name), distribution) for p in REPO_ROOT.glob('requirements*.txt')) else 'pinned nowhere'}. "
+        f"Expected one of {sorted(allowed)}."
+    )

--- a/tests/test_provider_availability_is_truthful.py
+++ b/tests/test_provider_availability_is_truthful.py
@@ -88,29 +88,61 @@ def _expected(distribution):
         return "Extended image"
     if _is_pinned(optional, distribution):
         return "Stable"          # per-cloud extras (aws/gcp/azure) are supported
-    if _is_only_a_comment(base + extended, distribution):
-        return {"Separate install", "Unavailable"}
+    # Not pinned anywhere: whether it is documented as a deliberate exclusion
+    # (a comment in requirements.txt) or absent entirely, the honest answers are
+    # the same two. An earlier version branched on that distinction and returned
+    # the identical set from both arms — a conditional that decided nothing.
+    del base, extended
     return {"Separate install", "Unavailable"}
 
 
 def _table_rows():
-    """(display name, availability) for every row of the provider table."""
+    """(display name, availability) for every row of the provider table.
+
+    The first version filtered out any line containing "Credentials" — intended
+    to drop the header, which does not need dropping (its cells carry no `**`,
+    so the pattern never matched it). What it actually dropped was every
+    provider whose credentials cell reads "API Credentials": EfficientIP
+    SOLIDserver and OVH went unchecked, and the >= 25 guard below did not
+    notice because 27 still cleared it. Found via Copilot on #535.
+    """
     rows = []
     for line in README.read_text(encoding="utf-8").splitlines():
         match = re.match(r"^\|\s*\*\*(.+?)\*\*[^|]*\|.*\|\s*\*\*([\w ]+)\*\*\s*\|\s*$",
                          line)
-        if match and "Credentials" not in line:
+        if match:
             name = re.sub(r"\s*\(.*?\)", "", match.group(1)).strip()
             rows.append((name, match.group(2).strip()))
     return rows
 
 
+# Parsed once: the parametrisation below needs both the values and the ids, and
+# reading README.md twice at collection time is two chances to disagree.
+TABLE_ROWS = _table_rows()
+
+
 def test_the_table_is_being_parsed():
-    rows = _table_rows()
-    assert len(rows) >= 25, (
-        f"parsed {len(rows)} provider rows out of README.md — the table format "
-        f"changed and every check below would pass over nothing."
+    rows = TABLE_ROWS
+    # Only the provider table: the legend underneath it is also a markdown
+    # table whose rows start with `| **`, and counting those would make this
+    # guard disagree with itself.
+    listed, inside = 0, False
+    for line in README.read_text(encoding="utf-8").splitlines():
+        if line.startswith("| Provider "):
+            inside = True
+            continue
+        if inside:
+            if not line.startswith("|"):
+                break
+            if line.startswith("| ---"):
+                continue
+            listed += 1
+    assert len(rows) == listed, (
+        f"parsed {len(rows)} rows but the table has {listed}. Silently covering "
+        f"fewer providers than the table lists is exactly how EfficientIP and "
+        f"OVH went unchecked."
     )
+    assert len(rows) >= 25, f"only {len(rows)} provider rows found"
     values = {status for _name, status in rows}
     assert len(values) > 1, (
         f"every row says {values}. A column with one value is decoration, not "
@@ -119,7 +151,7 @@ def test_the_table_is_being_parsed():
 
 
 @pytest.mark.parametrize("distribution", sorted(set(DISTRIBUTIONS.values())))
-def test_every_distribution_name_is_one_the_requirements_know(distribution):
+def test_every_distribution_name_is_known_to_the_requirements(distribution):
     """The table above must describe real packages, or it proves nothing."""
     everything = "".join(
         _requirements(p.name) for p in REPO_ROOT.glob("requirements*.txt"))
@@ -130,8 +162,8 @@ def test_every_distribution_name_is_one_the_requirements_know(distribution):
     )
 
 
-@pytest.mark.parametrize("name,claimed", _table_rows(),
-                         ids=[n for n, _s in _table_rows()])
+@pytest.mark.parametrize("name,claimed", TABLE_ROWS,
+                         ids=[n for n, _s in TABLE_ROWS])
 def test_the_availability_column_matches_the_requirements(name, claimed):
     if name in NATIVE:
         assert claimed == "Stable", (
@@ -146,8 +178,12 @@ def test_the_availability_column_matches_the_requirements(name, claimed):
     )
     expected = _expected(distribution)
     allowed = {expected} if isinstance(expected, str) else expected
+    pinned_in = sorted(
+        path.name for path in REPO_ROOT.glob("requirements*.txt")
+        if _is_pinned(_requirements(path.name), distribution)
+    )
+    where = "pinned in " + ", ".join(pinned_in) if pinned_in else "pinned nowhere"
     assert claimed in allowed, (
-        f"README says {name} is '{claimed}', but {distribution} is "
-        f"{'pinned in ' + ', '.join(p.name for p in REPO_ROOT.glob('requirements*.txt') if _is_pinned(_requirements(p.name), distribution)) if any(_is_pinned(_requirements(p.name), distribution) for p in REPO_ROOT.glob('requirements*.txt')) else 'pinned nowhere'}. "
+        f"README says {name} is '{claimed}', but {distribution} is {where}. "
         f"Expected one of {sorted(allowed)}."
     )


### PR DESCRIPTION
The README's provider table ended in a `Status` column reading **Stable** on
every single row. That is not a status: a column with one value cannot be wrong
about any particular provider, so nobody ever checked it — and four entries
were wrong, in the table people read *before* choosing a provider.

**Namecheap was the worst of them.** The only release on PyPI is
`certbot-dns-namecheap` 1.0.0, an alpha targeting Python 2.7-3.8, incompatible
with certbot 2.x on Python 3.12. This is not a judgement call:
`NamecheapStrategy`'s own docstring says exactly that and points users at
acme-dns instead, and requirements.txt records the removal in a comment. The
README said Stable. Now **Unavailable**, with the alternative named.

**Scaleway** (0.0.7, alpha, last released 2022) and **PowerDNS** (drags
`dns-lexicon<=3.5.6`, which conflicts with the rest of the extended set) were
never in the default image either. **Hurricane Electric** and **Dynu** are
extended-image only.

**Infomaniak was a supported provider whose plugin was never shipped.**
CertMate has an `InfomaniakStrategy`, a credentials-file writer, a README row
and a strategy-factory entry for it — and `certbot-dns-infomaniak` appeared in
no requirements file, pinned or commented. So `certbot --dns-infomaniak` failed
with "unrecognized arguments" in every image ever published. The plugin is
fine: 0.2.4 needs only `certbot>=0.31.0` and Python>=3.9. Verified in a clean
venv on requirements-minimal.txt — certbot stays at 2.10.0, the entry point
registers, `pip check` is clean — and the credential contract matches at the
source: the plugin reads `self.credentials.conf("token")`, which certbot
resolves to `dns_infomaniak_token`, which is exactly what
`create_infomaniak_config` writes. So it is now pinned rather than
documented-away, and the row is honestly **Stable**.

The column has four values now, and a legend saying what each means.

`tests/test_provider_availability_is_truthful.py` reads the requirements files
— the only thing that decides what is in an image — and compares them with what
each row claims. It also fails if the column goes back to one value everywhere,
which is the state that let this survive. The distribution names it maps are
themselves checked against the requirements files, because a mapping nobody can
verify is not evidence.

Suite 2464 passed / 6 skipped. Negative-verified three ways: Namecheap back to
Stable, the Infomaniak pin removed while the README still claims it, and the
whole column flattened to one value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)