### PR TITLE
docs: a whole storage backend that ships, and is documented nowhere

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ Welcome to the CertMate documentation. This folder contains comprehensive guides
 - **two dozen+ DNS providers** for Let's Encrypt DNS-01 challenges (see [DNS Providers](./dns-providers.md) for the full list)
 - **Multiple CA providers**: Let's Encrypt, DigiCert, Private CA
 - **Multi-account support** per DNS provider
-- **Pluggable storage backends**: Local, Azure Key Vault, AWS, Vault, Infisical
+- **Pluggable storage backends**: Local, Azure Key Vault, AWS, Vault, Infisical, S3-compatible
 - **Auto-renewal** with configurable thresholds
 - **Docker support** with multi-platform builds (ARM64 + AMD64)
 - **Log Sanitizer** — Automatically redacts API tokens, private keys, and sensitive credentials from CertMate logs

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ Welcome to the CertMate documentation. This folder contains comprehensive guides
 - **two dozen+ DNS providers** for Let's Encrypt DNS-01 challenges (see [DNS Providers](./dns-providers.md) for the full list)
 - **Multiple CA providers**: Let's Encrypt, DigiCert, Private CA
 - **Multi-account support** per DNS provider
-- **Pluggable storage backends**: Local, Azure Key Vault, AWS, Vault, Infisical, S3-compatible
+- **Pluggable storage backends**: Local, Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical, S3-compatible
 - **Auto-renewal** with configurable thresholds
 - **Docker support** with multi-platform builds (ARM64 + AMD64)
 - **Log Sanitizer** — Automatically redacts API tokens, private keys, and sensitive credentials from CertMate logs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ CertMate is a modular, pluggable SSL/TLS certificate management system built wit
 
 **Key Facts:**
 - **Language**: Python 3.12 (Flask, Flask-RESTX)
-- **Storage**: Local filesystem default + 4 cloud backends (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical)
+- **Storage**: Local filesystem default + 5 remote backends (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical, S3-compatible)
 - **CA Providers**: Let's Encrypt, DigiCert ACME, Private CA
 - **DNS Providers**: two dozen+ supported (Cloudflare, AWS Route53, Azure, Google, and more — see [DNS Providers](./dns-providers.md) for the full list)
 - **API**: REST with Swagger/OpenAPI via Flask-RESTX
@@ -181,6 +181,7 @@ All backends implement `CertificateStorageBackend`:
 | **AWS Secrets Manager** | AWS Secrets Manager |
 | **HashiCorp Vault** | Vault KV v1/v2 |
 | **Infisical** | Infisical secrets |
+| **S3-compatible** | Any S3 API: MinIO/Ceph self-hosted, or Hetzner, Contabo, OVHcloud, Scaleway, Exoscale, Wasabi |
 
 #### Azure Key Vault — storage modes
 

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -57,7 +57,7 @@ Willkommen in der CertMate-Dokumentation. Dieser Ordner enthält umfassende Anle
 - **Über zwei Dutzend DNS-Provider** für Let's Encrypt DNS-01-Challenges (vollständige Liste unter [DNS-Provider](./dns-providers.md))
 - **Mehrere CA-Provider**: Let's Encrypt, DigiCert, Private CA
 - **Multi-Account-Unterstützung** pro DNS-Provider
-- **Austauschbare Storage-Backends**: Lokal, Azure Key Vault, AWS, Vault, Infisical, S3-compatible
+- **Austauschbare Storage-Backends**: Lokal, Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical, S3-compatible
 - **Auto-Renewal** mit konfigurierbaren Schwellenwerten
 - **Docker-Unterstützung** mit Multi-Plattform-Builds (ARM64 + AMD64)
 - **Log Sanitizer** — Bereinigt automatisch API-Tokens, private Schlüssel und sensible Zugangsdaten aus den CertMate-Logs

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -57,7 +57,7 @@ Willkommen in der CertMate-Dokumentation. Dieser Ordner enthält umfassende Anle
 - **Über zwei Dutzend DNS-Provider** für Let's Encrypt DNS-01-Challenges (vollständige Liste unter [DNS-Provider](./dns-providers.md))
 - **Mehrere CA-Provider**: Let's Encrypt, DigiCert, Private CA
 - **Multi-Account-Unterstützung** pro DNS-Provider
