### PR TITLE
deps: Authlib floor to 1.7.2, and the comment that would have contradicted it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -98,7 +98,7 @@ APScheduler==3.10.4
 cryptography==46.0.7               # GHSA-537c-gmf6-5ccf (HIGH) is open by choice: 48.0.1 needs pyopenssl>=26.2.0, which breaks acme 3.3.0 at import. See SECURITY.md "Known dependency constraint"; unblocked by the certbot 5.x epic (#103).
 pyopenssl==26.0.0                  # Requires cryptography>=46.0.0,<47. Do not bump to 26.2.0+: it removes OpenSSL.crypto.X509Extension, which acme==3.3.0 evaluates at import time (certbot crashes). See SECURITY.md.
 bcrypt==5.0.0                      # Secure password hashing
-Authlib>=1.3.2,<2.0.0              # OIDC/OAuth2 client (Authorization Code + PKCE) for SSO. Floor at 1.3.2 (CVE GHSA-9c64-2c4r-vf2g fixed there); allow patch + minor pickup, ceiling at 2.0.0 because any major bump warrants an explicit compatibility check.
+Authlib>=1.7.2,<2.0.0              # OIDC/OAuth2 client (Authorization Code + PKCE) for SSO. Floor at 1.7.2, which is what the published image already resolves to; it is above 1.3.2, where GHSA-9c64-2c4r-vf2g was fixed. Allow patch + minor pickup, ceiling at 2.0.0 because any major bump warrants an explicit compatibility check.
 
 # Production server
 gunicorn==26.0.0


### PR DESCRIPTION
Dependabot's #549 raises the floor and leaves the comment saying 'Floor at
1.3.2'. Merged as proposed, requirements.txt would have stated a floor its own
constraint no longer had — a small drift, created by the bump itself, of
exactly the kind this repo has spent two days removing.

1.7.2 is not a leap: it is what the published v2.25.4 image already resolves to
(verified inside the pulled image). The bump raises the floor to reality. The
comment now says that, and keeps the reason the old floor existed — 1.3.2 is
where GHSA-9c64-2c4r-vf2g was fixed, and the new floor is above it.

Suite 2610 passed / 6 skipped.

Supersedes #549.

🤖 Generated with [Claude Code](https://claude.com/claude-code)