### PR TITLE
ci: check the wiki, which nothing has ever looked at

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,34 @@ jobs:
     - name: Ask every CA whether its directory still exists
       run: pytest tests/test_ca_endpoints_are_live.py -v --tb=short -m network
 
+  # The wiki is a separate git repository, so nothing in CI has ever looked at
+  # it — and it has now drifted three times, each time by keeping a second copy
+  # of something the repo had already corrected. The last sweep found four
+  # claims fixed in docs/ months earlier: Python 3.9, a DigiCert host that
+  # stopped resolving in February, an endpoint that returns 404, and an
+  # environment variable read by nothing.
+  #
+  # Weekly and not required, for the same reason as ca-endpoints: the wiki is
+  # not part of the merge decision, and a clone failing should never block a
+  # pull request. A finding here is news, not a broken build.
+  wiki:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v5
+      with:
+        python-version: '3.12'
+
+    - name: Clone the wiki
+      run: git clone --depth 1 https://github.com/${{ github.repository }}.wiki.git wiki
+
+    - name: Check the wiki against the repository
+      run: python scripts/check_wiki.py wiki
+
   # The Tailwind bundle (static/css/tailwind.min.css) is committed to the repo
   # and served as-is — there is no build step at deploy time. So a stale bundle
   # ships silently whenever input.css / tailwind.config.js change without a

--- a/scripts/check_wiki.py
+++ b/scripts/check_wiki.py
@@ -50,8 +50,15 @@ def _truth():
         raise SystemExit("cannot read the port or the Python version from the "
                          "repository — this script is checking nothing")
 
