### PR TITLE
deps: bcrypt 5.0.0, with the long-password lockout it would otherwise cause

### DIFF
--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -33,6 +33,29 @@ ROLE_HIERARCHY = {'viewer': 0, 'operator': 1, 'admin': 2}
 _UNSET = object()
 
 
+
+# bcrypt has always ignored everything past the 72nd byte of a password. Until
+# 4.x it truncated silently; 5.0.0 raises ValueError instead.
+#
+# That change is a lockout, not a crash, and it is invisible: `_verify_password`
+# catches ValueError and returns False, so every operator whose password is
+# longer than 72 bytes would simply be told their password is wrong, for ever,
+# with nothing in the logs to say why. Their stored hash was derived from the
+# truncated form, so it is still perfectly valid — only the call to check it
+# would fail.
+#
+# So the truncation is now explicit and applied on both sides, which keeps
+# behaviour identical to bcrypt 4.x rather than changing it during an upgrade.
+# It does mean two passwords sharing their first 72 bytes are equivalent, as
+# they always have been under bcrypt; that is a property of the algorithm, not
+# something introduced here.
+_BCRYPT_MAX_BYTES = 72
+
+
+def _bcrypt_input(password):
+    """The bytes bcrypt will actually consider, whatever the caller passed."""
+    return password.encode()[:_BCRYPT_MAX_BYTES]
+
 class AuthManager:
     """Class to handle authentication and authorization"""
     
@@ -88,7 +111,8 @@ class AuthManager:
         """
         if BCRYPT_AVAILABLE:
             # bcrypt handles salt internally, rounds=12 provides good security
-            return bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=12)).decode()
+            return bcrypt.hashpw(_bcrypt_input(password),
+                                 bcrypt.gensalt(rounds=12)).decode()
         # bcrypt import failed — scrypt KDF fallback (NOT a fast hash).
         # Format: "scrypt:<n>:<r>:<p>:<salt_hex>:<hash_hex>".
         if salt is None:
@@ -109,7 +133,8 @@ class AuthManager:
             # bcrypt hash (starts with $2b$ / $2a$)
             if stored_hash.startswith('$2'):
                 if BCRYPT_AVAILABLE:
-                    return bcrypt.checkpw(password.encode(), stored_hash.encode())
+                    return bcrypt.checkpw(_bcrypt_input(password),
+                                          stored_hash.encode())
                 logger.error("bcrypt hash found but bcrypt not available")
                 return False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -97,7 +97,7 @@ python-dotenv==1.2.2
 APScheduler==3.10.4
 cryptography==46.0.7               # GHSA-537c-gmf6-5ccf (HIGH) is open by choice: 48.0.1 needs pyopenssl>=26.2.0, which breaks acme 3.3.0 at import. See SECURITY.md "Known dependency constraint"; unblocked by the certbot 5.x epic (#103).
 pyopenssl==26.0.0                  # Requires cryptography>=46.0.0,<47. Do not bump to 26.2.0+: it removes OpenSSL.crypto.X509Extension, which acme==3.3.0 evaluates at import time (certbot crashes). See SECURITY.md.
-bcrypt==4.2.0                      # Secure password hashing
+bcrypt==5.0.0                      # Secure password hashing
 Authlib>=1.3.2,<2.0.0              # OIDC/OAuth2 client (Authorization Code + PKCE) for SSO. Floor at 1.3.2 (CVE GHSA-9c64-2c4r-vf2g fixed there); allow patch + minor pickup, ceiling at 2.0.0 because any major bump warrants an explicit compatibility check.
 
 # Production server

--- a/tests/test_bcrypt_long_password_compat.py
+++ b/tests/test_bcrypt_long_password_compat.py
@@ -20,8 +20,8 @@ So the truncation is explicit on both sides now, which preserves 4.x behaviour
 exactly rather than changing it during a dependency upgrade. These tests are
 what keep it that way.
 """
+import ast
 import pathlib
-import re
 
 import pytest
 
@@ -94,14 +94,41 @@ def test_neither_side_passes_bcrypt_an_untruncated_password():
     password — which tests bcrypt, not CertMate, and duly failed under 4.x
     where it truncates instead. What matters is that our code decides, in the
     same way, on both sides.
