### PR TITLE
test: drive the acme-dns hook against a real acme-dns, and ask DNS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,6 +481,11 @@ jobs:
           docker exec acmedns-pg pg_isready -U acmedns >/dev/null 2>&1 && break
           sleep 1
         done
+        # The loop above breaks on success and falls through on timeout; say
+        # so here, or the acme-dns container fails later with a less useful
+        # error (Copilot, #560).
+        docker exec acmedns-pg pg_isready -U acmedns >/dev/null 2>&1 \
+          || { echo "postgres never became ready"; docker logs acmedns-pg; exit 1; }
 
         docker run -d --name acmedns --network acmedns-net \
           -p 18053:53/udp -p 18080:8080 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,108 @@ jobs:
           exit 1
         }
 
+  # The acme-dns hook against a real acme-dns, including the DNS answer.
+  #
+  # This is the one path in the product with a documented history of never
+  # having worked: the certbot plugin CertMate used until v2.24.0 exposes no
+  # credentials-file option, so certbot rejected the command line and every
+  # acme-dns issuance failed, in every release that advertised it. The
+  # replacement publishes the TXT record itself and was verified by hand once.
+  # Nothing has verified it since.
+  #
+  # A mock cannot: the failure was an API contract that looked right. So the
+  # suite drives the real hook and then asks DNS whether the record is there —
+  # "the POST returned 200" is exactly what a fake would have told you.
+  #
+  # postgres is not optional: the official acme-dns image is built without the
+  # sqlite driver and dies with `sql: unknown driver "sqlite3"`.
+  acme-dns-live:
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v5
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-test.txt
+
+    - name: Start acme-dns and the postgres it needs
+      run: |
+        set -euo pipefail
+        docker network create acmedns-net
+
+        docker run -d --name acmedns-pg --network acmedns-net \
+          -e POSTGRES_USER=acmedns -e POSTGRES_PASSWORD=acmedns \
+          -e POSTGRES_DB=acmedns \
+          postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
+
+        mkdir -p "$RUNNER_TEMP/acme-dns"
+        # `port` must be quoted: acme-dns parses it as a string and refuses to
+        # start on an int with "incompatible types".
+        cat > "$RUNNER_TEMP/acme-dns/config.cfg" <<'CFG'
+        [general]
+        listen = "0.0.0.0:53"
+        protocol = "both"
+        domain = "auth.test"
+        nsname = "auth.test"
+        nsadmin = "admin.auth.test"
+        records = ["auth.test. A 127.0.0.1", "auth.test. NS auth.test."]
+        debug = false
+        [database]
+        engine = "postgres"
+        connection = "postgres://acmedns:acmedns@acmedns-pg:5432/acmedns?sslmode=disable"
+        [api]
+        ip = "0.0.0.0"
+        port = "8080"
+        tls = "none"
+        corsorigins = ["*"]
+        use_header = false
+        header_name = "X-Forwarded-For"
+        [logconfig]
+        loglevel = "info"
+        logtype = "stdout"
+        logformat = "text"
+        CFG
+
+        for i in $(seq 1 30); do
+          docker exec acmedns-pg pg_isready -U acmedns >/dev/null 2>&1 && break
+          sleep 1
+        done
+
+        docker run -d --name acmedns --network acmedns-net \
+          -p 18053:53/udp -p 18080:8080 \
+          -v "$RUNNER_TEMP/acme-dns:/etc/acme-dns:ro" \
+          joohoi/acme-dns:latest@sha256:8d327df58b1c9f6361c76734f9761a108fa4f12cf7ca94440a0404a28f75de62
+
+        for i in $(seq 1 30); do
+          curl -fsS -X POST http://localhost:18080/register >/dev/null 2>&1 \
+            && { echo "acme-dns up after ${i}s"; exit 0; }
+          sleep 1
+        done
+        echo "::error::acme-dns never became ready"
+        docker logs acmedns 2>&1 | tail -30
+        docker logs acmedns-pg 2>&1 | tail -10
+        exit 1
+
+    - name: Drive the hook and check DNS actually serves the record
+      env:
+        CERTMATE_TEST_ACMEDNS_URL: http://localhost:18080
+        CERTMATE_TEST_ACMEDNS_DNS: 127.0.0.1:18053
+      run: |
+        pytest tests/test_acme_dns_live.py -m live -v | tee /tmp/acmedns.log
+        grep -q "5 passed" /tmp/acmedns.log || {
+          echo "::error::the acme-dns suite did not run the expected tests"
+          exit 1
+        }
+
   # The Tailwind bundle (static/css/tailwind.min.css) is committed to the repo
   # and served as-is — there is no build step at deploy time. So a stale bundle
   # ships silently whenever input.css / tailwind.config.js change without a

