### PR TITLE
docs: the API reference mixed two path conventions, and the translations lost the one that made it work

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,14 @@
 
 The CertMate Client Certificates API provides REST endpoints for complete certificate management with authentication, rate limiting, and audit logging.
 
-**Base URL**: `http://localhost:8000/api`
+**Base URL**: `http://localhost:8000`
+
+> Every path below is absolute and starts with `/api`. It used to be a
+> mix: thirteen paths written relative to a base ending in `/api`, and
+> eight written with the prefix — so against the stated base one set
+> resolved to `/api/api/...`. The four translations had lost the base-URL
+> line entirely, which left their relative paths with nothing to resolve
+> against at all.
 **Authentication**: Bearer Token (required on all endpoints)
 **Content-Type**: `application/json`
 
@@ -87,7 +94,7 @@ HTTP 429 Too Many Requests
 
 #### 1. Create Certificate
 
-**Endpoint**: `POST /client-certs/create`
+**Endpoint**: `POST /api/client-certs/create`
 
 Create a new client certificate.
 
@@ -146,7 +153,7 @@ curl -X POST http://localhost:8000/api/client-certs/create \
 
 #### 2. List Certificates
 
-**Endpoint**: `GET /client-certs`
+**Endpoint**: `GET /api/client-certs`
 
 List all client certificates with optional filtering.
 
@@ -206,7 +213,7 @@ curl "http://localhost:8000/api/client-certs?search=user1" \
 
 #### 3. Get Certificate Details
 
-**Endpoint**: `GET /client-certs/<identifier>`
+**Endpoint**: `GET /api/client-certs/<identifier>`
 
 Get complete metadata for a certificate.
 
@@ -246,7 +253,7 @@ curl http://localhost:8000/api/client-certs/cert-001 \
 
 #### 4. Download Certificate Files
 
-**Endpoint**: `GET /client-certs/<identifier>/download/<type>`
+**Endpoint**: `GET /api/client-certs/<identifier>/download/<type>`
 
 Download certificate, private key, or CSR file.
 
@@ -280,7 +287,7 @@ curl http://localhost:8000/api/client-certs/cert-001/download/csr \
 
 #### 5. Revoke Certificate
 
-**Endpoint**: `POST /client-certs/<identifier>/revoke`
+**Endpoint**: `POST /api/client-certs/<identifier>/revoke`
 
 Revoke a certificate with optional reason.
 
@@ -314,7 +321,7 @@ curl -X POST http://localhost:8000/api/client-certs/cert-001/revoke \
 
 #### 6. Renew Certificate
 
-**Endpoint**: `POST /client-certs/<identifier>/renew`
+**Endpoint**: `POST /api/client-certs/<identifier>/renew`
 
 Renew a certificate (same CN, new serial).
 
@@ -340,7 +347,7 @@ curl -X POST http://localhost:8000/api/client-certs/cert-001/renew \
 
 #### 7. Get Statistics
 
-**Endpoint**: `GET /client-certs/stats`
+**Endpoint**: `GET /api/client-certs/stats`
 
 Get certificate usage statistics.
 
@@ -371,7 +378,7 @@ curl http://localhost:8000/api/client-certs/stats \
 
 #### 8. Batch Import Certificates
 
-**Endpoint**: `POST /client-certs/batch`
+**Endpoint**: `POST /api/client-certs/batch`
 
 Create multiple certificates from CSV data in single request.
 
@@ -428,7 +435,7 @@ curl -X POST http://localhost:8000/api/client-certs/batch \
 
 #### 9. OCSP Status Query
 
-**Endpoint**: `GET /ocsp/status/<serial_number>`
+**Endpoint**: `GET /api/ocsp/status/<serial_number>`
 
 Query certificate status via OCSP.
 
@@ -454,7 +461,7 @@ curl http://localhost:8000/api/ocsp/status/12345678 \
 
 #### 10. CRL Distribution
 
-**Endpoint**: `GET /crl/download/<format_type>`
+**Endpoint**: `GET /api/crl/download/<format_type>`
 
 Download Certificate Revocation List.
 
@@ -500,7 +507,7 @@ curl http://localhost:8000/api/crl/download/info \
 
 #### 11. Download Domain Certificate Files
 
-**Endpoint**: `GET /certificates/<domain>/download`
+**Endpoint**: `GET /api/certificates/<domain>/download`
 
 Download certificate files for a specific domain. By default, this endpoint returns a ZIP archive containing all certificate components. A specific file can be requested using the `file` query parameter. JSON mode is also available for automation that wants all PEMs in one response.
 
@@ -550,7 +557,7 @@ curl "http://localhost:8000/api/certificates/example.com/download?format=json" \
 
 #### 12. Reissue Domain Certificate (edit configuration)
 
