### PR TITLE
docs: the Python version the README told you to use cannot install this project

### DIFF
--- a/README.dockerhub.md
+++ b/README.dockerhub.md
@@ -9,7 +9,7 @@
 **CertMate** is an SSL certificate management system for modern infrastructure. Multi-DNS provider support, Docker-ready, comprehensive REST API.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/)
 [![Docker](https://img.shields.io/badge/docker-ready-blue)](https://hub.docker.com/)
 
  **Full Documentation**: https://github.com/fabriziosalmi/certmate

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Live Demo](https://img.shields.io/badge/Live%20Demo-try%20it%20now-2563eb?logo=probot&logoColor=white)](https://demo.certmate.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/)
 [![Docker](https://img.shields.io/badge/docker-ready-blue)](https://hub.docker.com/)
 [![API Documentation](https://img.shields.io/badge/API-Swagger-green)](#api-usage)
 [![PyPI - certmate-cli](https://img.shields.io/pypi/v/certmate-cli?label=certmate-cli&color=3775A9)](https://pypi.org/project/certmate-cli/)
@@ -532,7 +532,7 @@ For production deployments, CertMate should run as a system service. This sectio
 ### Prerequisites
 
 - Linux system with systemd
-- Python 3.9 or higher
+- Python 3.12
 - Root/sudo access
 
 ### 1. Create Dedicated System User

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ This document covers the complete CertMate architecture — both the main server
 CertMate is a modular, pluggable SSL/TLS certificate management system built with Python/Flask. It supports multiple CA providers, two dozen+ DNS providers, and pluggable storage backends.
 
 **Key Facts:**
-- **Language**: Python 3.9+ (Flask, Flask-RESTX)
+- **Language**: Python 3.12 (Flask, Flask-RESTX)
 - **Storage**: Local filesystem default + 4 cloud backends (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical)
 - **CA Providers**: Let's Encrypt, DigiCert ACME, Private CA
 - **DNS Providers**: two dozen+ supported (Cloudflare, AWS Route53, Azure, Google, and more — see [DNS Providers](./dns-providers.md) for the full list)
@@ -317,7 +317,7 @@ Renewals always preserve the shape that was in effect at creation time: certbot 
 
 | Layer | Technologies |
 |-------|-------------|
-| **Backend** | Python 3.9+, Flask, Flask-RESTX, APScheduler, Certbot |
+| **Backend** | Python 3.12, Flask, Flask-RESTX, APScheduler, Certbot |
 | **Frontend** | HTML5, Tailwind CSS, Vanilla JavaScript, Font Awesome |
 | **Cloud SDKs** | Azure SDK, boto3, hvac, infisical-python |
 | **Crypto** | cryptography (OpenSSL), certbot plugins |
@@ -790,7 +790,7 @@ Each certificate has a `metadata.json` file containing:
 
 ### Minimum Requirements
 
-- Python 3.9+
+- Python 3.12
 - 100MB disk space for CA and initial certificates
 - 50MB for audit logs per 1M operations
 - Low memory footprint

--- a/docs/de/architecture.md
+++ b/docs/de/architecture.md
@@ -23,7 +23,7 @@ Dieses Dokument beschreibt die vollständige Architektur von CertMate — sowohl
 CertMate ist ein modulares, erweiterbares SSL/TLS-Zertifikatsverwaltungssystem, das mit Python/Flask gebaut wurde. Es unterstützt mehrere CA-Anbieter, mehr als zwei Dutzend DNS-Anbieter sowie austauschbare Storage-Backends.
 
 **Wichtige Fakten:**
-- **Sprache**: Python 3.9+ (Flask, Flask-RESTX)
+- **Sprache**: Python 3.12 (Flask, Flask-RESTX)
 - **Speicher**: Lokales Dateisystem als Standard + 4 Cloud-Backends (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical)
 - **CA-Anbieter**: Let's Encrypt, DigiCert ACME, Private CA
 - **DNS-Anbieter**: mehr als zwei Dutzend unterstützt (Cloudflare, AWS Route53, Azure, Google und weitere — siehe [DNS-Anbieter](./dns-providers.md) für die vollständige Liste)
@@ -298,7 +298,7 @@ Erneuerungen behalten stets die Form bei, die zum Zeitpunkt der Erstellung gült
 
 | Schicht | Technologien |
 |-------|-------------|
-| **Backend** | Python 3.9+, Flask, Flask-RESTX, APScheduler, Certbot |
+| **Backend** | Python 3.12, Flask, Flask-RESTX, APScheduler, Certbot |
 | **Frontend** | HTML5, Tailwind CSS, Vanilla JavaScript, Font Awesome |
 | **Cloud-SDKs** | Azure SDK, boto3, hvac, infisical-python |
 | **Kryptografie** | cryptography (OpenSSL), certbot-Plugins |
@@ -767,7 +767,7 @@ Jedes Zertifikat besitzt eine `metadata.json`-Datei mit folgenden Inhalten:
 
 ### Mindestanforderungen
 
-- Python 3.9+
+- Python 3.12
 - 100 MB Speicherplatz für CA und initiale Zertifikate
 - 50 MB für Audit-Protokolle pro 1 Mio. Operationen
 - Geringer Speicherbedarf

--- a/docs/de/installation.md
+++ b/docs/de/installation.md
@@ -6,7 +6,7 @@ Diese Anleitung beschreibt alle Methoden zur Installation und zum Deployment von
 
 ## Voraussetzungen
 
-- Python 3.9 oder höher
+- Python 3.12
 - pip (Python-Paketverwaltung)
 - Docker (optional, für containerisiertes Deployment)
 

--- a/docs/de/testing.md
+++ b/docs/de/testing.md
@@ -241,7 +241,7 @@ def test_external_api(mock_get, client):
 
 Die CI-Pipeline läuft bei jedem Push und Pull Request:
 
-1. **Mehrere Python-Versionen**: Tests auf Python 3.9, 3.11, 3.12
+1. **Mehrere Python-Versionen**: Tests auf Python 3.12
 2. **Codequalität**: Linting mit flake8
 3. **Sicherheit**: Scanning mit bandit
 4. **Tests**: Vollständige Test-Suite mit Coverage

--- a/docs/es/architecture.md
+++ b/docs/es/architecture.md
@@ -23,7 +23,7 @@ Este documento cubre la arquitectura completa de CertMate — tanto el sistema p
 CertMate es un sistema modular y extensible de gestión de certificados SSL/TLS construido con Python/Flask. Admite múltiples proveedores CA, más de dos docenas de proveedores DNS y backends de almacenamiento intercambiables.
 
 **Datos clave:**
-- **Lenguaje**: Python 3.9+ (Flask, Flask-RESTX)
+- **Lenguaje**: Python 3.12 (Flask, Flask-RESTX)
 - **Almacenamiento**: Sistema de archivos local por defecto + 4 backends cloud (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical)
 - **Proveedores CA**: Let's Encrypt, DigiCert ACME, CA privada
 - **Proveedores DNS**: más de dos docenas admitidos (Cloudflare, AWS Route53, Azure, Google, y más — véase [Proveedores DNS](./dns-providers.md) para la lista completa)
@@ -298,7 +298,7 @@ Las renovaciones siempre preservan la forma que estaba en vigor en el momento de
 
 | Capa | Tecnologías |
 |------|-------------|
-| **Backend** | Python 3.9+, Flask, Flask-RESTX, APScheduler, Certbot |
+| **Backend** | Python 3.12, Flask, Flask-RESTX, APScheduler, Certbot |
 | **Frontend** | HTML5, Tailwind CSS, Vanilla JavaScript, Font Awesome |
 | **SDKs Cloud** | Azure SDK, boto3, hvac, infisical-python |
 | **Criptografía** | cryptography (OpenSSL), plugins de certbot |
@@ -767,7 +767,7 @@ Cada certificado tiene un archivo `metadata.json` que contiene:
 
 ### Requisitos mínimos
 
-- Python 3.9+
+- Python 3.12
 - 100 MB de espacio en disco para la CA y los certificados iniciales
 - 50 MB para los registros de auditoría por cada millón de operaciones
 - Huella de memoria reducida

--- a/docs/es/installation.md
+++ b/docs/es/installation.md
@@ -6,7 +6,7 @@ Esta guía cubre todos los métodos de instalación y despliegue de CertMate.
 
 ## Requisitos previos
 
-- Python 3.9 o superior
+- Python 3.12
 - pip (gestor de paquetes de Python)
 - Docker (opcional, para el despliegue en contenedor)
 

--- a/docs/es/testing.md
+++ b/docs/es/testing.md
@@ -241,7 +241,7 @@ def test_external_api(mock_get, client):
 
 El pipeline de CI se ejecuta en cada push y pull request:
 
-1. **Múltiples versiones de Python**: Pruebas en Python 3.9, 3.11, 3.12
+1. **Múltiples versiones de Python**: Pruebas en Python 3.12
 2. **Calidad de código**: Linting con flake8
 3. **Seguridad**: Escaneo con bandit
 4. **Pruebas**: Suite completa con cobertura

--- a/docs/fr/architecture.md
+++ b/docs/fr/architecture.md
@@ -23,7 +23,7 @@ Ce document couvre l'architecture complète de CertMate — à la fois le systè
 CertMate est un système modulaire et extensible de gestion de certificats SSL/TLS construit avec Python/Flask. Il supporte plusieurs fournisseurs CA, plus de deux douzaines de fournisseurs DNS et des backends de stockage interchangeables.
 
 **Points clés :**
-- **Langage** : Python 3.9+ (Flask, Flask-RESTX)
+- **Langage** : Python 3.12 (Flask, Flask-RESTX)
 - **Stockage** : Système de fichiers local par défaut + 4 backends cloud (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical)
 - **Fournisseurs CA** : Let's Encrypt, DigiCert ACME, CA privée
 - **Fournisseurs DNS** : plus de deux douzaines supportés (Cloudflare, AWS Route53, Azure, Google, etc. — voir [Fournisseurs DNS](./dns-providers.md) pour la liste complète)
@@ -298,7 +298,7 @@ Les renouvellements préservent toujours la forme qui était en vigueur à la cr
 
 | Couche | Technologies |
 |-------|-------------|
-| **Backend** | Python 3.9+, Flask, Flask-RESTX, APScheduler, Certbot |
+| **Backend** | Python 3.12, Flask, Flask-RESTX, APScheduler, Certbot |
 | **Frontend** | HTML5, Tailwind CSS, Vanilla JavaScript, Font Awesome |
 | **SDKs Cloud** | Azure SDK, boto3, hvac, infisical-python |
 | **Cryptographie** | cryptography (OpenSSL), plugins certbot |
@@ -768,7 +768,7 @@ Chaque certificat a un fichier `metadata.json` contenant :
 
 ### Configuration minimale
 
-- Python 3.9+
+- Python 3.12
 - 100 Mo d'espace disque pour la CA et les certificats initiaux
 - 50 Mo pour les journaux d'audit par million d'opérations
 - Faible empreinte mémoire

--- a/docs/fr/installation.md
+++ b/docs/fr/installation.md
@@ -6,7 +6,7 @@ Ce guide couvre toutes les méthodes d'installation et de déploiement de CertMa
 
 ## Prérequis
 
-- Python 3.9 ou supérieur
+- Python 3.12
 - pip (gestionnaire de paquets Python)
 - Docker (optionnel, pour le déploiement conteneurisé)
 

--- a/docs/fr/testing.md
+++ b/docs/fr/testing.md
@@ -241,7 +241,7 @@ def test_api_externe(mock_get, client):
 
 Le pipeline CI s'exécute sur chaque push et pull request :
 
-1. **Multiples versions Python** : Tests sur Python 3.9, 3.11, 3.12
+1. **Multiples versions Python** : Tests sur Python 3.12
 2. **Qualité du code** : Linting avec flake8
 3. **Sécurité** : Scan avec bandit
 4. **Tests** : Suite complète avec couverture

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ This guide covers all methods of installing and deploying CertMate.
 
 ## Prerequisites
 
-- Python 3.9 or higher
+- Python 3.12
 - pip (Python package manager)
 - Docker (optional, for containerized deployment)
 

--- a/docs/it/architecture.md
+++ b/docs/it/architecture.md
@@ -23,7 +23,7 @@ Questo documento descrive l'architettura completa di CertMate — sia il sistema
 CertMate è un sistema modulare ed estensibile per la gestione di certificati SSL/TLS costruito con Python/Flask. Supporta molteplici provider CA, oltre due dozzine di provider DNS e backend di archiviazione intercambiabili.
 
 **Informazioni principali:**
-- **Linguaggio**: Python 3.9+ (Flask, Flask-RESTX)
+- **Linguaggio**: Python 3.12 (Flask, Flask-RESTX)
 - **Archiviazione**: filesystem locale come impostazione predefinita + 4 backend cloud (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical)
 - **Provider CA**: Let's Encrypt, DigiCert ACME, CA privata
 - **Provider DNS**: oltre due dozzine supportati (Cloudflare, AWS Route53, Azure, Google e altri — vedere [Provider DNS](./dns-providers.md) per l'elenco completo)
@@ -298,7 +298,7 @@ I rinnovi preservano sempre la forma in uso al momento della creazione: certbot 
 
 | Livello | Tecnologie |
 |---------|-----------|
-| **Backend** | Python 3.9+, Flask, Flask-RESTX, APScheduler, Certbot |
+| **Backend** | Python 3.12, Flask, Flask-RESTX, APScheduler, Certbot |
 | **Frontend** | HTML5, Tailwind CSS, Vanilla JavaScript, Font Awesome |
 | **SDK Cloud** | Azure SDK, boto3, hvac, infisical-python |
 | **Crittografia** | cryptography (OpenSSL), plugin certbot |
@@ -768,7 +768,7 @@ Ogni certificato ha un file `metadata.json` contenente:
 
 ### Requisiti minimi
 
-- Python 3.9+
+- Python 3.12
 - 100 MB di spazio su disco per la CA e i certificati iniziali
 - 50 MB per i registri di audit per milione di operazioni
 - Basso utilizzo di memoria

--- a/docs/it/installation.md
+++ b/docs/it/installation.md
@@ -6,7 +6,7 @@ Questa guida illustra tutti i metodi di installazione e deploy di CertMate.
 
 ## Prerequisiti
 
-- Python 3.9 o superiore
+- Python 3.12
 - pip (gestore di pacchetti Python)
 - Docker (opzionale, per il deploy containerizzato)
 

--- a/docs/it/testing.md
+++ b/docs/it/testing.md
@@ -241,7 +241,7 @@ def test_external_api(mock_get, client):
 
 La pipeline CI viene eseguita ad ogni push e pull request:
 
-1. **Versioni Python multiple**: Test su Python 3.9, 3.11, 3.12
+1. **Versioni Python multiple**: Test su Python 3.12
 2. **Qualita del codice**: Linting con flake8
 3. **Sicurezza**: Scansione con bandit
 4. **Test**: Suite completa con copertura

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -241,7 +241,7 @@ def test_external_api(mock_get, client):
 
 The CI pipeline runs on every push and pull request:
 
-1. **Multiple Python Versions**: Tests on Python 3.9, 3.11, 3.12
+1. **Multiple Python Versions**: Tests on Python 3.12
 2. **Code Quality**: Linting with flake8
 3. **Security**: Scanning with bandit
 4. **Tests**: Full test suite with coverage

--- a/tests/test_documented_python_version.py
+++ b/tests/test_documented_python_version.py
@@ -64,6 +64,15 @@ def _documented():
             continue
         for number, line in enumerate(
                 path.read_text(encoding="utf-8").splitlines(), 1):
+            # A version stated *about a third-party package* is not a claim
+            # about what CertMate runs on, and treating it as one made this
+            # gate reject true sentences. The provider table explains that
+            # `certbot-dns-namecheap` 1.0.0 targets Python 2.7-3.8 — accurate,
+            # and the reason that plugin is marked Unavailable. Lines naming a
+            # backticked distribution are describing that distribution.
+            if re.search(r"`[\w.-]*(?:certbot|dns)[\w.-]*`|`Scaleway`|`PowerDNS`",
+                         line):
+                continue
             for match in re.finditer(r"[Pp]ython[- ](\d+\.\d+)", line):
                 found.append((str(path.relative_to(REPO_ROOT)), number,
                               match.group(1)))

--- a/tests/test_documented_python_version.py
+++ b/tests/test_documented_python_version.py
@@ -81,27 +81,46 @@ def _documented():
 
 def test_the_sources_of_truth_agree():
     """The image and the matrix must not drift apart from each other either."""
-    assert _dockerfile_version() in _ci_versions(), (
-        f"the image is built on Python {_dockerfile_version()} but CI tests "
-        f"{sorted(_ci_versions())} — nothing is testing what ships."
+    image, matrix = _dockerfile_version(), _ci_versions()
+    assert image in matrix, (
+        f"the image is built on Python {image} but CI tests {sorted(matrix)} — "
+        f"nothing is testing what ships."
     )
 
 
 def test_the_documentation_names_a_version():
+    """Anchored on a specific line, not on an arbitrary count.
+
+    `len(found) >= 10` cuts both ways: it fails a documentation refactor that
+    legitimately reduces the mentions, and it passes a scan that has quietly
+    stopped reading four of the five languages (Copilot, #536). So it checks
+    that the README badge — the most visible version claim in the project, and
+    the one that was wrong — is among what the scan found.
+    """
     found = _documented()
-    assert len(found) >= 10, (
-        f"found {len(found)} Python version mentions across the docs — the "
-        f"scan is not reading them, so the check below would pass vacuously."
+    assert found, "the scan found no Python version mentions at all"
+    assert any(entry[0] == "README.md" for entry in found), (
+        "the scan found no Python version in README.md. The badge at the top "
+        "of it is the claim this file exists to check; a scan that misses it "
+        "is not checking anything that matters."
     )
 
 
-@pytest.mark.parametrize("path,number,version", _documented(),
-                         ids=[f"{p}:{n}" for p, n, _v in _documented()])
+# Scanned once. Calling _documented() for the values and again for the ids is
+# two walks of the documentation and two chances for them to disagree in length
+# or order, which pytest reports as a parametrisation error rather than a docs
+# problem (Copilot, #536).
+DOCUMENTED = _documented()
+
+
+@pytest.mark.parametrize("path,number,version", DOCUMENTED,
+                         ids=[f"{p}:{n}" for p, n, _v in DOCUMENTED])
 def test_no_document_names_a_python_we_neither_build_nor_test(path, number, version):
-    allowed = {_dockerfile_version()} | _ci_versions()
+    image, matrix = _dockerfile_version(), _ci_versions()
+    allowed = {image} | matrix
     assert version in allowed, (
         f"{path}:{number} names Python {version}. The image is built on "
-        f"{_dockerfile_version()} and CI tests {sorted(_ci_versions())}. "
+        f"{image} and CI tests {sorted(matrix)}. "
         f"Documenting a version nothing builds or tests is how `Python 3.9+` "
         f"sat in the README badge while `pip install -r requirements.txt` "
         f"refused to run on 3.9."

--- a/tests/test_documented_python_version.py
+++ b/tests/test_documented_python_version.py
@@ -1,0 +1,122 @@
+"""The Python version the documentation names must be one that can install this.
+
+Every surface said **Python 3.9+** — the README badge, the README requirements
+list, the architecture guide in five languages, the installation guide in five
+languages — while `requirements.txt` cannot be installed on 3.9 at all. Not
+"is untested on": cannot be installed. Six pinned packages declare
+`Requires-Python >=3.10`, so pip refuses before it downloads anything:
+
+    $ python3.9 -m pip install -r requirements.txt
+    ERROR: Ignored the following versions that require a different python
+    version: ... 1.0.5 Requires-Python >=3.10 ...
+    ERROR: No matching distribution found for certbot-dns-hetzner-cloud==1.0.5
+
+    $ python3.9 -m pip install -r requirements-minimal.txt
+    ERROR: No matching distribution found for dns-lexicon==3.25.1
+
+Measured on 3.9.6, not inferred from metadata. So the very first command a
+source installer runs failed, on the version the badge at the top of the README
+told them to use, and `docs/testing.md` claimed CI covered 3.9 and 3.11 while
+the matrix has only ever held one entry.
+
+The floor and the tested version are two different questions, and the honest
+answer to both is the same number today: the image is built `FROM python:3.12`
+and the matrix is `['3.12']`. So the rule is that documentation names the
+version we actually build and test — not a floor nobody exercises.
+"""
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+_SKIP_DIRS = (".venv", "node_modules", ".git", "scratch", ".claude", "backups")
+# History records what was true then, including a version we have moved off.
+_SKIP_FILES = ("RELEASE_NOTES.md", "CHANGELOG.md")
+
+
+def _dockerfile_version():
+    text = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    found = set(re.findall(r"^FROM python:(\d+\.\d+)", text, re.M))
+    assert found, "Dockerfile no longer builds FROM a python: image"
+    assert len(found) == 1, f"Dockerfile builds from several Pythons: {found}"
+    return found.pop()
+
+
+def _ci_versions():
+    text = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    match = re.search(r"python-version:\s*\[([^\]]+)\]", text)
+    assert match, "ci.yml no longer declares a python-version matrix"
+    return {v.strip().strip("'\"") for v in match.group(1).split(",")}
+
+
+def _documented():
+    """(file, line number, version) for every Python version the docs name."""
+    found = []
+    targets = [REPO_ROOT / "README.md", REPO_ROOT / "README.dockerhub.md"]
+    targets += sorted(REPO_ROOT.glob("docs/**/*.md"))
+    targets += [REPO_ROOT / "CONTRIBUTING.md", REPO_ROOT / "SECURITY.md"]
+    for path in targets:
+        if not path.exists() or path.name in _SKIP_FILES:
+            continue
+        if any(part in path.parts for part in _SKIP_DIRS):
+            continue
+        for number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), 1):
+            for match in re.finditer(r"[Pp]ython[- ](\d+\.\d+)", line):
+                found.append((str(path.relative_to(REPO_ROOT)), number,
+                              match.group(1)))
+    return found
+
+
+def test_the_sources_of_truth_agree():
+    """The image and the matrix must not drift apart from each other either."""
+    assert _dockerfile_version() in _ci_versions(), (
+        f"the image is built on Python {_dockerfile_version()} but CI tests "
+        f"{sorted(_ci_versions())} — nothing is testing what ships."
+    )
+
+
+def test_the_documentation_names_a_version():
+    found = _documented()
+    assert len(found) >= 10, (
+        f"found {len(found)} Python version mentions across the docs — the "
+        f"scan is not reading them, so the check below would pass vacuously."
+    )
+
+
+@pytest.mark.parametrize("path,number,version", _documented(),
+                         ids=[f"{p}:{n}" for p, n, _v in _documented()])
+def test_no_document_names_a_python_we_neither_build_nor_test(path, number, version):
+    allowed = {_dockerfile_version()} | _ci_versions()
+    assert version in allowed, (
+        f"{path}:{number} names Python {version}. The image is built on "
+        f"{_dockerfile_version()} and CI tests {sorted(_ci_versions())}. "
+        f"Documenting a version nothing builds or tests is how `Python 3.9+` "
+        f"sat in the README badge while `pip install -r requirements.txt` "
+        f"refused to run on 3.9."
+    )
+
+
+def test_no_pin_requires_a_python_newer_than_the_one_we_build_on():
+    """The other direction: a bump that quietly raises the floor past the image.
+
+    Offline — reads the declared floor from any `python_requires` comment the
+    requirements files carry, plus the interpreter the image uses. The full
+    check against PyPI metadata belongs in CI, where the install happens for
+    real; this catches the case where someone writes the constraint down.
+    """
+    built_on = tuple(int(part) for part in _dockerfile_version().split("."))
+    offenders = []
+    for path in sorted(REPO_ROOT.glob("requirements*.txt")):
+        for number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), 1):
+            for match in re.finditer(r"[Rr]equires[-_ ][Pp]ython\s*>=\s*(\d+\.\d+)",
+                                     line):
+                needed = tuple(int(p) for p in match.group(1).split("."))
+                if needed > built_on:
+                    offenders.append(f"{path.name}:{number}: needs "
+                                     f"{match.group(1)}, image builds on "
+                                     f"{_dockerfile_version()}")
+    assert not offenders, "\n  ".join(offenders)


### PR DESCRIPTION
The badge at the top of README.md said **Python 3.9+**. So did the requirements
list under it, the architecture guide in five languages, and the installation
guide in five languages. `docs/testing.md` went further and claimed CI tested
"Python 3.9, 3.11, 3.12" — the matrix has one entry and always has.

`requirements.txt` cannot be installed on 3.9. Not untested on: cannot be
installed. Six pinned packages declare `Requires-Python >=3.10`, so pip refuses
before downloading anything. Measured on 3.9.6, not inferred:

    $ python3.9 -m pip install -r requirements.txt
    ERROR: No matching distribution found for certbot-dns-hetzner-cloud==1.0.5

    $ python3.9 -m pip install -r requirements-minimal.txt
    ERROR: No matching distribution found for dns-lexicon==3.25.1

Even the minimal set. So the first command a source installer runs failed, on
the version the badge sent them to, and the docs offered no way to find out
except by running it.

All 28 mentions now say 3.12, which is what the image is built from
(`FROM python:3.12-slim-trixie`) and what CI tests (`python-version: ['3.12']`).
3.10 is the floor the dependencies impose, but nothing exercises it, so
documenting it would repeat the same mistake one version up.

`tests/test_documented_python_version.py` checks each mention against the
Dockerfile and the CI matrix, and checks those two against each other — a
version we build but do not test is the same defect wearing different clothes.
Negative-verified three ways, including one translation left behind, which is
where every one of these has hidden so far.

Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)