### PR TITLE
fix: DigiCert ACME pointed at a hostname that stopped existing in February

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
+  schedule:
+    # Mondays 06:00 UTC — only the ca-endpoints job runs on this trigger.
+    - cron: '0 6 * * 1'
 
 # Default to read-only. The single job below only reads source and uploads
 # coverage via codecov-action (which manages its own auth via the upload
@@ -99,7 +102,14 @@ jobs:
         # false, so coverage could fall to zero with CI still green. 65 is
         # comfortably below the current number; raise it as a ratchet, never
         # lower it to make a red build pass.
-        pytest -v --tb=short --cov=modules --cov-report=xml --cov-report=html --cov-fail-under=65 -m "not ui"
+        # `not network`: the CA-reachability checks in
+        # tests/test_ca_endpoints_are_live.py fetch five external ACME
+        # directories. They found two real defects (a DigiCert host that no
+        # longer resolves, a Google staging endpoint whose certificate is for
+        # another name) — but as a required check they would turn every PR red
+        # on someone else's outage. They run on the weekly schedule below
+        # instead, where a failure is news rather than a blocked merge.
+        pytest -v --tb=short --cov=modules --cov-report=xml --cov-report=html --cov-fail-under=65 -m "not ui and not network"
 
     - name: Upload coverage reports
       if: matrix.python-version == '3.12'
@@ -235,6 +245,36 @@ jobs:
           echo "$combo -> certbot $got"
           echo "::endgroup::"
         done
+
+  # Every CA in the registry, asked whether its ACME directory still exists.
+  #
+  # `digicert` pointed at acme.digicert.com for months after DigiCert retired
+  # CertCentral's legacy ACME service on 24 February 2026 — the hostname stopped
+  # resolving and nothing said so, because a CA endpoint is only exercised
+  # during a real issuance against that CA, and the release gate issues against
+  # Let's Encrypt staging. Weekly is the right cadence: a CA does not retire an
+  # endpoint between two pull requests, and this must never be the reason a
+  # merge is blocked.
+  ca-endpoints:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v5
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-test.txt
+
+    - name: Ask every CA whether its directory still exists
+      run: pytest tests/test_ca_endpoints_are_live.py -v --tb=short -m network
 
   # The Tailwind bundle (static/css/tailwind.min.css) is committed to the repo
   # and served as-is — there is no build step at deploy time. So a stale bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,11 @@ on:
     branches: [ main, develop ]
   workflow_dispatch:
   schedule:
-    # Mondays 06:00 UTC — only the ca-endpoints job runs on this trigger.
+    # Mondays 06:00 UTC, for the ca-endpoints job. The other jobs opt out of
+    # this trigger explicitly (`if: github.event_name != 'schedule'`) — saying
+    # so in a comment did not make it so, and a weekly full run would turn a
+    # CA-reachability signal into noise from whatever else happened to break
+    # that week (Copilot, #538).
     - cron: '0 6 * * 1'
 
 # Default to read-only. The single job below only reads source and uploads
@@ -25,6 +29,7 @@ concurrency:
 
 jobs:
   test:
+    if: github.event_name != 'schedule'
     # GitHub-hosted, ephemeral VM per job. The e2e suite (tests/conftest.py)
     # builds and runs a FIXED-name container (certmate-test-suite) on port
     # 18888; on a shared self-hosted host, two test jobs from different
@@ -289,6 +294,7 @@ jobs:
   # regression that made the documented job-polling loop impossible sat there
   # undetected because nothing asked.
   mcp:
+    if: github.event_name != 'schedule'
     name: MCP server
     runs-on: ubuntu-latest
     steps:
@@ -309,6 +315,7 @@ jobs:
       run: npm test
 
   frontend-css:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code

--- a/docs/ca-providers.md
+++ b/docs/ca-providers.md
@@ -39,7 +39,7 @@ Converting a staging certificate to production requires a reissue with the produ
 - **Best For**: Enterprise environments, commercial applications
 
 **Configuration Requirements:**
-- **ACME Directory URL**: `https://acme.digicert.com/v2/acme/directory`
+- **ACME Directory URL**: `https://one.digicert.com/mpki/api/v1/acme/v2/directory`
 - **EAB Key ID**: Provided by DigiCert
 - **EAB HMAC Key**: Provided by DigiCert
 - **Email**: Required for certificate notifications