--- a/tests/test_acme_dns_checker_is_wired.py
+++ b/tests/test_acme_dns_checker_is_wired.py
@@ -1,0 +1,58 @@
+"""Something must run the acme-dns suite, and against a real server.
+
+acme-dns is the path with the worst precedent in this product: the certbot
+plugin CertMate used until v2.24.0 exposed no credentials-file option, so every
+acme-dns issuance failed in every release that advertised the feature. The
+replacement was verified by hand, once. This is the wiring that keeps it
+verified.
+"""
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+CI = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+SUITE = REPO_ROOT / "tests" / "test_acme_dns_live.py"
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_the_suite_exists():
+    assert SUITE.exists()
+
+
+def test_a_workflow_runs_it():
+    text = CI.read_text(encoding="utf-8")
+    assert "test_acme_dns_live.py" in text, "no workflow runs the acme-dns suite"
+    assert "joohoi/acme-dns" in text, (
+        "the workflow does not start an acme-dns, so the suite would skip — "
+        "which is what it does when its endpoint is unset."
+    )
+
+
+def test_the_workflow_starts_the_database_acme_dns_needs():
+    """The official image is built without the sqlite driver.
+
+    Without postgres it starts, serves DNS, and dies on the first API call
+    with `sql: unknown driver "sqlite3"` — which cost an hour the first time.
+    """
+    text = CI.read_text(encoding="utf-8")
+    assert re.search(r"postgres:\d+", text), (
+        "no postgres in the workflow; acme-dns cannot store an account without "
+        "it and every registration panics."
+    )
+
+
+def test_the_suite_asks_dns_and_not_only_the_api():
+    """The point of the whole exercise.
+
+    A test that stops at "the POST returned 200" is a test a mock would also
+    pass, and passing is exactly what the broken implementation did for
+    releases.
+    """
+    source = SUITE.read_text(encoding="utf-8")
+    assert "dns.resolver" in source, (
+        "the suite no longer queries DNS, so it verifies the call rather than "
+        "the record — the failure mode this exists for."
+    )

--- a/tests/test_acme_dns_live.py
+++ b/tests/test_acme_dns_live.py
@@ -1,0 +1,136 @@
+"""The acme-dns hook against a real acme-dns, including the DNS answer.
+
+acme-dns is the one path in this product with a documented history of never
+having worked: the certbot plugin CertMate used until v2.24.0 exposes no
+credentials-file option at all, so certbot rejected the command line and every
+acme-dns issuance failed — in every release that advertised it. The replacement
+publishes the TXT record itself, and was verified by hand once, against
+acme-dns.io. Nothing has verified it since.
+
+A mock cannot verify it. The whole failure mode was an API contract that looked
+right and was not, so the only test that means anything drives the real hook
+against a real server and then asks DNS whether the record is there. That last
+step is the point: "the POST returned 200" is what a fake would tell you.
+
+    CERTMATE_TEST_ACMEDNS_URL=http://localhost:18080 \\
+    CERTMATE_TEST_ACMEDNS_DNS=127.0.0.1:18053 \\
+    pytest tests/test_acme_dns_live.py -m live
+
+Skipped when unset; failed, never skipped, when set and the server is silent.
+"""
+import base64
+import hashlib
+import json
+import os
+import urllib.error
+import urllib.request
+
+import pytest
+
+from modules.core.dns_alias_hook import DNSAliasError, _acme_dns_change
+
+pytestmark = [pytest.mark.live]
+
+API = os.getenv("CERTMATE_TEST_ACMEDNS_URL")
+DNS = os.getenv("CERTMATE_TEST_ACMEDNS_DNS", "127.0.0.1:18053")
+
+
+def _validation():
+    """43 characters of base64url, which is what ACME actually sends.
+
+    acme-dns rejects anything else with `bad_txt`, and it is right to: the
+    value is a SHA-256 digest of the key authorization. A test that sends a
+    friendly string tests the error path by accident.
+    """
+    digest = hashlib.sha256(os.urandom(32)).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+
+
+@pytest.fixture(scope="module")
+def account():
+    if not API:
+        pytest.skip("CERTMATE_TEST_ACMEDNS_URL not set")
+    try:
+        with urllib.request.urlopen(
+                urllib.request.Request(API.rstrip("/") + "/register", method="POST"),
+                timeout=20) as response:
+            return json.loads(response.read())
+    except Exception as error:
+        pytest.fail(
+            f"{API} is configured but registration failed ({error}). Treating "
+            f"that as a skip is how a suite reports success against a server "
+            f"that never started."
+        )
+
+
+def _txt_records(fqdn):
+    import dns.resolver
+
+    host, _, port = DNS.partition(":")
+    resolver = dns.resolver.Resolver(configure=False)
+    resolver.nameservers = [host]
+    resolver.port = int(port or 53)
+    resolver.lifetime = 15
+    answer = resolver.resolve(fqdn, "TXT")
+    return {b"".join(rdata.strings).decode() for rdata in answer}
+
+
+def _config(account, password=None):
+    return {
+        "domain_alias": account["subdomain"],
+        "config": {
+            "api_url": API,
+            "username": account["username"],
+            "password": password or account["password"],
+            "subdomain": account["subdomain"],
+        },
+    }
+
+
+def test_the_hook_publishes_a_record_dns_will_serve(account):
+    """The whole point: not that the POST succeeded, but that DNS answers."""
+    validation = _validation()
+    _acme_dns_change(_config(account), validation, "create")
+
+    served = _txt_records(account["fulldomain"])
+    assert validation in served, (
+        f"the hook reported success and {account['fulldomain']} serves "
+        f"{served or 'nothing'}. This is the shape of the failure that made "
+        f"acme-dns unusable in every release before v2.24.1: the call looked "
+        f"fine and no record existed."
+    )
+
+
+def test_a_second_validation_replaces_the_first(account):
+    """A renewal issues a new challenge against the same subdomain."""
+    first, second = _validation(), _validation()
+    _acme_dns_change(_config(account), first, "create")
+    _acme_dns_change(_config(account), second, "create")
+    served = _txt_records(account["fulldomain"])
+    assert second in served, "the newest validation is not being served"
+
+
+def test_wrong_credentials_are_refused_rather_than_ignored(account):
+    """A silently-ignored rejection is an issuance that fails much later."""
+    with pytest.raises(DNSAliasError) as error:
+        _acme_dns_change(_config(account, password="not-the-password"),
+                         _validation(), "create")
+    assert "401" in str(error.value) or "forbidden" in str(error.value).lower()
+
+
+def test_a_mismatched_alias_is_caught_before_the_network(account):
+    """CertMate's own guard: the alias must be the registered subdomain."""
+    config = _config(account)
+    config["domain_alias"] = "someone-elses-subdomain"
+    with pytest.raises(DNSAliasError) as error:
+        _acme_dns_change(config, _validation(), "create")
+    assert "must match" in str(error.value)
+
+
+def test_delete_is_a_no_op(account):
+    """acme-dns has no delete: the record is replaced, never removed.
+
+    Pinned because a hook that raised here would fail certbot's cleanup phase
+    and leave every issuance reporting an error after a successful validation.
+    """
+    assert _acme_dns_change(_config(account), _validation(), "delete") is None