-- **Austauschbare Storage-Backends**: Lokal, Azure Key Vault, AWS, Vault, Infisical
+- **Austauschbare Storage-Backends**: Lokal, Azure Key Vault, AWS, Vault, Infisical, S3-compatible
 - **Auto-Renewal** mit konfigurierbaren Schwellenwerten
 - **Docker-Unterstützung** mit Multi-Plattform-Builds (ARM64 + AMD64)
 - **Log Sanitizer** — Bereinigt automatisch API-Tokens, private Schlüssel und sensible Zugangsdaten aus den CertMate-Logs

--- a/docs/de/architecture.md
+++ b/docs/de/architecture.md
@@ -24,7 +24,7 @@ CertMate ist ein modulares, erweiterbares SSL/TLS-Zertifikatsverwaltungssystem, 
 
 **Wichtige Fakten:**
 - **Sprache**: Python 3.12 (Flask, Flask-RESTX)
-- **Speicher**: Lokales Dateisystem als Standard + 4 Cloud-Backends (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical)
+- **Speicher**: Lokales Dateisystem als Standard + 5 entfernte Backends (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical, S3-compatible)
 - **CA-Anbieter**: Let's Encrypt, DigiCert ACME, Private CA
 - **DNS-Anbieter**: mehr als zwei Dutzend unterstützt (Cloudflare, AWS Route53, Azure, Google und weitere — siehe [DNS-Anbieter](./dns-providers.md) für die vollständige Liste)
 - **API**: REST mit Swagger/OpenAPI via Flask-RESTX
@@ -181,6 +181,7 @@ Alle Backends implementieren `CertificateStorageBackend`:
 | **AWS Secrets Manager** | AWS Secrets Manager |
 | **HashiCorp Vault** | Vault KV v1/v2 |
 | **Infisical** | Infisical-Secrets |
+| **S3-compatible** | Any S3 API: MinIO/Ceph self-hosted, or Hetzner, Contabo, OVHcloud, Scaleway, Exoscale, Wasabi |
 
 #### Azure Key Vault — Speichermodi
 

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -57,7 +57,7 @@ Bienvenido a la documentación de CertMate. Esta carpeta contiene guías complet
 - **Más de dos docenas de proveedores DNS** para los desafíos DNS-01 de Let's Encrypt (ver [Proveedores DNS](./dns-providers.md) para la lista completa)
 - **Múltiples proveedores CA**: Let's Encrypt, DigiCert, CA privada
 - **Soporte multi-cuenta** por proveedor DNS
-- **Backends de almacenamiento intercambiables**: Local, Azure Key Vault, AWS, Vault, Infisical, S3-compatible
+- **Backends de almacenamiento intercambiables**: Local, Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical, S3-compatible
 - **Renovación automática** con umbrales configurables
 - **Soporte Docker** con builds multiplataforma (ARM64 + AMD64)
 - **Log Sanitizer** — Elimina automáticamente tokens de API, claves privadas y credenciales sensibles de los logs de CertMate

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -57,7 +57,7 @@ Bienvenido a la documentación de CertMate. Esta carpeta contiene guías complet
 - **Más de dos docenas de proveedores DNS** para los desafíos DNS-01 de Let's Encrypt (ver [Proveedores DNS](./dns-providers.md) para la lista completa)
 - **Múltiples proveedores CA**: Let's Encrypt, DigiCert, CA privada
 - **Soporte multi-cuenta** por proveedor DNS
-- **Backends de almacenamiento intercambiables**: Local, Azure Key Vault, AWS, Vault, Infisical
+- **Backends de almacenamiento intercambiables**: Local, Azure Key Vault, AWS, Vault, Infisical, S3-compatible
 - **Renovación automática** con umbrales configurables
 - **Soporte Docker** con builds multiplataforma (ARM64 + AMD64)
 - **Log Sanitizer** — Elimina automáticamente tokens de API, claves privadas y credenciales sensibles de los logs de CertMate

--- a/docs/es/architecture.md
+++ b/docs/es/architecture.md
@@ -24,7 +24,7 @@ CertMate es un sistema modular y extensible de gestión de certificados SSL/TLS 
 
 **Datos clave:**
 - **Lenguaje**: Python 3.12 (Flask, Flask-RESTX)
-- **Almacenamiento**: Sistema de archivos local por defecto + 4 backends cloud (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical)
+- **Almacenamiento**: Sistema de archivos local por defecto + 5 backends remotos (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical, S3-compatible)
 - **Proveedores CA**: Let's Encrypt, DigiCert ACME, CA privada
 - **Proveedores DNS**: más de dos docenas admitidos (Cloudflare, AWS Route53, Azure, Google, y más — véase [Proveedores DNS](./dns-providers.md) para la lista completa)
 - **API**: REST con Swagger/OpenAPI mediante Flask-RESTX
