### PR TITLE
deps: gunicorn 26.0.0

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -24,7 +24,7 @@ cryptography==46.0.7               # GHSA-537c-gmf6-5ccf (HIGH) open by choice; 
 pyopenssl==26.0.0                  # Do not bump to 26.2.0+: removes X509Extension, breaks acme 3.3.0 at import (see SECURITY.md)
 
 # Production server
-gunicorn==23.0.0
+gunicorn==26.0.0
 
 # APScheduler's SQLAlchemyJobStore backs the persistent renewal schedule, and
 # modules/core/factory.py imports it at module scope — so this is not optional

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,7 +101,7 @@ bcrypt==4.2.0                      # Secure password hashing
 Authlib>=1.3.2,<2.0.0              # OIDC/OAuth2 client (Authorization Code + PKCE) for SSO. Floor at 1.3.2 (CVE GHSA-9c64-2c4r-vf2g fixed there); allow patch + minor pickup, ceiling at 2.0.0 because any major bump warrants an explicit compatibility check.
 
 # Production server
-gunicorn==23.0.0
+gunicorn==26.0.0
 
 # Monitoring and metrics
 prometheus_client==0.21.0


### PR DESCRIPTION
Dependabot's #352, taken after checking the things a process-manager major
could break rather than after reading the version number.

- Every flag the image's CMD passes still exists in 26:
  `--bind --workers --threads --timeout --access-logfile --error-logfile
  --log-level`.
- The image builds and boots, and answers /health.
- **One worker, still.** This matters more than the version: the APScheduler
  instance runs in-process, so a second worker would duplicate every renewal.
  Verified by reading /proc inside the container (the slim image has no `ps`) —
  one master, one worker — and by confirming each scheduler job is registered
  exactly once, from one pid.
- certbot inside the built image is still 2.10.0, i.e. the bump drags nothing.
- The real-cert E2E passes against Let's Encrypt staging through the container
  this gunicorn is serving: 13 tests, a genuine DNS-01 issuance via Cloudflare.

26.0.0 requires Python >=3.10; the image is built on 3.12.

Suite 2593 passed / 6 skipped.

Supersedes #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)