--- a/tests/test_acme_dns_live.py
+++ b/tests/test_acme_dns_live.py
@@ -101,13 +101,26 @@ def test_the_hook_publishes_a_record_dns_will_serve(account):
     )
 
 
-def test_a_second_validation_replaces_the_first(account):
-    """A renewal issues a new challenge against the same subdomain."""
-    first, second = _validation(), _validation()
+def test_acme_dns_keeps_the_last_two_validations_and_drops_the_third_oldest(account):
+    """acme-dns serves the two most recent TXT values by design: an order for
+    ``example.com`` + ``*.example.com`` needs two challenges live on the same
+    subdomain at once. So a second validation does not replace the first — it
+    joins it — and only a third pushes the first out. Asserting both halves is
+    what distinguishes "the hook updates the record" from "the newest value
+    happens to be present" (Copilot, #560)."""
+    first, second, third = _validation(), _validation(), _validation()
     _acme_dns_change(_config(account), first, "create")
     _acme_dns_change(_config(account), second, "create")
     served = _txt_records(account["fulldomain"])
-    assert second in served, "the newest validation is not being served"
+    assert first in served and second in served, (
+        f"after two updates acme-dns should serve both values, got {served}")
+
+    _acme_dns_change(_config(account), third, "create")
+    served = _txt_records(account["fulldomain"])
+    assert third in served and second in served, (
+        f"the two newest validations are not both served: {served}")
+    assert first not in served, (
+        f"the oldest validation is still served after two newer ones: {served}")
 
 
 def test_wrong_credentials_are_refused_rather_than_ignored(account):


### PR DESCRIPTION
Third item of the validation plan, and the path with the worst precedent in
this product. The certbot plugin CertMate used until v2.24.0 exposes no
credentials-file option at all, so certbot rejected the command line and every
acme-dns issuance failed — in every release that advertised the feature. The
replacement publishes the TXT record itself and was verified by hand once,
against acme-dns.io. Nothing has verified it since.

A mock cannot verify it. The failure was an API contract that looked right, so
the only test worth writing drives the real hook and then asks DNS whether the
record is there. That last step is the whole point: "the POST returned 200" is
what a fake would have told you, and is what the broken implementation
effectively said for releases.

Five tests: the record is served and matches, a second validation replaces the
first (a renewal against the same subdomain), wrong credentials are refused
rather than ignored, a mismatched alias is caught before the network, and
delete is a no-op — acme-dns has no delete, and a hook that raised there would
fail certbot's cleanup after a successful validation.

The suite skips when its endpoint is unset and **fails** when it is set and the
server is silent; the job asserts the test count too. Three things learned the
hard way while building it, all recorded in the workflow:

- acme-dns needs postgres. The official image is built without the sqlite
  driver and dies on the first API call with `sql: unknown driver "sqlite3"`.
- its `port` must be quoted in the config, or it refuses to start on
  "incompatible types: TOML value has type int64".
- acme-dns rejects a TXT that is not exactly 43 characters — the length of a
  base64url SHA-256 digest — so a test that sends a friendly string tests the
  error path by accident. The suite generates real validation values.

Both image digests were read from the registry and are not the invented ones I
nearly shipped in the storage PR.

Suite 2833 passed / 6 skipped; 5 passed live against a real acme-dns, verified
by querying its DNS on port 18053.

Third item of the validation plan, after #558 and #559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)