### PR TITLE
fix: Dependabot was free to reopen every bump that breaks the ACME stack

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,10 +30,37 @@ updates:
       - dependency-name: "certbot"
       - dependency-name: "josepy"
       - dependency-name: "acme"
-      # DNS plugins version-track certbot majors; block majors only so
-      # compatible minor/patch plugin fixes still arrive.
+      # DNS plugins used to be blocked at MAJOR only, on the reasoning that
+      # minor and patch fixes are compatible. They are not, and the exception
+      # cost a release: every plugin from certbot's own release train carries
+      # `certbot>=` its own version, so a MINOR bump drags certbot off the pin
+      # just as surely as a major one.
+      #
+      #   certbot-dns-route53 2.10.0 -> 2.11.0  requires certbot>=2.11.0
+      #   certbot-dns-azure   2.5.0  -> 2.6.1   requires certbot>=3.0,<4.0
+      #
+      # Both are minor bumps. The second is the one requirements-azure.txt
+      # already documents as breaking the install — and PR #387 proposed it.
+      # Measured: layering such a plugin moved certbot 2.10.0 -> 3.3.0 in a
+      # build that reported success (fixed in #533).
       - dependency-name: "certbot-dns-*"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: "certbot-plugin-*"
+      # The pins that actually hold the stack together, and that the previous
+      # list left entirely exposed. Each is documented in requirements.txt at
+      # the line it appears on; tests/test_dependabot_holds_the_stack.py fails
+      # if one is pinned-and-documented but missing here.
+      #
+      #   pyopenssl    26.2.0+ removes OpenSSL.crypto.X509Extension, which
+      #                acme 3.3.0 evaluates at import — certbot crashes before
+      #                it can issue anything.
+      #   cryptography 48.0.1 requires pyopenssl>=26.2.0, i.e. the same crash
+      #                by another route. GHSA-537c-gmf6-5ccf is open by choice
+      #                until the certbot 5.x epic; see SECURITY.md.
+      #   dns-lexicon  the resolver set is balanced around 3.25.1; moving it
+      #                breaks the lexicon-based plugins against each other.
+      - dependency-name: "pyopenssl"
+      - dependency-name: "cryptography"
+      - dependency-name: "dns-lexicon"
 
   - package-ecosystem: "npm"
     directories:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,3 +14,10 @@ playwright
 # server they wrap. Order matters: the SDK first (the CLI depends on it).
 -e ./clients/certmate-sdk
 -e ./clients/certmate-cli
+
+# Read by tests/test_dependabot_holds_the_stack.py to parse .github/dependabot.yml.
+# Pinned explicitly rather than relied on transitively: it arrives today via
+# bandit, cloudflare and dns-lexicon, so the test would start failing with
+# ModuleNotFoundError the day any of those drops it — for reasons having
+# nothing to do with what it checks.
+PyYAML==6.0.3

