### PR TITLE
ci/docs: hold cloudflare at 2.x, retry the CA reachability probe, say what /download can do

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,6 +61,13 @@ updates:
       - dependency-name: "pyopenssl"
       - dependency-name: "cryptography"
       - dependency-name: "dns-lexicon"
+      # python-cloudflare 3.x+ is a different SDK under the same name.
+      # certbot-dns-cloudflare 2.10.0 imports the 2.x client and declares
+      # only `cloudflare>=1.5.1`, so pip resolves a 5.x bump happily and
+      # certbot dies at import — tests/test_requirements_sets.py caught it
+      # on #568. Moves with #103. Ignored entirely, like the rest of the
+      # held set: 2.19.4 is where the 2.x line the plugin understands ends.
+      - dependency-name: "cloudflare"
 
   - package-ecosystem: "npm"
     directories:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,14 +477,17 @@ jobs:
         logformat = "text"
         CFG
 
-        for i in $(seq 1 30); do
-          docker exec acmedns-pg pg_isready -U acmedns >/dev/null 2>&1 && break
+        # Readiness over TCP (-h): during initdb the image's bootstrap server
+        # answers on the unix socket only, then restarts for real. 90 s: a
+        # cold runner has been seen to take more than 30 (#566).
+        for i in $(seq 1 90); do
+          docker exec acmedns-pg pg_isready -h 127.0.0.1 -U acmedns -d acmedns >/dev/null 2>&1 && break
           sleep 1
         done
         # The loop above breaks on success and falls through on timeout; say
         # so here, or the acme-dns container fails later with a less useful
         # error (Copilot, #560).
-        docker exec acmedns-pg pg_isready -U acmedns >/dev/null 2>&1 \
+        docker exec acmedns-pg pg_isready -h 127.0.0.1 -U acmedns -d acmedns >/dev/null 2>&1 \
           || { echo "postgres never became ready"; docker logs acmedns-pg; exit 1; }
 
         docker run -d --name acmedns --network acmedns-net \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -294,7 +294,7 @@ Renewals always preserve the shape that was in effect at creation time: certbot 
 | POST | `/api/certificates` | Create new certificate |
 | GET | `/api/certificates/{domain}` | Get certificate info |
 | POST | `/api/certificates/{domain}/renew` | Renew certificate |
-| GET | `/api/certificates/{domain}/download` | Download: ZIP by default, `?file=fullchain.pem` (or `privkey.pem`, `combined.pem`) for one PEM, `?format=json` for every PEM inline |
+| GET | `/api/certificates/{domain}/download` | Download: ZIP by default; `?file=<cert.pem\|chain.pem\|fullchain.pem\|privkey.pem\|combined.pem\|cert.pfx>` for one file; `?format=json` for every PEM inline |
 | GET | `/{domain}/tls` | Direct fullchain download |
 
 ### Client Certificates

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -294,7 +294,7 @@ Renewals always preserve the shape that was in effect at creation time: certbot 
 | POST | `/api/certificates` | Create new certificate |
 | GET | `/api/certificates/{domain}` | Get certificate info |
 | POST | `/api/certificates/{domain}/renew` | Renew certificate |
-| GET | `/api/certificates/{domain}/download` | Download as ZIP |
+| GET | `/api/certificates/{domain}/download` | Download: ZIP by default, `?file=fullchain.pem` (or `privkey.pem`, `combined.pem`) for one PEM, `?format=json` for every PEM inline |
 | GET | `/{domain}/tls` | Direct fullchain download |
 
 ### Client Certificates

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -12,7 +12,7 @@ josepy==1.13.0
 certbot-dns-cloudflare==2.10.0
 
 # Cloudflare API support
-cloudflare==2.19.4
+cloudflare==2.19.4                 # Hold at 2.x: 3.x+ is a different SDK, certbot-dns-cloudflare 2.10.0 breaks at import (#568); moves with #103
 dns-lexicon==3.25.1
 
 # Core application dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,7 +87,7 @@ boto3==1.43.67                    # AWS support
 azure-identity==1.25.3             # Azure support
 azure-mgmt-dns==8.1.0              # Azure DNS support
 google-cloud-dns==0.37.0           # Google Cloud support
-cloudflare==2.19.4                 # Cloudflare API support
+cloudflare==2.19.4                 # Cloudflare API support. Hold at 2.x: 3.x+ is a different SDK, certbot-dns-cloudflare 2.10.0 breaks at import (#568); moves with #103
 dns-lexicon==3.25.1                # Provider-neutral DNS API support for alias mode
 
 # Core application dependencies

