### PR TITLE
fix: the list of advisories we are living with had stopped being the list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,42 @@ jobs:
     - name: Check the wiki against the repository
       run: python scripts/check_wiki.py wiki
 
+  # Every dependency advisory we are living with must be written down.
+  #
+  # CertMate holds cryptography and pyopenssl behind their fixed versions on
+  # purpose, and records that decision in SECURITY.md while dismissing the
+  # alert as tolerable_risk pointing back at it. On 2026-08-21 the record had
+  # drifted: SECURITY.md documented one advisory, dismissed months earlier,
+  # while three published on 2026-08-03 against the same pin sat open,
+  # unassessed and unmentioned — through a release. The reasoning in the file
+  # was fine; it had stopped being the complete list, and nothing looked.
+  #
+  # Weekly rather than a merge gate because it needs the live alert list,
+  # which no test can see. A finding here is news: either an advisory arrived
+  # and nobody assessed it, or the pin can finally move.
+  advisories:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      # Listing Dependabot alerts needs this explicitly; the workflow-level
+      # read-all already grants it, but a job that reads security data should
+      # say so where someone reviewing the job can see it.
+      security-events: read
+      contents: read
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v5
+      with:
+        python-version: '3.12'
+
+    - name: Every carried advisory is documented in SECURITY.md
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: python scripts/check_advisories.py ${{ github.repository }}
+
   # Storage backends against real servers rather than a faithful fake.
   #
   # The in-memory S3 fake is a good test and cannot disagree with me: it

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,6 +106,19 @@ or download certificates.
 
 ## Known dependency constraint
 