--- a/tests/test_dependabot_holds_the_stack.py
+++ b/tests/test_dependabot_holds_the_stack.py
@@ -1,0 +1,163 @@
+"""A pin the code holds on purpose must be one Dependabot will not reopen.
+
+The ignore list named `certbot`, `josepy` and `acme` — the three obvious ones —
+and blocked `certbot-dns-*` at MAJOR only, on the reasoning that minor and
+patch fixes are compatible. They are not. Every plugin from certbot's own
+release train carries `certbot>=` its own version, so a minor bump drags certbot
+off the pin exactly as a major would:
+
+    certbot-dns-route53  2.10.0 -> 2.11.0   requires certbot>=2.11.0
+    certbot-dns-azure    2.5.0  -> 2.6.1    requires certbot>=3.0,<4.0
+
+Both minor. The second is the bump `requirements-azure.txt` already documents
+as breaking the install — and an open Dependabot PR proposed it. The first is
+how `requirements-aws.txt` came to hold 2.11.0 against a 2.10.0 base, which
+moved certbot to 3.3.0 in a build that reported success.
+
+Worse, the list left out the pins that actually hold the stack together:
+`pyopenssl` (26.2.0+ removes `OpenSSL.crypto.X509Extension`, which `acme`
+evaluates at import), `cryptography` (48.0.1 requires that pyopenssl, i.e. the
+same crash by another route) and `dns-lexicon`. Nothing stopped a bump to any
+of them.
+
+So this checks both directions: every package the requirements files document
+as held is ignored by Dependabot, and every ignore entry still corresponds to a
+real, documented pin. A list nobody can verify is how this one drifted.
+"""
+import pathlib
+import re
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+DEPENDABOT = REPO_ROOT / ".github" / "dependabot.yml"
+
+pytestmark = [pytest.mark.unit]
+
+# Packages held deliberately. The value is a phrase that must appear in a
+# requirements file near that pin — so an entry here cannot be a guess, and if
+# the reason is ever deleted from the requirements this test says so.
+HELD = {
+    "certbot": "Certificate management",
+    "josepy": "josepy",
+    "pyopenssl": "Do not bump to 26.2.0+",
+    "cryptography": "GHSA-537c-gmf6-5ccf",
+    "dns-lexicon": "dns-lexicon",
+}
+
+# Ignored defensively rather than held: `acme` is not pinned anywhere — it
+# arrives as certbot's own dependency — but an entry costs nothing and stops a
+# future direct pin from being bumped past the stack the moment it is added.
+# Kept separate from HELD so the "still pinned" check does not fail on it, and
+# so nobody reads it as a pin that exists.
+DEFENSIVE = {"acme"}
+
+# Wildcards cover a family; each needs at least one pinned member to be real.
+HELD_FAMILIES = {
+    "certbot-dns-*": "certbot-dns-",
+    "certbot-plugin-*": "certbot-plugin-",
+}
+
+
+def _pip_ignore():
+    config = yaml.safe_load(DEPENDABOT.read_text(encoding="utf-8"))
+    pip = [u for u in config["updates"] if u["package-ecosystem"] == "pip"]
+    assert pip, "dependabot.yml no longer configures the pip ecosystem"
+    return {
+        entry["dependency-name"]: entry.get("update-types")
+        for entry in pip[0].get("ignore", [])
+    }
+
+
+def _requirements_text():
+    return "".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted(REPO_ROOT.glob("requirements*.txt"))
+    )
+
+
+def test_the_config_is_being_read():
+    ignore = _pip_ignore()
+    assert len(ignore) >= 5, (
+        f"parsed {len(ignore)} ignore entries — the config shape changed and "
+        f"every check below would pass over nothing."
+    )
+
+
+@pytest.mark.parametrize("package", sorted(HELD))
+def test_every_held_package_is_ignored_entirely(package):
+    ignore = _pip_ignore()
+    assert package in ignore, (
+        f"{package} is pinned deliberately but Dependabot is free to propose "
+        f"bumps for it. Add it to the ignore list in .github/dependabot.yml."
+    )
+    assert ignore[package] is None, (
+        f"{package} is ignored only for {ignore[package]}. A narrower rule is "
+        f"how `certbot-dns-*` stayed open to minor bumps that carry "
+        f"`certbot>=` their own version — the exact drift this file exists to "
+        f"prevent. Ignore all updates."
+    )
+
+
+@pytest.mark.parametrize("pattern", sorted(HELD_FAMILIES))
+def test_every_held_family_is_ignored_entirely(pattern):
+    ignore = _pip_ignore()
+    assert pattern in ignore, f"{pattern} is not ignored by Dependabot"
+    assert ignore[pattern] is None, (
+        f"{pattern} is ignored only for {ignore[pattern]}. Minor and patch "
+        f"bumps of these plugins require a newer certbot — measured: "
+        f"certbot-dns-route53 2.11.0 needs certbot>=2.11.0, certbot-dns-azure "
+        f"2.6.1 needs certbot>=3.0."
+    )
+
+
+@pytest.mark.parametrize("package,evidence", sorted(HELD.items()))
+def test_every_held_package_is_still_pinned_and_explained(package, evidence):
+    """An ignore entry for something we no longer pin is a stale exception."""
+    text = _requirements_text()
+    assert re.search(rf"^{re.escape(package)}==", text, re.M | re.I), (
+        f"{package} is on the hold list but is no longer pinned in any "
+        f"requirements file. Remove the hold or restore the pin."
+    )
+    assert evidence in text, (
+        f"{package} is held, but the reason ({evidence!r}) is no longer "
+        f"written down next to the pin. A hold whose reason has been deleted "
+        f"is a hold nobody can review."
+    )
+
+
+@pytest.mark.parametrize("pattern,prefix", sorted(HELD_FAMILIES.items()))
+def test_every_held_family_has_at_least_one_member(pattern, prefix):
+    text = _requirements_text()
+    members = set(re.findall(rf"^({re.escape(prefix)}[\w.-]+)==", text, re.M))
+    assert members, (
+        f"{pattern} is ignored by Dependabot but no package matching it is "
+        f"pinned anywhere. The rule protects nothing."
+    )
+
+
+@pytest.mark.parametrize("package", sorted(DEFENSIVE))
+def test_a_defensive_entry_really_is_unpinned(package):
+    """If it acquires a direct pin, it stops being defensive and becomes held.
+
+    Which means it needs a documented reason like everything else in HELD —
+    this check is what forces that move rather than letting the entry quietly
+    change meaning.
+    """
+    assert not re.search(rf"^{re.escape(package)}==", _requirements_text(), re.M | re.I), (
+        f"{package} is now pinned directly. Move it from DEFENSIVE to HELD "
+        f"with the reason written next to the pin."
+    )
+
+
+def test_no_ignore_entry_is_unexplained():
+    """The other direction: everything ignored must be something we hold."""
+    known = set(HELD) | set(HELD_FAMILIES) | DEFENSIVE
+    unexplained = sorted(set(_pip_ignore()) - known)
+    assert not unexplained, (
+        f"these are ignored by Dependabot but are not on the hold list: "
+        f"{unexplained}. Either record why they are held — with the reason in "
+        f"the requirements file — or let Dependabot update them. Silently "
+        f"frozen dependencies are how a CVE goes unnoticed."
+    )