+    # sorted(): glob order is filesystem order, and the pins dict is
+    # last-write-wins. Two files pinning the same package differently would
+    # make the checker's verdict depend on directory layout — non-deterministic
+    # in exactly the way a checker must not be (Copilot, #555). The repo also
+    # forbids differing pins (tests/test_requirements_are_consistent.py), but
+    # this script must not lean on a guarantee it does not enforce itself.
     requirements = "".join(
-        p.read_text(encoding="utf-8") for p in REPO_ROOT.glob("requirements*.txt"))
+        p.read_text(encoding="utf-8")
+        for p in sorted(REPO_ROOT.glob("requirements*.txt")))
     pins = {
         re.sub(r"[-_.]+", "-", name).lower(): version
         for name, version in re.findall(r"^([A-Za-z0-9_.-]+)==([\w.]+)",

--- a/scripts/check_wiki.py
+++ b/scripts/check_wiki.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Check the GitHub wiki against the facts this repository holds.
+
+The wiki is a separate git repository, so nothing in CI has ever looked at it.
+It has now drifted three times, and each time in the same way: it keeps a
+second copy of something the repo has since corrected, and nobody notices until
+someone reads it. The last sweep found four claims that were already fixed in
+`docs/` — Python 3.9, a DigiCert host that stopped resolving in February, an
+endpoint that returns 404, and an environment variable read by nothing.
+
+This reads the truth from the repository — `app.py`, the `Dockerfile`, the
+requirements files — rather than from a list maintained here, so it cannot say
+"correct" about a number that has moved on.
+
+    scripts/check_wiki.py [path-to-wiki-clone]
+
+Exits non-zero with one line per finding. Intended for the weekly CI job, and
+for anyone about to edit the wiki.
+"""
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Hosts that no longer resolve, with what replaced them.
+RETIRED_HOSTS = {
+    "acme.digicert.com":
+        "retired by DigiCert on 2026-02-24; use "
+        "https://one.digicert.com/mpki/api/v1/acme/v2/directory (regional)",
+}
+
+# Paths the documentation has advertised that no route serves.
+PHANTOM_PATHS = {
+    r"/\{domain\}/tls":
+        "no such route; use /api/certificates/{domain}/download",
+}
+
+# Environment variables nothing reads.
+DEAD_VARIABLES = ("HOST", "FLASK_DEBUG")
+
+
+def _truth():
+    """The facts, read from the code rather than restated here."""
+    app = (REPO_ROOT / "app.py").read_text(encoding="utf-8")
+    port = re.search(r"--port['\"].*?default=(\d+)", app)
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    python = re.search(r"^FROM python:(\d+\.\d+)", dockerfile, re.M)
+    if not port or not python:
+        raise SystemExit("cannot read the port or the Python version from the "
+                         "repository — this script is checking nothing")
+
+    requirements = "".join(
+        p.read_text(encoding="utf-8") for p in REPO_ROOT.glob("requirements*.txt"))
+    pins = {
+        re.sub(r"[-_.]+", "-", name).lower(): version
+        for name, version in re.findall(r"^([A-Za-z0-9_.-]+)==([\w.]+)",
+                                        requirements, re.M)
+    }
+    if len(pins) < 20:
+        raise SystemExit(f"only {len(pins)} pins parsed — the requirements "
+                         f"format changed and the pin check would pass over "
+                         f"nothing")
+    return port.group(1), python.group(1), pins
+
+
+def check(wiki):
+    port, python_version, pins = _truth()
+    pages = sorted(wiki.glob("*.md"))
+    if not pages:
+        raise SystemExit(f"no wiki pages found under {wiki}")
+
+    findings = []
+    for page in pages:
+        fenced = False
+        for number, line in enumerate(
+                page.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+            if line.lstrip().startswith("```"):
+                fenced = not fenced
+                continue
+            where = f"{page.name}:{number}"
+
+            for match in re.finditer(
+                    r"https?://(?:localhost|127\.0\.0\.1):(\d{2,5})", line):
+                if match.group(1) != port:
+                    findings.append(
+                        f"{where}: {match.group(0)} — the app listens on {port}")
+
+            # Only inside fences: prose may legitimately name an old version
+            # while explaining why it moved.
+            if fenced:
+                for match in re.finditer(r"\b([A-Za-z][\w.-]*)==([\w.]+)", line):
+                    shipped = pins.get(re.sub(r"[-_.]+", "-", match.group(1)).lower())
+                    if shipped and shipped != match.group(2):
+                        findings.append(
+                            f"{where}: {match.group(0)} — we ship {shipped}")
+
+            for match in re.finditer(r"[Pp]ython[- ](\d+\.\d+)", line):
+                # A version stated about a third-party package is not a claim
+                # about what CertMate runs on.
+                if re.search(r"`[\w.-]*(?:certbot|dns)[\w.-]*`", line):
+                    continue
+                if match.group(1) != python_version:
+                    findings.append(
+                        f"{where}: Python {match.group(1)} — the image is built "
+                        f"on {python_version}")
+
+            for variable in DEAD_VARIABLES:
+                if re.search(rf"\b{variable}\s*=", line):
+                    findings.append(f"{where}: {variable} is read by nothing")
+
+            for host, reason in RETIRED_HOSTS.items():
+                if host in line:
+                    findings.append(f"{where}: {host} — {reason}")
+
+            for pattern, reason in PHANTOM_PATHS.items():
+                if re.search(pattern, line):
+                    findings.append(f"{where}: phantom endpoint — {reason}")
+
+            for match in re.finditer(r"hub\.docker\.com/r/([\w.-]+/[\w.-]+)", line):
+                if match.group(1) != "fabriziosalmi/certmate":
+                    findings.append(
+                        f"{where}: {match.group(1)} — we publish "
+                        f"fabriziosalmi/certmate")
+
+    return pages, findings
+
+
+def main():
+    wiki = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "wiki")
+    pages, findings = check(wiki)
+    print(f"checked {len(pages)} wiki pages against the repository")
+    if not findings:
+        print("no drift")
+        return 0
+    print(f"{len(findings)} finding(s):")
+    for finding in findings:
+        print(f"  {finding}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_wiki_checker_is_wired.py
+++ b/tests/test_wiki_checker_is_wired.py
@@ -1,0 +1,58 @@
+"""The wiki checker must exist, and something must run it.
+
+`scripts/check_wiki.py` compares the GitHub wiki — a separate git repository —
+against the facts this one holds. It was written because the wiki has drifted
+three times, each time by keeping a second copy of something already corrected
+here.
+
+A checker nothing runs is the shape this repository has spent a week removing:
+`mcp/` had two test suites referenced by no workflow while Dependabot updated
+its dependencies. So this asserts the wiring, not the logic — the logic is
+verified by running it against a wiki with each defect reintroduced.
+"""
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check_wiki.py"
+CI = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_the_checker_exists():
+    assert SCRIPT.exists(), "scripts/check_wiki.py is gone"
+
+
+def test_a_workflow_runs_it():
+    text = CI.read_text(encoding="utf-8")
+    assert "scripts/check_wiki.py" in text, (
+        "no workflow runs scripts/check_wiki.py. A checker nothing executes is "
+        "how mcp/ ended up with two suites that never ran."
+    )
+    assert ".wiki.git" in text, (
+        "the workflow does not clone the wiki, so the checker would run against "
+        "nothing."
+    )
+
+
+def test_it_reads_the_truth_from_the_repository():
+    """Not from a list inside itself, which is what goes stale.
+
+    The whole point is that the expected port, Python version and pins come
+    from app.py, the Dockerfile and requirements*.txt. A checker that restated
+    them would be a third copy to keep in sync.
+    """
+    source = SCRIPT.read_text(encoding="utf-8")
+    for reference in ('"app.py"', '"Dockerfile"', 'requirements*.txt'):
+        assert reference in source, (
+            f"check_wiki.py no longer reads {reference} — if the expected "
+            f"values have been written into the script instead, it has become "
+            f"the drift it was meant to catch."
+        )
+    assert re.search(r"raise SystemExit", source), (
+        "check_wiki.py no longer aborts when it cannot read the repository. "
+        "Printing a complaint and exiting zero is how a check goes quiet."
+    )

--- a/tests/test_wiki_checker_is_wired.py
+++ b/tests/test_wiki_checker_is_wired.py
@@ -10,6 +10,7 @@ A checker nothing runs is the shape this repository has spent a week removing:
 its dependencies. So this asserts the wiring, not the logic — the logic is
 verified by running it against a wiki with each defect reintroduced.
 """
+import importlib.util
 import pathlib
 import re
 
@@ -39,19 +40,42 @@ def test_a_workflow_runs_it():
 
 
 def test_it_reads_the_truth_from_the_repository():
-    """Not from a list inside itself, which is what goes stale.
+    """Behaviour, not substrings.
 
-    The whole point is that the expected port, Python version and pins come
-    from app.py, the Dockerfile and requirements*.txt. A checker that restated
-    them would be a third copy to keep in sync.
+    The point is that the expected port, Python version and pins come from the
+    repository rather than from a list inside the script — a restated value is
+    a third copy to keep in sync. An earlier version of this test asserted the
+    literal strings `"app.py"` and `"Dockerfile"` appeared in the source, which
+    would break on a harmless refactor and pass on a harmful one (Copilot,
+    #555). So it calls the function and compares what it returns with what the
+    repository says.
     """
+    spec = importlib.util.spec_from_file_location("check_wiki", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    port, python_version, pins = module._truth()
+
+    app = (REPO_ROOT / "app.py").read_text(encoding="utf-8")
+    assert port == re.search(r"--port['\"].*?default=(\d+)", app).group(1), (
+        "check_wiki.py's expected port does not come from app.py"
+    )
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    assert python_version == re.search(r"^FROM python:(\d+\.\d+)",
+                                       dockerfile, re.M).group(1), (
+        "check_wiki.py's expected Python version does not come from the Dockerfile"
+    )
+    assert pins.get("certbot") == re.search(
+        r"^certbot==([\w.]+)",
+        (REPO_ROOT / "requirements.txt").read_text(encoding="utf-8"),
+        re.M).group(1), (
+        "check_wiki.py's pins do not come from requirements.txt"
+    )
+
+
+def test_it_aborts_rather_than_reporting_success():
+    """A checker that cannot read its sources must not print 'no drift'."""
     source = SCRIPT.read_text(encoding="utf-8")
-    for reference in ('"app.py"', '"Dockerfile"', 'requirements*.txt'):
-        assert reference in source, (
-            f"check_wiki.py no longer reads {reference} — if the expected "
-            f"values have been written into the script instead, it has become "
-            f"the drift it was meant to catch."
-        )
     assert re.search(r"raise SystemExit", source), (
         "check_wiki.py no longer aborts when it cannot read the repository. "
         "Printing a complaint and exiting zero is how a check goes quiet."


### PR DESCRIPTION
The wiki is a separate git repository, so no workflow has ever read it — and it
has drifted three times, each time the same way: it keeps a second copy of
something this repo has since corrected, and nobody notices until someone
reads it.

Swept today with the checks built over the last week. Four findings, every one
already fixed in `docs/` months or days earlier:

- **Python 3.9**, five times, including "Tests on Python 3.9, 3.11, 3.12" when
  the matrix has one entry — and 3.9 cannot install requirements.txt at all.
- **`acme.digicert.com`**, twice. NXDOMAIN since DigiCert retired CertCentral's
  legacy ACME service on 24 February.
- **`GET /{domain}/tls`** in the endpoint table. Returns 404.
- **`export FLASK_DEBUG=1`**, read by nothing.

All four corrected in the wiki itself (commit 4b13318 there).

`scripts/check_wiki.py` reads the expected port, Python version and pins from
`app.py`, the `Dockerfile` and `requirements*.txt` rather than restating them —
a checker with its own copy of the numbers is a third thing to keep in sync. It
aborts rather than reporting success when it cannot read those sources, when
the wiki clone is empty, or when fewer than twenty pins parse: verified, all
three exit non-zero.

The job is weekly and not required, for the same reason as ca-endpoints. The
wiki is not part of the merge decision and a clone failing must never block a
pull request; a finding is news.

`tests/test_wiki_checker_is_wired.py` asserts the workflow actually runs it and
that it still reads its facts from the repository — a checker nothing executes
is exactly how `mcp/` ended up with two suites that never ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)