### PR TITLE
fix: the client-cert list keeps its filter, opens on Active, and offers the .pfx the API already serves

### DIFF
--- a/static/js/client-certs.js
+++ b/static/js/client-certs.js
@@ -12,10 +12,47 @@
     var ccCurrentStatus = '';  // '' = all — driven by the status filter chips
     var _initialized = false;
 
+    // The chips are remembered across page loads, and "Active" is the
+    // starting point: a client CA accumulates revoked and short-lived
+    // certificates quickly, and a list that opens on all of them — and
+    // snapped back to all of them after every revoke — meant re-clicking
+    // the same chip between each action (#562).
+    var CC_FILTER_KEY = 'certmate.clientCerts.filters';
+
+    function ccRememberFilters() {
+        try {
+            localStorage.setItem(CC_FILTER_KEY, JSON.stringify({ status: ccCurrentStatus, usage: ccCurrentUsage }));
+        } catch (e) { /* private mode / quota: a preference, not a feature */ }
+    }
+
+    function ccRestoreFilters() {
+        var status = 'active', usage = '';
+        try {
+            var saved = JSON.parse(localStorage.getItem(CC_FILTER_KEY) || 'null');
+            if (saved && typeof saved === 'object') {
+                if (['', 'active', 'revoked'].indexOf(saved.status) !== -1) status = saved.status;
+                if (typeof saved.usage === 'string') usage = saved.usage;
+            }
+        } catch (e) { /* fall through to the defaults */ }
+        ccCurrentStatus = status;
+        ccCurrentUsage = usage;
+        ccPressChips();
+    }
+
+    function ccPressChips() {
+        document.querySelectorAll('[data-cc-status-chip]').forEach(function (chip) {
+            chip.setAttribute('aria-pressed', chip.getAttribute('data-cc-status-chip') === ccCurrentStatus ? 'true' : 'false');
+        });
+        document.querySelectorAll('[data-cc-usage-chip]').forEach(function (chip) {
+            chip.setAttribute('aria-pressed', chip.getAttribute('data-cc-usage-chip') === ccCurrentUsage ? 'true' : 'false');
+        });
+    }
+
     // Public init — called when client tab becomes visible
     window.initClientCerts = function() {
         if (_initialized) return;
         _initialized = true;
+        ccRestoreFilters();
         ccLoadStatistics();
         ccLoadCertificates();
         ccSetupEventListeners();
@@ -82,11 +119,20 @@
             .catch(function(e) { console.error('Error loading client cert statistics:', e); });
     }
 
+    // Every (re)load applies the current chips, so a revoke or renew that
+    // refreshes the list lands back in the same view (#562).
     function ccLoadCertificates() {
+        var usage = ccCurrentUsage;
+        var status = ccCurrentStatus;
         fetch('/api/client-certs')
             .then(function(r) { return r.json(); })
             .then(function(data) {
-                certificatesData = data.certificates || [];
+                var all = data.certificates || [];
+                certificatesData = all.filter(function(cert) {
+                    var matchUsage = !usage || cert.cert_usage === usage;
+                    var matchStatus = !status || (status === 'active' && !cert.revoked) || (status === 'revoked' && cert.revoked);
+                    return matchUsage && matchStatus;
+                });
                 ccRenderCertificates();
             })
             .catch(function(e) { console.error('Error loading client certificates:', e); });
@@ -352,16 +398,14 @@
     // rest reset. ccCurrent{Status,Usage} are the source of truth read below.
     function ccSetStatusFilter(value) {
         ccCurrentStatus = value;
-        document.querySelectorAll('[data-cc-status-chip]').forEach(function (chip) {
-            chip.setAttribute('aria-pressed', chip.getAttribute('data-cc-status-chip') === value ? 'true' : 'false');
-        });
+        ccPressChips();
+        ccRememberFilters();
         ccFilterCertificates();
     }
     function ccSetUsageFilter(value) {
         ccCurrentUsage = value;
-        document.querySelectorAll('[data-cc-usage-chip]').forEach(function (chip) {
-            chip.setAttribute('aria-pressed', chip.getAttribute('data-cc-usage-chip') === value ? 'true' : 'false');
-        });
+        ccPressChips();
+        ccRememberFilters();
         ccFilterCertificates();
     }
     function ccRefresh() {
@@ -372,24 +416,10 @@
     window.ccSetUsageFilter = ccSetUsageFilter;
     window.ccRefresh = ccRefresh;
 
+    // Free-text CN/email search lives in the global ⌘K palette; the chips are
+    // applied by the loader itself.
     function ccFilterCertificates() {
-        var usage = ccCurrentUsage;
-        var status = ccCurrentStatus;
-
-        // Re-fetch original data and filter (free-text CN/email search now lives
-        // in the global ⌘K palette).
-        fetch('/api/client-certs')
-            .then(function(r) { return r.json(); })
-            .then(function(data) {
-                var all = data.certificates || [];
-                certificatesData = all.filter(function(cert) {
-                    var matchUsage = !usage || cert.cert_usage === usage;
-                    var matchStatus = !status || (status === 'active' && !cert.revoked) || (status === 'revoked' && cert.revoked);
-                    return matchUsage && matchStatus;
-                });
-                ccRenderCertificates();
-            })
-            .catch(function(e) { console.error('Error filtering client certificates:', e); });
+        ccLoadCertificates();
     }
 
     function ccShowCertDetails(id) {
@@ -451,11 +481,33 @@
         }
     });
 