+
+    It read the source line by line, which missed the call split across lines —
+    the form black would produce the moment the expression grew (Copilot,
+    #542). Parsing the AST asks about the call, not about how it is typed.
     """
-    source = (pathlib.Path(__file__).resolve().parent.parent
-              / "modules" / "core" / "auth.py").read_text(encoding="utf-8")
-    offenders = [
-        f"{number}: {line.strip()}"
-        for number, line in enumerate(source.splitlines(), 1)
-        if re.search(r"bcrypt\.(hashpw|checkpw)\(\s*password\.encode\(\)", line)
+    path = (pathlib.Path(__file__).resolve().parent.parent
+            / "modules" / "core" / "auth.py")
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+
+    calls = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in ("hashpw", "checkpw")
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "bcrypt"
     ]
+    assert calls, (
+        "no bcrypt.hashpw/checkpw call found in auth.py — this check has lost "
+        "its subject and would pass whatever the file said."
+    )
+
+    offenders = []
+    for call in calls:
+        if not call.args:
+            continue
+        first = call.args[0]
+        # `password.encode()` — the unbounded form. `_bcrypt_input(password)`
+        # is a Name call and never matches.
+        if (isinstance(first, ast.Call)
+                and isinstance(first.func, ast.Attribute)
+                and first.func.attr == "encode"):
+            offenders.append(f"line {call.lineno}: bcrypt.{call.func.attr}("
+                             f"{ast.unparse(first)}, ...)")
+
     assert not offenders, (
         "these hand bcrypt the full password instead of _bcrypt_input():\n  "
         + "\n  ".join(offenders)

--- a/tests/test_bcrypt_long_password_compat.py
+++ b/tests/test_bcrypt_long_password_compat.py
@@ -1,0 +1,111 @@
+"""A password longer than 72 bytes must keep working across the bcrypt 5 upgrade.
+
+bcrypt has always ignored everything past the 72nd byte. Up to 4.x it truncated
+silently; **5.0.0 raises `ValueError` instead**, and that turns a working login
+into a permanent, silent lockout:
+
+  * the stored hash was derived from the truncated form and is still valid;
+  * `_verify_password` catches `ValueError` and returns `False`, so the operator
+    is told their password is wrong — for ever, with nothing in the logs;
+  * `_hash_password` has no such catch, so *setting* a long password would have
+    raised out of the request instead.
+
+Neither is hypothetical. Measured before the bump was taken:
+
+    >>> h = bcrypt.hashpw(("a"*100).encode()[:72], bcrypt.gensalt())   # 4.x
+    >>> bcrypt.checkpw(("a"*100).encode(), h)                          # 5.0.0
+    ValueError: password cannot be longer than 72 bytes
+
+So the truncation is explicit on both sides now, which preserves 4.x behaviour
+exactly rather than changing it during a dependency upgrade. These tests are
+what keep it that way.
+"""
+import pathlib
+import re
+
+import pytest
+
+from modules.core.auth import _BCRYPT_MAX_BYTES, _bcrypt_input
+
+pytestmark = [pytest.mark.unit]
+
+try:
+    import bcrypt
+    BCRYPT = True
+except ImportError:                                  # pragma: no cover
+    BCRYPT = False
+
+
+def test_the_limit_is_the_one_bcrypt_uses():
+    assert _BCRYPT_MAX_BYTES == 72
+
+
+@pytest.mark.parametrize("password,expected", [
+    ("short", 5),
+    ("a" * 72, 72),
+    ("a" * 73, 72),
+    ("a" * 1000, 72),
+    # Multi-byte characters: the limit is bytes, not characters, and slicing
+    # bytes can land mid-character. What matters is that both sides slice
+    # identically — an exception here would be the same lockout by a different
+    # route.
+    ("é" * 40, 72),
+])
+def test_the_input_is_capped_at_the_byte_limit(password, expected):
+    assert len(_bcrypt_input(password)) == expected
+
+
+@pytest.mark.skipif(not BCRYPT, reason="bcrypt not installed; scrypt fallback in use")
+def test_a_long_password_round_trips():
+    """Set and verify, the path a new operator takes."""
+    from modules.core.auth import AuthManager
+    manager = AuthManager.__new__(AuthManager)
+    password = "correct horse battery staple " * 10          # 290 bytes
+    stored = AuthManager._hash_password(manager, password)
+    assert AuthManager._verify_password(manager, password, stored) is True
+    assert AuthManager._verify_password(manager, "something else", stored) is False
+
+
+@pytest.mark.skipif(not BCRYPT, reason="bcrypt not installed; scrypt fallback in use")
+def test_a_hash_written_by_bcrypt_4_still_accepts_its_password():
+    """The upgrade case: the hash already on disk, checked by the new library.
+
+    Reproduces what 4.x wrote — `hashpw` on the caller's full password, which
+    the library itself truncated — and checks it the way the running code does.
+    Without the explicit truncation this raises, and `_verify_password` turns
+    the exception into 'wrong password'.
+    """
+    from modules.core.auth import AuthManager
+    manager = AuthManager.__new__(AuthManager)
+    password = "x" * 100
+    legacy = bcrypt.hashpw(password.encode()[:72], bcrypt.gensalt(rounds=4)).decode()
+
+    assert AuthManager._verify_password(manager, password, legacy) is True
+
+
+def test_neither_side_passes_bcrypt_an_untruncated_password():
+    """Read the source, not the library.
+
+    The round-trip above can pass while broken if both sides break together,
+    so this checks the thing that must not come back: a bare
+    `password.encode()` handed to bcrypt.
+
+    An earlier version of this test asserted that bcrypt *raises* on a long
+    password — which tests bcrypt, not CertMate, and duly failed under 4.x
+    where it truncates instead. What matters is that our code decides, in the
+    same way, on both sides.
+    """
+    source = (pathlib.Path(__file__).resolve().parent.parent
+              / "modules" / "core" / "auth.py").read_text(encoding="utf-8")
+    offenders = [
+        f"{number}: {line.strip()}"
+        for number, line in enumerate(source.splitlines(), 1)
+        if re.search(r"bcrypt\.(hashpw|checkpw)\(\s*password\.encode\(\)", line)
+    ]
+    assert not offenders, (
+        "these hand bcrypt the full password instead of _bcrypt_input():\n  "
+        + "\n  ".join(offenders)
+        + "\nUnder bcrypt 5 that raises, and _verify_password turns the "
+          "exception into 'wrong password' — a silent, permanent lockout for "
+          "anyone whose password is longer than 72 bytes."
+    )


### PR DESCRIPTION
Dependabot proposed the bare bump in #354. Taken as-is it would have locked out
every operator whose password is longer than 72 bytes — silently, permanently,
with nothing in the logs.

bcrypt has always ignored everything past the 72nd byte. Up to 4.x it truncated
and carried on; **5.0.0 raises `ValueError`**. The stored hash was derived from
the truncated form and is still perfectly valid — only the call to check it
fails. And `_verify_password` catches `ValueError` and returns `False`, so the
operator is told their password is wrong. Setting a long password was worse
still: `_hash_password` has no such catch, so it would have raised out of the
request.

Measured before taking the bump, not reasoned about:

    >>> h = bcrypt.hashpw(("a"*100).encode()[:72], bcrypt.gensalt())   # 4.x
    >>> bcrypt.checkpw(("a"*100).encode(), h)                          # 5.0.0
    ValueError: password cannot be longer than 72 bytes

The truncation is now explicit and applied on both sides, so behaviour is
identical to 4.x rather than changing during a dependency upgrade. Two
passwords sharing their first 72 bytes remain equivalent, as they always have
been under bcrypt — a property of the algorithm, not something introduced here,
and now written down where the next reader will find it.

`tests/test_bcrypt_long_password_compat.py` covers the round trip, the
upgrade case (a hash written by 4.x, checked by 5.x), and — reading the source
rather than the library — that neither side hands bcrypt an untruncated
password. That last one replaced a first attempt that asserted bcrypt *raises*,
which tested bcrypt instead of CertMate and failed under 4.x; the suite now
passes on both versions.

Suite 2593 passed / 6 skipped. Negative-verified by removing the truncation and
watching the upgrade case fail.

Supersedes #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)