--- a/tests/test_dependabot_holds_the_stack.py
+++ b/tests/test_dependabot_holds_the_stack.py
@@ -60,14 +60,23 @@ HELD_FAMILIES = {
 }
 
 
-def _pip_ignore():
+def _pip_configs():
     config = yaml.safe_load(DEPENDABOT.read_text(encoding="utf-8"))
     pip = [u for u in config["updates"] if u["package-ecosystem"] == "pip"]
     assert pip, "dependabot.yml no longer configures the pip ecosystem"
+    return pip
+
+
+def _pip_ignore(config):
     return {
         entry["dependency-name"]: entry.get("update-types")
-        for entry in pip[0].get("ignore", [])
+        for entry in config.get("ignore", [])
     }
+
+
+def _directory(config):
+    """A pip block can target one directory or several."""
+    return config.get("directory") or ", ".join(config.get("directories", ["?"]))
 
 
 def _requirements_text():
@@ -77,20 +86,52 @@ def _requirements_text():
     )
 
 
+def _reason_near_pin(package, evidence, window=4):
+    """Is `evidence` written within `window` lines of `package`'s pin?
+
+    The first version of this asked whether the phrase appeared anywhere in the
+    concatenated requirements files, which is false confidence of the exact
+    kind this suite exists to remove: the reason for pyopenssl could have been
+    sitting next to cryptography, in another file, and the check would have
+    been satisfied (Copilot, #541). Proximity in the same file is what makes it
+    a reason *for that pin*.
+    """
+    for path in sorted(REPO_ROOT.glob("requirements*.txt")):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for number, line in enumerate(lines):
+            if not re.match(rf"^{re.escape(package)}==", line, re.I):
+                continue
+            near = lines[max(0, number - window):number + window + 1]
+            if any(evidence in candidate for candidate in near):
+                return True
+    return False
+
+
 def test_the_config_is_being_read():
-    ignore = _pip_ignore()
-    assert len(ignore) >= 5, (
-        f"parsed {len(ignore)} ignore entries — the config shape changed and "
-        f"every check below would pass over nothing."
-    )
+    for config in _pip_configs():
+        ignore = _pip_ignore(config)
+        assert len(ignore) >= 5, (
+            f"the pip block for {_directory(config)} has {len(ignore)} ignore "
+            f"entries — the config shape changed and every check below would "
+            f"pass over nothing."
+        )
 
 
 @pytest.mark.parametrize("package", sorted(HELD))
 def test_every_held_package_is_ignored_entirely(package):