-**Endpoint**: `POST /certificates/<domain>/reissue`
+**Endpoint**: `POST /api/certificates/<domain>/reissue`
 
 Edit a certificate's configuration and reissue it in place — extend or drop
 SAN entries without delete + recreate. Omitted fields keep the values the
@@ -572,7 +579,7 @@ explicitly changed (no key flags are sent and certbot keeps the lineage key).
 - `domain_alias`: omit to keep, `""` to clear
 - `dns_provider`, `account_id`, `ca_provider`, `challenge_type`: omit to keep
 - `key_type`/`key_size`/`elliptic_curve`: omit to keep the existing key shape
-- `async`: defer issuance to a background job (202 + job id, poll `GET /certificates/jobs/<job_id>`)
+- `async`: defer issuance to a background job (202 + job id, poll `GET /api/certificates/jobs/<job_id>`)
 
 **Response** (200 OK, or 202 Accepted with `async`): message, domain, dns_provider, ca_provider, duration.
 

--- a/docs/de/api.md
+++ b/docs/de/api.md
@@ -64,7 +64,7 @@ HTTP 429 Too Many Requests
 
 #### 1. Zertifikat erstellen
 
-**Endpoint**: `POST /client-certs/create`
+**Endpoint**: `POST /api/client-certs/create`
 
 Erstellt ein neues Client-Zertifikat.
 
@@ -123,7 +123,7 @@ curl -X POST http://localhost:8000/api/client-certs/create \
 
 #### 2. Zertifikate auflisten
 
-**Endpoint**: `GET /client-certs`
+**Endpoint**: `GET /api/client-certs`
 
 Listet alle Client-Zertifikate mit optionaler Filterung auf.
 
@@ -183,7 +183,7 @@ curl "http://localhost:8000/api/client-certs?search=user1" \
 
 #### 3. Zertifikatsdetails abrufen
 
-**Endpoint**: `GET /client-certs/<identifier>`
+**Endpoint**: `GET /api/client-certs/<identifier>`
 
 Ruft die vollständigen Metadaten eines Zertifikats ab.
 
@@ -223,7 +223,7 @@ curl http://localhost:8000/api/client-certs/cert-001 \
 
 #### 4. Zertifikatsdateien herunterladen
 
-**Endpoint**: `GET /client-certs/<identifier>/download/<type>`
+**Endpoint**: `GET /api/client-certs/<identifier>/download/<type>`
 
 Lädt das Zertifikat, den privaten Schlüssel oder die CSR-Datei herunter.
 
@@ -257,7 +257,7 @@ curl http://localhost:8000/api/client-certs/cert-001/download/csr \
 
 #### 5. Zertifikat widerrufen
 
-**Endpoint**: `POST /client-certs/<identifier>/revoke`
+**Endpoint**: `POST /api/client-certs/<identifier>/revoke`
 
 Widerruft ein Zertifikat mit optionalem Grund.
 
@@ -291,7 +291,7 @@ curl -X POST http://localhost:8000/api/client-certs/cert-001/revoke \
 
 #### 6. Zertifikat erneuern
 
-**Endpoint**: `POST /client-certs/<identifier>/renew`
+**Endpoint**: `POST /api/client-certs/<identifier>/renew`
 
 Erneuert ein Zertifikat (gleicher CN, neue Seriennummer).
 
@@ -317,7 +317,7 @@ curl -X POST http://localhost:8000/api/client-certs/cert-001/renew \
 
 #### 7. Statistiken abrufen
 
-**Endpoint**: `GET /client-certs/stats`
+**Endpoint**: `GET /api/client-certs/stats`
 
 Ruft Nutzungsstatistiken zu Zertifikaten ab.
 
@@ -348,7 +348,7 @@ curl http://localhost:8000/api/client-certs/stats \
 
 #### 8. Zertifikate im Batch importieren
 
-**Endpoint**: `POST /client-certs/batch`
+**Endpoint**: `POST /api/client-certs/batch`
 
 Erstellt mehrere Zertifikate aus CSV-Daten in einer einzigen Anfrage.
 
@@ -405,7 +405,7 @@ curl -X POST http://localhost:8000/api/client-certs/batch \
 
 #### 9. OCSP-Statusabfrage
 
-**Endpoint**: `GET /ocsp/status/<serial_number>`
+**Endpoint**: `GET /api/ocsp/status/<serial_number>`
 
 Fragt den Zertifikatsstatus per OCSP ab.
 
@@ -431,7 +431,7 @@ curl http://localhost:8000/api/ocsp/status/12345678 \
 
 #### 10. CRL-Distribution
 
-**Endpoint**: `GET /crl/download/<format_type>`
+**Endpoint**: `GET /api/crl/download/<format_type>`
 
 Lädt die Zertifikatssperrliste (CRL) herunter.
 
@@ -477,7 +477,7 @@ curl http://localhost:8000/api/crl/download/info \
 
 #### 11. Domain-Zertifikatsdateien herunterladen
 
