### PR TITLE
docs: a coverage floor nothing enforces, two dead variables, and an image nobody publishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1991,8 +1991,11 @@ services:
           memory: 256M
     environment:
       - FLASK_ENV=production
-      - GUNICORN_WORKERS=1
-      - GUNICORN_THREADS=8
+      # The worker and thread counts are fixed in the image
+      # (`--workers 1 --threads 8`): one worker because the scheduler runs
+      # in-process and a second would duplicate every renewal. GUNICORN_TIMEOUT
+      # is the one that is read.
+      - GUNICORN_TIMEOUT=300   # the image default; raise it for slow DNS providers
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
@@ -2607,7 +2610,7 @@ curl -sS -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/diagnostics
 - **API Documentation**: http://your-server:8000/docs/ (Swagger UI)
 - **Alternative API Docs**: http://your-server:8000/redoc/ (ReDoc)
 - **GitHub Repository**: https://github.com/fabriziosalmi/certmate
-- **Docker Hub**: https://hub.docker.com/r/certmate/certmate
+- **Docker Hub**: https://hub.docker.com/r/fabriziosalmi/certmate
 - **Issue Tracker**: https://github.com/fabriziosalmi/certmate/issues
 
 ### Examples Repository

--- a/docs/de/testing.md
+++ b/docs/de/testing.md
@@ -272,9 +272,10 @@ Hooks umfassen: Code-Formatierung (black, isort), Linting (flake8), Sicherheitsp
 
 ## Coverage-Anforderungen
 
-- Mindestens **80%** gesamte Code-Coverage
-- Kritische Pfade müssen **95%+** Coverage aufweisen
-- Alle neuen Funktionen müssen Tests enthalten
+- Die CI erzwingt eine Untergrenze von **65%** über `modules/`
+  (`--cov-fail-under`, eine Ratsche: anheben, niemals senken, damit ein Build
+  durchgeht). Der aktuelle Wert liegt komfortabel darüber.
+- Alle neuen Funktionen müssen Tests enthalten.
 
 ---
 

--- a/docs/es/testing.md
+++ b/docs/es/testing.md
@@ -272,9 +272,10 @@ Los hooks incluyen: formateo de código (black, isort), linting (flake8), verifi
 
 ## Requisitos de cobertura
 
-- Mínimo **80%** de cobertura de código global
-- Las rutas críticas deben tener **95%+** de cobertura
-- Toda nueva funcionalidad debe incluir pruebas
+- CI impone un mínimo del **65%** sobre `modules/` (`--cov-fail-under`, un
+  trinquete: súbalo, nunca lo baje para que pase una build). El número actual
+  está cómodamente por encima.
+- Todas las funcionalidades nuevas deben incluir tests.
 
 ---
 

--- a/docs/fr/testing.md
+++ b/docs/fr/testing.md
@@ -272,9 +272,10 @@ Les hooks incluent : formatage de code (black, isort), linting (flake8), vérifi
 
 ## Exigences de couverture
 
-- Minimum **80%** de couverture de code globale
-- Les chemins critiques doivent avoir **95%+** de couverture
-- Toute nouvelle fonctionnalité doit inclure des tests
+- La CI impose un plancher de **65%** sur `modules/` (`--cov-fail-under`, un
+  cliquet : à relever, jamais à abaisser pour faire passer une build). Le
+  chiffre actuel est confortablement au-dessus.
+- Toutes les nouvelles fonctionnalités doivent inclure des tests.
 
 ---
 

--- a/docs/it/testing.md
+++ b/docs/it/testing.md
@@ -272,9 +272,10 @@ Gli hook includono: formattazione del codice (black, isort), linting (flake8), v
 
 ## Requisiti di copertura
 