@@ -181,6 +181,7 @@ Todos los backends implementan `CertificateStorageBackend`:
 | **AWS Secrets Manager** | AWS Secrets Manager |
 | **HashiCorp Vault** | Vault KV v1/v2 |
 | **Infisical** | Secrets de Infisical |
+| **S3-compatible** | Any S3 API: MinIO/Ceph self-hosted, or Hetzner, Contabo, OVHcloud, Scaleway, Exoscale, Wasabi |
 
 #### Azure Key Vault — modos de almacenamiento
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -57,7 +57,7 @@ Bienvenue dans la documentation de CertMate. Ce dossier contient des guides comp
 - **Plus de deux douzaines de fournisseurs DNS** pour les défis Let's Encrypt DNS-01 (voir [Fournisseurs DNS](./dns-providers.md) pour la liste complète)
 - **Plusieurs fournisseurs CA** : Let's Encrypt, DigiCert, CA privée
 - **Support multi-comptes** par fournisseur DNS
-- **Backends de stockage interchangeables** : Local, Azure Key Vault, AWS, Vault, Infisical
+- **Backends de stockage interchangeables** : Local, Azure Key Vault, AWS, Vault, Infisical, S3-compatible
 - **Renouvellement automatique** avec seuils configurables
 - **Support Docker** avec constructions multi-plateforme (ARM64 + AMD64)
 - **Nettoyeur de logs** — Supprime automatiquement les tokens API, clés privées et identifiants sensibles des logs CertMate

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -57,7 +57,7 @@ Bienvenue dans la documentation de CertMate. Ce dossier contient des guides comp
 - **Plus de deux douzaines de fournisseurs DNS** pour les défis Let's Encrypt DNS-01 (voir [Fournisseurs DNS](./dns-providers.md) pour la liste complète)
 - **Plusieurs fournisseurs CA** : Let's Encrypt, DigiCert, CA privée
 - **Support multi-comptes** par fournisseur DNS
-- **Backends de stockage interchangeables** : Local, Azure Key Vault, AWS, Vault, Infisical, S3-compatible
+- **Backends de stockage interchangeables** : Local, Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical, S3-compatible
 - **Renouvellement automatique** avec seuils configurables
 - **Support Docker** avec constructions multi-plateforme (ARM64 + AMD64)
 - **Nettoyeur de logs** — Supprime automatiquement les tokens API, clés privées et identifiants sensibles des logs CertMate

--- a/docs/fr/architecture.md
+++ b/docs/fr/architecture.md
@@ -24,7 +24,7 @@ CertMate est un système modulaire et extensible de gestion de certificats SSL/T
 
 **Points clés :**
 - **Langage** : Python 3.12 (Flask, Flask-RESTX)
-- **Stockage** : Système de fichiers local par défaut + 4 backends cloud (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical)
+- **Stockage** : Système de fichiers local par défaut + 5 backends distants (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical, S3-compatible)
 - **Fournisseurs CA** : Let's Encrypt, DigiCert ACME, CA privée
 - **Fournisseurs DNS** : plus de deux douzaines supportés (Cloudflare, AWS Route53, Azure, Google, etc. — voir [Fournisseurs DNS](./dns-providers.md) pour la liste complète)
 - **API** : REST avec Swagger/OpenAPI via Flask-RESTX
@@ -181,6 +181,7 @@ Tous les backends implémentent `CertificateStorageBackend` :
 | **AWS Secrets Manager** | AWS Secrets Manager |
 | **HashiCorp Vault** | Vault KV v1/v2 |
 | **Infisical** | Secrets Infisical |
+| **S3-compatible** | Any S3 API: MinIO/Ceph self-hosted, or Hetzner, Contabo, OVHcloud, Scaleway, Exoscale, Wasabi |
 
 #### Azure Key Vault — modes de stockage
 

--- a/docs/it/README.md
+++ b/docs/it/README.md
@@ -57,7 +57,7 @@ Benvenuto nella documentazione di CertMate. Questa cartella contiene guide compl
 - **Oltre due dozzine di provider DNS** per le sfide Let's Encrypt DNS-01 (vedere [Provider DNS](./dns-providers.md) per l'elenco completo)
 - **Più provider CA**: Let's Encrypt, DigiCert, CA privata
 - **Supporto multi-account** per provider DNS
