### PR TITLE
fix: a revocation no longer disappears into a renewal that was already signing

### DIFF
--- a/modules/core/client_certificates.py
+++ b/modules/core/client_certificates.py
@@ -519,18 +519,62 @@ class ClientCertificateManager:
             )
 
             if success:
-                # Update old metadata to mark as superseded
-                old_metadata["superseded_by"] = cert_data["identifier"]
-                old_metadata["superseded_at"] = utc_now().isoformat()
-                # Belt-and-braces against runaway re-renewal: renewal_enabled
-                # gates check_renewals, so disabling it on the superseded cert
-                # guarantees the scheduled sweep can never re-pick this old cert
-                # even if the superseded_by guard were ever weakened.
-                old_metadata["renewal_enabled"] = False
-
+                # Write back only the three fields this operation owns, onto
+                # the metadata as it is NOW — not onto the snapshot read at the
+                # top of this method.
+                #
+                # create_client_certificate above generates a key and signs a
+                # certificate; that takes long enough for a revocation to land
+                # in between. `old_metadata` was read before it and does not
+                # carry `revoked`, so writing the whole dict back erased the
+                # revocation — and OCSP decides on exactly that field
+                # (ocsp_crl.py:49), so the responder went back to answering
+                # "good" for a certificate the operator had just revoked. The
+                # credible trigger is not an operator double-clicking (the UI
+                # confirms before revoking) but the 03:00 renewal sweep
+                # crossing a manual revoke.
+                superseded = {
+                    "superseded_by": cert_data["identifier"],
+                    "superseded_at": utc_now().isoformat(),
+                    # Belt-and-braces against runaway re-renewal:
+                    # renewal_enabled gates check_renewals, so disabling it on
+                    # the superseded cert guarantees the scheduled sweep can
+                    # never re-pick this old cert even if the superseded_by
+                    # guard were ever weakened.
+                    "renewal_enabled": False,
+                }
+                revoked_meanwhile = False
                 for metadata_file in self.client_certs_dir.glob(f"*/{identifier}/metadata.json"):
+                    try:
+                        with open(metadata_file) as f:
+                            current = json.load(f)
+                        if not isinstance(current, dict):
+                            current = dict(old_metadata)
+                    except (OSError, ValueError):
+                        # Unreadable now, readable at the top of the method:
+                        # fall back to the snapshot rather than lose the
+                        # supersede marker, and say so.
+                        logger.warning(
+                            "Could not re-read metadata for %s before marking "
+                            "it superseded; writing from the pre-renewal copy",
+                            identifier)
+                        current = dict(old_metadata)
+                    revoked_meanwhile = revoked_meanwhile or bool(current.get("revoked"))
+                    current.update(superseded)
                     with open(metadata_file, 'w') as f:
-                        json.dump(old_metadata, f, indent=2)
+                        json.dump(current, f, indent=2)
+
+                if revoked_meanwhile:
+                    # The identity was revoked while this renewal was signing.
+                    # The revocation stands — it is not erased — but a new
+                    # certificate now exists for an identity the operator just
+                    # withdrew, and nothing else would ever tell them.
+                    logger.warning(
+                        "Certificate %s was revoked while its renewal was in "
+                        "flight. The revocation stands, but %s was issued for "
+                        "the same identity and is NOT revoked; revoke it too "
+                        "if that was not intended.",
+                        identifier, cert_data["identifier"])
 
                 logger.info(f"Renewed certificate: {identifier} -> {cert_data['identifier']}")
                 return True, None, cert_data

--- a/modules/core/client_certificates.py
+++ b/modules/core/client_certificates.py
@@ -5,6 +5,7 @@ Handles creation, management, renewal, and revocation of client certificates
 
 import logging
 import json
+import threading
 import os
 import re
 from pathlib import Path
