### PR TITLE
fix: a batch of new domains is no longer a batch of new ACME accounts

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -314,8 +314,24 @@ class CertificateManager:
                     continue
                 if (metadata.get('ca_account_id') or None) != (ca_account_id or None):
                     continue
-                target.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copytree(donor, target, dirs_exist_ok=True)
+                # Stage, then promote. copytree failing halfway would
+                # otherwise leave a partial accounts/ tree, and the
+                # "already has an account" check above would read that
+                # wreckage as a registered account and skip seeding for
+                # good (Copilot, #604). Same shape as _publish_flat_files.
+                staging = target.parent / '.accounts-seeding'
+                shutil.rmtree(staging, ignore_errors=True)
+                try:
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copytree(donor, staging)
+                    if target.exists():
+                        shutil.copytree(staging, target, dirs_exist_ok=True)
+                        shutil.rmtree(staging, ignore_errors=True)
+                    else:
+                        staging.rename(target)
+                except Exception:
+                    shutil.rmtree(staging, ignore_errors=True)
+                    raise
                 logger.info(
                     "Reusing the ACME account registered for %s instead of "
                     "registering a new one for %s", candidate.name, domain)
@@ -1631,7 +1647,12 @@ class CertificateManager:
             # build_certbot_command created the per-domain config dir; hand
             # this domain the account a sibling already registered, so a batch
             # of new domains does not become a batch of new ACME accounts.