-- **Storage backend intercambiabili**: locale, Azure Key Vault, AWS, Vault, Infisical
+- **Storage backend intercambiabili**: locale, Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical, S3-compatible
 - **Rinnovo automatico** con soglie configurabili
 - **Supporto Docker** con build multi-piattaforma (ARM64 + AMD64)
 - **Log Sanitizer** — Oscura automaticamente token API, chiavi private e credenziali sensibili dai log di CertMate

--- a/docs/it/architecture.md
+++ b/docs/it/architecture.md
@@ -24,7 +24,7 @@ CertMate è un sistema modulare ed estensibile per la gestione di certificati SS
 
 **Informazioni principali:**
 - **Linguaggio**: Python 3.12 (Flask, Flask-RESTX)
-- **Archiviazione**: filesystem locale come impostazione predefinita + 4 backend cloud (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical)
+- **Archiviazione**: filesystem locale come impostazione predefinita + 5 backend remoti (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault, Infisical, S3-compatible)
 - **Provider CA**: Let's Encrypt, DigiCert ACME, CA privata
 - **Provider DNS**: oltre due dozzine supportati (Cloudflare, AWS Route53, Azure, Google e altri — vedere [Provider DNS](./dns-providers.md) per l'elenco completo)
 - **API**: REST con Swagger/OpenAPI tramite Flask-RESTX
@@ -181,6 +181,7 @@ Tutti i backend implementano `CertificateStorageBackend`:
 | **AWS Secrets Manager** | AWS Secrets Manager |
 | **HashiCorp Vault** | Vault KV v1/v2 |
 | **Infisical** | Secret Infisical |
+| **S3-compatible** | Any S3 API: MinIO/Ceph self-hosted, or Hetzner, Contabo, OVHcloud, Scaleway, Exoscale, Wasabi |
 
 #### Azure Key Vault — modalità di archiviazione
 

--- a/tests/test_storage_wiring_consistency.py
+++ b/tests/test_storage_wiring_consistency.py
@@ -148,17 +148,42 @@ _DOC_NAMES = {
 
 
 def test_every_dispatched_backend_has_a_documented_name():
-    """The mapping above must keep up with the dispatch, or the check below
-    silently stops covering the newest backend."""
-    missing = sorted(_canonical() - set(_DOC_NAMES) - _UNTRANSLATED_NAME)
+    """Both directions.
+
+    A dispatched backend with no name here silently stops being covered by the
+    guide check. A name here for a backend that is no longer dispatched is the
+    opposite failure — the guide would be required to document something that
+    does not exist, and nobody would know why (Copilot, #557).
+    """
+    canonical = _canonical()
+    named = set(_DOC_NAMES) | _UNTRANSLATED_NAME
+    missing = sorted(canonical - named)
     assert not missing, (
         f"these backends are dispatched but have no documented name here: "
         f"{missing}. Add them, and add them to the architecture guide."
     )
+    stale = sorted(named - canonical)
+    assert not stale, (
+        f"these have a documented name here but are no longer dispatched: "
+        f"{stale}. Remove them, or the guide is asked to describe a backend "
+        f"the application cannot use."
+    )
 
 
-@pytest.mark.parametrize("guide", sorted(
-    str(p.relative_to(_ROOT)) for p in _ROOT.glob("docs/**/architecture.md")))
+def _guides():
+    """Every document that states the backend list, in every language.
+
+    architecture.md and the docs landing README both enumerate them. Only the
+    former was covered at first, and the Italian README slipped through with
+    five backends and abbreviated names while the other four were corrected —
+    the translations blind spot, inside the very patch that fixed it.
+    """
+    found = [p for p in _ROOT.glob("docs/**/architecture.md")]
+    found += [p for p in _ROOT.glob("docs/**/README.md")]
+    return sorted(str(p.relative_to(_ROOT)) for p in found)
+
+
+@pytest.mark.parametrize("guide", _guides())
 def test_the_architecture_guide_lists_every_backend(guide):
     """The seventh surface, and the only one that was not pinned.
 
@@ -170,9 +195,12 @@ def test_the_architecture_guide_lists_every_backend(guide):
     "4 cloud backends" without it — in all five languages.
     """
     text = _read(guide)
+    # _canonical() reflects over the dispatch source; computed once rather than
+    # per entry inside the comprehension.
+    canonical = _canonical()
     missing = [
         f"{key} ({name})" for key, name in sorted(_DOC_NAMES.items())
-        if key in _canonical() and name not in text
+        if key in canonical and name not in text
     ]
     assert not missing, (
         f"{guide} does not mention {missing}. A backend the application "

--- a/tests/test_storage_wiring_consistency.py
+++ b/tests/test_storage_wiring_consistency.py
@@ -125,3 +125,57 @@ def test_settings_js_panel_map_matches_dispatch():
         f"settings.js storage panel map != dispatchable: "
         f"missing={sorted(canonical - panel_keys)} extra={sorted(panel_keys - canonical)}"
     )
+
+
+# The proper nouns each dispatched backend is documented under. Product names
+# stay in English in every translation, which is what makes them checkable
+# across all five guides.
+#
+# `local_filesystem` is deliberately absent: it is the only one whose name is a
+# common noun, and the translations render it as "Filesystem locale",
+# "Lokales Dateisystem", "Sistema de archivos local". Requiring the English
+# string there failed four correct documents — my check, not their prose. It is
+# also the default and appears in every guide's opening paragraph, so it is not
+# the one at risk of going undocumented.
+_UNTRANSLATED_NAME = {"local_filesystem"}
+_DOC_NAMES = {
+    "azure_keyvault": "Azure Key Vault",
+    "aws_secrets_manager": "AWS Secrets Manager",
+    "hashicorp_vault": "HashiCorp Vault",
+    "infisical": "Infisical",
+    "s3_compatible": "S3-compatible",
+}
+
+
+def test_every_dispatched_backend_has_a_documented_name():
+    """The mapping above must keep up with the dispatch, or the check below
+    silently stops covering the newest backend."""
+    missing = sorted(_canonical() - set(_DOC_NAMES) - _UNTRANSLATED_NAME)
+    assert not missing, (
+        f"these backends are dispatched but have no documented name here: "
+        f"{missing}. Add them, and add them to the architecture guide."
+    )
+
+
+@pytest.mark.parametrize("guide", sorted(
+    str(p.relative_to(_ROOT)) for p in _ROOT.glob("docs/**/architecture.md")))
+def test_the_architecture_guide_lists_every_backend(guide):
+    """The seventh surface, and the only one that was not pinned.
+
+    This file already cross-validates the API model enum, the resources'
+    available/valid/migrate lists, the settings select and the settings JS
+    panel map against the dispatch. The documentation was not among them, and
+    it had fallen a whole backend behind: `s3_compatible` ships with a class,
+    three test files and a settings-UI panel, and the architecture guide listed
+    "4 cloud backends" without it — in all five languages.
+    """
+    text = _read(guide)
+    missing = [
+        f"{key} ({name})" for key, name in sorted(_DOC_NAMES.items())
+        if key in _canonical() and name not in text
+    ]
+    assert not missing, (
+        f"{guide} does not mention {missing}. A backend the application "
+        f"dispatches, the API accepts and the settings page offers, described "
+        f"nowhere."
+    )


### PR DESCRIPTION
`s3_compatible` has a class, a factory branch, three test files, an API enum
entry and a panel in the settings page. The architecture guide says "Local
filesystem default + 4 cloud backends (Azure Key Vault, AWS Secrets Manager,
HashiCorp Vault, Infisical)" — in all five languages — and its backend table
lists the same five. S3-compatible appears in neither.

That is EU-sovereign object storage (Hetzner, Contabo, OVHcloud, Scaleway,
Exoscale, Wasabi) and self-hosted MinIO/Ceph, invisible to anyone reading the
documentation to decide where their certificates can live.

Found from the website, of all places: certmate-website declares
`STORAGE_BACKEND_COUNT = 6` and the product's docs said five. The site was
right.

I had reported this same claim as correct yesterday, and it was not. My check
grepped `^class [A-Za-z]+Backend`, which cannot match `S3CompatibleBackend` —
a digit in the class name. The count came out as five concrete plus the
abstract base, which read as "five backends, correct". Corrected here.

`tests/test_storage_wiring_consistency.py` already cross-validated the dispatch
against six surfaces — the API model enum, the resources' available/valid/
migrate lists, the settings select, the settings JS panel map. The
documentation was the seventh and the only one not pinned. It is now, in every
language, with a guard that a backend added to the dispatch without a
documented name fails rather than being skipped.

`local_filesystem` is deliberately outside that check: it is the only backend
whose name is a common noun, and the translations render it as "Filesystem
locale", "Lokales Dateisystem", "Sistema de archivos local". Requiring the
English string failed four correct documents — my check, not their prose.

Suite 2803 passed / 6 skipped. Negative-verified by removing S3-compatible from
a translation and by adding a backend to the dispatch with no documented name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)