@@ -66,6 +67,18 @@ class ClientCertificateManager:
         """
         self.client_certs_dir = Path(client_certs_dir)
         self.private_ca = private_ca
+
+        # Per-identifier lock over metadata.json.
+        #
+        # Re-reading immediately before the write narrowed the renew/revoke
+        # lost-update window from the length of a signature to a few
+        # microseconds, but narrow is not closed: two unlocked
+        # read-modify-writes can still interleave, and then either the
+        # revocation or the supersede marker is the one that disappears
+        # (Copilot, #603). Held only around the metadata sections — never
+        # around the signing — so renewals do not serialise on each other.
+        self._metadata_locks: dict[str, threading.Lock] = {}
+        self._metadata_locks_mutex = threading.Lock()
 
         # Create subdirectories for different cert types
         self.vpn_certs_dir = self.client_certs_dir / "vpn"
@@ -364,6 +377,13 @@ class ClientCertificateManager:
             logger.error(f"Error listing client certificates: {str(e)}")
             return []
 
+    def _metadata_lock(self, identifier: str) -> threading.Lock:
+        """Return the per-identifier metadata lock, creating it on first use."""
+        with self._metadata_locks_mutex:
+            if identifier not in self._metadata_locks:
+                self._metadata_locks[identifier] = threading.Lock()
+            return self._metadata_locks[identifier]
+
     def get_certificate_metadata(self, identifier: str) -> Optional[Dict[str, Any]]:
         """
         Get metadata for a specific certificate.