+    // Fetch, then hand the bytes to the browser: a refusal (no PFX password
+    // configured, viewer role on .key/.pfx) comes back as a toast with the
+    // server's reason instead of a bare JSON error page (#561).
     window.downloadCertFile = function(type) {
         if (!currentCertId) return;
         if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(currentCertId)) return;
-        if (['crt', 'key', 'csr'].indexOf(type) === -1) return;
-        window.location.href = '/api/client-certs/' + encodeURIComponent(currentCertId) + '/download/' + encodeURIComponent(type);
+        if (['crt', 'key', 'csr', 'pfx'].indexOf(type) === -1) return;
+        var id = currentCertId;
+        var url = '/api/client-certs/' + encodeURIComponent(id) + '/download/' + encodeURIComponent(type);
+        fetch(url, { credentials: 'same-origin' })
+            .then(function(r) {
+                if (r.ok) return r.blob().then(function(blob) {
+                    var a = document.createElement('a');
+                    var href = URL.createObjectURL(blob);
+                    a.href = href;
+                    a.download = id + '.' + type;
+                    document.body.appendChild(a);
+                    a.click();
+                    a.remove();
+                    setTimeout(function() { URL.revokeObjectURL(href); }, 1000);
+                });
+                return r.json().catch(function() { return {}; }).then(function(body) {
+                    var reason = (body && (body.message || body.error)) || ('HTTP ' + r.status);
+                    CertMate.toast(reason, 'error');
+                });
+            })
+            .catch(function() { CertMate.toast('Download failed', 'error'); });
     };
 
     function ccRevokeCert(id) {

--- a/static/js/client-certs.js
+++ b/static/js/client-certs.js
@@ -17,7 +17,7 @@
     // certificates quickly, and a list that opens on all of them — and
     // snapped back to all of them after every revoke — meant re-clicking
     // the same chip between each action (#562).
-    var CC_FILTER_KEY = 'certmate.clientCerts.filters';
+    var CC_FILTER_KEY = 'cm.clientTab.filters';
 
     function ccRememberFilters() {
         try {

--- a/templates/partials/_client_certs.html
+++ b/templates/partials/_client_certs.html
@@ -84,6 +84,9 @@
             <button type="button" onclick="downloadCertFile('csr')" aria-label="Download CSR file" class="btn btn-secondary flex-1 min-w-[6rem]">
                 <i class="fas fa-download mr-1.5"></i> .csr
             </button>
+            <button type="button" onclick="downloadCertFile('pfx')" aria-label="Download PKCS#12 bundle (certificate and private key, encrypted with the PFX password from Settings)" title="PKCS#12 bundle for Windows / browsers — encrypted with the PFX password set in Settings → General" class="btn btn-secondary flex-1 min-w-[6rem] text-warning-fg">
+                <i class="fas fa-file-archive mr-1.5"></i> .pfx
+            </button>
         </div>
     </div>
 </div>

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -387,6 +387,7 @@ class TestClientCertListKeepsItsFilter:
         expect(active_chip).to_have_attribute("aria-pressed", "true")
         # Assert on our two identifiers, not on a global count: the container
         # is session-scoped and other tests may leave certificates behind.
+
         def row(identifier):
             return browser_page.locator(
                 '#certTableBody button[data-cc-action="details"][data-id="%s"]' % identifier)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -343,10 +343,12 @@ class TestClientCertListKeepsItsFilter:
     def _open_client_tab(self, page):
         page.goto(BASE_URL)
         page.wait_for_load_state("domcontentloaded")
-        page.wait_for_timeout(1500)
-        client_btn = page.locator("text=Client Certificates").first
+        # The server/client segmented control is Alpine-bound; give the
+        # deferred x-data a moment, then switch to the client view.
+        client_btn = page.locator("#certViewClientBtn")
         expect(client_btn).to_be_visible(timeout=10000)
         client_btn.click()
+        expect(client_btn).to_have_attribute("aria-pressed", "true", timeout=10000)
         page.wait_for_timeout(800)
 
     def test_active_is_the_view_and_it_survives_refresh_and_reload(self, browser_page):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -332,3 +332,73 @@ class TestHelpPageUI:
         browser_page.goto(f"{BASE_URL}/help")
         browser_page.wait_for_load_state("networkidle")
         expect(browser_page.locator("section#troubleshooting")).to_be_visible()
+
+
+class TestClientCertListKeepsItsFilter:
+    """#562 / #561 — the client list opens on Active, keeps that view across
+    a refresh (the post-revoke reload used to snap back to All), remembers
+    it across page loads, and the details panel offers the .pfx bundle the
+    API has served since v2.24.0 but the UI never exposed."""
+
+    def _open_client_tab(self, page):
+        page.goto(BASE_URL)
+        page.wait_for_load_state("domcontentloaded")
+        page.wait_for_timeout(1500)
+        client_btn = page.locator("text=Client Certificates").first
+        expect(client_btn).to_be_visible(timeout=10000)
+        client_btn.click()
+        page.wait_for_timeout(800)
+
+    def test_active_is_the_view_and_it_survives_refresh_and_reload(self, browser_page):
+        browser_page.goto(f"{BASE_URL}/settings")
+        browser_page.wait_for_load_state("networkidle")
+        ids = browser_page.evaluate("""
+            async () => {
+                const out = [];
+                for (const cn of ['filter-keep-a', 'filter-keep-b']) {
+                    const r = await fetch('/api/client-certs', {
+                        method: 'POST', headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify({common_name: cn, cert_usage: 'api-mtls', days_valid: 30})
+                    });
+                    if (!r.ok) throw new Error('create ' + cn + ' -> ' + r.status);
+                    const body = await r.json();
+                    out.push(body.identifier || (body.certificate && body.certificate.identifier));
+                }
+                return out;
+            }
+        """)
+        assert len(ids) == 2 and all(ids), ids
+        browser_page.evaluate("localStorage.removeItem('certmate.clientCerts.filters')")
+
+        self._open_client_tab(browser_page)
+        active_chip = browser_page.locator('[data-cc-status-chip="active"]')
+        expect(active_chip).to_have_attribute("aria-pressed", "true")
+        rows = browser_page.locator('#certTableBody button[data-cc-action="details"]')
+        expect(rows).to_have_count(2, timeout=10000)
+
+        # Revoke one through the API and refresh the way the Revoke button
+        # does: the view must still be Active, with one row fewer.
+        browser_page.evaluate("""
+            async (id) => {
+                const r = await fetch('/api/client-certs/' + id + '/revoke', {
+                    method: 'POST', headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({reason: 'test'})
+                });
+                if (!r.ok) throw new Error('revoke -> ' + r.status);
+                window.ccRefresh();
+            }
+        """, ids[0])
+        expect(rows).to_have_count(1, timeout=10000)
+        expect(active_chip).to_have_attribute("aria-pressed", "true")
+
+        # Remembered across a page load.
+        browser_page.locator('[data-cc-status-chip="revoked"]').click()
+        expect(rows).to_have_count(1, timeout=10000)
+        self._open_client_tab(browser_page)
+        expect(browser_page.locator('[data-cc-status-chip="revoked"]')).to_have_attribute("aria-pressed", "true")
+        expect(rows).to_have_count(1, timeout=10000)
+
+        # The details panel has the PKCS#12 button next to crt/key/csr.
+        rows.first.click()
+        pfx = browser_page.locator('button[onclick="downloadCertFile(\'pfx\')"]')
+        expect(pfx).to_be_visible(timeout=5000)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -340,6 +340,14 @@ class TestClientCertListKeepsItsFilter:
     it across page loads, and the details panel offers the .pfx bundle the
     API has served since v2.24.0 but the UI never exposed."""
 
+    @staticmethod
+    def _drop_wizard(page):
+        # The first-run wizard is a fixed overlay (#setupWizard, z-[110]) that
+        # intercepts every click on a fresh container; other tests remove it
+        # the same way.
+        page.evaluate(
+            "() => { const w = document.getElementById('setupWizard'); if (w) w.remove(); }")
+
     def _open_client_tab(self, page):
         page.goto(BASE_URL)
         page.wait_for_load_state("domcontentloaded")
@@ -347,6 +355,8 @@ class TestClientCertListKeepsItsFilter:
         # deferred x-data a moment, then switch to the client view.
         client_btn = page.locator("#certViewClientBtn")
         expect(client_btn).to_be_visible(timeout=10000)
+        page.wait_for_timeout(1000)
+        self._drop_wizard(page)
         client_btn.click()
         expect(client_btn).to_have_attribute("aria-pressed", "true", timeout=10000)
         page.wait_for_timeout(800)
@@ -370,13 +380,18 @@ class TestClientCertListKeepsItsFilter:
             }
         """)
         assert len(ids) == 2 and all(ids), ids
-        browser_page.evaluate("localStorage.removeItem('certmate.clientCerts.filters')")
+        browser_page.evaluate("localStorage.removeItem('cm.clientTab.filters')")
 
         self._open_client_tab(browser_page)
         active_chip = browser_page.locator('[data-cc-status-chip="active"]')
         expect(active_chip).to_have_attribute("aria-pressed", "true")
-        rows = browser_page.locator('#certTableBody button[data-cc-action="details"]')
-        expect(rows).to_have_count(2, timeout=10000)
+        # Assert on our two identifiers, not on a global count: the container
+        # is session-scoped and other tests may leave certificates behind.
+        def row(identifier):
+            return browser_page.locator(
+                '#certTableBody button[data-cc-action="details"][data-id="%s"]' % identifier)
+        expect(row(ids[0])).to_be_visible(timeout=10000)
+        expect(row(ids[1])).to_be_visible(timeout=10000)
 
         # Revoke one through the API and refresh the way the Revoke button
         # does: the view must still be Active, with one row fewer.
@@ -390,17 +405,22 @@ class TestClientCertListKeepsItsFilter:
                 window.ccRefresh();
             }
         """, ids[0])
-        expect(rows).to_have_count(1, timeout=10000)
+        expect(row(ids[0])).to_have_count(0, timeout=10000)
+        expect(row(ids[1])).to_be_visible()
         expect(active_chip).to_have_attribute("aria-pressed", "true")
 
         # Remembered across a page load.
+        self._drop_wizard(browser_page)
         browser_page.locator('[data-cc-status-chip="revoked"]').click()
-        expect(rows).to_have_count(1, timeout=10000)
+        expect(row(ids[0])).to_be_visible(timeout=10000)
+        expect(row(ids[1])).to_have_count(0)
         self._open_client_tab(browser_page)
         expect(browser_page.locator('[data-cc-status-chip="revoked"]')).to_have_attribute("aria-pressed", "true")
-        expect(rows).to_have_count(1, timeout=10000)
+        expect(row(ids[0])).to_be_visible(timeout=10000)
+        expect(row(ids[1])).to_have_count(0)
 
         # The details panel has the PKCS#12 button next to crt/key/csr.
-        rows.first.click()
+        self._drop_wizard(browser_page)
+        row(ids[0]).click()
         pfx = browser_page.locator('button[onclick="downloadCertFile(\'pfx\')"]')
         expect(pfx).to_be_visible(timeout=5000)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -356,7 +356,7 @@ class TestClientCertListKeepsItsFilter:
             async () => {
                 const out = [];
                 for (const cn of ['filter-keep-a', 'filter-keep-b']) {
-                    const r = await fetch('/api/client-certs', {
+                    const r = await fetch('/api/client-certs/create', {
                         method: 'POST', headers: {'Content-Type': 'application/json'},
                         body: JSON.stringify({common_name: cn, cert_usage: 'api-mtls', days_valid: 30})
                     });


### PR DESCRIPTION
Closes #561, closes #562 (the list half; the configurable/resettable client CA is a feature and gets its own issue).

**#562 — filter lost after every revoke.** `ccRevokeCert`/`ccRenewCert` called `ccLoadCertificates()`, which fetched the list unfiltered, so the Active view snapped back to All after each action and a batch of revocations meant re-clicking the chip every time. The loader now applies the current chips on every refresh (`ccFilterCertificates` *is* the loader), the chips are remembered in `localStorage`, and **Active is the starting view** — a client CA accumulates revoked and short-lived certificates fast, and opening on all of them was the wrong default.

**#561 — where is the client .pfx?** The API has served `GET /api/client-certs/<id>/download/pfx` since v2.24.0 (encrypted with the *PFX password* from Settings → General, operator role), but the details panel only had crt/key/csr. Added the `.pfx` button. All four downloads now go through `fetch`, so a refusal — no PFX password configured, viewer role on key/pfx — is a toast with the server's reason instead of a bare JSON error page.

**Test.** `tests/test_ui.py::TestClientCertListKeepsItsFilter`: two certificates, Active by default, revoke one and refresh the way the button does → still Active with one row; switch to Revoked, reload the page → still Revoked; open details → `.pfx` is there.