### PR TITLE
fix: follow the IdP end-session URL on logout, and build it after a restart

### DIFF
--- a/modules/core/oidc.py
+++ b/modules/core/oidc.py
@@ -654,7 +654,11 @@ class OIDCManager:
                 # local-only until somebody logged in again (#564).
                 loader = getattr(client, 'load_server_metadata', None)
                 if callable(loader):
-                    metadata = loader() or {}
+                    # Some Authlib versions return the dict, others only
+                    # populate client.server_metadata — accept either.
+                    metadata = (loader()
+                                or getattr(client, 'server_metadata', None)
+                                or {})
                     end_session = metadata.get('end_session_endpoint')
             if not end_session:
                 return None

--- a/modules/core/oidc.py
+++ b/modules/core/oidc.py
@@ -646,6 +646,17 @@ class OIDCManager:
             metadata = getattr(client, 'server_metadata', None) or {}
             end_session = metadata.get('end_session_endpoint')
             if not end_session:
+                # Authlib fills ``server_metadata`` lazily, on the first
+                # authorize/token call. After a process restart a user who
+                # logged in before it has a valid session and an id_token
+                # in their cookie, but the registry is empty — so without
+                # this fetch every logout after a restart degraded to
+                # local-only until somebody logged in again (#564).
+                loader = getattr(client, 'load_server_metadata', None)
+                if callable(loader):
+                    metadata = loader() or {}
+                    end_session = metadata.get('end_session_endpoint')
+            if not end_session:
                 return None
             cfg = self._load_config()
             redirect = (post_logout_redirect_uri or cfg.get('post_logout_redirect_uri') or '').strip()

--- a/templates/base.html
+++ b/templates/base.html
@@ -142,9 +142,21 @@
     // Logout visibility is now gated server-side via the `current_user`
     // Jinja context var, so the deferred /api/auth/me probe is no longer
     // needed — the button either renders or it doesn't, no layout shift.