-            self._seed_acme_account(domain, cert_dir, ca_provider, ca_account_id)
+            # used_ca_account_id, not the request parameter: metadata persists
+            # the RESOLVED account (line ~1708), so comparing against the
+            # caller's `ca_account_id` — None whenever they did not name one —
+            # never matched a donor and the reuse silently never happened
+            # (Copilot, #604).
+            self._seed_acme_account(domain, cert_dir, ca_provider, used_ca_account_id)
 
             # Run certbot with isolated environment
             result = self.shell_executor.run(

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -276,6 +276,54 @@ class CertificateManager:
             tmp.unlink(missing_ok=True)
             raise
 
+    def _seed_acme_account(self, domain, cert_dir, ca_provider, ca_account_id):
+        """Give a new domain the ACME account a sibling already registered.
+
+        `--config-dir` is per domain (ca_manager.build_certbot_command), and
+        certbot keeps its ACME account under the config dir. So every new
+        domain registered a brand-new account with the CA: 50 domains through
+        POST /api/web/certificates/batch — the size this product accepts in one
+        request — is 50 registrations from one IP in one run, which no CA
+        allows. It also leaves 50 account private keys on disk, each one a
+        credential that every backup then carries.
+
+        Copying the donor's `accounts/` tree in before certbot runs makes it
+        find a registered account and skip registration. This cannot bind a
+        certificate to the wrong account: certbot indexes accounts by the ACME
+        directory URL, so a tree that does not match the `--server` in use is
+        ignored and certbot registers exactly as it does today. The
+        ca_account_id match is belt-and-braces on top of that, for two CA
+        accounts (different EAB credentials) on the same server.
+
+        Best-effort by design. Any failure leaves the directory untouched and
+        the run proceeds unchanged — this is an optimisation on the issuance
+        path, and the issuance path must not acquire a new way to fail.
+        """
+        try:
+            target = Path(cert_dir) / domain / 'accounts'
+            if target.exists() and any(target.rglob('*.json')):
+                return None                      # already has an account
+            for candidate in sorted(Path(cert_dir).iterdir()):
+                if not candidate.is_dir() or candidate.name == domain:
+                    continue
+                donor = candidate / 'accounts'
+                if not donor.is_dir() or not any(donor.rglob('*.json')):
+                    continue
+                metadata = self._load_metadata(candidate.name)
+                if metadata.get('ca_provider') != ca_provider:
+                    continue
+                if (metadata.get('ca_account_id') or None) != (ca_account_id or None):
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(donor, target, dirs_exist_ok=True)
+                logger.info(
+                    "Reusing the ACME account registered for %s instead of "
+                    "registering a new one for %s", candidate.name, domain)
+                return candidate.name
+        except Exception as e:                   # noqa: BLE001 - best effort
+            logger.debug("Could not seed an ACME account for %s: %s", domain, e)
+        return None
+
     def _stale_flat_files(self, src_dir: Path, dest_dir: Path):
         """Which of CERTIFICATE_FILES differ between live/ and the flat copy.
 
@@ -1579,6 +1627,11 @@ class CertificateManager:
                 else:
                     safe_cmd.append(str(part))
             logger.debug(f"Certbot command: {' '.join(safe_cmd)}")
+
+            # build_certbot_command created the per-domain config dir; hand
+            # this domain the account a sibling already registered, so a batch
+            # of new domains does not become a batch of new ACME accounts.
+            self._seed_acme_account(domain, cert_dir, ca_provider, ca_account_id)
 
             # Run certbot with isolated environment
             result = self.shell_executor.run(

--- a/tests/test_acme_account_is_reused_across_domains.py
+++ b/tests/test_acme_account_is_reused_across_domains.py
@@ -25,6 +25,8 @@ issuance path must not acquire a new way to fail.
 from __future__ import annotations
 
 import json
+import pathlib
+import shutil
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -167,6 +169,74 @@ def test_the_issuance_path_seeds_before_certbot_runs(manager):
         "will keep registering its own"
     )
     assert seen['called'][0] == "new.example.com"
+
+
+def test_the_resolved_ca_account_is_what_gets_matched(manager):
+    """The donor is matched on the account metadata RECORDS, not the one the
+    caller asked for.
+
+    `create_certificate` resolves the CA account through
+    `ca_manager.get_ca_config` and persists that resolved id
+    (`used_ca_account_id`). Passing the request parameter instead — `None`
+    whenever the caller did not name an account, which is the common case —
+    compared None against "production" and never found a donor, so the reuse
+    silently never happened (Copilot, #604). A fix that looks right and does
+    nothing is the worst kind.
+    """
+    cert_manager, cert_dir = manager
+    cert_manager.ca_manager = MagicMock()
+    cert_manager.ca_manager.get_ca_config.return_value = ({"server": "x"}, "production")
+    cert_manager.ca_manager.build_certbot_command.return_value = (["certbot"], {})
+    seen = {}
+
+    def record(domain, cd, ca_provider, ca_account_id):
+        seen['account'] = ca_account_id
+        return None
+
+    with patch.object(CertificateManager, "_seed_acme_account", side_effect=record):
+        with patch.object(cert_manager, "shell_executor") as shell:
+            shell.run.side_effect = RuntimeError("stop after seeding")
+            try:
+                cert_manager.create_certificate(
+                    domain="new.example.com", email="ops@example.com",
+                    dns_provider="cloudflare", dns_config={"api_token": "t"},
+                    ca_provider="letsencrypt")      # no ca_account_id: the common call
+            except Exception:
+                pass
+
+    assert seen.get('account') == "production", (
+        f"the seeder was handed {seen.get('account')!r}; metadata records the "
+        f"resolved account, so anything else never matches a donor"
+    )
+
+
+def test_a_copy_that_fails_halfway_leaves_nothing_behind(manager):
+    """A partial accounts/ tree would read as a registered account forever."""
+    cert_manager, cert_dir = manager
+    _seed_domain(cert_dir, "first.example.com")
+    target_domain = cert_dir / "second.example.com"
+    target_domain.mkdir()
+
+    real_copytree = shutil.copytree
+
+    def half_way(src, dst, **kwargs):
+        # Write something, then die: exactly what a full disk or a killed
+        # process does in the middle of a tree copy.
+        pathlib.Path(dst).mkdir(parents=True, exist_ok=True)
+        (pathlib.Path(dst) / "private_key.json").write_text("{}", encoding="utf-8")
+        raise OSError("disk full")
+
+    with patch("modules.core.certificates.shutil.copytree", side_effect=half_way):
+        assert cert_manager._seed_acme_account(
+            "second.example.com", cert_dir, "letsencrypt", None) is None
+
+    leftovers = sorted(p.name for p in target_domain.rglob("*.json"))
+    assert leftovers == [], (
+        f"a failed copy left {leftovers} behind; the next run would read that "
+        f"as an account already registered and never seed again"
+    )
+    assert not (target_domain / ".accounts-seeding").exists(), "staging dir left behind"
+    assert real_copytree is shutil.copytree
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_acme_account_is_reused_across_domains.py
+++ b/tests/test_acme_account_is_reused_across_domains.py
@@ -1,0 +1,173 @@
+"""A batch of new domains must not become a batch of new ACME accounts.
+
+`--config-dir` is per domain (`ca_manager.build_certbot_command`), and certbot
+keeps its ACME account under the config dir. So every new domain registered a
+brand-new account with the CA.
+
+That is not a rounding error in this product: `POST /api/web/certificates/batch`
+accepts **50 domains in one request** (`cert_routes.py:84`), and 50 domains was
+50 account registrations from one IP in one run — which no CA allows. It also
+left 50 account private keys on disk, each one a credential that every backup
+then carried.
+
+The fix copies a sibling domain's `accounts/` tree in before certbot runs, so
+certbot finds a registered account and skips registration. It cannot bind a
+certificate to the wrong account: certbot indexes accounts by the ACME
+directory URL, so a tree that does not match the `--server` in use is ignored
+and certbot registers exactly as before. Matching on ca_provider and
+ca_account_id is the belt-and-braces on top, for two CA accounts with different
+EAB credentials on the same server.
+
+Best-effort by design: any failure leaves the directory untouched and the run
+proceeds unchanged. This is an optimisation on the issuance path, and the
+issuance path must not acquire a new way to fail.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modules.core.certificates import CertificateManager
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def manager(tmp_path):
+    cert_dir = tmp_path / "certificates"
+    cert_dir.mkdir()
+    settings_manager = MagicMock()
+    settings_manager.load_settings.return_value = {}
+    return CertificateManager(
+        cert_dir=cert_dir, settings_manager=settings_manager,
+        dns_manager=MagicMock()), cert_dir
+
+
+def _seed_domain(cert_dir, name, *, ca_provider="letsencrypt", ca_account_id=None,
+                 with_account=True):
+    """A domain directory as certbot leaves it, with or without an account."""
+    domain_dir = cert_dir / name
+    domain_dir.mkdir(parents=True, exist_ok=True)
+    (domain_dir / "metadata.json").write_text(json.dumps({
+        "domain": name, "ca_provider": ca_provider, "ca_account_id": ca_account_id,
+    }), encoding="utf-8")
+    if with_account:
+        account = domain_dir / "accounts" / "acme-v02.api.letsencrypt.org" / "directory" / "abc123"
+        account.mkdir(parents=True)
+        (account / "private_key.json").write_text('{"n": "account-key"}', encoding="utf-8")
+        (account / "regr.json").write_text('{"uri": "https://acme/acct/1"}', encoding="utf-8")
+    return domain_dir
+
+
+def _accounts(domain_dir):
+    return sorted(p.name for p in (domain_dir / "accounts").rglob("*.json"))
+
+
+# --------------------------------------------------------------------------
+# The decision
+# --------------------------------------------------------------------------
+
+def test_a_new_domain_reuses_a_siblings_account(manager):
+    cert_manager, cert_dir = manager
+    _seed_domain(cert_dir, "first.example.com")
+    (cert_dir / "second.example.com").mkdir()
+
+    donor = cert_manager._seed_acme_account(
+        "second.example.com", cert_dir, "letsencrypt", None)
+
+    assert donor == "first.example.com"
+    assert _accounts(cert_dir / "second.example.com") == ["private_key.json", "regr.json"], (
+        "the account tree was not copied, so certbot will register a new "
+        "account for this domain"
+    )
+
+
+def test_a_domain_that_already_has_an_account_is_left_alone(manager):
+    """Never clobber a registered account with somebody else's."""
+    cert_manager, cert_dir = manager
+    _seed_domain(cert_dir, "first.example.com")
+    existing = _seed_domain(cert_dir, "second.example.com")
+    (existing / "accounts" / "acme-v02.api.letsencrypt.org" / "directory" / "abc123"
+     / "private_key.json").write_text('{"n": "its-own-key"}', encoding="utf-8")
+
+    donor = cert_manager._seed_acme_account(
+        "second.example.com", cert_dir, "letsencrypt", None)
+
+    assert donor is None
+    key = (existing / "accounts" / "acme-v02.api.letsencrypt.org" / "directory"
+           / "abc123" / "private_key.json").read_text(encoding="utf-8")
+    assert "its-own-key" in key, "an existing account key was overwritten"
+
+
+def test_a_different_ca_provider_is_not_a_donor(manager):
+    cert_manager, cert_dir = manager
+    _seed_domain(cert_dir, "first.example.com", ca_provider="zerossl")
+    (cert_dir / "second.example.com").mkdir()
+
+    assert cert_manager._seed_acme_account(
+        "second.example.com", cert_dir, "letsencrypt", None) is None
+
+
+def test_a_different_ca_account_is_not_a_donor(manager):
+    """Two accounts on one server, told apart by their EAB credentials."""
+    cert_manager, cert_dir = manager
+    _seed_domain(cert_dir, "first.example.com", ca_account_id="production")
+    (cert_dir / "second.example.com").mkdir()
+
+    assert cert_manager._seed_acme_account(
+        "second.example.com", cert_dir, "letsencrypt", "staging") is None
+
+
+def test_a_failure_never_reaches_the_caller(manager):
+    """The issuance path must not gain a new way to fail."""
+    cert_manager, cert_dir = manager
+    _seed_domain(cert_dir, "first.example.com")
+    (cert_dir / "second.example.com").mkdir()
+
+    with patch("modules.core.certificates.shutil.copytree",
+               side_effect=OSError("disk full")):
+        assert cert_manager._seed_acme_account(
+            "second.example.com", cert_dir, "letsencrypt", None) is None
+
+    assert not (cert_dir / "second.example.com" / "accounts").exists() or \
+        not list((cert_dir / "second.example.com" / "accounts").rglob("*.json"))
+
+
+# --------------------------------------------------------------------------
+# The real path
+# --------------------------------------------------------------------------
+
+def test_the_issuance_path_seeds_before_certbot_runs(manager):
+    """Pin the wiring: it is the create path that must do this, not a helper
+    nobody calls. Ordering matters — after certbot has run it is too late."""
+    cert_manager, cert_dir = manager
+    seen = {}
+
+    def record(domain, cd, ca_provider, ca_account_id):
+        seen['called'] = (domain, ca_provider, ca_account_id)
+        return None
+
+    with patch.object(CertificateManager, "_seed_acme_account", side_effect=record):
+        with patch.object(cert_manager, "shell_executor") as shell:
+            shell.run.side_effect = AssertionError(
+                "certbot ran before the account was seeded"
+                if 'called' not in seen else "stop here")
+            try:
+                cert_manager.create_certificate(
+                    domain="new.example.com", email="ops@example.com",
+                    dns_provider="cloudflare", dns_config={"api_token": "t"},
+                    ca_provider="letsencrypt")
+            except Exception:
+                pass
+
+    assert seen.get('called'), (
+        "create_certificate never seeded the ACME account; every new domain "
+        "will keep registering its own"
+    )
+    assert seen['called'][0] == "new.example.com"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Second of the 27 in #591. My own note on this one said *measure before changing — it sits on the issuance path*, so this is what the measuring found.

## The mechanism

`--config-dir` is per domain (`ca_manager.build_certbot_command:330`), and certbot keeps its ACME account under the config dir. Every new domain therefore registered a brand-new account with the CA.

## What makes it real, and what does not

The finder claimed this trips Let's Encrypt's per-IP account limit and quoted specific numbers. The verifier said the numbers were wrong, and I could not confirm them either — so they are not the argument here.

What is the argument is something this repository ships: **`POST /api/web/certificates/batch` accepts 50 domains in one request** (`cert_routes.py:84`). Onboarding a batch was 50 account registrations from one IP in one run. No CA allows that, whatever the exact threshold. And independently of any rate limit, it left 50 account private keys on disk — each a credential, each carried by every backup.

Nobody has reported hitting it (I checked issues and discussions). The defect is in the product's own advertised workflow rather than in a bug report, which is why it was worth fixing and also why it was worth measuring first instead of trusting the finding's framing.

## The fix, and why it cannot misfire

Before certbot runs, the new domain's config dir is seeded with the `accounts/` tree of a sibling issued under the same CA provider and CA account. certbot then finds a registered account and skips registration.

**It cannot bind a certificate to the wrong account.** certbot indexes accounts by the ACME directory URL, so a copied tree that does not match the `--server` in use is simply ignored and certbot registers exactly as it does today. The `ca_provider` / `ca_account_id` match is belt-and-braces on top of that, for the case of two CA accounts with different EAB credentials on the same server.

A domain that already has an account is left untouched — never clobber a registered key with somebody else's.

**Best-effort by design.** Any failure leaves the directory alone and the run proceeds unchanged. This is an optimisation on the issuance path, and the issuance path must not acquire a new way to fail.

## Verification

Six tests: the reuse itself; the three cases that must **not** donate (target already has an account, different CA provider, different CA account); a `copytree` failure that never reaches the caller; and the wiring — because a helper nobody calls fixes nothing, and after certbot has run it is too late to seed. The wiring test goes red when the call is removed from `create_certificate`.

Full suite: **2975 passed, 6 skipped, 0 failed**. `flake8` gate: 0.

## Worth knowing before merge

This changes what certbot sees on the issuance path, which is the most consequential place in the product. The release gate makes the real-cert E2E against LE staging mandatory for any change under `modules/`, so a break would surface before a tag — but a reviewer should read it as an issuance-path change, not as a tidy-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)