-- Minimo **80%** di copertura del codice complessiva
-- I percorsi critici devono avere una copertura **95%+**
-- Tutte le nuove funzionalita devono includere test
+- La CI impone un minimo del **65%** su `modules/` (`--cov-fail-under`, un
+  cricchetto: alzarlo, mai abbassarlo per far passare una build). Il numero
+  attuale è comodamente sopra.
+- Tutte le nuove funzionalità devono includere test.
 
 ---
 

--- a/tests/test_documented_numbers_are_real.py
+++ b/tests/test_documented_numbers_are_real.py
@@ -1,0 +1,150 @@
+"""Numbers and names the documentation states, checked against their source.
+
+Three separate claims, one shape: a value written down once and never compared
+with the thing it describes.
+
+  * **The coverage floor.** `docs/testing.md` was corrected to say CI enforces
+    65% (`--cov-fail-under=65`). All four translations still promised "80%
+    overall, 95%+ on critical paths" — numbers no gate has ever enforced.
+    codecov.yml marks both its statuses `informational: true` in as many words.
+    The English page being right is exactly what stopped anyone noticing.
+
+  * **Two environment variables in a compose example.** `GUNICORN_WORKERS=1`
+    and `GUNICORN_THREADS=8`, in the production docker-compose block. The image
+    hardcodes `--workers 1 --threads 8`; neither name is read anywhere in the
+    repository. An operator tuning them saw no change and no error.
+
+  * **A Docker Hub link to an image nobody publishes.** `certmate/certmate`,
+    once, among twenty correct `fabriziosalmi/certmate` references.
+
+Each check reads the source of truth rather than a second copy of the claim.
+"""
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+_SKIP_DIRS = (".venv", "node_modules", ".git", "scratch", ".claude", "backups")
+_SKIP_FILES = ("RELEASE_NOTES.md", "CHANGELOG.md")
+
+
+def _markdown():
+    return [
+        path for path in sorted(REPO_ROOT.rglob("*.md"))
+        if not any(part in path.parts for part in _SKIP_DIRS)
+        and path.name not in _SKIP_FILES
+    ]
+
+
+def _enforced_coverage_floor():
+    ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    match = re.search(r"--cov-fail-under=(\d+)", ci)
+    assert match, "ci.yml no longer passes --cov-fail-under; this check is stale"
+    return int(match.group(1))
+
+
+def test_the_scan_sees_the_documentation():
+    assert len(_markdown()) >= 20, f"only {len(_markdown())} markdown files found"
+
+
+@pytest.mark.parametrize("path", [p for p in _markdown() if p.name == "testing.md"],
+                         ids=lambda p: str(p.relative_to(REPO_ROOT)))
+def test_no_testing_guide_promises_a_coverage_floor_ci_does_not_enforce(path):
+    floor = _enforced_coverage_floor()
+    offenders = []
+    for number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1):
+        if not re.search(r"cov|Cov|copertura|couverture|cobertura|Abdeckung",
+                         line):
+            continue
+        for match in re.finditer(r"\*\*(\d{2})%", line):
+            if int(match.group(1)) != floor:
+                offenders.append(f"{path.name}:{number}: {line.strip()}")
+    assert not offenders, (
+        f"these promise a coverage number CI does not enforce (the only "
+        f"enforced floor is --cov-fail-under={floor}; codecov.yml marks both "
+        f"its statuses informational):\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_no_compose_example_sets_a_variable_nothing_reads():
+    """Applies to the docs' examples, not to the repo's own compose file.
+
+    The variables are read by the container's command line and the entrypoint,
+    so those are the files that decide. `GUNICORN_TIMEOUT` is real;
+    `GUNICORN_WORKERS` and `GUNICORN_THREADS` never were.
+    """
+    consumers = ""
+    for name in ("Dockerfile", "docker-compose.yml", "docker-entrypoint.sh",
+                 "entrypoint.sh"):
+        path = REPO_ROOT / name
+        if path.exists():
+            consumers += path.read_text(encoding="utf-8")
+    consumers += "".join(
+        p.read_text(encoding="utf-8") for p in REPO_ROOT.glob("modules/**/*.py"))
+    consumers += (REPO_ROOT / "app.py").read_text(encoding="utf-8")
+
+    offenders = []
+    for path in _markdown():
+        fenced = False
+        for number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), 1):
+            if line.lstrip().startswith("```"):
+                fenced = not fenced
+                continue
+            if not fenced:
+                continue
+            match = re.match(r"\s*-\s+(GUNICORN_[A-Z_]+)=", line)
+            if match and not re.search(rf"\b{match.group(1)}\b", consumers):
+                offenders.append(
+                    f"{path.relative_to(REPO_ROOT)}:{number}: {line.strip()}")
+    assert not offenders, (
+        "these compose examples set a variable nothing in the image reads, so "
+        "an operator tuning them gets no change and no error:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_every_docker_hub_reference_names_the_image_we_publish():
+    """The repository knows its own image name; the docs must agree.
+
+    Taken from the workflow that pushes it, not from a constant here — a name
+    typed twice is a name that can differ twice.
+    """
+    # The publish workflow builds the tag as `${namespace}/${IMAGE_NAME}`, and
+    # its own comment says the namespace falls back to the repository owner. So
+    # the owner is the truth, and it is written down in every GitHub link in
+    # the documentation — a surface independent of the Docker Hub links being
+    # checked. (Checking the Docker Hub links against each other would only
+    # prove they agree, not that they are right.)
+    workflow = (REPO_ROOT / ".github/workflows/docker-multiplatform.yml").read_text(
+        encoding="utf-8")
+    image = re.search(r"^\s*IMAGE_NAME:\s*(\S+)", workflow, re.M)
+    assert image, "the publish workflow no longer sets IMAGE_NAME"
+
+    owners = set()
+    for path in _markdown():
+        owners.update(re.findall(r"github\.com/([\w.-]+)/certmate\b",
+                                 path.read_text(encoding="utf-8")))
+    assert len(owners) == 1, (
+        f"the documentation names {len(owners)} different GitHub owners for "
+        f"this repository: {sorted(owners)}"
+    )
+    published = {f"{owners.pop()}/{image.group(1)}"}
+
+    offenders = []
+    for path in _markdown():
+        for number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), 1):
+            for match in re.finditer(r"hub\.docker\.com/r/([\w.-]+/[\w.-]+)",
+                                     line):
+                if match.group(1) not in published:
+                    offenders.append(
+                        f"{path.relative_to(REPO_ROOT)}:{number}: "
+                        f"{match.group(1)} — we publish {sorted(published)}")
+    assert not offenders, (
+        "documentation links to a Docker Hub image nobody publishes:\n  "
+        + "\n  ".join(offenders)
+    )