-**Endpoint**: `GET /certificates/<domain>/download`
+**Endpoint**: `GET /api/certificates/<domain>/download`
 
 Lädt Zertifikatsdateien für eine bestimmte Domain herunter. Standardmäßig gibt dieser Endpoint ein ZIP-Archiv zurück, das alle Zertifikatskomponenten enthält. Eine einzelne Datei kann über den Query-Parameter `file` angefordert werden. Ein JSON-Modus ist ebenfalls verfügbar für Automatisierung, die alle PEMs in einer einzigen Antwort erhalten möchte.
 
@@ -523,7 +523,7 @@ curl "http://localhost:8000/api/certificates/example.com/download?format=json" \
 
 #### 12. Domain-Zertifikat neu ausstellen (Konfiguration bearbeiten)
 
-**Endpoint**: `POST /certificates/<domain>/reissue`
+**Endpoint**: `POST /api/certificates/<domain>/reissue`
 
 Bearbeitet die Konfiguration eines Zertifikats und stellt es an Ort und Stelle neu aus — SAN-Einträge erweitern oder entfernen, ohne löschen + neu erstellen zu müssen. Ausgelassene Felder behalten die Werte, mit denen das Zertifikat ausgestellt wurde (aus den Metadaten gelesen), sodass die DNS/Alias/CA-Konfiguration nie erneut eingegeben werden muss. Das aktuelle Zertifikat wird weiterhin ausgeliefert, bis die Neuausstellung erfolgreich ist. Die Schlüsselform bleibt erhalten, sofern nicht explizit geändert (es werden keine Schlüssel-Flags gesendet und certbot behält den Lineage-Schlüssel).
 
@@ -540,7 +540,7 @@ Bearbeitet die Konfiguration eines Zertifikats und stellt es an Ort und Stelle n
 - `domain_alias`: weglassen zum Beibehalten, `""` zum Löschen
 - `dns_provider`, `account_id`, `ca_provider`, `challenge_type`: weglassen zum Beibehalten
 - `key_type`/`key_size`/`elliptic_curve`: weglassen, um die vorhandene Schlüsselform beizubehalten
-- `async`: Ausstellung an einen Hintergrund-Job verschieben (202 + Job-ID, `GET /certificates/jobs/<job_id>` abfragen)
+- `async`: Ausstellung an einen Hintergrund-Job verschieben (202 + Job-ID, `GET /api/certificates/jobs/<job_id>` abfragen)
 
 **Antwort** (200 OK oder 202 Accepted mit `async`): message, domain, dns_provider, ca_provider, duration.
 

--- a/docs/es/api.md
+++ b/docs/es/api.md
@@ -64,7 +64,7 @@ HTTP 429 Too Many Requests
 
 #### 1. Crear certificado
 
-**Endpoint**: `POST /client-certs/create`
+**Endpoint**: `POST /api/client-certs/create`
 
 Crea un nuevo certificado de cliente.
 
@@ -123,7 +123,7 @@ curl -X POST http://localhost:8000/api/client-certs/create \
 
 #### 2. Listar certificados
 
-**Endpoint**: `GET /client-certs`
+**Endpoint**: `GET /api/client-certs`
 
 Lista todos los certificados de cliente con filtrado opcional.
 
@@ -183,7 +183,7 @@ curl "http://localhost:8000/api/client-certs?search=user1" \
 
 #### 3. Obtener detalles de un certificado
 
-**Endpoint**: `GET /client-certs/<identifier>`
+**Endpoint**: `GET /api/client-certs/<identifier>`
 
 Obtiene los metadatos completos de un certificado.
 
@@ -223,7 +223,7 @@ curl http://localhost:8000/api/client-certs/cert-001 \
 
 #### 4. Descargar archivos de un certificado
 
-**Endpoint**: `GET /client-certs/<identifier>/download/<type>`
+**Endpoint**: `GET /api/client-certs/<identifier>/download/<type>`
 
 Descarga el certificado, la clave privada o el archivo CSR.
 
@@ -257,7 +257,7 @@ curl http://localhost:8000/api/client-certs/cert-001/download/csr \
 
 #### 5. Revocar un certificado
 
-**Endpoint**: `POST /client-certs/<identifier>/revoke`
+**Endpoint**: `POST /api/client-certs/<identifier>/revoke`
 
 Revoca un certificado con un motivo opcional.
 
@@ -291,7 +291,7 @@ curl -X POST http://localhost:8000/api/client-certs/cert-001/revoke \
 
 #### 6. Renovar un certificado
 
-**Endpoint**: `POST /client-certs/<identifier>/renew`
+**Endpoint**: `POST /api/client-certs/<identifier>/renew`
 
 Renueva un certificado (mismo CN, nuevo número de serie).
 
