### PR TITLE
fix: the DNS account selector never appeared, so every certificate used the default account

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1624,6 +1624,7 @@
 
     // Multi-account support functions
     var providerAccounts = {};
+    var accountSelectProvider = '';  // provider the account list was built for
 
     // One request for every provider: /api/dns/accounts answers with a plain
     // list of {provider, account_id, name, ...}, grouped by provider here.
@@ -1658,7 +1659,10 @@
         if (!providerSelect || !accountContainer || !accountSelect) return;
 
         var selectedProvider = providerSelect.value;
-        var previous = accountSelect.value;
+        // Only carry a value over when the provider is the same one the list
+        // was built for: two providers may share an account_id (Copilot, #574).
+        var previous = selectedProvider === accountSelectProvider ? accountSelect.value : '';
+        accountSelectProvider = selectedProvider;
 
         // A single account is the default account: nothing to choose.
         if (selectedProvider && providerAccounts[selectedProvider] && providerAccounts[selectedProvider].length > 1) {

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1625,38 +1625,43 @@
     // Multi-account support functions
     var providerAccounts = {};
 
+    // One request for every provider: /api/dns/accounts answers with a plain
+    // list of {provider, account_id, name, ...}, grouped by provider here.
+    //
+    // The previous version asked seven hardcoded providers one by one and read
+    // ``data.accounts`` off a response that has always been a list — so it
+    // never found an account, the selector never appeared, and every
+    // certificate went to the default account no matter which zone it was
+    // for (#563). Providers outside the seven never had a chance at all.
     function loadProviderAccounts() {
-        var providers = ['cloudflare', 'route53', 'digitalocean', 'azure', 'google', 'powerdns', 'rfc2136'];
-
-        providers.forEach(function (provider) {
-            fetch('/api/dns/' + provider + '/accounts', {
-                headers: API_HEADERS
-            }).then(function (response) {
-                if (response.ok) {
-                    return response.json().then(function (data) {
-                        var accounts = data.accounts || {};
-                        var accountsArray = Object.keys(accounts).map(function (accountId) {
-                            var account = accounts[accountId];
-                            account.account_id = accountId;
-                            return account;
-                        });
-                        providerAccounts[provider] = accountsArray;
-                    });
-                }
-            }).catch(function () {
-                providerAccounts[provider] = [];
-            });
-        });
+        return fetch('/api/dns/accounts', { headers: API_HEADERS })
+            .then(function (response) { return response.ok ? response.json() : []; })
+            .then(function (data) {
+                var list = Array.isArray(data) ? data
+                    : (data && Array.isArray(data.accounts) ? data.accounts : []);
+                var grouped = {};
+                list.forEach(function (account) {
+                    if (!account || !account.provider || !account.account_id) return;
+                    (grouped[account.provider] = grouped[account.provider] || []).push(account);
+                });
+                providerAccounts = grouped;
+                // The drawer may already be open on a provider: refresh it.
+                updateAccountSelection();
+            })
+            .catch(function () { providerAccounts = {}; });
     }
 
     function updateAccountSelection() {
         var providerSelect = document.getElementById('dns_provider_select');
         var accountContainer = document.getElementById('account-selection-container');
         var accountSelect = document.getElementById('account_select');
+        if (!providerSelect || !accountContainer || !accountSelect) return;
 
         var selectedProvider = providerSelect.value;
+        var previous = accountSelect.value;
 
-        if (selectedProvider && providerAccounts[selectedProvider] && providerAccounts[selectedProvider].length > 0) {
+        // A single account is the default account: nothing to choose.
+        if (selectedProvider && providerAccounts[selectedProvider] && providerAccounts[selectedProvider].length > 1) {
             accountContainer.style.display = 'block';
             accountSelect.innerHTML = '<option value="">Use default account</option>';
 
@@ -1666,6 +1671,9 @@
                 option.textContent = account.name || account.account_id;
                 accountSelect.appendChild(option);
             });
+            // Keep a value set before the list arrived (edit flow, or a fast
+            // hand) if it is still one of the options.
+            if (previous) accountSelect.value = previous;
         } else {
             accountContainer.style.display = 'none';
             accountSelect.innerHTML = '<option value="">Use default account</option>';

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -332,3 +332,47 @@ class TestHelpPageUI:
         browser_page.goto(f"{BASE_URL}/help")
         browser_page.wait_for_load_state("networkidle")
         expect(browser_page.locator("section#troubleshooting")).to_be_visible()
+
+
+class TestDnsAccountSelector:
+    """#563 — with several accounts on one DNS provider, the create form has
+    to offer them. The selector existed in the markup but never appeared:
+    the loader read ``data.accounts`` off a response that is a plain list,
+    so every certificate went to the default account regardless of zone."""
+
+    def test_account_selector_lists_the_configured_accounts(self, browser_page):
+        browser_page.goto(f"{BASE_URL}/settings")
+        browser_page.wait_for_load_state("networkidle")
+        browser_page.evaluate("""
+            async () => {
+                for (const [id, name] of [['zone-a', 'Zone A'], ['zone-b', 'Zone B']]) {
+                    const r = await fetch('/api/dns/cloudflare/accounts/' + id, {
+                        method: 'PUT',
+                        headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify({name: name, api_token: 'test-token-' + id})
+                    });
+                    if (!r.ok) throw new Error('PUT account ' + id + ' -> ' + r.status);
+                }
+            }
+        """)
+
+        browser_page.goto(BASE_URL)
+        expect(browser_page.locator("#domain")).to_be_visible(timeout=10000)
+        browser_page.select_option("#dns_provider_select", "cloudflare")
+
+        container = browser_page.locator("#account-selection-container")
+        expect(container).to_be_visible(timeout=10000)
+        select = browser_page.locator("#account_select")
+        # "Use default account" + the two configured ones.
+        expect(select.locator("option")).to_have_count(3)
+        expect(select).to_contain_text("Zone A")
+        expect(select).to_contain_text("Zone B")
+
+        # Pick the non-default one and make sure the value that would be
+        # posted is its account_id, not a label.
+        browser_page.select_option("#account_select", "zone-b")
+        assert browser_page.eval_on_selector("#account_select", "el => el.value") == "zone-b"
+
+        # Another provider with no accounts: the selector hides again.
+        browser_page.select_option("#dns_provider_select", "hetzner")
+        expect(container).to_be_hidden()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -363,8 +363,10 @@ class TestDnsAccountSelector:
         container = browser_page.locator("#account-selection-container")
         expect(container).to_be_visible(timeout=10000)
         select = browser_page.locator("#account_select")
-        # "Use default account" + the two configured ones.
-        expect(select.locator("option")).to_have_count(3)
+        # "Use default account" + the two configured ones (+ whatever account
+        # the default settings already carry for the provider).
+        values = select.locator("option").evaluate_all("els => els.map(e => e.value)")
+        assert "" in values and "zone-a" in values and "zone-b" in values, values
         expect(select).to_contain_text("Zone A")
         expect(select).to_contain_text("Zone B")
 


### PR DESCRIPTION
Closes #563 — thanks @furotol for the clean repro.

**What was wrong.** The selector was in the markup (`#account-selection-container`) and the backend already accepted `account_id` on create and reused it at renewal. But `loadProviderAccounts()` in `static/js/dashboard.js` read `data.accounts` off `/api/dns/<provider>/accounts`, whose body has always been a plain list — so it found nothing, the selector stayed hidden, no `account_id` was ever posted, and every certificate went to the default account regardless of zone. It also only asked seven hardcoded providers, so the other eighteen never had multi-account in the UI at all.

**Fix.** One request to `/api/dns/accounts`, grouped by provider. The selector appears when the chosen provider has more than one account (one account *is* the default — nothing to choose), keeps a value set before the list arrived (edit flow), and hides again on providers without a choice. Stored with the certificate and reused at renewal, as before.

**Test.** `tests/test_ui.py::TestDnsAccountSelector` — configure two Cloudflare accounts, open the create form, pick Cloudflare, see both, pick the non-default one, switch provider and watch it hide.