### PR TITLE
fix: the four defects that survived the full-field audit

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -3036,7 +3036,15 @@ def create_api_resources(api, models, managers):
                 pre_restore_backup = None
                 if create_backup:
                     current_settings = settings_manager.load_settings()
-                    pre_restore_backup = file_ops.create_unified_backup(current_settings, "pre_restore")
+                    # include_secrets=True: this archive exists for exactly one
+                    # purpose — putting the instance back if the restore below
+                    # goes wrong. A masked rollback cannot recover a single
+                    # credential, which makes it a file that looks like a
+                    # safety net and is not one. It never leaves the host and
+                    # is written chmod 0600, and the opt-in is audit-logged
+                    # with the restore entry below.
+                    pre_restore_backup = file_ops.create_unified_backup(
+                        current_settings, "pre_restore", include_secrets=True)
                     logger.info(f"Created pre-restore backup: {pre_restore_backup}")
 
                 # Restore from unified backup

--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -810,7 +810,16 @@ class AuthManager:
                     settings['users'] = stored_users
 
                 try:
-                    self.settings_manager.update(_touch, "user_management")
+                    # No backup for a plain login. save_settings writes a full
+                    # unified ZIP of settings + certificates for every reason
+                    # that is not None and then prunes to MAX_BACKUPS_PER_TYPE
+                    # (50), so recording last_login evicted a real restore
+                    # point every time somebody signed in. A hash upgrade IS
+                    # worth a restore point; a timestamp is not. The
+                    # backup_reason=None idiom already exists for exactly this
+                    # (api_keys last_used_at).
+                    self.settings_manager.update(
+                        _touch, "password_hash_upgraded" if upgraded else None)
                     if upgraded:
                         logger.info(
                             f"Upgraded the stored password hash for '{username}'"

--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -1004,11 +1004,50 @@ class AuthManager:
         OIDC/SSO-only deployment — but the instance stayed world-open because
         local auth was never enabled. A fresh install with no operator-provided
         credential is unchanged: it stays in setup mode so onboarding works."""
+        return self.setup_mode_for(self.settings_manager.load_settings())
+
+    def setup_mode_for(self, settings):
+        """``is_setup_mode()`` evaluated against an arbitrary settings dict.
+
+        One definition, two callers: the live predicate above, and
+        ``would_open_setup_mode`` below, which asks the same question about a
+        change that has not been written yet. Keeping them as one function is
+        the point — a guard that re-implements the predicate it defends drifts
+        away from it, and the drift is invisible until the day it matters.
+        """
         if self.has_operator_bearer_token():
             return False
-        if self._is_oidc_configured():
+        oidc = settings.get('oidc') or {}
+        if oidc.get('enabled') and oidc.get('issuer_url') and oidc.get('client_id'):
             return False
-        return not (self.is_local_auth_enabled() and self.has_any_users())
+        users = settings.get('users') or {}
+        return not (settings.get('local_auth_enabled', False) and len(users) > 0)
+
+    def would_open_setup_mode(self, candidate_settings):
+        """True iff applying *candidate_settings* would leave this instance
+        serving every gated endpoint to anonymous callers as admin.
+
+        Setup mode is not a mild state. ``_authenticate_request`` returns
+        ``{'username': 'setup_user', 'role': 'admin'}`` for a caller with no
+        credential at all, which is enough to read /api/settings, mint API
+        keys, create admin users and download private keys.
+
+        It exists so a fresh install can be bootstrapped, and it closes as soon
+        as the operator configures ANY credential. The hole this guards is the
+        way back: an SSO-only deployment (no API_BEARER_TOKEN, local auth never
+        enabled because OIDC JIT provisioning does not flip it) is held closed
+        by the OIDC branch alone, so unchecking "Enable OIDC/SSO" reopened the
+        whole instance. That branch was added in v2.21.4 to CLOSE the
+        world-open hole on SSO-only boxes; it also made closure depend on a
+        checkbox, and nothing checked the transition.
+
+        Returns False when the instance is already in setup mode: a fresh
+        install must still be configurable, and this guard is about not
+        REGRESSING out of a secured state.
+        """
+        if self.is_setup_mode():
+            return False
+        return self.setup_mode_for(candidate_settings)
 
     def needs_credentialed_bootstrap(self):
         """RESTRICTED (never world-open) bootstrap signal for the web UI only.

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -308,12 +308,25 @@ class CertificateManager:
         returns before this copy ever runs again, so nothing repaired it and
         check_renewals booked it as skipped_not_due — no failure, no alert.
 
-        Staging every file first means a failure mid-way leaves the flat copy
-        exactly as it was: still the old certificate, still internally
-        consistent, still serving. The promote loop is four renames within the
-        same directory, which is as close to atomic as a multi-file publish
-        gets on a POSIX filesystem.
+        Staging every file first means a failure while staging leaves the
+        flat copy exactly as it was: still the old certificate, still
+        internally consistent, still serving. The promote loop is four renames
+        within the same directory — not a transaction: a failure between the
+        second and the third rename still leaves a mixed generation. What
+        changed is that the window shrank from four full read+write copies to
+        four metadata renames, and that the state is no longer permanent: the
+        next renewal check compares the flat copy with live/ and republishes
+        (see the not-yet-due branch of renew_certificate), where the old code
+        returned before the copy loop and booked skipped_not_due forever.
+        Promoting privkey.pem first would not help — new key beside old
+        certificate is just as unusable.
         """
+        # Leftovers from an attempt that died between staging and promote
+        # (SIGKILL, OOM, container stopped) are cleaned by nobody else; the
+        # caller holds the domain lock, so whatever is here is from a dead
+        # attempt and not from a publish in flight.
+        for leftover in dest_dir.glob('*.staging'):
+            leftover.unlink(missing_ok=True)
         staged = []
         try:
             for file_name in CERTIFICATE_FILES:

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -324,9 +324,11 @@ class CertificateManager:
         # Leftovers from an attempt that died between staging and promote
         # (SIGKILL, OOM, container stopped) are cleaned by nobody else; the
         # caller holds the domain lock, so whatever is here is from a dead
-        # attempt and not from a publish in flight.
-        for leftover in dest_dir.glob('*.staging'):
-            leftover.unlink(missing_ok=True)
+        # attempt and not from a publish in flight. Four known names, no
+        # wildcard: this is a delete, and the set of files it can ever touch
+        # is spelled out here rather than matched.
+        for file_name in CERTIFICATE_FILES:
+            (dest_dir / f"{file_name}.staging").unlink(missing_ok=True)
         staged = []
         try:
             for file_name in CERTIFICATE_FILES:

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -265,6 +265,76 @@ class CertificateManager:
             tmp.unlink(missing_ok=True)
             raise
 
+    def _stale_flat_files(self, src_dir: Path, dest_dir: Path):
+        """Which of CERTIFICATE_FILES differ between live/ and the flat copy.
+
+        `live/<domain>/` is certbot's copy and the only ground truth. The flat
+        files beside it are what /download serves, what deploy hooks ship and
+        what the storage backends push, so any disagreement between the two is
+        an operator-visible defect regardless of how it happened.
+
+        Returns [] when the live directory is absent — an imported or
+        externally-managed certificate has nothing to reconcile against, and
+        must not be reported as stale.
+        """
+        if not src_dir.is_dir():
+            return []
+        stale = []
+        for file_name in CERTIFICATE_FILES:
+            src_file, dest_file = src_dir / file_name, dest_dir / file_name
+            if not src_file.exists():
+                continue
+            try:
+                if (not dest_file.exists()
+                        or src_file.read_bytes() != dest_file.read_bytes()):
+                    stale.append(file_name)
+            except OSError:
+                stale.append(file_name)
+        return stale
+
+    def _publish_flat_files(self, src_dir: Path, dest_dir: Path) -> dict:
+        """Copy live/ to the flat directory as one unit, not four.
+
+        `_atomic_binary_copy` is atomic per file and there was no atomicity
+        across the four, no rollback on the exception paths, and privkey.pem is
+        LAST in CERTIFICATE_FILES. A failure on the fourth file therefore left
+        a new cert.pem, chain.pem and fullchain.pem beside the PREVIOUS
+        privkey.pem — a pair that cannot complete a handshake, served straight
+        off local disk by /api/certificates/<domain>/download and pushed to
+        every deploy hook.
+
+        Worse than the window was the permanence: the next scheduled renewal
+        fingerprints live/, finds it already fresh, concludes renewed=False and
+        returns before this copy ever runs again, so nothing repaired it and
+        check_renewals booked it as skipped_not_due — no failure, no alert.
+
+        Staging every file first means a failure mid-way leaves the flat copy
+        exactly as it was: still the old certificate, still internally
+        consistent, still serving. The promote loop is four renames within the
+        same directory, which is as close to atomic as a multi-file publish
+        gets on a POSIX filesystem.
+        """
+        staged = []
+        try:
+            for file_name in CERTIFICATE_FILES:
+                src_file = src_dir / file_name
+                if not src_file.exists():
+                    continue
+                staging = dest_dir / f"{file_name}.staging"
+                staging.write_bytes(src_file.read_bytes())
+                shutil.copymode(src_file, staging)
+                staged.append((staging, dest_dir / file_name))
+        except Exception:
+            for staging, _dest in staged:
+                staging.unlink(missing_ok=True)
+            raise
+
+        published = {}
+        for staging, dest_file in staged:
+            staging.replace(dest_file)
+            published[dest_file.name] = dest_file.read_bytes()
+        return published
+
     @staticmethod
     def _atomic_json_write(path: Path, data: dict) -> None:
         """Write JSON atomically via a temp file + rename to avoid partial writes on crash."""
@@ -1857,11 +1927,37 @@ class CertificateManager:
 
                 if not renewed:
                     logger.info(f"Certificate for {domain} is not yet due for renewal; no action taken")
+                    # Before returning: does the flat copy still agree with
+                    # live/? This branch is where a half-finished publish
+                    # became permanent — it returns before the copy below, so
+                    # nothing ever retried it and the daily run kept booking
+                    # the domain as skipped_not_due. Reconciling here is what
+                    # heals an instance that is already in that state; the
+                    # staged publish above is what stops it happening again.
+                    stale = self._stale_flat_files(domain_dir / 'live' / domain, domain_dir)
+                    if stale:
+                        logger.warning(
+                            "Certificate for %s did not need renewing, but its "
+                            "served copy disagreed with certbot's: %s. "
+                            "Republishing — this is the state where a new "
+                            "certificate can sit beside the previous private "
+                            "key.", domain, ", ".join(stale))
+                        try:
+                            self._publish_flat_files(domain_dir / 'live' / domain, domain_dir)
+                        except Exception as republish_error:
+                            logger.error(
+                                "Could not republish the served copy for %s: %s",
+                                domain, republish_error)
+                            raise RuntimeError(
+                                f"{domain} is serving files that do not match "
+                                f"its certificate and they could not be "
+                                f"repaired: {republish_error}") from republish_error
                     self._invalidate_certificate_info_cache(domain)
                     return {
                         'success': True,
                         'renewed': False,
                         'domain': domain,
+                        'repaired': stale or None,
                         'message': 'Certificate not yet due for renewal',
                     }
 
@@ -1869,14 +1965,7 @@ class CertificateManager:
                 src_dir = domain_dir / 'live' / domain
                 dest_dir = domain_dir
                 
-                cert_files = {}
-                for file_name in CERTIFICATE_FILES:
-                    src_file = src_dir / file_name
-                    dest_file = dest_dir / file_name
-                    if src_file.exists():
-                        self._atomic_binary_copy(src_file, dest_file)
-                        with open(dest_file, 'rb') as f:
-                            cert_files[file_name] = f.read()
+                cert_files = self._publish_flat_files(src_dir, dest_dir)
                 
                 # Stamp the renewal BEFORE storing, so the external copy
                 # carries the same renewed_at as the local one; then persist

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -877,7 +877,24 @@ class SettingsManager:
                 settings = self.file_ops.safe_file_read(self.settings_file, is_json=True)
                 if not isinstance(settings, dict):
                     logger.warning("Settings file exists but is empty or corrupted, attempting backup restore")
+                    # Empty and unreadable are different cases. The refusal
+                    # below exists to protect CONTENT a text editor could
+                    # repair; a zero-byte file has nothing to lose, so for it
+                    # the first-time template is still the right answer.
+                    # Unreadable (permissions) counts as "has content": we
+                    # cannot tell, and that is precisely where overwriting
+                    # destroys something good.
+                    try:
+                        has_content = bool(self.settings_file.read_text(
+                            encoding='utf-8', errors='replace').strip())
+                    except OSError:
+                        has_content = True
                     settings = self._try_restore_from_backup()
+                    if settings is None and not has_content:
+                        logger.warning("Settings file is empty and no usable backup exists; "
+                                       "recreating it with the first-time template")
+                        self.save_settings(first_time_template)
+                        return first_time_template
                     if settings is None:
                         # Do NOT recreate the file. safe_file_read returns the
                         # default for a JSON typo, a PermissionError and an

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -102,6 +102,16 @@ SETTINGS_REJECT_KEYS = frozenset({
 
 SECRET_MASK_SENTINEL = '********'
 
+
+class SettingsUnreadableError(RuntimeError):
+    """settings.json is present but unusable, and no backup can replace it.
+
+    Raised instead of silently recreating the file. app.py wraps create_app in
+    try/except and exits 1, so the operator gets one clear line and a container
+    that stops, rather than an instance that came up with every credential set
+    to the mask sentinel.
+    """
+
 # Field-name pattern identifying secret-like keys. Must stay in sync with
 # the masking regex in modules/web/settings_routes.py so a value masked on
 # GET is also recognised on POST. An empty string in one of these fields
@@ -613,8 +623,45 @@ class SettingsManager:
                     del merged[key]
             return self.save_settings(merged)
 
+    @staticmethod
+    def _backup_can_restore_credentials(zf, names, settings):
+        """True iff this backup's secrets are real and not the mask sentinel.
+
+        Every AUTOMATIC backup is masked: `save_settings` calls
+        `create_unified_backup(settings, reason)` and `include_secrets`
+        defaults to False, which writes SECRET_MASK_SENTINEL in place of every
+        credential. That default is right — a leaked backup must not also be a
+        credential dump — but it means the newest backup on disk is almost
+        always one that CANNOT restore this instance.
+
+        The manifest has said so since unified backups existed
+        (`secrets_masked` in backup_metadata.json). Nothing read it. Older or
+        hand-made archives may not carry the field, so a missing flag falls
+        back to looking for the sentinel in the settings themselves rather
+        than assuming the archive is usable.
+        """
+        import json
+        if "backup_metadata.json" in names:
+            try:
+                metadata = json.loads(zf.read("backup_metadata.json").decode("utf-8"))
+                if isinstance(metadata, dict) and "secrets_masked" in metadata:
+                    return not metadata["secrets_masked"]
+            except (ValueError, KeyError, UnicodeDecodeError):
+                pass                       # fall through to the content check
+        return SECRET_MASK_SENTINEL not in json.dumps(settings)
+
     def _try_restore_from_backup(self):
-        """Attempt to restore settings from the most recent unified backup."""
+        """Restore settings from the most recent backup that can actually restore.
+
+        Returns None when every candidate is masked. The caller must not treat
+        that as "no backup found and I may recreate the file": installing a
+        masked archive writes the mask sentinel as every password hash, bearer
+        token, API key hash, OIDC client secret and DNS credential. No local
+        login works, no token works, SSO is broken, every renewal fails at the
+        provider — and `setup_completed` is still True, so the wizard does not
+        reopen. The log line said "Settings restored successfully from backup".
+        """
+        masked_only = []
         try:
             import io, zipfile, json
             from .file_operations import (
@@ -637,15 +684,27 @@ class SettingsManager:
                     with zipfile.ZipFile(zip_source, 'r') as zf:
                         if "settings.json" not in zf.namelist():
                             continue
+                        names = zf.namelist()
                         raw = json.loads(zf.read("settings.json").decode('utf-8'))
                         settings = raw.get('settings') if isinstance(raw, dict) and 'settings' in raw else raw
                         if isinstance(settings, dict) and settings:
+                            if not self._backup_can_restore_credentials(zf, names, settings):
+                                masked_only.append(backup_path.name)
+                                continue
                             logger.info(f"Restored settings from backup: {backup_path.name}")
                             return settings
                 except Exception as e:
                     logger.debug(f"Could not read backup {backup_path.name}: {e}")
         except Exception as e:
             logger.error(f"Backup restore failed: {e}")
+        if masked_only:
+            logger.error(
+                "Found %d recent backup(s) but every one of them has its "
+                "secrets masked, so restoring it would install the mask "
+                "sentinel as every credential and lock this instance out: %s. "
+                "A backup that can restore is made with include_secrets=true "
+                "(POST /api/backups/create).",
+                len(masked_only), ", ".join(masked_only))
         return None
 
     def load_settings(self, use_cache=True):
@@ -820,9 +879,23 @@ class SettingsManager:
                     logger.warning("Settings file exists but is empty or corrupted, attempting backup restore")
                     settings = self._try_restore_from_backup()
                     if settings is None:
-                        logger.warning("No usable backup found, recreating settings with defaults")
-                        self.save_settings(first_time_template)
-                        return first_time_template
+                        # Do NOT recreate the file. safe_file_read returns the
+                        # default for a JSON typo, a PermissionError and an
+                        # empty read alike, and settings.json is written
+                        # atomically (mkstemp + fsync + rename), so the
+                        # application never produces this state itself —
+                        # something outside it did. Overwriting with the
+                        # first-time template destroys the operator's only
+                        # copy of a file a text editor could have repaired,
+                        # and leaves the instance in setup mode, which is
+                        # world-open on the network.
+                        raise SettingsUnreadableError(
+                            f"{self.settings_file} exists but could not be "
+                            f"read as JSON, and no backup on disk can restore "
+                            f"it (see the log above). Refusing to overwrite "
+                            f"it. Fix the file, or restore a backup made with "
+                            f"include_secrets=true, then restart."
+                        )
                     logger.info("Settings restored successfully from backup")
 
                 # Downgrade detection: warn loudly if settings.json was saved
@@ -1038,6 +1111,15 @@ class SettingsManager:
                     return _copy.deepcopy(settings)
                 return settings
 
+            except SettingsUnreadableError:
+                # Must not be swallowed by the handler below. Returning the
+                # defaults in-memory leaves setup_completed False, which makes
+                # is_setup_mode() true and serves every gated endpoint to
+                # anonymous callers as admin — an instance that cannot read
+                # its own credentials must not come up world-open instead.
+                # app.py catches this and exits 1, so the operator gets a
+                # container that stops with one actionable line.
+                raise
             except Exception as e:
                 logger.error(f"Error loading settings: {e}")
                 logger.warning("Returning default settings in-memory (existing file preserved on disk)")

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -567,7 +567,8 @@ class SettingsManager:
         callers can react to validation failures.
         """
         with self._lock:
-            settings = self.load_settings()
+            # From disk, never from the request cache — see load_settings.
+            settings = self.load_settings(use_cache=False)
             mutator(settings)
             return self.save_settings(settings, reason)
 
@@ -586,7 +587,11 @@ class SettingsManager:
         credential for the same backend or CA provider.
         """
         with self._lock:
-            existing = self.load_settings()
+            # From disk, never from the request cache — see load_settings.
+            # `protected_keys` below restores users/api_keys from `existing`,
+            # so a cached `existing` made the protection restore a stale copy:
+            # it protected the snapshot, not the file.
+            existing = self.load_settings(use_cache=False)
             merged = {**existing, **incoming}
             for key, value in incoming.items():
                 if (key in _DEEP_MERGE_SETTINGS_KEYS
@@ -643,7 +648,7 @@ class SettingsManager:
             logger.error(f"Backup restore failed: {e}")
         return None
 
-    def load_settings(self):
+    def load_settings(self, use_cache=True):
         """Load settings from file with improved error handling.
 
         Acquires the re-entrant lock so concurrent saves cannot observe a
@@ -653,8 +658,20 @@ class SettingsManager:
         return a deepcopy of the cached parsed dict. The cache is cleared
         on any successful save (atomic_update / save_settings) and lives
         only for the current request. See `_request_cache_*` above.
+
+        ``use_cache=False`` forces a disk read. Every read-modify-write MUST
+        pass it, because the cache is scoped to the request and not to the
+        lock: `update`/`atomic_update` hold `self._lock` for the whole
+        read-modify-write, which stops two writes interleaving, but a cached
+        base makes the "read" a snapshot taken when the request STARTED. On
+        the synchronous issuance path that snapshot is minutes old —
+        cert_service.py loads settings, runs certbot, then writes — so every
+        concurrent write (a user created, a domain registered, a credential
+        saved) was silently rolled back by whichever request finished last.
+        A domain rolled out of `settings['domains']` is never visited by
+        check_renewals again and its certificate expires in silence.
         """
-        cached = self._request_cache_get()
+        cached = self._request_cache_get() if use_cache else None
         if cached is not None:
             # Deepcopy so callers that mutate the returned dict (load →
             # mutate in place → save) don't pollute the request-scoped

--- a/modules/web/auth_routes.py
+++ b/modules/web/auth_routes.py
@@ -165,6 +165,18 @@ def register_auth_routes(app, managers, require_web_auth, auth_manager,
         if enable and not auth_manager.has_any_users():
             return jsonify({'error': 'Create admin first'}), 400
 
+        candidate = dict(auth_manager.settings_manager.load_settings())
+        candidate['local_auth_enabled'] = enable
+        if auth_manager.would_open_setup_mode(candidate):
+            return jsonify({
+                'error': 'Refusing to disable the last way in',
+                'hint': 'Turning local authentication off here would put this '
+                        'instance back into setup mode, where every endpoint '
+                        'answers an anonymous caller as admin — including the '
+                        'private-key download. Configure SSO or set '
+                        'API_BEARER_TOKEN first, then disable local auth.',
+            }), 409
+
         before = auth_manager.is_local_auth_enabled()
         if auth_manager.enable_local_auth(enable):
             if audit_logger and before != enable:

--- a/modules/web/oidc_routes.py
+++ b/modules/web/oidc_routes.py
@@ -220,6 +220,37 @@ def register_oidc_routes(app, managers, auth_manager, oidc_manager,
         prior_secret_plain = (
             settings_manager.load_settings().get('oidc', {}).get('client_secret', '')
         )
+
+        # An SSO-only deployment is held out of setup mode by this config
+        # alone. Disabling it — or clearing issuer_url/client_id, which
+        # un-configures it just as effectively — hands the whole instance to
+        # any anonymous caller on the network as admin. The admin's intent was
+        # "turn SSO off"; nothing told them it also turns authentication off.
+        current = settings_manager.load_settings()
+        candidate = dict(current)
+        candidate['oidc'] = {
+            **(current.get('oidc') or {}),
+            **{key: value for key, value in payload.items()
+               if key in ('enabled', 'issuer_url', 'client_id')},
+        }
+        # Only the deliberate turn-off. A payload that CLEARS issuer_url or
+        # client_id while `enabled` stays true is rejected by
+        # _validate_config with a 400 and never written, so the door does not
+        # open and the specific "client_id is required" message is the more
+        # useful answer. Firing here first would have replaced it with a
+        # security refusal that does not describe what the admin got wrong.
+        turning_off = not candidate['oidc'].get('enabled')
+        if turning_off and auth_manager.would_open_setup_mode(candidate):
+            return jsonify({
+                'error': 'Refusing to disable the last way in',
+                'hint': 'SSO is the only credential configured on this '
+                        'instance, so turning it off would put it back into '
+                        'setup mode, where every endpoint answers an anonymous '
+                        'caller as admin — including the private-key download. '
+                        'Enable local authentication with an admin user, or '
+                        'set API_BEARER_TOKEN, before disabling SSO.',
+            }), 409
+
         ok, err = oidc_manager.update_config(payload)
         if not ok:
             return jsonify({'error': err or 'invalid OIDC settings'}), 400

--- a/templates/partials/settings_oidc.html
+++ b/templates/partials/settings_oidc.html
@@ -49,11 +49,18 @@
 
                     <!-- Enable toggle + provider name -->
                     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                        <label class="flex items-center space-x-2">
-                            <input type="checkbox" x-model="cfg.enabled"
-                                   class="h-4 w-4 text-primary focus:ring-primary border-border rounded">
-                            <span class="text-sm font-medium text-label">Enable OIDC/SSO</span>
-                        </label>
+                        <div>
+                            <label class="flex items-center space-x-2">
+                                <input type="checkbox" x-model="cfg.enabled"
+                                       class="h-4 w-4 text-primary focus:ring-primary border-border rounded">
+                                <span class="text-sm font-medium text-label">Enable OIDC/SSO</span>
+                            </label>
+                            <p class="text-xs text-muted mt-1">
+                                On an SSO-only instance this is the only thing keeping the
+                                instance closed. Saving with it off is refused unless local
+                                authentication or an API bearer token is configured first.
+                            </p>
+                        </div>
                         <div>
                             <label class="block text-xs text-muted mb-1">Provider display name</label>
                             <input type="text" x-model="cfg.provider_name" placeholder="SSO"

--- a/tests/test_disaster_recovery_round_trip.py
+++ b/tests/test_disaster_recovery_round_trip.py
@@ -217,3 +217,35 @@ def test_logging_in_does_not_consume_restore_points(instance):
 
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])
+
+
+def test_an_empty_settings_file_still_boots_with_the_first_time_template(tmp_path):
+    """The refusal to overwrite exists to protect content a text editor could
+    repair. A zero-byte settings.json has nothing to lose: a fresh boot with
+    the first-time template is the pre-existing behaviour and stays."""
+    from modules.core.file_operations import FileOperations
+    from modules.core.settings import SettingsManager
+    dirs = [tmp_path / n for n in ("certificates", "data", "backups", "logs")]
+    for d in dirs:
+        d.mkdir()
+    settings_file = dirs[1] / "settings.json"
+    settings_file.write_text("")
+    sm = SettingsManager(file_ops=FileOperations(*dirs), settings_file=settings_file)
+    settings = sm.load_settings()
+    assert isinstance(settings, dict) and 'dns_providers' in settings
+    assert settings_file.stat().st_size > 0
+
+
+def test_a_corrupt_settings_file_with_no_usable_backup_refuses_to_boot(tmp_path):
+    from modules.core.file_operations import FileOperations
+    from modules.core.settings import SettingsManager, SettingsUnreadableError
+    dirs = [tmp_path / n for n in ("certificates", "data", "backups", "logs")]
+    for d in dirs:
+        d.mkdir()
+    settings_file = dirs[1] / "settings.json"
+    settings_file.write_text('{"users": {"admin": {"password_hash": "$2b$12$real"}, "domains": [')
+    sm = SettingsManager(file_ops=FileOperations(*dirs), settings_file=settings_file)
+    import pytest as _pytest
+    with _pytest.raises(SettingsUnreadableError):
+        sm.load_settings()
+    assert 'password_hash' in settings_file.read_text(), "the operator's only copy must survive"

--- a/tests/test_disaster_recovery_round_trip.py
+++ b/tests/test_disaster_recovery_round_trip.py
@@ -1,0 +1,219 @@
+"""Can a backup actually bring this instance back?
+
+Nobody had asked. There are tests for creating a backup, for listing them, for
+masking secrets inside one, for the restore endpoint's authorization and for
+its zip-bomb limits. There was no test that took a working instance, destroyed
+it, restored it, and then tried to log in — so nothing noticed that the answer
+was no.
+
+Every AUTOMATIC backup is masked. `save_settings` calls
+`create_unified_backup(settings, reason)` and `include_secrets` defaults to
+False, which writes the mask sentinel in place of every credential. That
+default is correct: a leaked backup must not also be a credential dump. What
+was wrong is that every restore path treated those archives as authoritative:
+
+  * `_try_restore_from_backup` installed the newest one as live settings when
+    settings.json could not be parsed, producing an instance whose every
+    password hash, bearer token, API key hash, OIDC client secret and DNS
+    credential was the literal sentinel — and `setup_completed` was still True,
+    so the setup wizard did not reopen. The operator was locked out, and the
+    log said "Settings restored successfully from backup".
+  * the pre-restore rollback archive was masked too, so the safety net under a
+    manual restore could not recover a single credential.
+  * and every successful login wrote one of these archives and then pruned to
+    MAX_BACKUPS_PER_TYPE, so fifty logins evicted every older restore point.
+
+Together: restore points created constantly by routine noise, evicting the real
+ones, none of which could restore. This file is the round trip that makes that
+combination impossible to reintroduce.
+"""
+from __future__ import annotations
+
+import json
+import zipfile
+
+import pytest
+
+from modules.core.auth import AuthManager
+from modules.core.file_operations import FileOperations
+from modules.core.settings import (
+    SECRET_MASK_SENTINEL,
+    SettingsManager,
+    SettingsUnreadableError,
+)
+
+pytestmark = [pytest.mark.unit]
+
+PASSWORD = "correct horse battery staple"
+
+
+@pytest.fixture
+def instance(tmp_path):
+    """A configured CertMate: an admin who can log in, and a DNS credential."""
+    dirs = {name: tmp_path / name for name in
+            ("certificates", "data", "backups", "logs")}
+    for d in dirs.values():
+        d.mkdir()
+    file_ops = FileOperations(
+        cert_dir=dirs["certificates"], data_dir=dirs["data"],
+        backup_dir=dirs["backups"], logs_dir=dirs["logs"],
+    )
+    settings_manager = SettingsManager(
+        file_ops=file_ops, settings_file=dirs["data"] / "settings.json")
+    auth = AuthManager(settings_manager)
+    settings_manager.save_settings({
+        'email': 'ops@example.com',
+        'setup_completed': True,
+        'local_auth_enabled': True,
+        'dns_provider': 'cloudflare',
+        'dns_providers': {'cloudflare': {'api_token': 'cf-real-token-value'}},
+        'users': {'admin': {
+            'password_hash': auth._hash_password(PASSWORD),
+            'role': 'admin',
+        }},
+    })
+    # Two things have to happen before a test can measure anything.
+    # The first save writes no backup — save_settings only backs up a file
+    # that already exists — and the first load runs the DNS multi-account
+    # migration, which saves again and legitimately does write one. Both are
+    # one-time events; get them out of the way so a test that counts backups
+    # is counting what it thinks it is.
+    settings_manager.load_settings()
+    settings_manager.save_settings(settings_manager.load_settings())
+    return type('Instance', (), {
+        'settings': settings_manager, 'file_ops': file_ops,
+        'auth': auth, 'data': dirs["data"], 'backups': dirs["backups"],
+    })
+
+
+def _unified(instance):
+    return sorted((instance.backups / "unified").glob("backup_*"))
+
+
+def _credential_survived(settings):
+    """The token, wherever it ended up.
+
+    `dns_providers` is rewritten into the multi-account shape by the migration
+    that runs inside load_settings, so asserting on a fixed key path tests the
+    migration rather than the round trip. What matters is that the real secret
+    came back instead of the mask sentinel.
+    """
+    return 'cf-real-token-value' in json.dumps(settings)
+
+
+def _can_log_in(instance):
+    users = instance.settings.load_settings().get('users', {})
+    record = users.get('admin') or {}
+    return instance.auth._verify_password(PASSWORD, record.get('password_hash', ''))
+
+
+# --------------------------------------------------------------------------
+# The round trip itself
+# --------------------------------------------------------------------------
+
+def test_a_plaintext_backup_brings_the_instance_back(instance):
+    """Configure, back up, destroy, restore, log in."""
+    assert _can_log_in(instance), "fixture is wrong: the admin cannot log in"
+
+    filename = instance.file_ops.create_unified_backup(
+        instance.settings.load_settings(), "manual", include_secrets=True)
+    assert filename, "the backup was not written"
+
+    (instance.data / "settings.json").unlink()
+
+    assert instance.file_ops.restore_unified_backup(
+        str(instance.backups / "unified" / filename))
+
+    assert _can_log_in(instance), (
+        "restored, and the admin still cannot log in — the backup did not "
+        "carry a usable password hash"
+    )
+    assert _credential_survived(instance.settings.load_settings()), (
+        "the DNS credential did not survive the round trip, so every renewal "
+        "after this restore would fail at the provider"
+    )
+
+
+def test_an_automatic_backup_cannot_bring_it_back_and_says_so(instance):
+    """The masked archive must be refused, not installed as credentials."""
+    # save_settings has already written masked archives for the fixture.
+    automatic = _unified(instance)
+    assert automatic, "expected save_settings to have left automatic backups"
+    with zipfile.ZipFile(automatic[-1]) as zf:
+        metadata = json.loads(zf.read("backup_metadata.json").decode("utf-8"))
+        assert metadata["secrets_masked"] is True, (
+            "this test is built on the assumption that automatic backups are "
+            "masked; if that changed, the whole file needs rethinking"
+        )
+
+    # settings.json becomes unparseable — a hand-edit typo, a truncation.
+    (instance.data / "settings.json").write_text("{ this is not json", encoding="utf-8")
+
+    with pytest.raises(SettingsUnreadableError) as raised:
+        instance.settings.load_settings(use_cache=False)
+
+    assert "include_secrets" in str(raised.value), (
+        "the error must tell the operator how to make a backup that would "
+        "have worked, or it is just a crash"
+    )
+    # And it must NOT have destroyed the file a text editor could repair.
+    assert (instance.data / "settings.json").read_text(encoding="utf-8") == "{ this is not json", (
+        "the corrupt settings.json was overwritten — that was the operator's "
+        "only copy of their real configuration"
+    )
+
+
+def test_a_masked_backup_is_never_installed_as_credentials(instance):
+    """The specific outcome that locked operators out."""
+    (instance.data / "settings.json").write_text("{ broken", encoding="utf-8")
+    try:
+        settings = instance.settings.load_settings(use_cache=False)
+    except SettingsUnreadableError:
+        return                      # refused outright: the correct outcome
+    blob = json.dumps(settings)
+    assert SECRET_MASK_SENTINEL not in blob, (
+        "settings were restored from a masked backup, so every credential is "
+        "now the literal mask sentinel and no login, token or renewal works"
+    )
+
+
+def test_a_plaintext_backup_is_preferred_over_a_newer_masked_one(instance):
+    """Recency must not beat usability when picking a restore source."""
+    instance.file_ops.create_unified_backup(
+        instance.settings.load_settings(), "manual", include_secrets=True)
+    # Now write a NEWER masked one, the way any settings save would.
+    instance.settings.save_settings(instance.settings.load_settings())
+
+    (instance.data / "settings.json").write_text("nonsense", encoding="utf-8")
+    settings = instance.settings.load_settings(use_cache=False)
+
+    assert _credential_survived(settings), (
+        "the newest backup won even though it could not restore; the restore "
+        "must pick the newest backup that CAN"
+    )
+
+
+# --------------------------------------------------------------------------
+# Restore points must survive routine noise
+# --------------------------------------------------------------------------
+
+def test_logging_in_does_not_consume_restore_points(instance):
+    """A login is not a configuration change and must not evict a backup."""
+    before = len(_unified(instance))
+
+    for _ in range(5):
+        assert instance.auth.authenticate_user('admin', PASSWORD), (
+            "the fixture user cannot authenticate; the rest of this test is "
+            "meaningless"
+        )
+
+    after = len(_unified(instance))
+    assert after == before, (
+        f"{after - before} backup(s) were written by 5 logins. Retention is "
+        f"MAX_BACKUPS_PER_TYPE, so login traffic alone evicts every restore "
+        f"point an operator actually wanted."
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/test_flat_copy_is_published_as_one_unit.py
+++ b/tests/test_flat_copy_is_published_as_one_unit.py
@@ -1,0 +1,201 @@
+"""A new certificate must never end up beside the previous private key.
+
+The renewal path copied certbot's four files from `live/<domain>/` to the flat
+directory one at a time. `_atomic_binary_copy` is atomic per file; there was no
+atomicity across the four, the exception handlers unlink credential files and
+release the domain lock but roll nothing back, and `privkey.pem` is LAST in
+CERTIFICATE_FILES.
+
+So a failure on the fourth file left a new cert.pem, chain.pem and
+fullchain.pem beside the OLD privkey.pem. Those flat files are what
+`/api/certificates/<domain>/download` serves off local disk, what deploy hooks
+ship, and what the storage backends push. The pair cannot complete a handshake.
+
+The permanence is the part that made it dangerous rather than merely unlucky.
+The next scheduled renewal fingerprints `live/`, finds it already fresh,
+concludes `renewed=False` and returns BEFORE the copy loop — so nothing ever
+retried it, and `check_renewals` booked the domain as `skipped_not_due`: no
+failure, no `certificate_failed` event, no email. Only `force=true` broke out,
+and an operator has no reason to force a certificate the dashboard says is
+fine.
+
+Two changes, tested here. The publish stages all four files and only then
+promotes them, so a failure leaves the previous generation intact and
+internally consistent. And the no-op branch reconciles instead of returning
+blind, which is what repairs an instance that is already wedged.
+"""
+from __future__ import annotations
+
+import pathlib
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.certificates import CertificateManager
+from modules.core.constants import CERTIFICATE_FILES
+from modules.core.shell import MockShellExecutor
+
+pytestmark = [pytest.mark.unit]
+
+DOMAIN = 'wedged.example.com'
+OLD = {name: f"OLD {name} generation-1\n".encode() for name in CERTIFICATE_FILES}
+NEW = {name: f"NEW {name} generation-2\n".encode() for name in CERTIFICATE_FILES}
+
+
+@pytest.fixture
+def manager(tmp_path):
+    settings_manager = MagicMock()
+    settings_manager.load_settings.return_value = {
+        'default_ca': 'letsencrypt',
+        'challenge_type': 'dns-01',
+        'dns_propagation_seconds': {'cloudflare': 1},
+    }
+    settings_manager.get_domain_dns_provider.return_value = 'cloudflare'
+    dns_manager = MagicMock()
+    dns_manager.get_dns_provider_account_config.return_value = (
+        {'api_token': 'token'}, 'production')
+    shell = MockShellExecutor()
+    cert_dir = tmp_path / "certificates"
+    cert_dir.mkdir()
+    manager = CertificateManager(
+        cert_dir=cert_dir, settings_manager=settings_manager,
+        dns_manager=dns_manager, shell_executor=shell)
+    return manager, shell, cert_dir
+
+
+def _seed(cert_dir, *, flat, live):
+    """A domain directory with a flat copy and certbot's live copy."""
+    domain_dir = cert_dir / DOMAIN
+    live_dir = domain_dir / 'live' / DOMAIN
+    live_dir.mkdir(parents=True)
+    for name, content in flat.items():
+        (domain_dir / name).write_bytes(content)
+    for name, content in live.items():
+        (live_dir / name).write_bytes(content)
+    (domain_dir / 'metadata.json').write_text(
+        '{"domain": "%s", "dns_provider": "cloudflare", '
+        '"account_id": "production"}' % DOMAIN)
+    return domain_dir, live_dir
+
+
+def _flat(domain_dir):
+    return {name: (domain_dir / name).read_bytes()
+            for name in CERTIFICATE_FILES if (domain_dir / name).exists()}
+
+
+# --------------------------------------------------------------------------
+# The publish is one unit
+# --------------------------------------------------------------------------
+
+def test_a_publish_that_fails_partway_leaves_the_previous_pair_intact(manager, monkeypatch):
+    """The exact shape: privkey.pem is last, and writing it fails."""
+    cert_manager, _shell, cert_dir = manager
+    domain_dir, live_dir = _seed(cert_dir, flat=OLD, live=NEW)
+
+    real_read_bytes = pathlib.Path.read_bytes
+
+    def fail_on_the_private_key(self):
+        if self.name == 'privkey.pem' and 'live' in self.parts:
+            raise OSError("simulated I/O failure on the fourth file")
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(pathlib.Path, 'read_bytes', fail_on_the_private_key)
+
+    with pytest.raises(OSError):
+        cert_manager._publish_flat_files(live_dir, domain_dir)
+
+    monkeypatch.undo()
+    served = _flat(domain_dir)
+    assert served == OLD, (
+        "the served copy is a mixture of generations. Whatever is in cert.pem "
+        "no longer matches privkey.pem, and /download hands that pair to "
+        "whoever asks for it"
+    )
+    assert not list(domain_dir.glob('*.staging')), (
+        "staging files were left behind for the storage backends and the "
+        "next listing to trip over"
+    )
+
+
+def test_a_publish_that_succeeds_replaces_every_file(manager):
+    cert_manager, _shell, cert_dir = manager
+    domain_dir, live_dir = _seed(cert_dir, flat=OLD, live=NEW)
+
+    published = cert_manager._publish_flat_files(live_dir, domain_dir)
+
+    assert _flat(domain_dir) == NEW
+    assert published == NEW, "the returned bytes must be what was published"
+    assert not list(domain_dir.glob('*.staging'))
+
+
+def test_the_private_key_keeps_its_permissions(manager):
+    """certbot writes privkey.pem 0600; a world-readable copy is a leak."""
+    cert_manager, _shell, cert_dir = manager
+    domain_dir, live_dir = _seed(cert_dir, flat=OLD, live=NEW)
+    (live_dir / 'privkey.pem').chmod(0o600)
+    (domain_dir / 'privkey.pem').chmod(0o644)
+
+    cert_manager._publish_flat_files(live_dir, domain_dir)
+
+    mode = (domain_dir / 'privkey.pem').stat().st_mode & 0o777
+    assert mode == 0o600, f"privkey.pem landed {oct(mode)}"
+
+
+# --------------------------------------------------------------------------
+# A no-op renewal repairs instead of returning blind
+# --------------------------------------------------------------------------
+
+def test_a_no_op_renewal_republishes_a_served_copy_that_disagrees(manager):
+    """The wedged instance heals itself on the next nightly run."""
+    cert_manager, shell, cert_dir = manager
+    # The state a half-finished publish leaves: three new files, old key.
+    wedged = dict(NEW)
+    wedged['privkey.pem'] = OLD['privkey.pem']
+    domain_dir, _live_dir = _seed(cert_dir, flat=wedged, live=NEW)
+    shell.set_next_result(returncode=0, stdout="Cert not yet due for renewal")
+
+    result = cert_manager.renew_certificate(DOMAIN)
+
+    assert result['success'] is True
+    assert result['renewed'] is False
+    assert _flat(domain_dir) == NEW, (
+        "the renewal ran, saw nothing was due, and left the mismatched pair "
+        "on disk exactly as it found it — which is how this state became "
+        "permanent in the first place"
+    )
+    assert result.get('repaired') == ['privkey.pem'], (
+        f"the repair must be reported, not silent: got {result.get('repaired')}"
+    )
+
+
+def test_a_no_op_renewal_touches_nothing_when_the_copy_agrees(manager):
+    """No spurious writes on the ordinary daily path."""
+    cert_manager, shell, cert_dir = manager
+    domain_dir, _live_dir = _seed(cert_dir, flat=NEW, live=NEW)
+    before = {name: (domain_dir / name).stat().st_mtime_ns
+              for name in CERTIFICATE_FILES}
+    shell.set_next_result(returncode=0, stdout="Cert not yet due for renewal")
+
+    result = cert_manager.renew_certificate(DOMAIN)
+
+    assert result['renewed'] is False
+    assert result.get('repaired') is None
+    after = {name: (domain_dir / name).stat().st_mtime_ns
+             for name in CERTIFICATE_FILES}
+    assert after == before, "files were rewritten although nothing had changed"
+
+
+def test_a_certificate_with_no_live_directory_is_not_called_stale(manager):
+    """Imported or externally-managed certs have nothing to reconcile."""
+    cert_manager, _shell, cert_dir = manager
+    domain_dir = cert_dir / DOMAIN
+    domain_dir.mkdir()
+    for name, content in OLD.items():
+        (domain_dir / name).write_bytes(content)
+
+    assert cert_manager._stale_flat_files(
+        domain_dir / 'live' / DOMAIN, domain_dir) == []
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/test_flat_copy_is_published_as_one_unit.py
+++ b/tests/test_flat_copy_is_published_as_one_unit.py
@@ -199,3 +199,26 @@ def test_a_certificate_with_no_live_directory_is_not_called_stale(manager):
 
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])
+
+
+def test_leftovers_from_a_killed_attempt_are_removed_before_publishing(tmp_path):
+    """A process killed between staging and promote (SIGKILL, OOM) leaves
+    *.staging files that no exception handler can clean. The next publish
+    removes them first; the domain lock guarantees they are not in flight."""
+    from modules.core.certificates import CertificateManager
+    from unittest.mock import MagicMock
+    src = tmp_path / 'live'
+    dest = tmp_path / 'flat'
+    src.mkdir()
+    dest.mkdir()
+    for name in ('cert.pem', 'chain.pem', 'fullchain.pem', 'privkey.pem'):
+        (src / name).write_text(f'new-{name}')
+        (dest / name).write_text(f'old-{name}')
+    (dest / 'privkey.pem.staging').write_text('from-a-dead-attempt')
+    (dest / 'cert.pem.staging').write_text('from-a-dead-attempt')
+    cm = CertificateManager.__new__(CertificateManager)
+    cm.shell_executor = MagicMock()
+    published = cm._publish_flat_files(src, dest)
+    assert set(published) == {'cert.pem', 'chain.pem', 'fullchain.pem', 'privkey.pem'}
+    assert not list(dest.glob('*.staging'))
+    assert (dest / 'privkey.pem').read_text() == 'new-privkey.pem'