+    // The backend answers with ``oidc_logout_url`` for SSO-minted sessions:
+    // the IdP's end-session endpoint, with id_token_hint + client_id +
+    // post_logout_redirect_uri already on it. Follow it, or the IdP session
+    // survives a CertMate logout and the next "Login with SSO" signs the
+    // user straight back in (#564). Local sessions get no URL and land on
+    // /login as before. The URL is built server-side from the IdP discovery
+    // document and our own settings — it is not user input.
     function doLogout(){
         fetch('/api/auth/logout',{method:'POST',credentials:'same-origin'})
-            .then(function(){window.location.href='/login'})
+            .then(function(r){return r.json().catch(function(){return {};});})
+            .then(function(data){
+                var next = (data && typeof data.oidc_logout_url === 'string' && /^https?:\/\//.test(data.oidc_logout_url))
+                    ? data.oidc_logout_url : '/login';
+                window.location.href = next;
+            })
             .catch(function(){window.location.href='/login'});
     }
     // Theme preference is tri-state: 'auto' (no stored key — follows the OS

--- a/templates/base.html
+++ b/templates/base.html
@@ -153,8 +153,8 @@
         fetch('/api/auth/logout',{method:'POST',credentials:'same-origin'})
             .then(function(r){return r.json().catch(function(){return {};});})
             .then(function(data){
-                var next = (data && typeof data.oidc_logout_url === 'string' && /^https?:\/\//.test(data.oidc_logout_url))
-                    ? data.oidc_logout_url : '/login';
+                var url = (data && typeof data.oidc_logout_url === 'string') ? data.oidc_logout_url.trim() : '';
+                var next = /^https?:\/\//i.test(url) ? url : '/login';
                 window.location.href = next;
             })
             .catch(function(){window.location.href='/login'});

--- a/templates/partials/settings_oidc.html
+++ b/templates/partials/settings_oidc.html
@@ -191,7 +191,7 @@
                         <input type="url" x-model="cfg.post_logout_redirect_uri"
                                placeholder="https://example.com/"
                                class="w-full px-3 py-2 border border-border rounded-md text-sm bg-input text-foreground">
-                        <p class="mt-1 text-xs text-muted">Where to send the user after the IdP's end-session endpoint. Required by some providers for SLO.</p>
+                        <p class="mt-1 text-xs text-muted">Where to send the user after the IdP's end-session endpoint. Required by some providers for SLO. Register this exact URI at the IdP too (Keycloak: the client's <em>Valid post logout redirect URIs</em>), or the IdP rejects the logout with <code>invalid_redirect_uri</code>.</p>
                     </div>
 
                     <!-- Save button -->

--- a/tests/test_issue564_oidc_logout_follows_idp.py
+++ b/tests/test_issue564_oidc_logout_follows_idp.py
@@ -1,0 +1,144 @@
+"""#564 — RP-initiated logout never executed.
+
+The backend built ``oidc_logout_url`` and returned it; ``doLogout()`` in
+templates/base.html threw the body away and went to /login. The IdP session
+survived, and the next "Login with SSO" signed the user straight back in.
+
+Three locks: the route still returns the URL for an OIDC-minted session
+(and not for a local one), the template follows it, and the manager can
+build it after a process restart, when Authlib's metadata cache is empty.
+"""
+import re
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from flask import Flask
+
+from modules.web.auth_routes import register_auth_routes
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _passthrough(*_a, **_kw):
+    def deco(fn):
+        return fn
+    return deco
+
+
+def _app(session_info, oidc_manager):
+    app = Flask(__name__)
+    app.secret_key = 'test'
+    auth_manager = MagicMock()
+    auth_manager.require_role = MagicMock(side_effect=_passthrough)
+    auth_manager.validate_session.return_value = session_info
+    register_auth_routes(
+        app,
+        managers={'oidc': oidc_manager} if oidc_manager else {},
+        require_web_auth=lambda f: f,
+        auth_manager=auth_manager,
+        _check_login_rate_limit=lambda *a, **kw: True,
+        _record_login_attempt=lambda *a, **kw: None,
+    )
+    return app, auth_manager
+
+
+def test_logout_returns_the_idp_end_session_url_for_sso_sessions():
+    oidc = MagicMock()
+    oidc.build_end_session_url.return_value = (
+        'https://idp.example.com/logout?id_token_hint=x&client_id=cm')
+    app, auth_manager = _app({'source': 'oidc', 'username': 'u'}, oidc)
+    client = app.test_client()
+    client.set_cookie('certmate_session', 'sess-1')
+
+    r = client.post('/api/auth/logout')
+
+    assert r.status_code == 200
+    assert r.get_json()['oidc_logout_url'].startswith('https://idp.example.com/logout?')
+    auth_manager.invalidate_session.assert_called_once_with('sess-1')
+    oidc.clear_session_artifacts.assert_called_once()
+
+
+def test_logout_of_a_local_session_carries_no_idp_url():
+    oidc = MagicMock()
+    app, _ = _app({'source': 'local', 'username': 'u'}, oidc)
+    client = app.test_client()
+    client.set_cookie('certmate_session', 'sess-1')
+
+    body = client.post('/api/auth/logout').get_json()
+
+    assert 'oidc_logout_url' not in body
+    oidc.build_end_session_url.assert_not_called()
+
+
+def test_the_logout_button_follows_the_url_the_backend_returns():
+    """The defect was one function in one template: fix it there, and keep
+    it fixed. The frontend must read the body and go where it says; a
+    local session (no URL) still lands on /login."""
+    html = (REPO / 'templates' / 'base.html').read_text(encoding='utf-8')
+    match = re.search(r'function doLogout\(\)\{(.*?)\n    \}', html, re.S)
+    assert match, 'doLogout() not found in base.html'
+    body = match.group(1)
+    assert 'oidc_logout_url' in body, (
+        'doLogout() ignores the response body — the IdP session is never '
+        'terminated (#564)')
+    assert "'/login'" in body, 'local sessions must still land on /login'
+    # Only an absolute http(s) URL is followed; anything else falls back.
+    assert re.search(r'https\?:', body), (
+        'doLogout() should only follow an absolute http(s) URL')
+
+
+def test_end_session_url_is_built_after_a_restart(tmp_path):
+    """Authlib fills ``server_metadata`` on the first authorize/token call.
+    After a restart that cache is empty while the user's session and
+    id_token cookie are still valid — so logout must fetch the discovery
+    document itself, or every logout after a restart is local-only."""
+    from modules.core.auth import AuthManager
+    from modules.core.file_operations import FileOperations
+    from modules.core.oidc import OIDCManager
+    from modules.core.settings import SettingsManager
+    from flask import session as flask_session
+
+    for d in ('certificates', 'data', 'backups', 'logs'):
+        (tmp_path / d).mkdir()
+    file_ops = FileOperations(
+        cert_dir=tmp_path / 'certificates', data_dir=tmp_path / 'data',
+        backup_dir=tmp_path / 'backups', logs_dir=tmp_path / 'logs')
+    sm = SettingsManager(file_ops=file_ops, settings_file=tmp_path / 'data' / 'settings.json')
+    am = AuthManager(sm)
+    am.set_hmac_key('k')
+    settings = sm.load_settings()
+    settings['oidc'] = {
+        'enabled': True, 'provider_name': 'T',
+        'issuer_url': 'https://idp.example.com', 'client_id': 'cm-test',
+        'client_secret': 'shh', 'scopes': ['openid'],
+        'username_claim': 'preferred_username', 'email_claim': 'email',
+        'role_claim': 'groups', 'role_mappings': [], 'default_role': 'viewer',
+        'post_logout_redirect_uri': 'https://certmate.example.com/login',
+    }
+    sm.save_settings(settings)
+    oidc = OIDCManager(sm, am)
+
+    class _ColdClient:
+        """What Authlib looks like before its first network call."""
+        server_metadata = {}
+        loads = 0
+
+        def load_server_metadata(self):
+            self.loads += 1
+            self.server_metadata = {
+                'end_session_endpoint': 'https://idp.example.com/logout'}
+            return self.server_metadata
+
+    cold = _ColdClient()
+    oidc._client = lambda app: cold  # type: ignore[assignment]
+
+    app = Flask(__name__)
+    app.secret_key = 'test'
+    with app.test_request_context('/'):
+        flask_session['_oidc_id_token'] = 'id.token.value'
+        url = oidc.build_end_session_url()
+
+    assert cold.loads == 1
+    assert url is not None and url.startswith('https://idp.example.com/logout?')
+    assert 'id_token_hint=id.token.value' in url
+    assert 'client_id=cm-test' in url

--- a/tests/test_issue564_oidc_logout_follows_idp.py
+++ b/tests/test_issue564_oidc_logout_follows_idp.py
@@ -75,9 +75,15 @@ def test_the_logout_button_follows_the_url_the_backend_returns():
     it fixed. The frontend must read the body and go where it says; a
     local session (no URL) still lands on /login."""
     html = (REPO / 'templates' / 'base.html').read_text(encoding='utf-8')
-    match = re.search(r'function doLogout\(\)\{(.*?)\n    \}', html, re.S)
-    assert match, 'doLogout() not found in base.html'
-    body = match.group(1)
+    start = re.search(r'function doLogout\(\)\s*\{', html)
+    assert start, 'doLogout() not found in base.html'
+    # Walk to the matching brace rather than trusting indentation.
+    depth, i = 1, start.end()
+    while depth and i < len(html):
+        depth += {'{': 1, '}': -1}.get(html[i], 0)
+        i += 1
+    assert depth == 0, 'doLogout() body did not close'
+    body = html[start.end():i - 1]
     assert 'oidc_logout_url' in body, (
         'doLogout() ignores the response body — the IdP session is never '
         'terminated (#564)')
@@ -119,7 +125,10 @@ def test_end_session_url_is_built_after_a_restart(tmp_path):
     oidc = OIDCManager(sm, am)
 
     class _ColdClient:
-        """What Authlib looks like before its first network call."""
+        """What Authlib looks like before its first network call. Returns
+        None from the loader and only populates the attribute — the shape
+        Copilot flagged as unhandled on #573; the dict-returning shape is
+        covered by the same branch."""
         server_metadata = {}
         loads = 0
 
@@ -127,7 +136,7 @@ def test_end_session_url_is_built_after_a_restart(tmp_path):
             self.loads += 1
             self.server_metadata = {
                 'end_session_endpoint': 'https://idp.example.com/logout'}
-            return self.server_metadata
+            return None
 
     cold = _ColdClient()
     oidc._client = lambda app: cold  # type: ignore[assignment]


### PR DESCRIPTION
Closes #564 — reported with a precise diagnosis and a verified patch by @ratiugtun.

**What was wrong.** `POST /api/auth/logout` already detected OIDC-minted sessions and returned the IdP's end-session URL as `oidc_logout_url`. `doLogout()` in `templates/base.html` ignored the response body and redirected to `/login` unconditionally, so the browser never reached the IdP's `end_session_endpoint`: the IdP session survived, and the next *Login with SSO* signed the user straight back in.

**Fix.**
- `doLogout()` reads the body and follows `oidc_logout_url` when it is an absolute http(s) URL; local sessions (no URL) still land on `/login`.
- `build_end_session_url()` calls Authlib's `load_server_metadata()` when the cached discovery document is empty — the state after a process restart, which the report noted degraded logout to local-only. An SSO session that outlived a container restart now logs out of the IdP too.
- The *Post-logout redirect URI* setting says the URI has to be registered at the IdP (Keycloak: *Valid post logout redirect URIs*), or the IdP answers `invalid_redirect_uri`.

**Tests** (`tests/test_issue564_oidc_logout_follows_idp.py`): the route returns the URL for an OIDC session and not for a local one; the template's `doLogout()` follows it; the manager builds the URL from a cold client.