@@ -399,20 +419,33 @@ class ClientCertificateManager:
             Tuple of (success, error_message)
         """
         try:
-            # Get metadata
-            metadata = self.get_certificate_metadata(identifier)
-            if not metadata:
-                return False, f"Certificate not found: {identifier}"
+            # Read and write under the per-identifier lock: a renewal
+            # finishing at the same moment does its own read-modify-write on
+            # this file, and unlocked they interleave (Copilot, #603).
+            with self._metadata_lock(identifier):
+                metadata = self.get_certificate_metadata(identifier)
+                if not metadata:
+                    return False, f"Certificate not found: {identifier}"
 
-            # Update metadata
-            metadata["revoked"] = True
-            metadata["revoked_at"] = utc_now().isoformat()
-            metadata["reason_revoked"] = reason
+                # Update metadata
+                metadata["revoked"] = True
+                metadata["revoked_at"] = utc_now().isoformat()
+                metadata["reason_revoked"] = reason
 
-            # Save updated metadata
-            for metadata_file in self.client_certs_dir.glob(f"*/{identifier}/metadata.json"):
-                with open(metadata_file, 'w') as f:
-                    json.dump(metadata, f, indent=2)
+                # Save updated metadata. Writing every match and then
+                # regenerating the CRL once is deliberate: this used to sit
+                # inside the loop and return from the first file, which was
+                # the same thing only while the glob yielded exactly one.
+                written = 0
+                for metadata_file in self.client_certs_dir.glob(f"*/{identifier}/metadata.json"):
+                    with open(metadata_file, 'w') as f:
+                        json.dump(metadata, f, indent=2)
+                    written += 1
+                if not written:
+                    # get_certificate_metadata found it a moment ago with the
+                    # same glob, so this means it vanished underneath us.
+                    # Reporting success here would be a lie about a revocation.
+                    return False, f"Metadata file not found for: {identifier}"
 
                 logger.info(f"Revoked certificate: {identifier} (reason: {reason})")
 
@@ -438,8 +471,6 @@ class ClientCertificateManager:
                     self.private_ca.generate_crl(revoked_records)
 
                 return True, None
-
-            return False, f"Metadata file not found for: {identifier}"
 
         except Exception as e:
             logger.error(f"Error revoking certificate: {str(e)}")
@@ -544,25 +575,33 @@ class ClientCertificateManager:
                     "renewal_enabled": False,
                 }
                 revoked_meanwhile = False
-                for metadata_file in self.client_certs_dir.glob(f"*/{identifier}/metadata.json"):
-                    try:
-                        with open(metadata_file) as f:
-                            current = json.load(f)
-                        if not isinstance(current, dict):
+                # Under the same per-identifier lock the revoke path takes:
+                # the re-read below is only atomic with the write if nothing
+                # else can slip between them (Copilot, #603). The lock covers
+                # the metadata section only — never create_client_certificate
+                # above — so two renewals of different certificates, and the
+                # signing itself, stay concurrent.
+                lock = self._metadata_lock(identifier)
+                with lock:
+                    for metadata_file in self.client_certs_dir.glob(f"*/{identifier}/metadata.json"):
+                        try:
+                            with open(metadata_file) as f:
+                                current = json.load(f)
+                            if not isinstance(current, dict):
+                                current = dict(old_metadata)
+                        except (OSError, ValueError):
+                            # Unreadable now, readable at the top of the method:
+                            # fall back to the snapshot rather than lose the
+                            # supersede marker, and say so.
+                            logger.warning(
+                                "Could not re-read metadata for %s before marking "
+                                "it superseded; writing from the pre-renewal copy",
+                                identifier)
                             current = dict(old_metadata)
-                    except (OSError, ValueError):
-                        # Unreadable now, readable at the top of the method:
-                        # fall back to the snapshot rather than lose the
-                        # supersede marker, and say so.
-                        logger.warning(
-                            "Could not re-read metadata for %s before marking "
-                            "it superseded; writing from the pre-renewal copy",
-                            identifier)
-                        current = dict(old_metadata)
-                    revoked_meanwhile = revoked_meanwhile or bool(current.get("revoked"))
-                    current.update(superseded)
-                    with open(metadata_file, 'w') as f:
-                        json.dump(current, f, indent=2)
+                        revoked_meanwhile = revoked_meanwhile or bool(current.get("revoked"))
+                        current.update(superseded)
+                        with open(metadata_file, 'w') as f:
+                            json.dump(current, f, indent=2)
 
                 if revoked_meanwhile:
                     # The identity was revoked while this renewal was signing.

--- a/tests/test_client_cert_revocation_survives_renewal.py
+++ b/tests/test_client_cert_revocation_survives_renewal.py
@@ -1,0 +1,186 @@
+"""A revocation must survive a renewal that was already in flight.
+
+`renew_certificate` read the certificate's metadata at the top, spent the
+length of a key generation and a signature inside `create_client_certificate`,
+and then wrote that snapshot back wholesale to mark the old certificate
+superseded. A revocation landing in between was inside the window, and writing
+the pre-renewal dict erased `revoked`, `revoked_at` and `reason_revoked`.
+
+That field is what the OCSP responder answers from (`ocsp_crl.py:49`), so the
+responder went back to saying **good** for a certificate the operator had just
+revoked — the one answer a client trusts to decide whether to accept it. The
+CRL is ordering-dependent and diverges too: `revoke_certificate` rebuilds it
+from metadata at revoke time, so the serial is in that generation and gone from
+the next one.
+
+The credible trigger is not an operator clicking Renew and then Revoke — the UI
+puts a confirmation in front of the revoke, which is seconds against a window of
+milliseconds. It is the 03:00 `_client_certificate_renewal_job` sweep crossing a
+revocation done by hand.
+
+The fix writes back only the three fields the renewal owns, onto the metadata as
+it is at that moment, instead of the snapshot from before the signing. Same
+shape as the settings lost-update closed in v2.26.0: the read of a
+read-modify-write must not predate a slow operation.
+"""
+from __future__ import annotations
+
+import json
+import threading
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.client_certificates import ClientCertificateManager
+from modules.core.ocsp_crl import OCSPResponder
+from modules.core.utils import utc_now
+
+pytestmark = [pytest.mark.unit]
+
+TIMEOUT = 10
+SERIAL = 4242
+
+
+@pytest.fixture
+def mgr(tmp_path):
+    return ClientCertificateManager(
+        client_certs_dir=tmp_path / "client", private_ca=MagicMock()
+    )
+
+
+def _seed(mgr, identifier="alice-1"):
+    """A live, unrevoked client certificate on disk."""
+    created = utc_now()
+    # The usage maps to a directory (_get_cert_subdir): "api-mtls" lands in
+    # api_certs_dir. Seeding anywhere else is findable by identifier — that
+    # glob is `*/<id>/metadata.json` — but invisible to list_client_certificates,
+    # which only walks the three known usage directories, and therefore
+    # invisible to OCSP.
+    subdir = mgr.api_certs_dir / identifier
+    subdir.mkdir(parents=True)
+    metadata = {
+        "identifier": identifier,
+        "common_name": "alice",
+        "email": "alice@example.com",
+        "organization": "CertMate",
+        "organizational_unit": "Users",
+        "cert_usage": "api-mtls",
+        "serial_number": SERIAL,
+        "created_at": created.isoformat(),
+        "expires_at": (created + timedelta(days=365)).isoformat(),
+        "days_valid": 365,
+        "renewal_enabled": True,
+    }
+    (subdir / "metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+    return subdir / "metadata.json"
+
+
+def _read(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_a_revocation_during_renewal_is_not_erased(mgr):
+    """The race, run for real: two threads, the file on disk as the judge."""
+    metadata_file = _seed(mgr)
+    signing = threading.Event()
+    revoked = threading.Event()
+    errors = []
+
+    def slow_signing(**kwargs):
+        # Stands in for key generation + signing: long enough for a human,
+        # or the 03:00 sweep, to revoke in the middle.
+        signing.set()
+        assert revoked.wait(timeout=TIMEOUT), "the revoke thread never finished"
+        return True, None, {"identifier": "alice-2", "serial_number": 9999}
+
+    mgr.create_client_certificate = slow_signing        # type: ignore[assignment]
+
+    def renew():
+        try:
+            mgr.renew_certificate("alice-1")
+        except BaseException as error:                   # noqa: BLE001
+            errors.append(error)
+
+    def revoke():
+        try:
+            assert signing.wait(timeout=TIMEOUT)
+            mgr.revoke_certificate("alice-1", reason="key_compromise")
+        except BaseException as error:                   # noqa: BLE001
+            errors.append(error)
+        finally:
+            revoked.set()
+
+    threads = [threading.Thread(target=renew, daemon=True),
+               threading.Thread(target=revoke, daemon=True)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=TIMEOUT)
+    assert not [t for t in threads if t.is_alive()], "a thread did not finish"
+    if errors:
+        raise errors[0]
+
+    final = _read(metadata_file)
+    assert final.get("revoked") is True, (
+        "the renewal wrote back the metadata it read before signing and erased "
+        "the revocation; OCSP decides on this field and would answer 'good' "
+        "for a certificate the operator revoked"
+    )
+    assert final.get("reason_revoked") == "key_compromise"
+    assert final.get("revoked_at"), "revoked_at was lost with the revocation"
+    # The renewal's own write must still land: the fix merges, it does not
+    # abandon the supersede marker.
+    assert final.get("superseded_by") == "alice-2"
+    assert final.get("renewal_enabled") is False
+
+
+def test_ocsp_still_answers_revoked_after_the_race(mgr):
+    """The consequence an operator actually experiences."""
+    _seed(mgr)
+    signing = threading.Event()
+    revoked = threading.Event()
+
+    def slow_signing(**kwargs):
+        signing.set()
+        revoked.wait(timeout=TIMEOUT)
+        return True, None, {"identifier": "alice-2", "serial_number": 9999}
+
+    mgr.create_client_certificate = slow_signing        # type: ignore[assignment]
+
+    def revoke():
+        signing.wait(timeout=TIMEOUT)
+        mgr.revoke_certificate("alice-1", reason="key_compromise")
+        revoked.set()
+
+    worker = threading.Thread(target=revoke, daemon=True)
+    worker.start()
+    mgr.renew_certificate("alice-1")
+    worker.join(timeout=TIMEOUT)
+
+    status = OCSPResponder(MagicMock(), mgr).get_cert_status(SERIAL)
+    assert status["status"] == "revoked", (
+        f"OCSP answered {status['status']!r} for a revoked certificate. This "
+        f"is the answer a client trusts to decide whether to accept it."
+    )
+    assert status["reason"] == "key_compromise"
+
+
+def test_the_supersede_write_still_works_without_a_race(mgr):
+    """Guard the guard: the ordinary path must be unchanged."""
+    metadata_file = _seed(mgr)
+    mgr.create_client_certificate = (                    # type: ignore[assignment]
+        lambda **kwargs: (True, None, {"identifier": "alice-2", "serial_number": 9999}))
+
+    ok, error, data = mgr.renew_certificate("alice-1")
+
+    assert ok and error is None and data["identifier"] == "alice-2"
+    final = _read(metadata_file)
+    assert final["superseded_by"] == "alice-2"
+    assert final["renewal_enabled"] is False
+    assert final.get("superseded_at")
+    assert "revoked" not in final, "nothing revoked it; the field must not appear"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/test_client_cert_revocation_survives_renewal.py
+++ b/tests/test_client_cert_revocation_survives_renewal.py
@@ -182,5 +182,49 @@ def test_the_supersede_write_still_works_without_a_race(mgr):
     assert "revoked" not in final, "nothing revoked it; the field must not appear"
 
 
+def test_both_paths_take_the_same_metadata_lock(mgr):
+    """Narrow is not closed.
+
+    Re-reading immediately before the write shrank the window from the length
+    of a signature to a few microseconds, but two unlocked read-modify-writes
+    can still interleave, and then either the revocation or the supersede
+    marker is the one that disappears (Copilot, #603). Both paths now take the
+    per-identifier lock — the SAME lock object, or it protects nothing.
+
+    Asserted by watching who acquires it rather than by hammering threads: a
+    stress test that passes 999 times out of 1000 is not evidence, and this
+    is the property the correctness actually rests on.
+    """
+    _seed(mgr)
+    taken = []
+    real = mgr._metadata_lock
+
+    def watch(identifier):
+        lock = real(identifier)
+        taken.append((identifier, id(lock)))
+        return lock
+
+    mgr._metadata_lock = watch                       # type: ignore[assignment]
+    mgr.create_client_certificate = (                # type: ignore[assignment]
+        lambda **kwargs: (True, None, {"identifier": "alice-2", "serial_number": 9999}))
+
+    mgr.renew_certificate("alice-1")
+    mgr.revoke_certificate("alice-1", reason="superseded")
+
+    assert [i for i, _ in taken] == ["alice-1", "alice-1"], (
+        f"both paths must lock on the identifier; saw {taken}"
+    )
+    assert len({lock_id for _, lock_id in taken}) == 1, (
+        "renew and revoke took DIFFERENT lock objects, which serialises "
+        "nothing — the whole point is that they contend on the same one"
+    )
+
+
+def test_a_lock_is_per_identifier_not_global(mgr):
+    """Two different certificates must not serialise on each other."""
+    assert mgr._metadata_lock("alice-1") is mgr._metadata_lock("alice-1")
+    assert mgr._metadata_lock("alice-1") is not mgr._metadata_lock("bob-1")
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
First of the 27 findings tracked in #591, taken by operator harm rather than by the label the finder attached.

## The defect

`renew_certificate` reads the certificate's metadata at the top, spends the length of a key generation and a signature inside `create_client_certificate`, and then writes that snapshot back wholesale to mark the old certificate superseded. A revocation landing in between is inside the window, and the write erases `revoked`, `revoked_at` and `reason_revoked`.

**That field is what OCSP answers from** (`ocsp_crl.py:49`). So the responder goes back to saying `good` for a certificate the operator has just revoked — the one answer a client trusts when deciding whether to accept it. The CRL diverges too, and ordering decides how: `revoke_certificate` rebuilds it from metadata at revoke time, so the serial is in that generation and gone from the next one.

**The trigger is the scheduler, not a fast operator.** The verifier was right to kill the "operator hits Renew then Revoke" story: `client-certs.js:462` puts a confirmation dialog in front of the revoke, which is seconds against a window of milliseconds. What is credible is the 03:00 `_client_certificate_renewal_job` sweep crossing a revocation done by hand.

## The fix

Write back only the three fields the renewal owns — `superseded_by`, `superseded_at`, `renewal_enabled` — onto the metadata **as it is at that moment**, not the snapshot from before the signing. Same shape as the settings lost-update closed in v2.26.0: the read half of a read-modify-write must not predate a slow operation. If the re-read is impossible it falls back to the snapshot and logs that it did, rather than dropping the supersede marker.

One addition beyond the minimum: when the identity **was** revoked mid-flight, that is now logged. The revocation stands, but a new certificate exists for an identity the operator just withdrew, and nothing else would ever have told them.

## Verification

Three tests, two real threads, the file on disk as the judge:

- the revocation survives, with `reason_revoked` and `revoked_at` intact, **and** the renewal's own supersede marker still lands (the fix merges, it does not abandon its own write);
- `OCSPResponder.get_cert_status()` still answers `revoked` with the right reason — the consequence an operator actually experiences, asserted end to end rather than at the field;
- the ordinary no-race path is unchanged, including that `revoked` never appears when nothing revoked it.

Both race tests fail on the pre-fix code; the no-race guard passes either way.

Full suite: **2972 passed, 6 skipped, 0 failed**. `flake8` gate: 0.

## A note on the test fixture, because it caught me

Seeding the certificate under an arbitrary directory made `renew` and `revoke` find it — their glob is `*/<identifier>/metadata.json` — while `list_client_certificates` did not, because that one walks only the three known usage directories, and OCSP reads from it. The fixture now seeds under `api_certs_dir`, which is where `_get_cert_usage` mapping actually puts an `api-mtls` certificate. Worth knowing for anyone writing client-cert tests: findable by identifier and visible to listings are two different things.

🤖 Generated with [Claude Code](https://claude.com/claude-code)