@@ -317,7 +317,7 @@ curl -X POST http://localhost:8000/api/client-certs/cert-001/renew \
 
 #### 7. Obtener estadísticas
 
-**Endpoint**: `GET /client-certs/stats`
+**Endpoint**: `GET /api/client-certs/stats`
 
 Obtiene estadísticas de uso de los certificados.
 
@@ -348,7 +348,7 @@ curl http://localhost:8000/api/client-certs/stats \
 
 #### 8. Importación por lotes de certificados
 
-**Endpoint**: `POST /client-certs/batch`
+**Endpoint**: `POST /api/client-certs/batch`
 
 Crea múltiples certificados a partir de datos CSV en una sola solicitud.
 
@@ -405,7 +405,7 @@ curl -X POST http://localhost:8000/api/client-certs/batch \
 
 #### 9. Consulta de estado OCSP
 
-**Endpoint**: `GET /ocsp/status/<serial_number>`
+**Endpoint**: `GET /api/ocsp/status/<serial_number>`
 
 Consulta el estado de un certificado mediante OCSP.
 
@@ -431,7 +431,7 @@ curl http://localhost:8000/api/ocsp/status/12345678 \
 
 #### 10. Distribución de la CRL
 
-**Endpoint**: `GET /crl/download/<format_type>`
+**Endpoint**: `GET /api/crl/download/<format_type>`
 
 Descarga la lista de revocación de certificados (CRL).
 
@@ -477,7 +477,7 @@ curl http://localhost:8000/api/crl/download/info \
 
 #### 11. Descargar archivos de certificado de dominio
 
-**Endpoint**: `GET /certificates/<domain>/download`
+**Endpoint**: `GET /api/certificates/<domain>/download`
 
 Descarga los archivos de certificado para un dominio específico. Por defecto, este endpoint devuelve un archivo ZIP con todos los componentes del certificado. Se puede solicitar un archivo concreto mediante el parámetro de consulta `file`. También está disponible el modo JSON para la automatización que necesite todos los PEM en una sola respuesta.
 
@@ -523,7 +523,7 @@ curl "http://localhost:8000/api/certificates/example.com/download?format=json" \
 
 #### 12. Reemitir un certificado de dominio (editar la configuración)
 
-**Endpoint**: `POST /certificates/<domain>/reissue`
+**Endpoint**: `POST /api/certificates/<domain>/reissue`
 
 Edita la configuración de un certificado y lo reemite en su lugar — permite ampliar o eliminar entradas SAN sin necesidad de eliminar y volver a crear. Los campos omitidos conservan los valores con los que se emitió el certificado (leídos desde sus metadatos), por lo que la configuración de DNS/alias/CA no es necesario volver a introducirla. El certificado actual sigue sirviéndose hasta que la reemisión tenga éxito. La forma de la clave se preserva salvo cambio explícito (no se envían indicadores de clave y certbot conserva la clave de la cadena de certificados).
 
@@ -540,7 +540,7 @@ Edita la configuración de un certificado y lo reemite en su lugar — permite a
 - `domain_alias`: omitir para conservar, `""` para borrar
 - `dns_provider`, `account_id`, `ca_provider`, `challenge_type`: omitir para conservar
 - `key_type`/`key_size`/`elliptic_curve`: omitir para conservar la forma de clave existente
-- `async`: diferir la emisión a un job en segundo plano (202 + ID del job, consultar `GET /certificates/jobs/<job_id>`)
+- `async`: diferir la emisión a un job en segundo plano (202 + ID del job, consultar `GET /api/certificates/jobs/<job_id>`)
 
 **Respuesta** (200 OK, o 202 Accepted con `async`): message, domain, dns_provider, ca_provider, duration.
 

--- a/docs/fr/api.md
+++ b/docs/fr/api.md
@@ -64,7 +64,7 @@ HTTP 429 Too Many Requests
 
 #### 1. Créer un certificat
 
-**Endpoint** : `POST /client-certs/create`
+**Endpoint** : `POST /api/client-certs/create`
 
 Crée un nouveau certificat client.
 
@@ -123,7 +123,7 @@ curl -X POST http://localhost:8000/api/client-certs/create \
 
 #### 2. Lister les certificats
 
-**Endpoint** : `GET /client-certs`
+**Endpoint** : `GET /api/client-certs`
 
 Liste tous les certificats clients avec filtrage optionnel.
 
@@ -183,7 +183,7 @@ curl "http://localhost:8000/api/client-certs?search=user1" \
 
 #### 3. Obtenir les détails d'un certificat
 
-**Endpoint** : `GET /client-certs/<identifier>`
+**Endpoint** : `GET /api/client-certs/<identifier>`
 
 Récupère les métadonnées complètes d'un certificat.
 
@@ -223,7 +223,7 @@ curl http://localhost:8000/api/client-certs/cert-001 \
 
 #### 4. Télécharger les fichiers d'un certificat
 
