### PR TITLE
ci: ask the built image whether its providers can actually reach certbot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,25 @@ jobs:
             exit 1
           fi
 
+          # Ask the built image whether every provider it offers can actually
+          # reach certbot. The suite validates the issuance path against mocks
+          # — nine test files stub `check_certbot_plugin_installed` to True —
+          # so the guard between a configured provider and certbot's
+          # "unrecognized arguments" is never exercised for real. That is how
+          # Infomaniak shipped with a strategy, a credentials writer, a README
+          # row and no plugin in any published image.
+          #
+          # In the image, not in a developer's virtualenv, where the answer is
+          # whatever happens to be installed locally. The requirements file is
+          # passed explicitly: it is what this build was meant to carry, and
+          # guessing it is the difference between a missing plugin and an
+          # optional one.
+          if ! docker exec "$cid" python /app/scripts/check_providers.py "$req"; then
+            echo "::error::$req built an image whose providers cannot all reach certbot"
+            docker rm -f "$cid" >/dev/null 2>&1 || true
+            exit 1
+          fi
+
           docker rm -f "$cid" >/dev/null 2>&1 || true
           echo "::endgroup::"
         done

--- a/scripts/check_providers.py
+++ b/scripts/check_providers.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Ask the built image whether every provider it offers can actually issue.
+
+The test suite validates the issuance path against mocks. Every test that
+touches `check_certbot_plugin_installed` replaces it with a stub returning
+True — nine files do — so the one guard standing between a configured provider
+and certbot's "unrecognized arguments" is never exercised against reality.
+
+That is how Infomaniak shipped: a strategy, a credentials writer, a factory
+entry, a README row, and no plugin in any image ever published. Nothing was
+wrong with the code. The plugin simply was not there, and nothing looked.
+
+This looks, inside the artefact rather than in a developer's virtualenv, where
+the answer is whatever happens to be installed locally. It needs no test
+dependencies and no hand-maintained table of names: the environment says which
+distribution provides which certbot plugin, and the requirements files say what
+we meant to ship.
+
+    python scripts/check_providers.py [requirements-file]
+
+The argument names the requirements file this image was built from — what it
+was meant to carry. It defaults to requirements.txt, which is what the
+published image installs; pass requirements-minimal.txt when checking that
+variant. Getting this wrong in either direction is the difference between a
+missing plugin and an optional one, so it is an explicit input rather than a
+guess.
+
+Exits non-zero when a plugin we meant to ship is missing or misnamed. Prints —
+without failing — the providers this variant does not carry, which is a
+legitimate state for the optional ones.
+"""
+import pathlib
+import re
+import sys
+from importlib.metadata import distributions
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _normalise(name):
+    """PEP 503. `certbot_dns_porkbun` and `certbot-dns-porkbun` are one package.
+
+    The first version of this script normalised the requirements side and not
+    the metadata side, so every comparison missed and it reported two perfectly
+    working plugins as broken. Same mistake as the entry-point contract test
+    made before it — which is why it is one function now, used on both sides.
+    """
+    return re.sub(r"[-_.]+", "-", name or "").lower()
+
+
+def _registered():
+    """entry-point name -> distribution that provides it, from the environment."""
+    owner = {}
+    for dist in distributions():
+        name = _normalise((dist.metadata or {}).get("Name"))
+        for entry in dist.entry_points:
+            if entry.group == "certbot.plugins":
+                owner[entry.name] = name
+    return owner
+
+
+def _installed_plugin_distributions():
+    """Installed distributions whose name marks them as a certbot plugin."""
+    found = {}
+    for dist in distributions():
+        name = (dist.metadata or {}).get("Name") or ""
+        if re.match(r"certbot[-_](dns|plugin)[-_]", name, re.I):
+            found[_normalise(name)] = dist
+    return found
+
+
+def _pinned_plugin_distributions(requirements):
+    """Plugin distributions *this build* pins — what it was meant to carry.
+
+    One file, not every requirements*.txt in the tree. Reading them all made
+    `he-ddns` — which lives in requirements-extended.txt — look missing from an
+    image that never claimed to carry it.
+
+    Comments are not pins. `certbot-dns-namecheap` appears in requirements.txt
+    only inside a comment explaining why it was removed; reading that as an
+    intention to ship would fail on a deliberate exclusion.
+    """
+    pinned = {}
+    for path in [REPO_ROOT / requirements]:
+        if not path.exists():
+            raise SystemExit(f"{path} does not exist — this check cannot tell "
+                             f"a missing plugin from an optional one without it")
+        for number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), 1):
+            match = re.match(r"^([A-Za-z0-9_.-]+)==", line.strip())
+            if not match:
+                continue
+            name = _normalise(match.group(1))
+            if re.match(r"certbot-(dns|plugin)-", name):
+                pinned.setdefault(name, f"{path.name}:{number}")
+    return pinned
+
+
+def _providers():
+    """provider key -> the plugin name its strategy will hand to certbot."""
+    from modules.core.dns_strategies import DNSStrategyFactory
+    from modules.core.utils import _DNS_PROVIDER_CREDENTIALS
+
+    wanted = {}
+    for key in sorted(set(DNSStrategyFactory._strategies) | set(_DNS_PROVIDER_CREDENTIALS)):
+        try:
+            plugin = DNSStrategyFactory.get_strategy(key).plugin_name
+        except Exception as error:                       # pragma: no cover
+            wanted[key] = f"<{type(error).__name__}>"
+            continue
+        wanted[key] = plugin
+    return wanted
+
+
+# Providers that reach their DNS API without a certbot plugin. `manual` is the
+# marker CertMate's own strategies use for these; acme-dns publishes its TXT
+# record through modules/core/dns_alias_hook.py, and http-01 does not use DNS
+# at all.
+NATIVE = {"manual", "acme-dns", "http-01"}
+
+
+def main():
+    requirements = sys.argv[1] if len(sys.argv) > 1 else "requirements.txt"
+    registered = _registered()
+    installed = _installed_plugin_distributions()
+    pinned = _pinned_plugin_distributions(requirements)
+    providers = _providers()
+
+    if not registered:
+        print("no certbot plugins are registered at all — this is not a "
+              "CertMate image, or certbot is broken", file=sys.stderr)
+        return 1
+    if not providers:
+        print("the strategy factory offers no providers — nothing to check",
+              file=sys.stderr)
+        return 1
+
+    failures, unshipped, native = [], [], []
+
+    # A distribution we installed that registers nothing is broken packaging:
+    # the pin says we wanted it, and certbot cannot see it.
+    for name, where in sorted(pinned.items()):
+        if name not in installed:
+            continue
+        if name not in set(registered.values()):
+            failures.append(
+                f"{name} is pinned ({where}) and installed, but registers no "
+                f"certbot plugin — certbot cannot use it")
+
+    # Note on what is NOT a failure: a distribution pinned only in an optional
+    # requirements file is not an intention to ship in this image — the default
+    # build installs requirements.txt alone. Treating any pin as an intention
+    # reported he-ddns, which lives in requirements-extended.txt, as missing
+    # from an image that never claimed to carry it.
+    for key, plugin in sorted(providers.items()):
+        if plugin in NATIVE or plugin.startswith("<"):
+            native.append(f"{key} ({plugin})")
+            continue
+        if plugin in registered:
+            continue
+        # The plugin is missing. Did we mean to ship it?
+        candidate = "certbot-" + plugin
+        # Which distribution would provide this plugin? Derived names are not
+        # always right — `dns-dynu` comes from certbot-dns-dynudns, `dns-ns1`
+        # from certbot-dns-nsone — so the pinned set is searched for one whose
+        # name contains the provider key before falling back to the guess.
+        owner = next((d for d in pinned if key.replace("-", "") in d.replace("-", "")),
+                     candidate)
+        if candidate in installed:
+            failures.append(
+                f"{key}: certbot has no plugin '{plugin}', yet {candidate} is "
+                f"installed — the entry point is named something else, so "
+                f"issuance fails with 'unrecognized arguments'")
+        elif owner in pinned:
+            failures.append(
+                f"{key}: certbot has no plugin '{plugin}', but {owner} is "
+                f"pinned in {requirements} ({pinned[owner]}) — this build was "
+                f"meant to carry it. Issuance fails with 'unrecognized "
+                f"arguments'.")
+        else:
+            unshipped.append(f"{key} (plugin '{plugin}' not installed)")
+
+    print(f"providers offered: {len(providers)}   "
+          f"certbot plugins registered: {len(registered)}")
+    if native:
+        print(f"native, no plugin needed ({len(native)}): {', '.join(native)}")
+    if unshipped:
+        print(f"not carried by this image ({len(unshipped)}):")
+        for item in unshipped:
+            print(f"  {item}")
+    if not failures:
+        print("every provider this image claims to carry can reach certbot")
+        return 0
+    print(f"{len(failures)} problem(s):", file=sys.stderr)
+    for failure in failures:
+        print(f"  {failure}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_providers.py
+++ b/scripts/check_providers.py
@@ -160,16 +160,27 @@ def main():
         if plugin in registered:
             continue
         # The plugin is missing. Did we mean to ship it?
-        candidate = "certbot-" + plugin
-        # Which distribution would provide this plugin? Derived names are not
-        # always right — `dns-dynu` comes from certbot-dns-dynudns, `dns-ns1`
-        # from certbot-dns-nsone — so the pinned set is searched for one whose
-        # name contains the provider key before falling back to the guess.
-        owner = next((d for d in pinned if key.replace("-", "") in d.replace("-", "")),
-                     candidate)
-        if candidate in installed:
+        # Which distribution would provide this plugin? A derived name is only
+        # a guess and is wrong more often than it looks: `dns-dynu` comes from
+        # certbot-dns-dynudns, `dns-ns1` from certbot-dns-nsone, and `edgedns`
+        # from certbot-PLUGIN-edgedns rather than certbot-dns-anything. So the
+        # installed and pinned sets are searched for a distribution matching
+        # the provider key first, and the guess is the last resort — normalised
+        # like everything else, or it could never match either set.
+        #
+        # Using the guess for the "installed" test, as the first version did,
+        # meant the misnamed-entry-point failure could not be detected for any
+        # provider whose distribution is not literally `certbot-<plugin>`
+        # (Copilot, #558).
+        candidate = _normalise("certbot-" + plugin)
+        owner = next(
+            (d for d in list(installed) + list(pinned)
+             if _normalise(key).replace("-", "") in d.replace("-", "")),
+            candidate,
+        )
+        if owner in installed:
             failures.append(
-                f"{key}: certbot has no plugin '{plugin}', yet {candidate} is "
+                f"{key}: certbot has no plugin '{plugin}', yet {owner} is "
                 f"installed — the entry point is named something else, so "
                 f"issuance fails with 'unrecognized arguments'")
         elif owner in pinned:

--- a/tests/test_provider_checker_is_wired.py
+++ b/tests/test_provider_checker_is_wired.py
@@ -1,0 +1,65 @@
+"""The in-image provider check must exist, ship, and be run by something.
+
+`scripts/check_providers.py` asks the built image whether every provider it
+offers can actually reach certbot. It exists because the suite validates that
+path against mocks: nine test files stub `check_certbot_plugin_installed` to
+return True, so the one guard between a configured provider and certbot's
+"unrecognized arguments" is never exercised for real. Infomaniak shipped that
+way — strategy, credentials writer, factory entry, README row, no plugin.
+
+A checker nothing runs is the shape this repository keeps finding, so this
+asserts the wiring rather than the logic. The logic is verified by running it
+against an image with the plugin removed, and against one with its entry point
+renamed; both exit non-zero.
+"""
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check_providers.py"
+CI = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+DOCKERIGNORE = REPO_ROOT / ".dockerignore"
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_the_checker_exists():
+    assert SCRIPT.exists(), "scripts/check_providers.py is gone"
+
+
+def test_ci_runs_it_against_the_built_image():
+    text = CI.read_text(encoding="utf-8")
+    assert "check_providers.py" in text, (
+        "no workflow runs scripts/check_providers.py"
+    )
+    assert re.search(r"docker exec[^\n]*check_providers\.py", text), (
+        "check_providers.py is referenced but not run inside the container. "
+        "Running it on the CI host checks the runner's virtualenv, which is "
+        "not what ships."
+    )
+
+
+def test_ci_passes_the_requirements_file_it_built_from():
+    """Without it the check cannot tell a missing plugin from an optional one."""
+    text = CI.read_text(encoding="utf-8")
+    assert re.search(r"check_providers\.py\s+\"?\$\{?req", text), (
+        "the workflow does not pass the requirements file to the checker. "
+        "Defaulting to requirements.txt while building requirements-minimal "
+        "would report every extended provider as missing."
+    )
+
+
+def test_the_script_ships_in_the_image():
+    """`tests/` is dockerignored; `scripts/` must not be."""
+    if not DOCKERIGNORE.exists():
+        return
+    ignored = [
+        line.strip() for line in DOCKERIGNORE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    assert not any(re.fullmatch(r"scripts/?\*?", entry) for entry in ignored), (
+        "scripts/ is excluded from the image, so the checker cannot run there. "
+        "That is how tests/ ended up unavailable in the container."
+    )


### PR DESCRIPTION
The suite validates the issuance path against mocks. Nine test files stub
`check_certbot_plugin_installed` to return True, so the one guard between a
configured provider and certbot's "unrecognized arguments" is never exercised
against reality.

That is how Infomaniak shipped: a strategy, a credentials writer, a factory
entry, a README row, and no plugin in any image ever published. Nothing was
wrong with the code — the plugin simply was not there, and nothing looked.

`scripts/check_providers.py` looks, inside the artefact rather than in a
developer's virtualenv where the answer is whatever happens to be installed
locally. It needs no test dependencies (the image has no pytest) and no
hand-maintained table of names: the environment says which distribution
provides which certbot plugin, and the requirements file says what the build
was meant to carry. It catches two failure modes, both verified by mutating a
real image:

  infomaniak: certbot has no plugin 'dns-infomaniak', but
  certbot-dns-infomaniak is pinned in requirements.txt (requirements.txt:63) —
  this build was meant to carry it.

  infomaniak: certbot has no plugin 'dns-infomaniak', yet
  certbot-dns-infomaniak is installed — the entry point is named something
  else.

The second is the shape of #364, where porkbun's credential keys did not match
its entry point.

The requirements file is an explicit argument, not a guess: reading every
requirements*.txt made `he-ddns` — which lives in requirements-extended.txt —
look missing from an image that never claimed to carry it. Verified against
both published variants: the default image reports five providers it does not
carry and exits zero; the minimal image reports many more and also exits zero,
because neither was meant to carry them.

Two bugs of mine, found by running it rather than by reading it. It first
reported three problems, all false: I normalised distribution names PEP 503 on
the requirements side and not on the metadata side, so `certbot_dns_porkbun`
never matched `certbot-dns-porkbun` and two working plugins looked broken —
the same mistake the entry-point contract test made before it, which is why
normalisation is one function now, used on both sides.

And the first mutation test said the check did not catch Infomaniak. It did:
`pip uninstall` had failed with PermissionError because the container runs as a
non-root user, so the plugin was never removed and I read the result of a
mutation that never happened.

Suite 2829 passed / 6 skipped.

First item of the validation plan: move the issuance path's provider check out of the mocked suite and into the artefact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)