--- a/tests/test_ca_endpoints_are_live.py
+++ b/tests/test_ca_endpoints_are_live.py
@@ -144,6 +144,14 @@ def test_every_ca_serves_a_real_acme_directory(key, field, url):
                 body = response.read(1024 * 1024).decode("utf-8", "replace")
             error = None
             break
+        except urllib.error.HTTPError as exc:
+            # The server answered — a 404/410 is a verdict, not a transient.
+            # No retry, no sleep: fall through to the status assertion below
+            # with what it said (Copilot, #577).
+            status = exc.code
+            body = exc.read(1024 * 1024).decode("utf-8", "replace") if exc.fp else ""
+            error = None
+            break
         except (urllib.error.URLError, TimeoutError, OSError) as exc:
             error = exc
             if attempt < 2:

--- a/tests/test_ca_endpoints_are_live.py
+++ b/tests/test_ca_endpoints_are_live.py
@@ -20,6 +20,7 @@ suite skips it. What runs everywhere is the offline half: the shape of the URLs
 and the fact that a dead one cannot come back unnoticed.
 """
 import json
+import time
 import re
 import urllib.error
 import urllib.request
@@ -127,15 +128,27 @@ def test_every_ca_serves_a_real_acme_directory(key, field, url):
     otherwise meet on their first certificate.
     """
     request = urllib.request.Request(url, headers={"User-Agent": "certmate-ca-check"})
-    try:
-        with urllib.request.urlopen(request, timeout=30) as response:
-            status = response.status
-            # Read to EOF, capped. 4096 bytes truncated mid-object on any
-            # directory larger than that, so a healthy CA would have failed on
-            # a JSON error (Copilot, #538). 1 MiB is far past any real
-            # directory and still bounds a misbehaving server.
-            body = response.read(1024 * 1024).decode("utf-8", "replace")
-    except urllib.error.URLError as error:
+    # A CA that is slow once is not a CA that is gone: ZeroSSL timed out a
+    # single read on 2026-08-17 and the weekly run went red for nothing.
+    # Three attempts, a pause between them; a retired host fails all three
+    # just as fast as it failed one.
+    error = None
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                status = response.status
+                # Read to EOF, capped. 4096 bytes truncated mid-object on any
+                # directory larger than that, so a healthy CA would have failed
+                # on a JSON error (Copilot, #538). 1 MiB is far past any real
+                # directory and still bounds a misbehaving server.
+                body = response.read(1024 * 1024).decode("utf-8", "replace")
+            error = None
+            break
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            error = exc
+            if attempt < 2:
+                time.sleep(5)
+    if error is not None:
         pytest.fail(
             f"{key}.{field} ({url}) is unreachable: {error}. If the CA has "
             f"retired this endpoint, update modules/core/ca_manager.py, the "

--- a/tests/test_dependabot_holds_the_stack.py
+++ b/tests/test_dependabot_holds_the_stack.py
@@ -44,6 +44,7 @@ HELD = {
     "pyopenssl": "Do not bump to 26.2.0+",
     "cryptography": "GHSA-537c-gmf6-5ccf",
     "dns-lexicon": "dns-lexicon",
+    "cloudflare": "#568",
 }
 
 # Ignored defensively rather than held: `acme` is not pinned anywhere — it


### PR DESCRIPTION
Three small things from today's sweep.

- **Dependabot holds `cloudflare` at 2.x.** #568 (cloudflare 2.19.4 → 5.6.0) failed on `test_the_certbot_cli_actually_runs`: python-cloudflare 3.x+ is a different SDK under the same name, the pinned `certbot-dns-cloudflare==2.10.0` imports the 2.x client and only declares `cloudflare>=1.5.1`, so pip resolves the bump and certbot dies at import. Held entirely like the rest of the set, with the reason on both requirement lines and in `tests/test_dependabot_holds_the_stack.py`. Moves with #103.
- **CA reachability probe retries.** The weekly `ca-endpoints` job went red on 2026-08-17 because ZeroSSL timed out one read. Three attempts with a pause between them; a retired host fails all three as fast as it failed one.
- **`docs/architecture.md` endpoint table** said only *Download as ZIP* for `/api/certificates/{domain}/download`; `?file=` and `?format=json` are now on the row (#572 — the website row gets the same treatment).