@@ -126,7 +126,7 @@ curl -X POST http://localhost:8000/api/settings/test-ca-provider \
   -d '{
     "ca_provider": "digicert",
     "config": {
-      "acme_url": "https://acme.digicert.com/v2/acme/directory",
+      "acme_url": "https://one.digicert.com/mpki/api/v1/acme/v2/directory",
       "eab_kid": "your_key_id",
       "eab_hmac": "your_hmac_key",
       "email": "admin@example.com"

--- a/docs/de/ca-providers.md
+++ b/docs/de/ca-providers.md
@@ -36,7 +36,7 @@ Staging ist ein eigenständiger Zertifizierungsstellen-Eintrag (seit v2.12.0), k
 - **Am besten geeignet für**: Unternehmensumgebungen, kommerzielle Anwendungen
 
 **Konfigurationsanforderungen:**
-- **ACME Directory URL**: `https://acme.digicert.com/v2/acme/directory`
+- **ACME Directory URL**: `https://one.digicert.com/mpki/api/v1/acme/v2/directory`
 - **EAB Key ID**: Von DigiCert bereitgestellt
 - **EAB HMAC Key**: Von DigiCert bereitgestellt
 - **E-Mail**: Erforderlich für Zertifikatsbenachrichtigungen
@@ -123,7 +123,7 @@ curl -X POST http://localhost:8000/api/settings/test-ca-provider \
   -d '{
     "ca_provider": "digicert",
     "config": {
-      "acme_url": "https://acme.digicert.com/v2/acme/directory",
+      "acme_url": "https://one.digicert.com/mpki/api/v1/acme/v2/directory",
       "eab_kid": "your_key_id",
       "eab_hmac": "your_hmac_key",
       "email": "admin@example.com"

--- a/docs/es/ca-providers.md
+++ b/docs/es/ca-providers.md
@@ -36,7 +36,7 @@ El staging es una entrada de autoridad de certificación independiente (desde v2
 - **Ideal para**: Entornos empresariales, aplicaciones comerciales
 
 **Requisitos de configuración:**
-- **URL del directorio ACME**: `https://acme.digicert.com/v2/acme/directory`
+- **URL del directorio ACME**: `https://one.digicert.com/mpki/api/v1/acme/v2/directory`
 - **EAB Key ID**: Proporcionado por DigiCert
 - **EAB HMAC Key**: Proporcionada por DigiCert
 - **Email**: Requerido para las notificaciones de certificado
@@ -123,7 +123,7 @@ curl -X POST http://localhost:8000/api/settings/test-ca-provider \
   -d '{
     "ca_provider": "digicert",
     "config": {
-      "acme_url": "https://acme.digicert.com/v2/acme/directory",
+      "acme_url": "https://one.digicert.com/mpki/api/v1/acme/v2/directory",
       "eab_kid": "your_key_id",
       "eab_hmac": "your_hmac_key",
       "email": "admin@example.com"

--- a/docs/fr/ca-providers.md
+++ b/docs/fr/ca-providers.md
@@ -36,7 +36,7 @@ Le staging est une entrée d'autorité de certification distincte (depuis v2.12.
 - **Meilleur pour** : Environnements d'entreprise, applications commerciales
 
 **Configuration requise :**
-- **URL du répertoire ACME** : `https://acme.digicert.com/v2/acme/directory`
+- **URL du répertoire ACME** : `https://one.digicert.com/mpki/api/v1/acme/v2/directory`
 - **EAB Key ID** : Fourni par DigiCert
 - **EAB HMAC Key** : Fournie par DigiCert
 - **Email** : Requis pour les notifications de certificat
@@ -122,7 +122,7 @@ curl -X POST http://localhost:8000/api/settings/test-ca-provider \
   -d '{
     "ca_provider": "digicert",
     "config": {
-      "acme_url": "https://acme.digicert.com/v2/acme/directory",
+      "acme_url": "https://one.digicert.com/mpki/api/v1/acme/v2/directory",
       "eab_kid": "votre_key_id",
       "eab_hmac": "votre_hmac_key",
       "email": "admin@example.com"

--- a/docs/it/ca-providers.md
+++ b/docs/it/ca-providers.md
@@ -36,7 +36,7 @@ Lo staging e una voce di Certificate Authority separata (dalla v2.12.0), non un 
 - **Ideale per**: Ambienti enterprise, applicazioni commerciali
 
 **Requisiti di configurazione:**
-- **URL directory ACME**: `https://acme.digicert.com/v2/acme/directory`
+- **URL directory ACME**: `https://one.digicert.com/mpki/api/v1/acme/v2/directory`
 - **EAB Key ID**: Fornito da DigiCert
 - **EAB HMAC Key**: Fornita da DigiCert
 - **Email**: Obbligatoria per le notifiche sui certificati
@@ -123,7 +123,7 @@ curl -X POST http://localhost:8000/api/settings/test-ca-provider \
   -d '{
     "ca_provider": "digicert",
     "config": {
-      "acme_url": "https://acme.digicert.com/v2/acme/directory",
+      "acme_url": "https://one.digicert.com/mpki/api/v1/acme/v2/directory",
       "eab_kid": "your_key_id",
       "eab_hmac": "your_hmac_key",
       "email": "admin@example.com"

--- a/modules/core/ca_manager.py
+++ b/modules/core/ca_manager.py
@@ -43,8 +43,25 @@ class CAManager:
             },
             'digicert': {
                 'name': 'DigiCert',
-                'production_url': 'https://acme.digicert.com/v2/DV',
-                'staging_url': 'https://acme.digicert.com/v2/DV/staging',
+                # `acme.digicert.com` no longer exists — NXDOMAIN, verified
+                # against Cloudflare's resolver while every other digicert.com
+                # host answers. It was CertCentral's legacy ACME service, which
+                # DigiCert stopped supporting on 24 February 2026; this entry
+                # kept pointing at it for months afterwards while the README
+                # advertised DigiCert ACME as a supported CA.
+                #
+                # The replacement is the DigiCert ONE mPKI endpoint, which
+                # returns a real directory (newAccount / newNonce / newOrder /
+                # renewalInfo) and sets externalAccountRequired: true, matching
+                # requires_eab below. It is REGIONAL: an account outside the
+                # default region has its own directory URL, shown in
+                # CertCentral. Operators override it per certificate via
+                # `acme_url`; this is the default, not the only value.
+                'production_url': 'https://one.digicert.com/mpki/api/v1/acme/v2/directory',
+                # DigiCert publishes no public ACME staging directory. Pointing
+                # this at an invented `/staging` path is what produced the dead
+                # URL above, so it names the same endpoint rather than a guess.
+                'staging_url': 'https://one.digicert.com/mpki/api/v1/acme/v2/directory',
                 'requires_eab': True,
                 'supports_wildcard': True,
                 'certificate_types': ['DV', 'OV', 'EV'],
@@ -71,7 +88,12 @@ class CAManager:
             'google': {
                 'name': 'Google Trust Services',
                 'production_url': 'https://dv.acme-v02.api.pki.goog/directory',
-                'staging_url': 'https://dv.acme-staging.api.pki.goog/directory',
+                # dv.acme-staging.api.pki.goog serves a certificate for a
+                # different name, so the TLS handshake fails hostname
+                # verification and no ACME client will talk to it. Google's
+                # staging directory is dv.acme-v02.test-api.pki.goog, which
+                # answers correctly and advertises externalAccountRequired.
+                'staging_url': 'https://dv.acme-v02.test-api.pki.goog/directory',
                 'requires_eab': True,
                 'supports_wildcard': True,
                 'certificate_types': ['DV'],

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,6 +15,7 @@ markers =
     dns: DNS provider tests
     e2e: End-to-end tests requiring a running server
     ui: Playwright browser tests
+    network: needs outbound HTTPS (CA directory reachability)
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -2612,7 +2612,7 @@
 
         // DigiCert configuration
         caProviders.digicert = {
-            acme_url: document.getElementById('digicert-acme-url').value || 'https://acme.digicert.com/v2/acme/directory',
+            acme_url: document.getElementById('digicert-acme-url').value || 'https://one.digicert.com/mpki/api/v1/acme/v2/directory',
             eab_kid: document.getElementById('digicert-eab-kid').value || '',
             eab_hmac: document.getElementById('digicert-eab-hmac').value || '',
             email: document.getElementById('digicert-email').value || ''

--- a/templates/partials/settings_ca.html
+++ b/templates/partials/settings_ca.html
@@ -194,8 +194,8 @@
                                         <label class="block text-xs text-info-strong mb-1">ACME Directory URL</label>
                                         <input type="url" id="digicert-acme-url" 
                                                class="w-full px-2 py-1 text-sm border border-info-line rounded bg-surface text-foreground"
-                                               placeholder="https://acme.digicert.com/v2/acme/directory"
-                                               value="https://acme.digicert.com/v2/acme/directory">
+                                               placeholder="https://one.digicert.com/mpki/api/v1/acme/v2/directory"
+                                               value="https://one.digicert.com/mpki/api/v1/acme/v2/directory">
                                     </div>
                                     <div>
                                         <label class="block text-xs text-info-strong mb-1">External Account Binding (EAB) Key ID</label>

--- a/tests/test_ca_endpoints_are_live.py
+++ b/tests/test_ca_endpoints_are_live.py
@@ -1,0 +1,186 @@
+"""Every built-in CA must serve an ACME directory that exists.
+
+`digicert` pointed at `https://acme.digicert.com/v2/DV`. That hostname does not
+resolve — NXDOMAIN from Cloudflare's resolver, while `one.digicert.com`,
+`www.digicert.com` and `docs.digicert.com` all answer, so it is the name that is
+gone, not the network. It was CertCentral's legacy ACME service, which DigiCert
+stopped supporting on **24 February 2026**. The entry, the settings UI's
+pre-filled default, and the CA guide in five languages went on naming it for
+months afterwards, while the README advertised DigiCert ACME as a supported CA
+with EAB.
+
+Nobody noticed because a CA endpoint is only exercised during a real issuance
+against that CA, and CertMate's release gate issues against Let's Encrypt
+staging. Four CAs (ZeroSSL, Google Trust Services, SSL.com, Actalis) were
+probed at the same time and all four answered correctly — this was one entry
+rotting, not a systemic problem, which is precisely why nothing surfaced it.
+
+The reachability check needs the network and lives in CI, marked so the offline
+suite skips it. What runs everywhere is the offline half: the shape of the URLs
+and the fact that a dead one cannot come back unnoticed.
+"""
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from modules.core.ca_manager import CAManager  # noqa: E402
+
+pytestmark = [pytest.mark.unit]
+
+
+def _network_is_reachable():
+    """One probe, cached, against a host that is not one of the CAs.
+
+    The network-marked tests below skip when this fails — but only then, and
+    only after saying so. A gate that skips whenever its subject is missing is
+    how the entry-point contract test spent months asserting the negation of
+    its own guard; the difference here is that CI always has the network, so
+    the checks always run where it counts.
+    """
+    if not hasattr(_network_is_reachable, "_result"):
+        try:
+            urllib.request.urlopen(
+                urllib.request.Request(
+                    "https://acme-v02.api.letsencrypt.org/directory",
+                    headers={"User-Agent": "certmate-ca-check"}),
+                timeout=15).close()
+            _network_is_reachable._result = True
+        except Exception:
+            _network_is_reachable._result = False
+    return _network_is_reachable._result
+
+
+requires_network = pytest.mark.skipif(
+    not _network_is_reachable(),
+    reason="no outbound HTTPS: CA reachability not checked (CI always has it)")
+
+# Hosts known to be gone. A regression here is not hypothetical: this is the
+# exact string that shipped, and re-adding it must fail offline, immediately,
+# without waiting for a network probe.
+RETIRED_HOSTS = {
+    "acme.digicert.com": (
+        "CertCentral's legacy ACME service, retired 24 February 2026. The "
+        "hostname no longer resolves. Use the DigiCert ONE mPKI directory: "
+        "https://one.digicert.com/mpki/api/v1/acme/v2/directory (regional — an "
+        "account outside the default region has its own, shown in CertCentral)."
+    ),
+}
+
+
+def _registry():
+    providers = CAManager(settings_manager=None).ca_providers
+    assert len(providers) >= 5, f"only {len(providers)} CAs in the registry"
+    return providers
+
+
+def _urls():
+    found = []
+    for key, config in _registry().items():
+        for field in ("production_url", "staging_url"):
+            url = config.get(field)
+            if url and url != "custom":
+                found.append((key, field, url))
+    return found
+
+
+def test_the_registry_exposes_urls():
+    """Guard the guard: an empty list would make every check below vacuous."""
+    assert len(_urls()) >= 8, f"only {len(_urls())} CA URLs found in the registry"
+
+
+@pytest.mark.parametrize("key,field,url", _urls(),
+                         ids=[f"{k}.{f}" for k, f, _u in _urls()])
+def test_no_ca_points_at_a_retired_host(key, field, url):
+    host = re.sub(r"^https?://([^/]+).*$", r"\1", url)
+    assert host not in RETIRED_HOSTS, (
+        f"{key}.{field} points at {host}: {RETIRED_HOSTS[host]}"
+    )
+
+
+@pytest.mark.parametrize("key,field,url", _urls(),
+                         ids=[f"{k}.{f}" for k, f, _u in _urls()])
+def test_every_ca_url_is_https(key, field, url):
+    assert url.startswith("https://"), (
+        f"{key}.{field} is {url!r} — an ACME directory fetched over plain HTTP "
+        f"lets whoever is in the middle choose the CA."
+    )
+
+
+@pytest.mark.network
+@requires_network
+@pytest.mark.parametrize("key,field,url", _urls(),
+                         ids=[f"{k}.{f}" for k, f, _u in _urls()])
+def test_every_ca_serves_a_real_acme_directory(key, field, url):
+    """Fetch each directory and check it is one. Requires the network.
+
+    A directory that 404s, or answers with something that is not a directory,
+    means issuance against that CA cannot start — the failure an operator would
+    otherwise meet on their first certificate.
+    """
+    request = urllib.request.Request(url, headers={"User-Agent": "certmate-ca-check"})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            status = response.status
+            body = response.read(4096).decode("utf-8", "replace")
+    except urllib.error.URLError as error:
+        pytest.fail(
+            f"{key}.{field} ({url}) is unreachable: {error}. If the CA has "
+            f"retired this endpoint, update modules/core/ca_manager.py, the "
+            f"settings UI default, the CA guide in all five languages, and add "
+            f"the dead host to RETIRED_HOSTS so it cannot come back."
+        )
+
+    assert status == 200, f"{key}.{field} ({url}) returned HTTP {status}"
+    try:
+        directory = json.loads(body)
+    except ValueError:
+        pytest.fail(f"{key}.{field} ({url}) did not return JSON: {body[:200]!r}")
+
+    missing = [f for f in ("newNonce", "newAccount", "newOrder")
+               if f not in directory]
+    assert not missing, (
+        f"{key}.{field} ({url}) answered, but the document is missing "
+        f"{missing} — it is not an ACME directory."
+    )
+
+
+@pytest.mark.network
+@requires_network
+def test_no_ca_demands_eab_without_the_registry_knowing():
+    """One direction only, because only one direction breaks issuance.
+
+    If a directory sets `externalAccountRequired` and the registry does not,
+    account registration fails on a message about external account binding
+    that names neither the CA nor the setting to fix.
+
+    The converse is legitimate and this test used to fail on it: RFC 8555 does
+    not oblige a CA to advertise the field, and SSL.com's directory reports
+    `false` while its ACME credentials are issued from the customer portal.
+    Requiring symmetry made the check reject a correct registry entry.
+    """
+    mismatches = []
+    for key, config in _registry().items():
+        url = config.get("production_url")
+        if not url or url == "custom":
+            continue
+        request = urllib.request.Request(
+            url, headers={"User-Agent": "certmate-ca-check"})
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                directory = json.loads(response.read(4096).decode("utf-8", "replace"))
+        except Exception:
+            continue          # reachability is the previous test's business
+        advertised = bool(directory.get("meta", {}).get("externalAccountRequired"))
+        if advertised and not config.get("requires_eab"):
+            mismatches.append(
+                f"{key}: the directory sets externalAccountRequired, but the "
+                f"registry has requires_eab={config.get('requires_eab')} — "
+                f"registration will fail without EAB credentials")
+    assert not mismatches, "\n  ".join(mismatches)

--- a/tests/test_ca_endpoints_are_live.py
+++ b/tests/test_ca_endpoints_are_live.py
@@ -32,7 +32,10 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from modules.core.ca_manager import CAManager  # noqa: E402
 
-pytestmark = [pytest.mark.unit]
+# Deliberately NO module-level `unit` mark. Marks are additive, so one here
+# would put the network tests into `make test-unit` — an offline suite that
+# quietly reaches five external CAs (Copilot, #538). The offline tests carry
+# `unit` individually; the network ones carry `network` only.
 
 
 def _network_is_reachable():
@@ -90,11 +93,13 @@ def _urls():
     return found
 
 
+@pytest.mark.unit
 def test_the_registry_exposes_urls():
     """Guard the guard: an empty list would make every check below vacuous."""
     assert len(_urls()) >= 8, f"only {len(_urls())} CA URLs found in the registry"
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize("key,field,url", _urls(),
                          ids=[f"{k}.{f}" for k, f, _u in _urls()])
 def test_no_ca_points_at_a_retired_host(key, field, url):
@@ -104,6 +109,7 @@ def test_no_ca_points_at_a_retired_host(key, field, url):
     )
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize("key,field,url", _urls(),
                          ids=[f"{k}.{f}" for k, f, _u in _urls()])
 def test_every_ca_url_is_https(key, field, url):
@@ -128,7 +134,11 @@ def test_every_ca_serves_a_real_acme_directory(key, field, url):
     try:
         with urllib.request.urlopen(request, timeout=30) as response:
             status = response.status
-            body = response.read(4096).decode("utf-8", "replace")
+            # Read to EOF, capped. 4096 bytes truncated mid-object on any
+            # directory larger than that, so a healthy CA would have failed on
+            # a JSON error (Copilot, #538). 1 MiB is far past any real
+            # directory and still bounds a misbehaving server.
+            body = response.read(1024 * 1024).decode("utf-8", "replace")
     except urllib.error.URLError as error:
         pytest.fail(
             f"{key}.{field} ({url}) is unreachable: {error}. If the CA has "
@@ -174,7 +184,8 @@ def test_no_ca_demands_eab_without_the_registry_knowing():
             url, headers={"User-Agent": "certmate-ca-check"})
         try:
             with urllib.request.urlopen(request, timeout=30) as response:
-                directory = json.loads(response.read(4096).decode("utf-8", "replace"))
+                directory = json.loads(
+                    response.read(1024 * 1024).decode("utf-8", "replace"))
         except Exception:
             continue          # reachability is the previous test's business
         advertised = bool(directory.get("meta", {}).get("externalAccountRequired"))

--- a/tests/test_ca_provider_test_endpoint.py
+++ b/tests/test_ca_provider_test_endpoint.py
@@ -61,7 +61,7 @@ class TestCAProviderTestEndpoint:
         r = api.post_json("/api/settings/test-ca-provider", {
             "ca_provider": "digicert",
             "config": {
-                "acme_url": "https://acme.digicert.com/v2/acme/directory",
+                "acme_url": "https://one.digicert.com/mpki/api/v1/acme/v2/directory",
                 "eab_key_id": "kid-canonical-spelling",
                 "eab_hmac_key": "hmac-canonical-spelling-long-enough-to-pass",
                 "email": "admin@example.com",


### PR DESCRIPTION
`acme.digicert.com` does not resolve. NXDOMAIN from Cloudflare's resolver,
while `one.digicert.com`, `www.digicert.com` and `docs.digicert.com` all
answer — so the name is gone, not the network. It was CertCentral's legacy
ACME service, which DigiCert stopped supporting on **24 February 2026**.

CertMate went on naming it for the six months since, in four places at once:
the CA registry (`production_url` and an invented `/v2/DV/staging` path), the
settings UI's pre-filled default and its placeholder, the CA guide in five
languages, and a test that asserted the dead URL. Meanwhile the README
advertises DigiCert ACME with EAB as a supported CA. Anyone who tried it got a
DNS failure.

The replacement is the DigiCert ONE mPKI directory, which returns a real one —
`newAccount`, `newNonce`, `newOrder`, `renewalInfo` — and sets
`externalAccountRequired: true`, matching `requires_eab`. It is regional: an
account outside the default region has its own URL, shown in CertCentral, and
`acme_url` already overrides it per certificate.

**Google's staging endpoint was broken too, differently.**
`dv.acme-staging.api.pki.goog` serves a certificate issued for another name, so
the TLS handshake fails hostname verification and no ACME client will talk to
it. Google's staging directory is `dv.acme-v02.test-api.pki.goog`, which
answers correctly. Found by the new test, not by looking.

`tests/test_ca_endpoints_are_live.py` asks every CA in the registry whether its
directory still exists. Two halves:

- offline, runs everywhere: every URL is https, and no URL names a host in
  RETIRED_HOSTS — so `acme.digicert.com` cannot come back quietly;
- network-marked, weekly: fetch each directory and check it is one, and fail if
  a directory demands EAB the registry does not know about.

The network half is deliberately **not** a required check. It found two real
defects, but five external CAs as a merge gate means someone else's outage
blocks a pull request; a CA does not retire an endpoint between two PRs. It
runs Mondays at 06:00 UTC and on demand.

The EAB check is one-directional on purpose. Requiring symmetry failed on
SSL.com, whose directory reports `externalAccountRequired: false` while its
ACME credentials come from the customer portal — RFC 8555 does not oblige a CA
to advertise the field, and only the other direction breaks issuance.

The other four CAs — ZeroSSL, Google production, SSL.com, Actalis — were probed
at the same time and all answered correctly. Suite 2541 passed / 6 skipped;
every check negative-verified, including one mutation that silently failed to
apply and had to be redone before it proved anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)