+CertMate pins `cryptography==46.0.7` and `pyopenssl==26.0.0`. Every version
+that would clear the advisories below needs a pyOpenSSL that breaks the pinned
+ACME stack, so the pins are held deliberately: the alerts are open by choice,
+not by oversight. One reason blocks all of them, and one fix clears all of
+them (issue #103); both are described once, after the advisories.
+
+**Four advisories are held by this constraint.** The first is a flaw in the
+OpenSSL statically linked into the `cryptography` wheel; the other three,
+published 2026-08-03, are in `cryptography`'s own code and are reached only
+through specific APIs. That difference is what makes the reachability argument
+below hold for the three, and it is why they are analysed separately rather
+than folded into the first.
+
 ### GHSA-537c-gmf6-5ccf — vulnerable OpenSSL statically linked in `cryptography` wheels
 
 CertMate currently pins `cryptography==46.0.7`, which is flagged HIGH by
@@ -179,12 +192,48 @@ answers. The real fix remains the certbot 5.x stack migration (#103).
   provider APIs) uses Python's `ssl` module, which links the interpreter's
   own OpenSSL, not the copy inside the cryptography wheel.
 
+### The 2026-08-03 advisories in `cryptography`'s own code
+
+Three further advisories against `cryptography <= 46.0.7` were published on
+2026-08-03. They are a different shape from the one above: the defect is in
+`cryptography`'s own Rust and Python code, not in the linked OpenSSL, so each
+is reached through one named API and through nothing else.
+
+| Advisory | Severity | Defect | Reached through | First fixed in |
+| --- | --- | --- | --- | --- |
+| GHSA-g6cj-pr64-35w5 | HIGH | duplicate self-signed intermediates cause exponential X.509 path building | `cryptography.x509.verification` | 49.0.0 |
+| GHSA-jwv3-5hgf-82ww | HIGH | PKCS#7 `EnvelopedData` decryption exposes a Bleichenbacher oracle | the PKCS#7 decryption API | 50.0.0 |
+| GHSA-m2h6-j472-rp4c | MEDIUM | the verifier accepts wildcard DNS names, allowing escape from `permittedSubtrees` name constraints | `cryptography.x509.verification` | 49.0.0 |
+
+**Actual exposure: none of the three is reachable.** Two need the X.509
+verifier (`PolicyBuilder` / `ClientVerifier` / `ServerVerifier`), one needs
+PKCS#7 `EnvelopedData` decryption. Neither API is called anywhere in the
+shipped stack — verified across `modules/`, `app.py` and the pinned
+`certbot==2.10.0` / `acme==3.3.0` / `josepy==1.13.0`, none of which references
+`x509.verification`, `PolicyBuilder`, `ClientVerifier`, `ServerVerifier`,
+`pkcs7` or `EnvelopedData`.
+
+What CertMate does use from `cryptography` is X.509 parsing and building,
+`Fernet`, hashes, key serialization, RSA and Ed25519 key generation, and
+PBKDF2. The `.pfx` export
+(`modules/core/storage_backends.py:175`) calls `serialization.pkcs12`, which
+is PKCS#12 — a different structure and a different code path from the PKCS#7
+`EnvelopedData` decryption the Bleichenbacher advisory describes. CertMate
+never decrypts PKCS#7 at all; it only ever writes PKCS#12.
+
+**The constraint has tightened, not loosened.** Clearing all three needs
+`cryptography>=50.0.0`, and 50.0.0 is the exact version the re-verification
+above proves fatal: it installs cleanly and then `certbot --version` dies on
+`X509Req`. The version that would close these alerts is the version that
+breaks issuance.
+
 **Fix path.** The certbot 5.x migration epic (issue #103): newer `acme`
 releases drop the removed pyOpenSSL API but require `josepy>=2` and a newer
 certbot line. Once that migration lands, `pyopenssl>=26.2.0` and
-`cryptography>=48.0.1` unblock together, and the Dependabot alerts for
-GHSA-537c-gmf6-5ccf can be closed. Until then the alerts remain open by
-choice, not by oversight.
+`cryptography>=48.0.1` unblock together, and all four Dependabot alerts above
+can be closed. Until then they remain open by choice, not by oversight, and
+this section is the record of that choice: an advisory against `cryptography`
+that is not listed here has not been assessed, and should be treated as new.
 
 ## Coordinated disclosure
 

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -20,7 +20,7 @@ urllib3!=2.2.0,>=2.7.0,<3      # CVE-2025-66418, CVE-2025-66471, CVE-2026-21441 
 requests==2.34.2
 python-dotenv==1.2.3
 APScheduler==3.11.3
-cryptography==46.0.7               # GHSA-537c-gmf6-5ccf (HIGH) open by choice; blocked by acme 3.3.0 (see SECURITY.md "Known dependency constraint")
+cryptography==46.0.7               # Held: 4 advisories open by choice, none reachable. Do NOT name them here — this line named one and three more arrived unnoticed. SECURITY.md "Known dependency constraint" is the list.
 pyopenssl==26.0.0                  # Do not bump to 26.2.0+: removes X509Extension, breaks acme 3.3.0 at import (see SECURITY.md)
 
 # Production server

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,7 +95,7 @@ urllib3!=2.2.0,>=2.7.0,<3      # CVE-2025-66418, CVE-2025-66471, CVE-2026-21441 
 requests==2.34.2
 python-dotenv==1.2.3
 APScheduler==3.11.3
-cryptography==46.0.7               # GHSA-537c-gmf6-5ccf (HIGH) is open by choice: 48.0.1 needs pyopenssl>=26.2.0, which breaks acme 3.3.0 at import. See SECURITY.md "Known dependency constraint"; unblocked by the certbot 5.x epic (#103).
+cryptography==46.0.7               # Held deliberately: every version that clears the open advisories needs pyopenssl>=26.2.0, which breaks acme 3.3.0 at import; 50.0.0 installs clean and then kills `certbot --version`. The advisories, their reachability and the fix path (#103) live in SECURITY.md "Known dependency constraint" — deliberately not duplicated here, because this line used to name one advisory and three more arrived without anyone noticing.
 pyopenssl==26.0.0                  # Requires cryptography>=46.0.0,<47. Do not bump to 26.2.0+: it removes OpenSSL.crypto.X509Extension, which acme==3.3.0 evaluates at import time (certbot crashes). See SECURITY.md.
 bcrypt==5.0.0                      # Secure password hashing
 Authlib>=1.7.2,<2.0.0              # OIDC/OAuth2 client (Authorization Code + PKCE) for SSO. Floor at 1.7.2, which is what the published image already resolves to; it is above 1.3.2, where GHSA-9c64-2c4r-vf2g was fixed. Allow patch + minor pickup, ceiling at 2.0.0 because any major bump warrants an explicit compatibility check.

--- a/scripts/check_advisories.py
+++ b/scripts/check_advisories.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Every dependency advisory we are living with must be written down.
+
+CertMate holds `cryptography` and `pyopenssl` behind their fixed versions on
+purpose: every release that clears the advisories needs a pyOpenSSL that
+breaks the pinned ACME stack, and `cryptography==50.0.0` installs cleanly and
+then kills `certbot --version`. That decision is recorded in SECURITY.md under
+"Known dependency constraint", and the Dependabot alert is dismissed as
+`tolerable_risk` pointing at it. Two steps, and the pair is the whole record.
+
+On 2026-08-21 the record had drifted. SECURITY.md documented one advisory,
+GHSA-537c-gmf6-5ccf, which had been dismissed months earlier. Three more had
+been published on 2026-08-03 against the same pin and were sitting open,
+undocumented, unassessed and unmentioned — through a release. Nothing was
+wrong with the reasoning in SECURITY.md; it had simply stopped being the
+complete list, and nothing looked.
+
+A test cannot see live alerts, so this is a scheduled job rather than a gate
+on the merge. It asks the repository which advisories it is actually carrying
+and fails when one of them is missing from the file that claims to enumerate
+them.
+
+    GITHUB_TOKEN=... python scripts/check_advisories.py [owner/repo]
+
+The rule is deliberately asymmetric:
+
+  * An alert that is OPEN, or dismissed as `tolerable_risk`, MUST appear in
+    SECURITY.md. Both are decisions to keep running with a known flaw, and a
+    decision nobody wrote down is indistinguishable from an oversight.
+  * An advisory documented in SECURITY.md but no longer alerting is NOT a
+    failure. That is the normal end state of a dismissal: GHSA-537c-gmf6-5ccf
+    is dismissed and still documented, correctly — the history of why a pin
+    exists outlives the alert.
+  * Alerts dismissed as `fixed`, `inaccurate`, `not_used` or `no_bandwidth`
+    are ignored: those are not "we are living with this".
+"""
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+REPO_DEFAULT = "fabriziosalmi/certmate"
+SECURITY_MD = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                           "SECURITY.md")
+# A dismissal that means "we accept this and keep running" — the only kind
+# that still needs the reasoning written down.
+ACCEPTED_DISMISSALS = {"tolerable_risk"}
+
+
+def documented_advisories():
+    """Every GHSA id named in SECURITY.md."""
+    try:
+        with open(SECURITY_MD, encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError as error:
+        raise SystemExit(f"cannot read SECURITY.md ({error}) — this check has "
+                         f"lost its subject and must not pass quietly")
+    if "Known dependency constraint" not in text:
+        raise SystemExit(
+            "SECURITY.md no longer has a 'Known dependency constraint' "
+            "section. If the constraint is gone the pins should have moved "
+            "with it; if it was renamed, this script needs renaming too.")
+    return set(re.findall(r"GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}", text))
+
+
+def carried_advisories(repo, token):
+    """Advisories the repository is living with: open, or accepted as tolerable.
+
+    Returns {ghsa_id: (severity, state, package)}.
+
+    The alerts endpoint paginates by CURSOR, not by page number: passing
+    `?page=2` is answered with `400 Pagination using the 'page' parameter is
+    not supported`. The next page is the `rel="next"` URL in the Link header,
+    and following it is the only way to see the tail on a repository with more
+    than one page of alerts.
+    """
+    carried = {}
+    url = (f"https://api.github.com/repos/{repo}/dependabot/alerts"
+           f"?per_page=100")
+    while url:
+        request = urllib.request.Request(
+            url,
+            headers={"Authorization": f"Bearer {token}",
+                     "Accept": "application/vnd.github+json",
+                     "User-Agent": "certmate-advisory-check"})
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                batch = json.loads(response.read().decode("utf-8"))
+                link = response.headers.get("Link", "")
+        except urllib.error.HTTPError as error:
+            if error.code in (403, 404):
+                raise SystemExit(
+                    f"the Dependabot alerts API answered {error.code}. The "
+                    f"token needs `security-events: read` on {repo}; without "
+                    f"it this check cannot see what it is meant to check, and "
+                    f"passing would be worse than failing.")
+            raise
+        for alert in batch:
+            state = alert.get("state")
+            if state == "open" or (state == "dismissed"
+                                   and alert.get("dismissed_reason") in ACCEPTED_DISMISSALS):
+                advisory = alert.get("security_advisory") or {}
+                ghsa = advisory.get("ghsa_id")
+                if ghsa:
+                    package = ((alert.get("dependency") or {}).get("package") or {}).get("name", "?")
+                    carried[ghsa] = (advisory.get("severity", "?"), state, package)
+        following = re.search(r'<([^>]+)>;\s*rel="next"', link)
+        url = following.group(1) if following else None
+    return carried
+
+
+def main():
+    repo = sys.argv[1] if len(sys.argv) > 1 else REPO_DEFAULT
+    token = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+    if not token:
+        raise SystemExit("GITHUB_TOKEN is not set; refusing to report success "
+                         "on a check that never ran")
+
+    documented = documented_advisories()
+    carried = carried_advisories(repo, token)
+    undocumented = {g: v for g, v in carried.items() if g not in documented}
+
+    print(f"advisories carried by {repo}: {len(carried)}   "
+          f"documented in SECURITY.md: {len(documented)}")
+    for ghsa, (severity, state, package) in sorted(carried.items()):
+        mark = "ok " if ghsa in documented else ">>>"
+        print(f"  {mark} {severity.upper():8} {ghsa}  {package}  ({state})")
+
+    if not undocumented:
+        print("every advisory this repository carries is written down")
+        return 0
+
+    print(f"\n{len(undocumented)} advisory/advisories are being carried with no "
+          f"entry in SECURITY.md:", file=sys.stderr)
+    for ghsa, (severity, state, package) in sorted(undocumented.items()):
+        print(f"  {severity.upper()} {ghsa} ({package}, {state})", file=sys.stderr)
+    print("\nAdd them to the 'Known dependency constraint' section with their "
+          "reachability, or fix the dependency. An accepted risk that is not "
+          "written down cannot be told apart from one nobody noticed — which "
+          "is exactly what happened on 2026-08-21.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_advisory_checker_is_wired.py
+++ b/tests/test_advisory_checker_is_wired.py
@@ -1,0 +1,109 @@
+"""The advisory checker must exist, something must run it, and it must refuse
+to report success when it cannot see.
+
+CertMate holds `cryptography` and `pyopenssl` behind their fixed versions
+deliberately: every release that clears the advisories needs a pyOpenSSL that
+breaks the pinned ACME stack, and `cryptography==50.0.0` installs cleanly and
+then kills `certbot --version`. The decision is recorded in SECURITY.md and
+the alert is dismissed as `tolerable_risk` pointing at it.
+
+On 2026-08-21 the record had drifted. SECURITY.md named one advisory,
+dismissed months earlier; three more, published 2026-08-03 against the same
+pin, were open, unassessed and unmentioned — through a release. The reasoning
+in the file was correct and current. It had simply stopped being the complete
+list, and nothing looked.
+
+`scripts/check_advisories.py` looks. This file asserts the wiring and the
+refusal-to-pass-quietly, not the comparison logic — that was verified by
+running it against the pre-fix SECURITY.md, where it exits 1 and names the
+three, and against the corrected one, where it exits 0.
+"""
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check_advisories.py"
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+SECURITY = REPO_ROOT / "SECURITY.md"
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_the_checker_exists():
+    assert SCRIPT.is_file(), f"{SCRIPT} is missing"
+
+
+def test_a_workflow_runs_it():
+    """A checker nothing runs is the shape this repository keeps removing."""
+    runners = [path.name for path in WORKFLOWS.glob("*.yml")
+               if "check_advisories.py" in path.read_text(encoding="utf-8")]
+    assert runners, (
+        "no workflow runs scripts/check_advisories.py. The drift it exists to "
+        "catch is invisible to the test suite — only a scheduled job can see "
+        "the live alert list, so an unwired checker catches nothing."
+    )
+
+
+def test_the_job_can_read_the_alerts():
+    """`security-events: read` is what the Dependabot alerts API needs.
+
+    Without it the API answers 403 and the script exits non-zero with a
+    message naming the missing scope — loud, but weekly-loud. Asserting the
+    permission here turns that into a failure at review time instead.
+    """
+    ci = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
+    job = ci.split("  advisories:", 1)
+    assert len(job) == 2, "the `advisories` job is gone from ci.yml"
+    # The job's own block ends at the next top-level job key.
+    block = re.split(r"\n  [a-z][a-z0-9-]*:\n", job[1])[0]
+    assert "security-events: read" in block, (
+        "the advisories job no longer declares `security-events: read`; "
+        "listing Dependabot alerts needs it and the job would fail on 403"
+    )
+
+
+def test_it_refuses_to_pass_without_a_token():
+    """No token means the check did not run. That must not look like success."""
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert "refusing to report success" in source, (
+        "check_advisories.py no longer refuses to run without GITHUB_TOKEN. A "
+        "check that returns 0 when it could not look is worse than no check: "
+        "it is a green tick over an unread alert list."
+    )
+
+
+def test_a_dismissed_tolerable_risk_still_counts_as_carried():
+    """The asymmetry is the whole design and must not be flattened.
+
+    An alert dismissed as `tolerable_risk` IS a decision to keep running with
+    a known flaw, so it still has to be written down — GHSA-537c-gmf6-5ccf is
+    dismissed and documented, and correctly so. A dismissal for `fixed` or
+    `inaccurate` is not that, and is ignored.
+    """
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert 'ACCEPTED_DISMISSALS = {"tolerable_risk"}' in source, (
+        "the set of dismissal reasons that still require documentation has "
+        "changed; if `tolerable_risk` no longer counts as carried, an accepted "
+        "risk can leave SECURITY.md without anything noticing"
+    )
+
+
+def test_security_md_still_has_the_section_the_checker_reads():
+    text = SECURITY.read_text(encoding="utf-8")
+    assert "Known dependency constraint" in text, (
+        "check_advisories.py reads this section; renaming it makes the "
+        "checker exit with an explanatory failure rather than pass, but the "
+        "rename should be deliberate"
+    )
+    found = set(re.findall(r"GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}", text))
+    assert len(found) >= 4, (
+        f"SECURITY.md documents {len(found)} advisories; the constraint held "
+        f"four as of 2026-08-21. Fewer means an entry was dropped without the "
+        f"pin moving."
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/test_dependabot_holds_the_stack.py
+++ b/tests/test_dependabot_holds_the_stack.py
@@ -42,7 +42,15 @@ HELD = {
     "certbot": "Certificate management",
     "josepy": "josepy",
     "pyopenssl": "Do not bump to 26.2.0+",
-    "cryptography": "GHSA-537c-gmf6-5ccf",
+    # Not a GHSA id any more. This entry used to be "GHSA-537c-gmf6-5ccf",
+    # and the requirements comment named that one advisory — which is how the
+    # record drifted: three more were published on 2026-08-03 against the same
+    # pin and the comment still named the first. The list of advisories now
+    # lives in exactly one place (SECURITY.md, checked weekly against the live
+    # alerts by scripts/check_advisories.py), and what has to sit next to the
+    # pin is the pointer to it. A pointer does not go stale when an advisory
+    # arrives; an enumeration does.
+    "cryptography": 'SECURITY.md "Known dependency constraint"',
     "dns-lexicon": "dns-lexicon",
     "cloudflare": "#568",
 }


### PR DESCRIPTION
CertMate holds `cryptography` and `pyopenssl` behind their fixed versions on purpose. Every release that clears the advisories needs a pyOpenSSL that breaks the pinned ACME stack, and `cryptography==50.0.0` installs cleanly and then kills `certbot --version`. The decision is recorded in `SECURITY.md` and the Dependabot alert is dismissed as `tolerable_risk` pointing at it. Two steps, and the pair is the whole record.

**The record had drifted.** `SECURITY.md` documented `GHSA-537c-gmf6-5ccf`, dismissed months ago. Three more advisories against the same pin were published on **2026-08-03** and sat open, unassessed and unmentioned:

| Advisory | Severity | Defect | Reached through | Fixed in |
| --- | --- | --- | --- | --- |
| GHSA-g6cj-pr64-35w5 | HIGH | duplicate self-signed intermediates cause exponential X.509 path building | `cryptography.x509.verification` | 49.0.0 |
| GHSA-jwv3-5hgf-82ww | HIGH | PKCS#7 `EnvelopedData` decryption exposes a Bleichenbacher oracle | the PKCS#7 decryption API | 50.0.0 |
| GHSA-m2h6-j472-rp4c | MEDIUM | the verifier accepts wildcard DNS names, escaping `permittedSubtrees` | `cryptography.x509.verification` | 49.0.0 |

The comment beside the pin named the dismissed one too. Nothing in the reasoning was wrong — the 2026-08-08 re-verification against `cryptography==50.0.0` is accurate and still the reason the pin holds. It had simply stopped being the complete list, and nothing looked. v2.26.0 shipped past it.

## Assessed: none of the three is reachable

Two need the X.509 verifier (`PolicyBuilder` / `ClientVerifier` / `ServerVerifier`); one needs PKCS#7 `EnvelopedData` decryption. Neither API is called anywhere in the shipped stack — checked across `modules/`, `app.py` and the pinned `certbot==2.10.0` / `acme==3.3.0` / `josepy==1.13.0`.

What CertMate uses from `cryptography` is X.509 parsing and building, `Fernet`, hashes, key serialization, RSA and Ed25519, and PBKDF2. The `.pfx` export (`storage_backends.py:175`) calls `serialization.pkcs12` — PKCS#**12**, a different structure and a different code path from the PKCS#7 `EnvelopedData` the Bleichenbacher advisory describes. CertMate never decrypts PKCS#7; it only ever writes PKCS#12.

That distinction is what makes the argument hold. `GHSA-537c` was a flaw in the **statically linked OpenSSL**, reachable in principle from anything calling into it, which is why its assessment had to enumerate the operations that run there. These three are in `cryptography`'s **own code**, reached through one named API each — so "we do not call that API" is a complete answer rather than a partial one.

**And the constraint has tightened.** Clearing all three needs `cryptography>=50.0.0`, the exact version `SECURITY.md` already proves fatal. The version that would close these alerts is the version that breaks issuance.

## The pin does not move. The record is repaired and guarded

- **`SECURITY.md`** lists all four with severity, defect, the API that reaches them and the first fixed version — and now states that an advisory *not* listed there has not been assessed and should be treated as new.
- **The requirements comments no longer enumerate advisories.** Naming one is how this drifted; they point at the section instead. `test_dependabot_holds_the_stack` anchors on that pointer rather than on a GHSA id for the same reason: a pointer does not go stale when an advisory arrives. That test failed on this change, which was it doing its job — it enforces *a reason next to the pin*, not *a GHSA next to the pin* (for `pyopenssl` the anchor is "Do not bump to 26.2.0+", for `cloudflare` it is "#568"), so the anchor moved and the contract did not.
- **`scripts/check_advisories.py`** asks the repository which advisories it is actually carrying and fails when one is missing from `SECURITY.md`. The rule is deliberately asymmetric: *open* or *dismissed as `tolerable_risk`* must be documented — both are decisions to keep running with a known flaw — while a documented advisory that no longer alerts is **not** a failure, because that is the normal end state of a dismissal (`GHSA-537c` is dismissed and still documented, correctly). Dismissals for `fixed` / `inaccurate` / `not_used` are ignored.
- **A weekly CI job runs it.** No test can see live alerts, so a merge gate could not have caught this. Weekly matches the existing `ca-endpoints` and `wiki` jobs; a finding is news.

## Verification

- Run against the live repository: **exit 1 naming the three** on the pre-fix `SECURITY.md`, **exit 0** on the corrected one.
- The wiring tests go red when the job is dismantled (removing `security-events: read` or the run step) and green when restored.
- Full suite: **2969 passed, 6 skipped, 0 failed**. `flake8` gate: 0. No emoji in any touched file.
- Two mistakes of mine caught on the way, both by running rather than reading: the alerts endpoint rejects `?page=` (it paginates by cursor via the `Link` header), and my first "does it fail without the fix?" check stashed the untracked script along with the file, so it reported success on a script that did not exist.

## Not done here

- **The three alerts are still open.** The established practice is document *and* dismiss as `tolerable_risk` citing `SECURITY.md`, which is how `GHSA-537c` was handled. Dismissing security alerts is @fabriziosalmi's call; the reasoning is now written, so it is a one-command follow-up.
- `test_dependabot_holds_the_stack` is satisfied when **any one** requirements file carries the reason beside the pin, not every file that pins the package. Pre-existing and defensible; noted rather than widened.
- The real fix for all four remains the certbot 5.x migration (#103). These alerts have no independent solution — they are a symptom of that epic, which makes it the work that clears the security queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)