-    ignore = _pip_ignore()
+    # Every pip block, not just the first. A second one — for another
+    # directory, say — would otherwise be completely unconstrained while this
+    # test went on passing against the first (Copilot, #541).
+    for config in _pip_configs():
+        _assert_held(package, config)
+
+
+def _assert_held(package, config):
+    ignore = _pip_ignore(config)
     assert package in ignore, (
         f"{package} is pinned deliberately but Dependabot is free to propose "
-        f"bumps for it. Add it to the ignore list in .github/dependabot.yml."
+        f"bumps for it in the {_directory(config)} block. Add it to the "
+        f"ignore list in .github/dependabot.yml."
     )
     assert ignore[package] is None, (
         f"{package} is ignored only for {ignore[package]}. A narrower rule is "
@@ -102,8 +143,14 @@ def test_every_held_package_is_ignored_entirely(package):
 
 @pytest.mark.parametrize("pattern", sorted(HELD_FAMILIES))
 def test_every_held_family_is_ignored_entirely(pattern):
-    ignore = _pip_ignore()
-    assert pattern in ignore, f"{pattern} is not ignored by Dependabot"
+    for config in _pip_configs():
+        _assert_family_held(pattern, config)
+
+
+def _assert_family_held(pattern, config):
+    ignore = _pip_ignore(config)
+    assert pattern in ignore, (
+        f"{pattern} is not ignored in the {_directory(config)} block")
     assert ignore[pattern] is None, (
         f"{pattern} is ignored only for {ignore[pattern]}. Minor and patch "
         f"bumps of these plugins require a newer certbot — measured: "
@@ -120,10 +167,11 @@ def test_every_held_package_is_still_pinned_and_explained(package, evidence):
         f"{package} is on the hold list but is no longer pinned in any "
         f"requirements file. Remove the hold or restore the pin."
     )
-    assert evidence in text, (
-        f"{package} is held, but the reason ({evidence!r}) is no longer "
-        f"written down next to the pin. A hold whose reason has been deleted "
-        f"is a hold nobody can review."
+    assert _reason_near_pin(package, evidence), (
+        f"{package} is held, but the reason ({evidence!r}) is not written "
+        f"within a few lines of its pin in any requirements file. A hold whose "
+        f"reason has been deleted — or which borrowed another package's — is a "
+        f"hold nobody can review."
     )
 
 
@@ -154,7 +202,10 @@ def test_a_defensive_entry_really_is_unpinned(package):
 def test_no_ignore_entry_is_unexplained():
     """The other direction: everything ignored must be something we hold."""
     known = set(HELD) | set(HELD_FAMILIES) | DEFENSIVE
-    unexplained = sorted(set(_pip_ignore()) - known)
+    seen = set()
+    for config in _pip_configs():
+        seen |= set(_pip_ignore(config))
+    unexplained = sorted(seen - known)
     assert not unexplained, (
         f"these are ignored by Dependabot but are not on the hold list: "
         f"{unexplained}. Either record why they are held — with the reason in "


### PR DESCRIPTION
The ignore list named `certbot`, `josepy` and `acme` — the three obvious ones —
and blocked `certbot-dns-*` at MAJOR only, reasoning that minor and patch fixes
are compatible. They are not, and the exception cost a release. Every plugin
from certbot's own release train carries `certbot>=` its own version:

    certbot-dns-route53  2.10.0 -> 2.11.0   requires certbot>=2.11.0
    certbot-dns-azure    2.5.0  -> 2.6.1    requires certbot>=3.0,<4.0

Both are minor bumps, so both were allowed. The first is how
`requirements-aws.txt` came to hold 2.11.0 against a 2.10.0 base, which moved
certbot to 3.3.0 in a build that reported success (fixed in #533 — this is the
rule that would have prevented it). The second is the bump
`requirements-azure.txt` already documents as breaking the install, and PR #387
proposes it today.

Worse, the list left out the pins that actually hold the stack together, with
nothing stopping a bump to any of them:

- `pyopenssl` — 26.2.0+ removes `OpenSSL.crypto.X509Extension`, which `acme`
  evaluates at import, so certbot crashes before it can issue anything;
- `cryptography` — 48.0.1 requires that pyopenssl, the same crash by another
  route. GHSA-537c-gmf6-5ccf is open by choice until the certbot 5.x epic;
- `dns-lexicon` — the resolver set is balanced around 3.25.1.

All now ignored entirely, with the evidence in the config rather than in
someone's memory.

`tests/test_dependabot_holds_the_stack.py` checks both directions: every held
package is ignored with no narrowing, and every ignore entry corresponds to a
pin that still exists and still carries its reason in the requirements file. A
frozen dependency nobody can justify is how a CVE goes unnoticed, so an
unexplained entry fails too. `acme` is tracked separately as defensive — it is
not pinned directly, and the test fails if that ever changes without the entry
being reclassified.

Negative-verified four ways, including restoring the major-only rule and
deleting a pin's stated reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)