-**Endpoint** : `GET /client-certs/<identifier>/download/<type>`
+**Endpoint** : `GET /api/client-certs/<identifier>/download/<type>`
 
 Télécharge le certificat, la clé privée ou le CSR.
 
@@ -257,7 +257,7 @@ curl http://localhost:8000/api/client-certs/cert-001/download/csr \
 
 #### 5. Révoquer un certificat
 
-**Endpoint** : `POST /client-certs/<identifier>/revoke`
+**Endpoint** : `POST /api/client-certs/<identifier>/revoke`
 
 Révoque un certificat avec une raison optionnelle.
 
@@ -291,7 +291,7 @@ curl -X POST http://localhost:8000/api/client-certs/cert-001/revoke \
 
 #### 6. Renouveler un certificat
 
-**Endpoint** : `POST /client-certs/<identifier>/renew`
+**Endpoint** : `POST /api/client-certs/<identifier>/renew`
 
 Renouvelle un certificat (même CN, nouveau numéro de série).
 
@@ -317,7 +317,7 @@ curl -X POST http://localhost:8000/api/client-certs/cert-001/renew \
 
 #### 7. Obtenir les statistiques
 
-**Endpoint** : `GET /client-certs/stats`
+**Endpoint** : `GET /api/client-certs/stats`
 
 Récupère les statistiques d'utilisation des certificats.
 
@@ -348,7 +348,7 @@ curl http://localhost:8000/api/client-certs/stats \
 
 #### 8. Import par lots de certificats
 
-**Endpoint** : `POST /client-certs/batch`
+**Endpoint** : `POST /api/client-certs/batch`
 
 Crée plusieurs certificats à partir de données CSV en une seule requête.
 
@@ -405,7 +405,7 @@ curl -X POST http://localhost:8000/api/client-certs/batch \
 
 #### 9. Requête de statut OCSP
 
-**Endpoint** : `GET /ocsp/status/<serial_number>`
+**Endpoint** : `GET /api/ocsp/status/<serial_number>`
 
 Interroge le statut d'un certificat via OCSP.
 
@@ -431,7 +431,7 @@ curl http://localhost:8000/api/ocsp/status/12345678 \
 
 #### 10. Distribution de la CRL
 
-**Endpoint** : `GET /crl/download/<format_type>`
+**Endpoint** : `GET /api/crl/download/<format_type>`
 
 Télécharge la liste de révocation des certificats (CRL).
 
@@ -477,7 +477,7 @@ curl http://localhost:8000/api/crl/download/info \
 
 #### 11. Télécharger les fichiers de certificat de domaine
 
-**Endpoint** : `GET /certificates/<domain>/download`
+**Endpoint** : `GET /api/certificates/<domain>/download`
 
 Télécharge les fichiers de certificat pour un domaine spécifique. Par défaut, cet endpoint renvoie une archive ZIP contenant tous les composants du certificat. Un fichier spécifique peut être demandé via le paramètre de requête `file`. Un mode JSON est également disponible pour l'automatisation qui souhaite obtenir tous les PEM en une seule réponse.
 
@@ -523,7 +523,7 @@ curl "http://localhost:8000/api/certificates/example.com/download?format=json" \
 
 #### 12. Réémettre un certificat de domaine (modifier la configuration)
 