--- a/tests/test_documented_numbers_are_real.py
+++ b/tests/test_documented_numbers_are_real.py
@@ -19,6 +19,8 @@ with the thing it describes.
 
 Each check reads the source of truth rather than a second copy of the claim.
 """
+import functools
+import os
 import pathlib
 import re
 
@@ -30,12 +32,22 @@ _SKIP_DIRS = (".venv", "node_modules", ".git", "scratch", ".claude", "backups")
 _SKIP_FILES = ("RELEASE_NOTES.md", "CHANGELOG.md")
 
 
+@functools.lru_cache(maxsize=1)
 def _markdown():
-    return [
-        path for path in sorted(REPO_ROOT.rglob("*.md"))
-        if not any(part in path.parts for part in _SKIP_DIRS)
-        and path.name not in _SKIP_FILES
-    ]
+    """Every markdown file, pruning the heavy trees instead of walking them.
+
+    `rglob` descends into `.git`, `node_modules` and `.venv` in full and only
+    then discards what it found — tens of thousands of stats for a set that is
+    static within a run (Copilot, #537). `os.walk` with in-place pruning of
+    `dirs` never enters them.
+    """
+    found = []
+    for root, dirs, files in os.walk(REPO_ROOT):
+        dirs[:] = [d for d in dirs if d not in _SKIP_DIRS]
+        for name in files:
+            if name.endswith(".md") and name not in _SKIP_FILES:
+                found.append(pathlib.Path(root) / name)
+    return tuple(sorted(found))
 
 
 def _enforced_coverage_floor():
@@ -108,10 +120,19 @@ def test_no_compose_example_sets_a_variable_nothing_reads():
 
 
 def test_every_docker_hub_reference_names_the_image_we_publish():
-    """The repository knows its own image name; the docs must agree.
+    """The docs must name the image this repository publishes.
 
-    Taken from the workflow that pushes it, not from a constant here — a name
-    typed twice is a name that can differ twice.
+    An earlier docstring here claimed the expected name was derived from the
+    publish workflow. It is not, and saying so was the kind of overclaim this
+    file exists to catch (Copilot, #537). The workflow builds the namespace
+    from `secrets.DOCKERHUB_USER`, which no test can read, falling back to the
+    repository owner. So the owner is what this checks against — correct while
+    the secret matches it, which is the documented fallback and the case today.
+
+    If publishing ever moves to an organisation account whose name differs from
+    the GitHub owner, this test fails on correct documentation. The failure
+    message says so, and the fix is to name the account here rather than to
+    delete the check.
     """
     # The publish workflow builds the tag as `${namespace}/${IMAGE_NAME}`, and
     # its own comment says the namespace falls back to the repository owner. So
@@ -143,7 +164,10 @@ def test_every_docker_hub_reference_names_the_image_we_publish():
                 if match.group(1) not in published:
                     offenders.append(
                         f"{path.relative_to(REPO_ROOT)}:{number}: "
-                        f"{match.group(1)} — we publish {sorted(published)}")
+                        f"{match.group(1)} — expected {sorted(published)} "
+                        f"(the GitHub owner, which is the namespace the "
+                        f"publish workflow falls back to; if DOCKERHUB_USER "
+                        f"now names a different account, record it here)")
     assert not offenders, (
         "documentation links to a Docker Hub image nobody publishes:\n  "
         + "\n  ".join(offenders)


### PR DESCRIPTION
Three claims, one shape: a value written down once and never compared with the
thing it describes.

**The coverage floor, in four languages.** `docs/testing.md` had been corrected
to say CI enforces 65% (`--cov-fail-under=65`). Every translation still
promised "80% overall, 95%+ on critical paths" — numbers no gate has ever
enforced; codecov.yml marks both its statuses `informational: true` in as many
words. The English page being right is precisely what stopped anyone noticing,
which is now the fourth time today that the translations were the blind spot.

**Two environment variables in the production compose example.**
`GUNICORN_WORKERS=1` and `GUNICORN_THREADS=8`. The image hardcodes
`--workers 1 --threads 8` on its CMD line and neither name appears anywhere
else in the repository, so an operator tuning them got no change and no error.
Replaced with `GUNICORN_TIMEOUT`, which is real — at its actual default of 300,
not the 120 I first wrote, and with the reason one worker is deliberate: the
scheduler runs in-process and a second would duplicate every renewal.

**A Docker Hub link to an image nobody publishes** — `certmate/certmate`, once,
among twenty correct references.

`tests/test_documented_numbers_are_real.py` checks each against its source: the
floor against `--cov-fail-under`, the variables against the files that actually
consume them, and the image against the repository owner the publish workflow
falls back to — read from the GitHub links, a surface independent of the Docker
Hub links being checked, because comparing those with each other would only
prove they agree.

Two items from the same list turned out to be fine and were left alone: the
provider count (29, correct) and the storage backends ("local + 4 cloud",
correct in every language).

Suite 2464 passed / 6 skipped, each check negative-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)