--- a/tests/test_settings_lost_update.py
+++ b/tests/test_settings_lost_update.py
@@ -1,0 +1,191 @@
+"""Two overlapping writes must both survive.
+
+`test_settings_request_scoped_cache.py` pins the cache's contract and every
+one of its six assertions is still true. What it never asked is what the cache
+does to a read-modify-write, and the answer was: it turns every one of them
+into a lost update.
+
+`update()` and `atomic_update()` hold `self._lock` for the whole
+read-modify-write, so two writes cannot interleave. But the "read" was
+`load_settings()`, which inside a request returns the dict cached on `flask.g`
+when the request STARTED. The lock was protecting a snapshot, not the file.
+
+The window is not theoretical and it is not milliseconds. On the synchronous
+issuance path — the default, since async is opt-in — `cert_service.py` loads
+settings at :183, runs certbot, and writes at :242. Everything between those
+two lines happens in the same request thread, so for the whole duration of an
+issuance any other write to settings.json was silently rolled back: a user
+created, a domain registered, a DNS credential saved.
+
+The second test is the one that decides whether this is a nuisance or a
+security defect. `atomic_update`'s `protected_keys` exists to stop a partial
+settings POST from dropping `users` and `api_keys`; it restores them from
+`existing`. With `existing` coming from the cache it restored them from the
+stale snapshot — so an account deleted by a concurrent request came back,
+password hash included, and `delete_user` had already reported success.
+
+Both tests fail on the pre-fix code. Neither uses a mock: the threads are real,
+the request contexts are real, and the file on disk is the judge.
+"""
+from __future__ import annotations
+
+import threading
+
+import pytest
+from flask import Flask
+
+from modules.core.file_operations import FileOperations
+from modules.core.settings import SettingsManager
+
+pytestmark = [pytest.mark.unit]
+
+TIMEOUT = 15  # generous: a stuck thread must fail the test, not hang the suite
+
+
+@pytest.fixture
+def settings_manager(tmp_path):
+    dirs = {name: tmp_path / name for name in
+            ("certificates", "data", "backups", "logs")}
+    for d in dirs.values():
+        d.mkdir()
+    file_ops = FileOperations(
+        cert_dir=dirs["certificates"], data_dir=dirs["data"],
+        backup_dir=dirs["backups"], logs_dir=dirs["logs"],
+    )
+    manager = SettingsManager(
+        file_ops=file_ops, settings_file=dirs["data"] / "settings.json")
+    manager.save_settings({
+        'email': 'seed@example.com',
+        'dns_provider': 'cloudflare',
+        'domains': [],
+        'users': {'bob': {'password_hash': 'sha256:seeded', 'role': 'operator'}},
+    })
+    return manager
+
+
+def _run(*targets):
+    """Run the callables as threads and re-raise whatever they raised.
+
+    A thread that dies with an exception otherwise leaves the test asserting
+    on a half-finished state and reporting a confusing failure.
+    """
+    errors = []
+
+    def guard(target):
+        def wrapped():
+            try:
+                target()
+            except BaseException as error:      # noqa: BLE001 - re-raised below
+                errors.append(error)
+        return wrapped
+
+    threads = [threading.Thread(target=guard(t), daemon=True) for t in targets]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=TIMEOUT)
+    alive = [t for t in threads if t.is_alive()]
+    assert not alive, f"{len(alive)} thread(s) did not finish within {TIMEOUT}s"
+    if errors:
+        raise errors[0]
+
+
+def test_a_long_request_does_not_roll_back_a_concurrent_write(settings_manager):
+    """The issuance shape: load, spend minutes in certbot, then write."""
+    app = Flask(__name__)
+    holding_snapshot = threading.Event()
+    other_write_landed = threading.Event()
+
+    def slow_issuance():
+        # cert_service.prepare_create -> load_settings (caches on flask.g)
+        with app.test_request_context('/api/certificates/create'):
+            settings_manager.load_settings()
+            holding_snapshot.set()
+            # ... certbot runs here, for minutes, in this same thread ...
+            assert other_write_landed.wait(timeout=TIMEOUT)
+
+            def add_domain(settings):
+                settings.setdefault('domains', []).append(
+                    {'domain': 'issued.example.com', 'dns_provider': 'cloudflare'})
+
+            settings_manager.update(add_domain, 'certificate_created')
+
+    def concurrent_settings_write():
+        assert holding_snapshot.wait(timeout=TIMEOUT)
+        with app.test_request_context('/api/settings'):
+            def set_email(settings):
+                settings['email'] = 'changed@example.com'
+
+            settings_manager.update(set_email, 'settings_updated')
+        other_write_landed.set()
+
+    _run(slow_issuance, concurrent_settings_write)
+
+    final = settings_manager.load_settings()
+    assert final['email'] == 'changed@example.com', (
+        "the issuance wrote back a snapshot taken before certbot ran and "
+        "reverted a settings change made while it was running"
+    )
+    assert [d['domain'] for d in final.get('domains', [])] == ['issued.example.com'], (
+        "the newly issued domain is missing from settings — a domain that is "
+        "not in settings['domains'] is never visited by check_renewals again"
+    )
+
+
+def test_a_deleted_user_does_not_come_back(settings_manager):
+    """`protected_keys` must protect the file, not the caller's snapshot."""
+    app = Flask(__name__)
+    holding_snapshot = threading.Event()
+    user_deleted = threading.Event()
+
+    def long_request_then_partial_settings_post():
+        with app.test_request_context('/api/web/settings'):
+            settings_manager.load_settings()          # snapshot still has bob
+            holding_snapshot.set()
+            assert user_deleted.wait(timeout=TIMEOUT)
+            # A settings POST that carries no 'users' key at all: the shape
+            # protected_keys was written for.
+            settings_manager.atomic_update({'email': 'partial@example.com'})
+
+    def admin_deletes_the_user():
+        assert holding_snapshot.wait(timeout=TIMEOUT)
+        with app.test_request_context('/api/users/bob'):
+            def drop_bob(settings):
+                settings.get('users', {}).pop('bob', None)
+
+            settings_manager.update(drop_bob, 'user_management')
+        user_deleted.set()
+
+    _run(long_request_then_partial_settings_post, admin_deletes_the_user)
+
+    final = settings_manager.load_settings()
+    assert 'bob' not in final.get('users', {}), (
+        "a revoked account was restored — password hash included — by a "
+        "concurrent settings POST, after delete_user reported success"
+    )
+    assert final['email'] == 'partial@example.com', (
+        "the settings POST itself was lost, which would be the same bug "
+        "pointing the other way"
+    )
+
+
+def test_the_write_path_still_sees_its_own_earlier_write(settings_manager):
+    """Reading from disk must not break read-your-own-writes within a request.
+
+    The cache exists because `/api/certificates` re-reads settings 15+ times
+    per request. Forcing the write path to disk must leave that intact: a
+    route that writes and then reads still sees what it just wrote.
+    """
+    app = Flask(__name__)
+    with app.test_request_context('/api/settings'):
+        settings_manager.load_settings()
+
+        def set_email(settings):
+            settings['email'] = 'self@example.com'
+
+        assert settings_manager.update(set_email, 'settings_updated')
+        assert settings_manager.load_settings()['email'] == 'self@example.com'
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/test_setup_mode_is_a_one_way_door.py
+++ b/tests/test_setup_mode_is_a_one_way_door.py
@@ -1,0 +1,209 @@
+"""Setup mode must be a door that only closes.
+
+`is_setup_mode()` is not a mild state. `_authenticate_request` returns
+`{'username': 'setup_user', 'role': 'admin'}` for a caller with no credential
+at all, which is enough to read /api/settings, mint API keys, create admin
+users, and download private keys — `resources.py` gates the private-key
+download on the operator role, and setup_user is admin.
+
+It exists so a fresh install can be bootstrapped, and it closes as soon as the
+operator configures any credential. What nothing checked was the way back.
+
+v2.21.4 added the OIDC branch to `is_setup_mode()` to CLOSE a real hole: an
+SSO-only deployment has no bearer token and never gets `local_auth_enabled`
+set, because OIDC JIT provisioning does not flip it, so such a box sat in setup
+mode — world-open — forever. The fix was right. Its side effect was that
+closure now depends on a checkbox: unchecking "Enable OIDC/SSO" in the settings
+UI put the whole instance back into anonymous-admin, with no guard on the route
+and no warning next to the toggle (the "Authentication is disabled" banner
+lives on the separate Users tab).
+
+`delete_user` already refuses to remove the last admin, so that third way in is
+closed. These tests pin the other two, and the two shapes that must keep
+working: a fresh install still has to be configurable, and an instance with
+another credential must still be free to turn SSO off.
+"""
+from __future__ import annotations
+
+import pytest
+from flask import Flask
+
+from modules.core.auth import AuthManager
+from modules.core.file_operations import FileOperations
+from modules.core.oidc import OIDCManager
+from modules.core.settings import SettingsManager
+from modules.web.auth_routes import register_auth_routes
+from modules.web.oidc_routes import register_oidc_routes
+
+pytestmark = [pytest.mark.unit]
+
+CONFIGURED_OIDC = {
+    'enabled': True,
+    'provider_name': 'TestIdP',
+    'issuer_url': 'https://idp.example.com',
+    'client_id': 'cm-test',
+    'client_secret': 'shh',
+}
+
+
+def _allow_all(_min_role):
+    def decorator(fn):
+        return fn
+    return decorator
+
+
+def _build(tmp_path, *, oidc=None, local_auth=False, users=True):
+    dirs = {name: tmp_path / name for name in
+            ("certificates", "data", "backups", "logs")}
+    for d in dirs.values():
+        d.mkdir()
+    file_ops = FileOperations(
+        cert_dir=dirs["certificates"], data_dir=dirs["data"],
+        backup_dir=dirs["backups"], logs_dir=dirs["logs"])
+    settings_manager = SettingsManager(
+        file_ops=file_ops, settings_file=dirs["data"] / "settings.json")
+    settings_manager.load_settings()
+
+    auth_manager = AuthManager(settings_manager)
+    auth_manager.set_hmac_key('test-secret-for-hmac')
+    auth_manager.require_role = _allow_all       # type: ignore[assignment]
+    # Deterministic: the env of the machine running the suite must not decide
+    # whether this instance has an operator bearer token.
+    auth_manager._operator_bearer_token = False
+
+    if users:
+        auth_manager.create_user('admin-user', 'pw123abc', role='admin')
+
+    def apply(settings):
+        settings['local_auth_enabled'] = local_auth
+        settings['setup_completed'] = True
+        if oidc is not None:
+            settings['oidc'] = dict(oidc)
+
+    settings_manager.update(apply, 'test_setup')
+
+    oidc_manager = OIDCManager(settings_manager, auth_manager)
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.secret_key = 'test'
+    managers = {'settings': settings_manager, 'auth': auth_manager,
+                'oidc': oidc_manager, 'audit': None}
+    register_oidc_routes(app, managers, auth_manager, oidc_manager,
+                         lambda *a, **k: (True, None),
+                         lambda *a, **k: None)
+    register_auth_routes(app, managers, _allow_all, auth_manager,
+                         lambda *a, **k: (True, None),
+                         lambda *a, **k: None)
+    return app, auth_manager
+
+
+# --------------------------------------------------------------------------
+# The transitions that must be refused
+# --------------------------------------------------------------------------
+
+def test_sso_only_instance_refuses_to_turn_off_its_only_credential(tmp_path):
+    app, auth = _build(tmp_path, oidc=CONFIGURED_OIDC, local_auth=False)
+    assert auth.is_setup_mode() is False, "fixture is wrong: already open"
+
+    response = app.test_client().post('/api/auth/oidc/settings',
+                                      json={**CONFIGURED_OIDC, 'enabled': False})
+
+    assert response.status_code == 409, (
+        f"unchecking Enable OIDC/SSO returned {response.status_code}; on an "
+        f"SSO-only box that hands every endpoint to anonymous callers as admin"
+    )
+    assert auth.is_setup_mode() is False, (
+        "the instance is in setup mode after the refusal — the write happened "
+        "anyway and the status code was decoration"
+    )
+
+
+def test_clearing_the_issuer_url_cannot_open_the_door_either(tmp_path):
+    """The other half of _is_oidc_configured(), closed by a different gate.
+
+    Un-configuring OIDC would open the instance exactly like un-checking it,
+    but a payload that clears issuer_url while `enabled` stays true is invalid:
+    _validate_config rejects it with a 400 and NOTHING is written. The setup
+    guard deliberately does not fire here, because "client_id is required"
+    tells the admin what they got wrong and a security refusal does not.
+
+    What this test pins is the outcome, not which gate produced it: the
+    instance must still be closed afterwards.
+    """
+    app, auth = _build(tmp_path, oidc=CONFIGURED_OIDC, local_auth=False)
+
+    response = app.test_client().post('/api/auth/oidc/settings',
+                                      json={**CONFIGURED_OIDC, 'issuer_url': ''})
+
+    assert response.status_code == 400, (
+        f"got {response.status_code}: expected the config validator to refuse "
+        f"an enabled OIDC block with no issuer_url"
+    )
+    assert auth.is_setup_mode() is False, (
+        "an invalid OIDC payload was persisted anyway and opened the instance"
+    )
+
+
+def test_local_only_instance_refuses_to_turn_off_local_auth(tmp_path):
+    app, auth = _build(tmp_path, oidc=None, local_auth=True)
+    assert auth.is_setup_mode() is False
+
+    response = app.test_client().post('/api/auth/config',
+                                      json={'local_auth_enabled': False})
+
+    assert response.status_code == 409, (
+        f"got {response.status_code}: POST /api/auth/config guarded only the "
+        f"ENABLE direction ('Create admin first'); disabling was unguarded"
+    )
+    assert auth.is_setup_mode() is False
+
+
+# --------------------------------------------------------------------------
+# The shapes that must keep working
+# --------------------------------------------------------------------------
+
+def test_sso_can_be_turned_off_when_local_auth_still_holds_the_door(tmp_path):
+    app, auth = _build(tmp_path, oidc=CONFIGURED_OIDC, local_auth=True)
+
+    response = app.test_client().post('/api/auth/oidc/settings',
+                                      json={**CONFIGURED_OIDC, 'enabled': False})
+
+    assert response.status_code == 200, (
+        f"got {response.status_code}: an admin with local auth configured must "
+        f"still be free to stop using SSO — a guard that blocks this is a "
+        f"guard nobody can live with"
+    )
+    assert auth.is_setup_mode() is False
+
+
+def test_a_bearer_token_makes_the_toggle_inert(tmp_path):
+    """API_BEARER_TOKEN short-circuits is_setup_mode, so nothing to protect."""
+    app, auth = _build(tmp_path, oidc=CONFIGURED_OIDC, local_auth=False)
+    auth._operator_bearer_token = True
+
+    response = app.test_client().post('/api/auth/oidc/settings',
+                                      json={**CONFIGURED_OIDC, 'enabled': False})
+
+    assert response.status_code == 200, (
+        f"got {response.status_code}: with a bearer token configured the "
+        f"instance never enters setup mode, so refusing is pure obstruction"
+    )
+
+
+def test_a_fresh_install_can_still_be_configured(tmp_path):
+    """Already in setup mode: the guard is about not regressing, not about
+    freezing a box that has not been secured yet."""
+    app, auth = _build(tmp_path, oidc=None, local_auth=False, users=False)
+    assert auth.is_setup_mode() is True
+
+    response = app.test_client().post('/api/auth/config',
+                                      json={'local_auth_enabled': False})
+
+    assert response.status_code != 409, (
+        "a brand-new install cannot be configured because the guard refuses "
+        "to leave a state it is already in"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -124,38 +124,39 @@ class TestSettingsUI:
         expect(cloudflare_card).to_be_visible(timeout=5000)
 
     def test_auth_security_banner_visible(self, browser_page):
+        """Disabling local auth on an instance where it is the only credential
+        is refused (409) since #581: it would put the instance back into setup
+        mode, where every endpoint answers an anonymous caller as admin. So the
+        'authentication is disabled' banner must NOT appear, the toggle must
+        stay on, and the refusal must say why. (Before #581 this test disabled
+        auth and asserted the banner; that path is now the guarded one.)"""
         browser_page.goto(f"{BASE_URL}/settings")
         browser_page.wait_for_load_state("networkidle")
 
-        # Disable local auth via browser fetch (authenticated via session cookie)
-        browser_page.evaluate("""
-            fetch('/api/auth/config', {
-                method: 'POST',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({local_auth_enabled: false})
-            })
+        result = browser_page.evaluate("""
+            async () => {
+                const r = await fetch('/api/auth/config', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({local_auth_enabled: false})
+                });
+                return {status: r.status, body: await r.json()};
+            }
         """)
-        browser_page.wait_for_timeout(500)
+        assert result["status"] == 409, result
+        assert "setup mode" in (result["body"].get("hint") or ""), result
 
-        # Reload to pick up change
+        # Reload: the door stayed closed, so no banner.
         browser_page.reload()
         browser_page.wait_for_load_state("networkidle")
-
-        # Banner is inside the Users tab — switch to it first
         browser_page.locator('button[role="tab"]:has-text("Users")').click(timeout=10000)
         browser_page.wait_for_timeout(500)
+        expect(browser_page.locator("#authSecurityBanner")).to_be_hidden()
 
-        banner = browser_page.locator("#authSecurityBanner")
-        expect(banner).to_be_visible(timeout=10000)
-
-        # Re-enable auth for subsequent tests
-        browser_page.evaluate("""
-            fetch('/api/auth/config', {
-                method: 'POST',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({local_auth_enabled: true})
-            })
+        still_on = browser_page.evaluate("""
+            async () => { const r = await fetch('/api/auth/config'); return (await r.json()); }
         """)
+        assert still_on.get("local_auth_enabled") is True, still_on
 
     def test_save_settings_button(self, browser_page):
         browser_page.goto(f"{BASE_URL}/settings")


### PR DESCRIPTION
A 146-agent audit ran over twelve dimensions of this codebase on 2026-08-18, with an adversarial layer whose job was to demolish each finding rather than confirm it. 66 findings were proposed, 23 were killed by the refuters, 43 survived — and every one of the survivors came back with a correction attached, most of them deflating the severity the finder had claimed.

I then re-read the worst ones in the code myself, because two agents agreeing is not evidence. Four held up. This PR closes those four and nothing else; the remaining 39 are smaller and follow separately, grouped by theme.

Each fix has a test that fails on the code it describes. That is the acceptance criterion for all four — no exceptions, because "it looks right now" is how three of these got in.

## 1. The settings lock protected a snapshot, not the file

`update()` and `atomic_update()` hold `self._lock` for the whole read-modify-write, so two writes cannot interleave. But the "read" was `load_settings()`, which inside a request returns the dict cached on `flask.g` when the request *started*.

The window is not milliseconds. On the synchronous issuance path — the default, since async is opt-in — `cert_service.py` loads settings at :183, runs certbot, and writes at :242, all in the same request thread. For the whole duration of an issuance every other write to `settings.json` was silently reverted: a user created, a domain registered, a DNS credential saved. **A domain rolled out of `settings['domains']` is never visited by `check_renewals` again and its certificate expires in silence.**

The same snapshot defeated the protection meant to prevent exactly this: `atomic_update`'s `protected_keys` restores `users` and `api_keys` from `existing`, so a cached `existing` restored a deleted account — password hash included — after `delete_user` had reported success.

`load_settings` grows `use_cache`; the two write methods pass `False`. Nothing outside `settings.py` calls `save_settings`, so those two methods are every write path in the product. The read path is untouched and all six contracts in `test_settings_request_scoped_cache.py` still hold.

## 2. A backup that cannot restore is not a backup

Every automatic backup is masked — `save_settings` calls `create_unified_backup(settings, reason)` and `include_secrets` defaults to `False`. That default is right: a leaked backup must not also be a credential dump. What was wrong is that every restore path treated those archives as authoritative. The manifest has recorded `secrets_masked` since unified backups existed; nothing read it.

So when `settings.json` could not be parsed, `load_settings` installed the newest masked archive as live settings: every password hash, bearer token, API key hash, OIDC client secret and DNS credential became the literal sentinel. No login, no token, no SSO, every renewal failing at the provider — and `setup_completed` still `True`, so the wizard did not reopen. The log said "Settings restored successfully from backup".

Four changes, one defect:

- the restore skips archives that cannot restore and picks the newest one that can, saying in the log what it found and how to make a usable backup;
- when nothing usable exists it **refuses instead of recreating the file**. `safe_file_read` returns the default for a JSON typo, a `PermissionError` and an empty read alike, and `settings.json` is written atomically, so the app never produces this state itself. Overwriting destroys the operator's only copy of a file a text editor could have repaired. `SettingsUnreadableError` deliberately escapes the catch-all below it, because returning defaults in-memory leaves `setup_completed` False — an instance that cannot read its credentials must not come up world-open;
- the pre-restore rollback archive is written with `include_secrets=True`. It exists solely to undo the restore that follows it; masked, it was a safety net that could not catch anything;
- **a login no longer writes a backup.** Recording `last_login` wrote a full ZIP of settings + certificates and then pruned to `MAX_BACKUPS_PER_TYPE`, so login traffic alone evicted every restore point an operator wanted. A password-hash upgrade still writes one.

`test_disaster_recovery_round_trip.py` is the test nobody had written: configure an instance, back it up, destroy it, restore it, log in. There were tests for creating backups, listing them, masking them, and the restore endpoint's authorization and zip-bomb limits — none that asked whether a backup can bring the instance back.

## 3. Setup mode must be a door that only closes

`_authenticate_request` returns `{'username': 'setup_user', 'role': 'admin'}` for a caller with no credential at all — enough to read `/api/settings`, mint API keys, create admins and download private keys.

v2.21.4 added the OIDC branch to `is_setup_mode()` to *close* a real hole: an SSO-only box has no bearer token and never gets `local_auth_enabled` set, so it sat world-open forever. That fix was right. Its side effect was that closure now depends on a checkbox — and unchecking "Enable OIDC/SSO" put the instance back into anonymous-admin, with no guard on the route and no warning beside the toggle.

`is_setup_mode()` is now expressed once as `setup_mode_for(settings)`, and `would_open_setup_mode(candidate)` asks the same question about a change not yet written. One definition, two callers: a guard that re-implements the predicate it defends drifts away from it. It returns `False` when the instance is already in setup mode, so a fresh install stays configurable.

On the OIDC route it fires only for the deliberate turn-off: a payload clearing `issuer_url` while `enabled` stays true is already rejected by `_validate_config` with a 400 and never written, and "client_id is required" is the more useful answer. `delete_user` already refused to remove the last admin, so that third way in was closed.

## 4. Publish the four PEMs as one unit

`_atomic_binary_copy` is atomic per file. There was no atomicity across the four, the exception handlers roll nothing back, and `privkey.pem` is **last** in `CERTIFICATE_FILES`. A failure on the fourth file left a new `cert.pem`/`chain.pem`/`fullchain.pem` beside the previous `privkey.pem` — the pair `/download` serves and deploy hooks ship, and it cannot complete a handshake.

The permanence is what made it dangerous: the next renewal fingerprints `live/`, finds it fresh, concludes `renewed=False` and returns *before* the copy loop. Nothing retried it; `check_renewals` booked it as `skipped_not_due`. No failure, no event, no email.

`_publish_flat_files` stages all four then promotes them, so a failure leaves the previous generation intact and internally consistent. The no-op branch now reconciles against `live/` and republishes when they disagree, reporting what it repaired — that is what heals an instance already wedged.

## Verification

- full suite green: 2853 passed, 6 skipped
- every fix disabled in turn to confirm its test goes red; the pre-fix four-file copy reproduced directly (leaves `cert.pem` NEW, `privkey.pem` OLD)
- `flake8` gate clean; `bandit` severities identical to `main` (29 LOW both sides)
- no new dependencies

Not included, deliberately: `/api/activity` is readable by the viewer role while the audit-log endpoints are admin-only. That looks like a product decision rather than a defect — the activity page is built for the viewer role — so it wants a call from @fabriziosalmi rather than a silent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)