-**Endpoint** : `POST /certificates/<domain>/reissue`
+**Endpoint** : `POST /api/certificates/<domain>/reissue`
 
 Modifie la configuration d'un certificat et le réémet sur place — permet d'étendre ou de supprimer des entrées SAN sans supprimer + recréer. Les champs omis conservent les valeurs avec lesquelles le certificat a été émis (lues depuis ses métadonnées), évitant ainsi de ressaisir la configuration DNS/alias/CA. Le certificat actuel continue d'être servi jusqu'à ce que la réémission réussisse. La forme de la clé est préservée sauf modification explicite (aucun indicateur de clé n'est envoyé et certbot conserve la clé de la lignée).
 
@@ -540,7 +540,7 @@ Modifie la configuration d'un certificat et le réémet sur place — permet d'�
 - `domain_alias` : omettre pour conserver, `""` pour effacer
 - `dns_provider`, `account_id`, `ca_provider`, `challenge_type` : omettre pour conserver
 - `key_type`/`key_size`/`elliptic_curve` : omettre pour conserver la forme de clé existante
-- `async` : différer l'émission vers un job d'arrière-plan (202 + ID du job, interroger `GET /certificates/jobs/<job_id>`)
+- `async` : différer l'émission vers un job d'arrière-plan (202 + ID du job, interroger `GET /api/certificates/jobs/<job_id>`)
 
 **Réponse** (200 OK, ou 202 Accepted avec `async`) : message, domain, dns_provider, ca_provider, duration.
 

--- a/docs/it/api.md
+++ b/docs/it/api.md
@@ -64,7 +64,7 @@ HTTP 429 Too Many Requests
 
 #### 1. Crea certificato
 
-**Endpoint**: `POST /client-certs/create`
+**Endpoint**: `POST /api/client-certs/create`
 
 Crea un nuovo certificato client.
 
@@ -123,7 +123,7 @@ curl -X POST http://localhost:8000/api/client-certs/create \
 
 #### 2. Elenca certificati
 
-**Endpoint**: `GET /client-certs`
+**Endpoint**: `GET /api/client-certs`
 
 Elenca tutti i certificati client con filtro opzionale.
 
@@ -183,7 +183,7 @@ curl "http://localhost:8000/api/client-certs?search=user1" \
 
 #### 3. Ottieni dettagli certificato
 
-**Endpoint**: `GET /client-certs/<identifier>`
+**Endpoint**: `GET /api/client-certs/<identifier>`
 
 Recupera i metadati completi di un certificato.
 
@@ -223,7 +223,7 @@ curl http://localhost:8000/api/client-certs/cert-001 \
 
 #### 4. Scarica file del certificato
 
-**Endpoint**: `GET /client-certs/<identifier>/download/<type>`
+**Endpoint**: `GET /api/client-certs/<identifier>/download/<type>`
 
 Scarica il certificato, la chiave privata o il file CSR.
 
@@ -257,7 +257,7 @@ curl http://localhost:8000/api/client-certs/cert-001/download/csr \
 
 #### 5. Revoca certificato
 
-**Endpoint**: `POST /client-certs/<identifier>/revoke`
+**Endpoint**: `POST /api/client-certs/<identifier>/revoke`
 
 Revoca un certificato con motivo opzionale.
 
@@ -291,7 +291,7 @@ curl -X POST http://localhost:8000/api/client-certs/cert-001/revoke \
 
 #### 6. Rinnova certificato
 
-**Endpoint**: `POST /client-certs/<identifier>/renew`
+**Endpoint**: `POST /api/client-certs/<identifier>/renew`
 
 Rinnova un certificato (stesso CN, nuovo numero seriale).
 
@@ -317,7 +317,7 @@ curl -X POST http://localhost:8000/api/client-certs/cert-001/renew \
 
 #### 7. Ottieni statistiche
 
-**Endpoint**: `GET /client-certs/stats`
+**Endpoint**: `GET /api/client-certs/stats`
 
 Recupera le statistiche di utilizzo dei certificati.
 
@@ -348,7 +348,7 @@ curl http://localhost:8000/api/client-certs/stats \
 
 #### 8. Importazione batch di certificati
 
-**Endpoint**: `POST /client-certs/batch`
+**Endpoint**: `POST /api/client-certs/batch`
 
 Crea piu certificati da dati CSV in un'unica richiesta.
 
@@ -405,7 +405,7 @@ curl -X POST http://localhost:8000/api/client-certs/batch \
 
 #### 9. Query di stato OCSP
 
-**Endpoint**: `GET /ocsp/status/<serial_number>`
+**Endpoint**: `GET /api/ocsp/status/<serial_number>`
 
 Interroga lo stato di un certificato tramite OCSP.
 
@@ -431,7 +431,7 @@ curl http://localhost:8000/api/ocsp/status/12345678 \
 
 #### 10. Distribuzione della CRL
 
-**Endpoint**: `GET /crl/download/<format_type>`
+**Endpoint**: `GET /api/crl/download/<format_type>`
 
 Scarica la Certificate Revocation List.
 
@@ -477,7 +477,7 @@ curl http://localhost:8000/api/crl/download/info \
 
 #### 11. Scarica file del certificato di dominio
 
-**Endpoint**: `GET /certificates/<domain>/download`
+**Endpoint**: `GET /api/certificates/<domain>/download`
 
 Scarica i file del certificato per un dominio specifico. Per impostazione predefinita, questo endpoint restituisce un archivio ZIP contenente tutti i componenti del certificato. E possibile richiedere un file specifico tramite il parametro di query `file`. E disponibile anche una modalita JSON per l'automazione che desidera ottenere tutti i PEM in un'unica risposta.
 
@@ -523,7 +523,7 @@ curl "http://localhost:8000/api/certificates/example.com/download?format=json" \
 
 #### 12. Riemetti un certificato di dominio (modifica la configurazione)
 
-**Endpoint**: `POST /certificates/<domain>/reissue`
+**Endpoint**: `POST /api/certificates/<domain>/reissue`
 
 Modifica la configurazione di un certificato e lo riemette sul posto — estende o rimuove le voci SAN senza cancellare e ricreare. I campi omessi mantengono i valori con cui il certificato e stato emesso (letti dai suoi metadati), evitando cosi di dover reinserire la configurazione DNS/alias/CA. Il certificato attuale continua ad essere servito fino al completamento della riemissione. La forma della chiave e preservata salvo modifica esplicita (nessun flag di chiave viene inviato e certbot mantiene la chiave della lineage).
 
@@ -540,7 +540,7 @@ Modifica la configurazione di un certificato e lo riemette sul posto — estende
 - `domain_alias`: omettere per mantenere, `""` per cancellare
 - `dns_provider`, `account_id`, `ca_provider`, `challenge_type`: omettere per mantenere
 - `key_type`/`key_size`/`elliptic_curve`: omettere per mantenere la forma di chiave esistente
-- `async`: rinvia l'emissione a un job in background (202 + ID del job, interrogare `GET /certificates/jobs/<job_id>`)
+- `async`: rinvia l'emissione a un job in background (202 + ID del job, interrogare `GET /api/certificates/jobs/<job_id>`)
 
 **Risposta** (200 OK, o 202 Accepted con `async`): message, domain, dns_provider, ca_provider, duration.
 

--- a/tests/test_api_docs_paths_resolve.py
+++ b/tests/test_api_docs_paths_resolve.py
@@ -21,7 +21,6 @@ exists, which is the only thing that knows.
 """
 import pathlib
 import re
-import sys
 
 import pytest
 
@@ -52,7 +51,11 @@ def url_map(tmp_path_factory):
     anchor = module_dir / "factory.py"
     anchor.write_text("# test path anchor\n", encoding="utf-8")
 
-    sys.path.insert(0, str(REPO_ROOT))
+    # No sys.path insert: pytest's rootdir handling already puts the repo
+    # root first, and a session fixture that prepends to sys.path leaks
+    # that for the rest of the run — global state escaping a fixture
+    # (Copilot, #554). Verified the import still resolves without it, in
+    # isolation and in the full suite.
     with pytest.MonkeyPatch.context() as patch:
         patch.setenv("TESTING", "true")
         patch.setenv("FLASK_ENV", "testing")

--- a/tests/test_api_docs_paths_resolve.py
+++ b/tests/test_api_docs_paths_resolve.py
@@ -1,0 +1,141 @@
+"""Every endpoint the API reference documents must resolve against the route map.
+
+`templates/help.html` got this check when `GET /{domain}/tls` turned out to be
+a 404 advertised four times. The API reference — the document people integrate
+against — did not, and it had drifted a different way.
+
+`docs/api.md` declared `Base URL: http://localhost:8000/api`, then wrote
+thirteen paths relative to that base (`POST /client-certs/create`) and eight
+with the prefix already on them (`GET /api/settings/rate-limits`). Read against
+its own stated base, the second set resolved to `/api/api/...`. Whichever
+convention a reader picked, one set was wrong.
+
+The four translations were worse: they had **lost the base-URL line entirely**
+while keeping the thirteen relative paths, so those had nothing to resolve
+against at all. The same blind spot as every other defect found in this sweep —
+the English page carried the piece that made it work, and the translations did
+not.
+
+Every path is absolute now, and this asks the application whether each one
+exists, which is the only thing that knows.
+"""
+import pathlib
+import re
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+API_DOCS = sorted(REPO_ROOT.glob("docs/**/api.md"))
+
+pytestmark = [pytest.mark.unit]
+
+
+def _normalise(path):
+    path = re.sub(r"<[^>]+>", "<X>", path)
+    path = re.sub(r"\{[^}]+\}", "<X>", path)
+    return path.rstrip("/") or "/"
+
+
+@pytest.fixture(scope="session")
+def url_map(tmp_path_factory):
+    """The route table, built once under a temporary root.
+
+    `setup_directories()` creates data/, certificates/ and logs/ relative to
+    `factory.__file__`, so a test that only reads the route table would
+    otherwise write into the checkout. Same anchoring as
+    tests/test_advertised_endpoints_exist.py.
+    """
+    root = tmp_path_factory.mktemp("apidocs") / "certmate"
+    module_dir = root / "modules" / "core"
+    module_dir.mkdir(parents=True)
+    anchor = module_dir / "factory.py"
+    anchor.write_text("# test path anchor\n", encoding="utf-8")
+
+    sys.path.insert(0, str(REPO_ROOT))
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setenv("TESTING", "true")
+        patch.setenv("FLASK_ENV", "testing")
+        from modules.core.factory import create_app
+        patch.setattr("modules.core.factory.__file__", str(anchor))
+        result = create_app()
+    app = result[0] if isinstance(result, tuple) else result
+    return {
+        _normalise(str(rule)): {m for m in rule.methods
+                                if m not in ("HEAD", "OPTIONS")}
+        for rule in app.url_map.iter_rules()
+    }
+
+
+def _documented():
+    """(file, line, verb, path) for every endpoint the API docs state."""
+    found = []
+    for doc in API_DOCS:
+        for number, line in enumerate(
+                doc.read_text(encoding="utf-8").splitlines(), 1):
+            for match in re.finditer(
+                    r"\b(GET|POST|PUT|PATCH|DELETE)\s+(/[\w/{}.<>:-]+)", line):
+                path = re.sub(r"\?.*$", "", match.group(2)).rstrip(".,`)")
+                found.append((str(doc.relative_to(REPO_ROOT)), number,
+                              match.group(1), path))
+    return found
+
+
+DOCUMENTED = _documented()
+
+
+def test_the_api_docs_are_being_read():
+    assert len(API_DOCS) >= 5, (
+        f"found {len(API_DOCS)} api.md files — English plus four translations "
+        f"is five; a smaller number means the scan is missing languages, which "
+        f"is exactly where these defects live."
+    )
+    assert len(DOCUMENTED) >= 50, (
+        f"parsed {len(DOCUMENTED)} endpoints out of them — the format changed "
+        f"and every check below would pass over nothing."
+    )
+
+
+@pytest.mark.parametrize("doc,number,verb,path", DOCUMENTED,
+                         ids=[f"{d}:{n}" for d, n, _v, _p in DOCUMENTED])
+def test_every_documented_path_is_absolute(doc, number, verb, path):
+    """One convention, so no reader has to guess which base to prepend."""
+    assert path.startswith("/api"), (
+        f"{doc}:{number} documents `{verb} {path}`, which is relative. The "
+        f"file used to mix relative and absolute paths, and the translations "
+        f"had lost the base-URL line that made the relative ones resolvable."
+    )
+
+
+@pytest.mark.parametrize("doc,number,verb,path", DOCUMENTED,
+                         ids=[f"{d}:{n}" for d, n, _v, _p in DOCUMENTED])
+def test_every_documented_path_is_a_real_route(doc, number, verb, path, url_map):
+    wanted = _normalise(path).strip("/").split("/")
+
+    # Literal segments win over parameters, the way a router resolves. Without
+    # this, `/api/client-certs/batch` matched `/api/client-certs/<identifier>`
+    # first — a GET-only route — and the check reported a POST mismatch on an
+    # endpoint that is perfectly correct. Candidates are ranked by how many
+    # segments they match literally.
+    matches = []
+    for candidate, methods in url_map.items():
+        parts = candidate.strip("/").split("/")
+        if len(parts) != len(wanted):
+            continue
+        if not all(p == "<X>" or p == w for p, w in zip(parts, wanted)):
+            continue
+        literal = sum(1 for p in parts if p != "<X>")
+        matches.append((literal, candidate, methods))
+
+    if matches:
+        _score, candidate, methods = max(matches, key=lambda m: m[0])
+        assert verb in methods, (
+            f"{doc}:{number} documents `{verb} {path}`, but {candidate} "
+            f"accepts {sorted(methods)}."
+        )
+        return
+    pytest.fail(
+        f"{doc}:{number} documents `{verb} {path}`, which is not a route this "
+        f"application serves. Anyone integrating against the API reference "
+        f"gets a 404."
+    )

--- a/tests/test_ca_endpoints_are_live.py
+++ b/tests/test_ca_endpoints_are_live.py
@@ -20,15 +20,11 @@ suite skips it. What runs everywhere is the offline half: the shape of the URLs
 and the fact that a dead one cannot come back unnoticed.
 """
 import json
-import os
 import re
-import sys
 import urllib.error
 import urllib.request
 
 import pytest
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from modules.core.ca_manager import CAManager  # noqa: E402
 


### PR DESCRIPTION
`templates/help.html` got a route-map check yesterday, when `GET /{domain}/tls`
turned out to be a 404 advertised four times. The API reference — the document
people integrate against — did not, and it had drifted a different way.

`docs/api.md` declared `Base URL: http://localhost:8000/api`, then wrote
thirteen paths relative to that base (`POST /client-certs/create`) and eight
with the prefix already on them (`GET /api/settings/rate-limits`). Read against
its own stated base, the second set resolves to `/api/api/...`. Whichever
convention a reader picked, one set was wrong.

The four translations were worse: they had **lost the base-URL line entirely**
while keeping the thirteen relative paths, so those had nothing to resolve
against at all. Fourth time in this sweep that the English page carried the
piece that made it work and the translations did not.

Every path is absolute now — sixty-five of them across five languages — and the
base URL is the host alone, so the convention no longer depends on a line a
translation can drop.

`tests/test_api_docs_paths_resolve.py` asks the application whether each one
exists, and whether it accepts the verb documented beside it. Its matcher
prefers literal segments over parameters the way a router does: without that,
`/api/client-certs/batch` matched `/api/client-certs/<identifier>` first and the
check reported a POST mismatch on an endpoint that is perfectly correct — a
false positive I hit and fixed before trusting the result.

Suite 2797 passed / 6 skipped. Negative-verified on a non-existent path, a
wrong verb, and a relative path coming back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)