### PR TITLE
fix: an operator-supplied bearer token is honoured or refused, never ignored

### DIFF
--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -491,18 +491,25 @@ def _bearer_token_from_env_or_generate():
     """Return a valid api_bearer_token for the default settings template.
 
     Resolution order (mutually exclusive):
-    1. API_BEARER_TOKEN_FILE — if set, read the token from that file. Any
-       read error or validation failure generates a fresh token immediately;
-       API_BEARER_TOKEN is never consulted (to avoid encouraging both vars).
-    2. API_BEARER_TOKEN — only checked when API_BEARER_TOKEN_FILE is absent.
-       An invalid value (too short, weak pattern, insufficient entropy) is
-       logged and a fresh token is generated instead. This prevents a
-       misconfigured env var (issue #108: docker-compose passing an empty or
-       weak ${API_BEARER_TOKEN}) from poisoning save_settings with a
-       misleading "API token length must be between 32 and 512 characters"
-       rejection.
-    3. generate_secure_token() — fallback when neither variable is set or
-       both fail validation.
+    1. API_BEARER_TOKEN_FILE — if set, read the token from that file. A read
+       error, or a token that fails validation, raises
+       BearerTokenUnusableError; API_BEARER_TOKEN is never consulted as a
+       fallback (to avoid encouraging both vars, and because falling back
+       would defeat the point of the refusal).
+    2. API_BEARER_TOKEN — only checked when API_BEARER_TOKEN_FILE is absent,
+       and stripped first, so an empty or whitespace-only value reads as "not
+       configured" and falls through to (3). That is issue #108's case:
+       docker-compose passing an unexpanded ${API_BEARER_TOKEN}. A non-empty
+       value that fails validation raises BearerTokenUnusableError.
+    3. generate_secure_token() — when neither variable is set.
+
+    Raises:
+        BearerTokenUnusableError: the operator supplied a token that cannot be
+            used. Substituting a generated one would leave the instance with
+            no operator credential at all, which is the failure this refusal
+            exists to prevent; #108's requirement (an unusable value must
+            never reach settings.json) is met by refusing rather than by
+            silently replacing.
     """
     # An operator who sets API_BEARER_TOKEN or API_BEARER_TOKEN_FILE has said
     # "this instance is authenticated". If the value turns out unusable we must

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -134,6 +134,18 @@ _NON_SECRET_KEY_NAMES = frozenset({
 })
 
 
+class BearerTokenUnusableError(SettingsUnreadableError):
+    """The operator configured an API bearer token that cannot be used.
+
+    Subclasses SettingsUnreadableError on purpose: load_settings re-raises that
+    type instead of falling through to "return the defaults in-memory", and the
+    auth layer turns it into a 401 on every request. Both are what we want here.
+    Ignoring an operator-supplied token and generating a random one in its place
+    is the one outcome that must never happen — see the raise sites below.
+    """
+
+
+
 def _is_secret_key(name: str) -> bool:
     if name in _NON_SECRET_KEY_NAMES:
         return False
@@ -492,33 +504,51 @@ def _bearer_token_from_env_or_generate():
     3. generate_secure_token() — fallback when neither variable is set or
        both fail validation.
     """
+    # An operator who sets API_BEARER_TOKEN or API_BEARER_TOKEN_FILE has said
+    # "this instance is authenticated". If the value turns out unusable we must
+    # NOT quietly substitute a random token: _detect_operator_bearer_token()
+    # then sees no operator credential, is_setup_mode() stays true, and every
+    # gated endpoint answers an anonymous caller as admin. The operator did the
+    # right thing, the log said a fresh token had been generated, and the
+    # instance was open to the network. Fail closed instead.
     token_file = os.getenv('API_BEARER_TOKEN_FILE')
     if token_file:
         try:
             file_token = Path(token_file).read_text().strip()
-            is_valid, reason = validate_api_token(file_token)
-            if is_valid:
-                return file_token
-            logger.warning(
-                "API_BEARER_TOKEN_FILE token is invalid (%s); "
-                "falling back to API_BEARER_TOKEN or a generated token.",
-                reason)
         except Exception as e:
-            logger.warning("Could not read API_BEARER_TOKEN_FILE (%s): %s", token_file, e)
-            return generate_secure_token()
+            raise BearerTokenUnusableError(
+                f"API_BEARER_TOKEN_FILE is set to {token_file!r} but could not "
+                f"be read ({e}). Refusing to serve: ignoring it would leave this "
+                f"instance with NO AUTHENTICATION, answering every endpoint to "
+                f"anonymous callers as admin. Fix the path/permissions, or unset "
+                f"API_BEARER_TOKEN_FILE."
+            ) from e
+        is_valid, reason = validate_api_token(file_token)
+        if is_valid:
+            return file_token
+        raise BearerTokenUnusableError(
+            f"The token in API_BEARER_TOKEN_FILE ({token_file}) is not usable: "
+            f"{reason} Refusing to serve: ignoring it would leave this instance "
+            f"with NO AUTHENTICATION, answering every endpoint to anonymous "
+            f"callers as admin. Replace it with a token that satisfies the "
+            f"requirement above, or unset API_BEARER_TOKEN_FILE."
+        )
 
-    env_token = os.getenv('API_BEARER_TOKEN')
+    # Stripped, so that API_BEARER_TOKEN= (the unexpanded default in
+    # docker-compose.yml, issue #108) and a value that is only whitespace both
+    # read as "not configured" and generate a token, exactly as before. Only a
+    # non-empty value the operator actually meant reaches the refusal below.
+    env_token = (os.getenv('API_BEARER_TOKEN') or '').strip()
     if env_token:
         is_valid, reason = validate_api_token(env_token)
         if is_valid:
             return env_token
-        logger.warning(
-            "API_BEARER_TOKEN environment variable is invalid (%s); "
-            "ignoring it and generating a fresh random bearer token. "
-            "Set a valid token (32-512 chars, no weak patterns, >=12 unique "
-            "chars) in your .env file or unset API_BEARER_TOKEN to silence "
-            "this warning.",
-            reason,
+        raise BearerTokenUnusableError(
+            f"API_BEARER_TOKEN is set but not usable: {reason} Refusing to "
+            f"serve: ignoring it would leave this instance with NO "
+            f"AUTHENTICATION, answering every endpoint to anonymous callers as "
+            f"admin. Set a token that satisfies the requirement above, or "
+            f"unset API_BEARER_TOKEN to let CertMate generate one."
         )
     return generate_secure_token()
 
@@ -1158,8 +1188,10 @@ class SettingsManager:
                 # is_setup_mode() true and serves every gated endpoint to
                 # anonymous callers as admin — an instance that cannot read
                 # its own credentials must not come up world-open instead.
-                # app.py catches this and exits 1, so the operator gets a
-                # container that stops with one actionable line.
+                # Nothing catches this above: it reaches the auth layer,
+                # which logs the reason and answers 401. The container keeps
+                # running and serves nothing, which is the safe end of the
+                # trade — verified in a container, not assumed.
                 raise
             except Exception as e:
                 logger.error(f"Error loading settings: {e}")

--- a/modules/core/utils.py
+++ b/modules/core/utils.py
@@ -38,10 +38,23 @@ def utc_now_iso() -> str:
 _MIN_TOKEN_LENGTH = 32  # Increased minimum for better security
 _MAX_TOKEN_LENGTH = 512
 _MIN_UNIQUE_CHARS = 12  # Increased for better entropy
+# Placeholder and classic-weak values, matched as substrings anywhere in the
+# token. Deliberately NOT generic nouns: 'api', 'key', 'token', 'secret',
+# 'admin', 'test', 'demo', 'default' and 'example' used to be in this set, and
+# any of them appearing ANYWHERE rejected the token — so
+# `certmate-api-token-<32 random chars>` was refused while being perfectly
+# strong. That refusal was not a warning the operator could act on: the token
+# was dropped, a random one generated in its place, and the instance came up
+# with no operator credential at all (see _bearer_token_from_env_or_generate).
+# What actually protects against a guessable token is the length floor and the
+# character-variety floor below. This set exists only to catch a value copied
+# out of the documentation without editing it; note that the value we ship in
+# .env.example ('your_secure_api_token_here') is 26 characters and is already
+# refused by _MIN_TOKEN_LENGTH, so it does not depend on this list.
 _WEAK_TOKEN_PATTERNS = {
-    'password', '12345', 'admin', 'test', 'demo', 'change-this',
-    'default', 'secret', 'token', 'key', 'api', 'qwerty', 'example',
-    'your_token_here', 'your_super_secure_api_token_here_change_this'
+    'password', '12345', 'qwerty', 'letmein', 'change-this', 'change_this',
+    'changeme', 'your_token_here', 'your_secure_api_token_here',
+    'your_super_secure_api_token_here_change_this',
 }
 
 # A mapping of DNS providers to their required credential fields for validation.

--- a/tests/test_bearer_token_fails_closed.py
+++ b/tests/test_bearer_token_fails_closed.py
@@ -1,0 +1,125 @@
+"""An operator-supplied bearer token is honoured or refused — never ignored.
+
+`_bearer_token_from_env_or_generate` used to drop an operator's API_BEARER_TOKEN
+when `validate_api_token` disliked it, generate a random one in its place, and
+carry on. The consequence was not a weaker token, it was *no authentication at
+all*: `_detect_operator_bearer_token()` reports False, `is_setup_mode()` stays
+true, and every gated endpoint answers an anonymous caller as admin. The log
+said "generating a fresh random bearer token", which reads like the instance is
+still protected.
+
+Two halves, and both matter:
+
+* the rejection was far too eager — the weak-pattern list held the bare nouns
+  'api', 'key', 'token', 'secret', 'admin', 'test', matched as substrings, so
+  `certmate-api-token-<random>` was refused for containing "api";
+* and the reaction to a rejection was fail-open.
+
+These tests pin both, plus the control that a first run with no token at all
+still generates one and boots normally.
+"""
+import os
+
+import pytest
+
+from modules.core.settings import (
+    BearerTokenUnusableError,
+    SettingsUnreadableError,
+    _bearer_token_from_env_or_generate,
+)
+from modules.core.utils import validate_api_token
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv('API_BEARER_TOKEN', raising=False)
+    monkeypatch.delenv('API_BEARER_TOKEN_FILE', raising=False)
+
+
+# --- the over-eager rejection -------------------------------------------------
+
+@pytest.mark.parametrize('token', [
+    'certmate-api-token-7f3a9c2e5b8d1046af23',
+    'prod-key-Zr7Qv3Xm9Lb2Nf6Hd8Wc4Ty1Ps5Gj0',
+    'admin-console-Qv3Xm9Lb2Nf6Hd8Wc4Ty1Ps5G',
+    'certmate-secret-Xm9Lb2Nf6Hd8Wc4Ty1Ps5Gj0',
+    'staging-test-9Lb2Nf6Hd8Wc4Ty1Ps5Gj0KqZr7',
+])
+def test_a_strong_token_is_not_refused_for_containing_an_ordinary_word(token):
+    """These are long, varied, unguessable — and every one was refused."""
+    ok, reason = validate_api_token(token)
+    assert ok, f"{token!r} refused: {reason}"
+
+
+def test_the_placeholder_we_ship_is_still_refused():
+    """.env.example carries API_BEARER_TOKEN=your_secure_api_token_here.
+
+    It must stay refused after the weak-pattern list was narrowed. It is, on
+    length alone (26 characters), which is why narrowing the list is safe.
+    """
+    ok, reason = validate_api_token('your_secure_api_token_here')
+    assert not ok
+    assert 'length' in reason
+
+
+@pytest.mark.parametrize('token,expect', [
+    ('short', 'length'),
+    ('a' * 40, 'variety'),
+    ('changeme-changeme-changeme-changeme', 'weak'),
+    ('your_token_here_your_token_here_xx', 'weak'),
+])
+def test_genuinely_weak_tokens_are_still_refused(token, expect):
+    ok, reason = validate_api_token(token)
+    assert not ok and expect in reason.lower()
+
+
+# --- the fail-open reaction ---------------------------------------------------
+
+def test_an_unusable_env_token_refuses_instead_of_generating(monkeypatch):
+    monkeypatch.setenv('API_BEARER_TOKEN', 'short')
+    with pytest.raises(BearerTokenUnusableError) as raised:
+        _bearer_token_from_env_or_generate()
+    assert 'NO AUTHENTICATION' in str(raised.value)
+
+
+def test_an_unusable_file_token_refuses_instead_of_generating(monkeypatch, tmp_path):
+    bad = tmp_path / 'token'
+    bad.write_text('short')
+    monkeypatch.setenv('API_BEARER_TOKEN_FILE', str(bad))
+    with pytest.raises(BearerTokenUnusableError):
+        _bearer_token_from_env_or_generate()
+
+
+def test_an_unreadable_token_file_refuses_instead_of_generating(monkeypatch, tmp_path):
+    """The operator pointed at a file. A path typo must not mean "no auth"."""
+    monkeypatch.setenv('API_BEARER_TOKEN_FILE', str(tmp_path / 'does-not-exist'))
+    with pytest.raises(BearerTokenUnusableError):
+        _bearer_token_from_env_or_generate()
+
+
+def test_a_usable_token_is_returned_unchanged(monkeypatch):
+    monkeypatch.setenv('API_BEARER_TOKEN', 'certmate-api-token-7f3a9c2e5b8d1046af23')
+    assert (_bearer_token_from_env_or_generate()
+            == 'certmate-api-token-7f3a9c2e5b8d1046af23')
+
+
+def test_no_token_configured_still_generates_one():
+    """CONTROL. A first run with no API_BEARER_TOKEN must keep working, or the
+    fix above would have turned every fresh install into a hard failure."""
+    generated = _bearer_token_from_env_or_generate()
+    ok, reason = validate_api_token(generated)
+    assert ok, reason
+
+
+# --- the reason it is this exception type ------------------------------------
+
+def test_the_error_is_not_swallowed_into_world_open_defaults():
+    """load_settings re-raises SettingsUnreadableError specifically so it does
+    not fall through to "return the defaults in-memory" — those carry
+    setup_completed False, which is setup mode, which is world-open. The bearer
+    token error inherits that treatment by subclassing it; if someone ever
+    re-parents this exception, this test fails and says why.
+    """
+    assert issubclass(BearerTokenUnusableError, SettingsUnreadableError)

--- a/tests/test_bearer_token_fails_closed.py
+++ b/tests/test_bearer_token_fails_closed.py
@@ -18,7 +18,6 @@ Two halves, and both matter:
 These tests pin both, plus the control that a first run with no token at all
 still generates one and boots normally.
 """
-import os
 
 import pytest
 

--- a/tests/test_issue108_bearer_token_env.py
+++ b/tests/test_issue108_bearer_token_env.py
@@ -8,12 +8,27 @@ call. The previous behavior was: env var copied verbatim into the in-memory
 defaults, then validate_api_token rejected it on every save with a
 misleading "API token length must be between 32 and 512 characters" error,
 breaking onboarding and user creation alike.
+
+That requirement still holds and is still tested here: an unusable token
+never reaches settings.json.
+
+What changed is the *reaction* to an unusable token. #108 substituted a
+freshly generated one and carried on, which fixed the poisoned saves and
+introduced something worse: the operator had said "this instance is
+authenticated" by setting the variable, `_detect_operator_bearer_token()`
+then found no operator credential, `is_setup_mode()` stayed true, and the
+instance answered every gated endpoint to anonymous callers as admin —
+while the log said a fresh token had been generated. The substitution is
+now a refusal (`BearerTokenUnusableError`, which the auth layer turns into
+401 on every request). The empty and whitespace-only cases that motivated
+#108 are unchanged: they read as "not configured" and still generate.
 """
 
 import pytest
 
 from modules.core.file_operations import FileOperations
 from modules.core.settings import (
+    BearerTokenUnusableError,
     SettingsManager,
     _bearer_token_from_env_or_generate,
 )
@@ -38,15 +53,13 @@ def settings_manager(tmp_path):
     return SettingsManager(file_ops=file_ops, settings_file=data_dir / "settings.json")
 
 
-def test_helper_falls_back_when_env_var_too_short(monkeypatch, caplog):
+def test_too_short_env_var_refuses_instead_of_falling_back(monkeypatch):
     monkeypatch.setenv("API_BEARER_TOKEN", "shortbad")  # 8 chars, < 32
-    with caplog.at_level("WARNING"):
-        token = _bearer_token_from_env_or_generate()
-    is_valid, _ = validate_api_token(token)
-    assert is_valid, "fallback token must pass validation"
-    assert token != "shortbad"
-    assert any("API_BEARER_TOKEN" in rec.message for rec in caplog.records), (
-        "must log a warning so the operator knows their env var was rejected"
+    with pytest.raises(BearerTokenUnusableError) as raised:
+        _bearer_token_from_env_or_generate()
+    assert "NO AUTHENTICATION" in str(raised.value), (
+        "the message must say what ignoring it would cost, not just that the "
+        "token was rejected"
     )
 
 
@@ -65,17 +78,14 @@ def test_helper_generates_when_env_var_missing(monkeypatch):
     assert is_valid
 
 
-def test_helper_rejects_weak_pattern(monkeypatch, caplog):
-    # Long enough but matches the weak-pattern denylist.
+def test_a_documentation_placeholder_refuses(monkeypatch):
+    # Long enough, but it is the value from the docs, unedited.
     monkeypatch.setenv(
         "API_BEARER_TOKEN",
         "your_super_secure_api_token_here_change_this",
     )
-    with caplog.at_level("WARNING"):
-        token = _bearer_token_from_env_or_generate()
-    is_valid, _ = validate_api_token(token)
-    assert is_valid
-    assert any("API_BEARER_TOKEN" in rec.message for rec in caplog.records)
+    with pytest.raises(BearerTokenUnusableError):
+        _bearer_token_from_env_or_generate()
 
 
 GOOD_TOKEN = "9aZ8bY7cX6dW5eV4fU3gT2hS1iR0jQpNmLkJiHgF"  # 40 chars, valid
@@ -102,29 +112,23 @@ def test_file_var_takes_precedence_over_env_var(monkeypatch, tmp_path):
     assert _bearer_token_from_env_or_generate() == GOOD_TOKEN
 
 
-def test_file_read_error_generates_immediately(monkeypatch, caplog):
-    """If the file cannot be read, generate a fresh token without consulting API_BEARER_TOKEN."""
+def test_file_read_error_refuses_and_does_not_consult_the_env_var(monkeypatch):
+    """A path typo must not silently downgrade to another source, or to none."""
     monkeypatch.setenv("API_BEARER_TOKEN_FILE", "/nonexistent/path/token.txt")
-    monkeypatch.setenv("API_BEARER_TOKEN", "Z" * 40)  # must be ignored
-    with caplog.at_level("WARNING"):
-        token = _bearer_token_from_env_or_generate()
-    is_valid, _ = validate_api_token(token)
-    assert is_valid
-    assert token != "Z" * 40, "API_BEARER_TOKEN must not be consulted after file failure"
-    assert any("API_BEARER_TOKEN_FILE" in rec.message for rec in caplog.records)
+    monkeypatch.setenv("API_BEARER_TOKEN", GOOD_TOKEN)  # must not rescue it
+    with pytest.raises(BearerTokenUnusableError) as raised:
+        _bearer_token_from_env_or_generate()
+    assert "API_BEARER_TOKEN_FILE" in str(raised.value)
 
 
-def test_file_with_invalid_token_generates_immediately(monkeypatch, tmp_path, caplog):
-    """An invalid token in the file must generate immediately, not fall through to API_BEARER_TOKEN."""
+def test_file_with_invalid_token_refuses(monkeypatch, tmp_path):
+    """And does not fall through to API_BEARER_TOKEN either."""
     token_file = tmp_path / "token.txt"
     token_file.write_text("tooshort")
     monkeypatch.setenv("API_BEARER_TOKEN_FILE", str(token_file))
-    monkeypatch.setenv("API_BEARER_TOKEN", "Z" * 40)  # must be ignored
-    with caplog.at_level("WARNING"):
-        token = _bearer_token_from_env_or_generate()
-    is_valid, _ = validate_api_token(token)
-    assert is_valid
-    assert token != "Z" * 40, "API_BEARER_TOKEN must not be consulted after invalid file token"
+    monkeypatch.setenv("API_BEARER_TOKEN", GOOD_TOKEN)  # must not rescue it
+    with pytest.raises(BearerTokenUnusableError):
+        _bearer_token_from_env_or_generate()
 
 
 def test_file_var_absent_falls_through_to_env_var(monkeypatch):
@@ -145,12 +149,15 @@ def test_file_strips_whitespace(monkeypatch, tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_save_settings_succeeds_after_bad_env_var(settings_manager, monkeypatch):
-    """The end-to-end repro: with a bad API_BEARER_TOKEN env var, the
-    initial save during the setup wizard must NOT fail."""
+def test_an_unusable_env_var_never_reaches_settings_json(settings_manager,
+                                                        monkeypatch):
+    """#108's actual requirement, kept: the invalid value must never be
+    written. What changed is that the instance now refuses to serve rather
+    than substituting a token nobody holds — the wizard save raises instead
+    of succeeding into an unauthenticated instance.
+    """
     monkeypatch.setenv("API_BEARER_TOKEN", "weak")  # 4 chars
 
-    # Simulate the setup wizard payload (no api_bearer_token field).
     wizard_payload = {
         "email": "test@example.com",
         "dns_provider": "cloudflare",
@@ -163,9 +170,28 @@ def test_save_settings_succeeds_after_bad_env_var(settings_manager, monkeypatch)
         "setup_completed": True,
     }
 
-    assert settings_manager.atomic_update(wizard_payload) is True, (
-        "atomic_update must not fail because of a bad API_BEARER_TOKEN env var"
+    with pytest.raises(BearerTokenUnusableError):
+        settings_manager.atomic_update(wizard_payload)
+
+    on_disk = settings_manager.settings_file
+    assert not on_disk.exists() or "weak" not in on_disk.read_text(), (
+        "the rejected value must never be persisted — that was the whole "
+        "point of #108"
     )
+
+
+def test_the_wizard_still_works_with_a_usable_env_var(settings_manager,
+                                                      monkeypatch):
+    """CONTROL for the test above: the refusal is caused by the bad token,
+    not by the wizard path being broken."""
+    monkeypatch.setenv("API_BEARER_TOKEN", GOOD_TOKEN)
+
+    assert settings_manager.atomic_update({
+        "email": "test@example.com",
+        "dns_provider": "cloudflare",
+        "auto_renew": True,
+        "setup_completed": True,
+    }) is True
 
     saved = settings_manager.load_settings()
     assert saved["email"] == "test@example.com"


### PR DESCRIPTION
Hardening of the API bearer token bootstrap. Two changes that only matter together.

## The validator refused tokens that are not weak

`validate_api_token` matched a denylist of bare nouns — `api`, `key`, `token`, `secret`, `admin`, `test`, `demo`, `default`, `example` — as substrings anywhere in the value. So `certmate-api-token-<32 random chars>` was refused, for containing "api".

Those are words that appear in tokens people actually choose, not weak passwords. What protects against a guessable token is the length floor (32) and the character-variety floor (12 distinct characters), and both are unchanged. The denylist now holds only unambiguous placeholders.

Narrowing it is safe because the placeholder we ship in `.env.example`, `your_secure_api_token_here`, is 26 characters and is refused on length alone — there is a test pinning exactly that, so the list can never silently become the only thing standing between a copied-and-pasted default and production.

## The reaction to a rejection was to carry on

`_bearer_token_from_env_or_generate` dropped the rejected value, generated a random token in its place, and logged that it had done so.

Setting `API_BEARER_TOKEN` (or `API_BEARER_TOKEN_FILE`) is how an operator states that the instance is authenticated. With the value discarded, `_detect_operator_bearer_token()` finds no operator credential and the instance keeps behaving as one that has not been configured yet. The log line — "ignoring it and generating a fresh random bearer token" — reads like the instance is still protected.

It now raises `BearerTokenUnusableError`, and the message names the consequence rather than only the rejection, so the operator knows what refusing bought them.

The exception subclasses `SettingsUnreadableError` on purpose: `load_settings` already re-raises that type rather than falling through to "return the defaults in-memory", and the auth layer already turns it into a 401. Reusing that path keeps the failure mode identical to the one #581 established and tested, instead of inventing a second one.

## #108 is preserved, not reverted

That issue's requirement — an unusable value must never reach `settings.json` and poison every subsequent save — still holds and is still tested. What changed is the reaction: refusal instead of substitution.

The cases that motivated #108 still work. `API_BEARER_TOKEN=` left unexpanded by docker-compose, and whitespace-only values, are now explicitly stripped and read as "not configured": they generate a token and boot normally. The five tests in `test_issue108_bearer_token_env.py` that pinned the old reaction are rewritten to the new contract, with the reasoning in the module docstring, plus a control proving the wizard path still works with a usable token.

## A comment that was wrong

`settings.py` claimed "app.py catches this and exits 1, so the operator gets a container that stops with one actionable line". Nothing catches `SettingsUnreadableError` anywhere outside settings.py and the tests. Checked in a container rather than assumed: the instance stays up and answers 401 to everything. That is the safe end of the trade, but it is not what the comment said, so the comment now says what happens.

## Testing

- 16 new tests in `tests/test_bearer_token_fails_closed.py`, including a control that a first run with no token configured still generates one and boots
- behavioural control run against the pre-change code: it discards the operator's token and returns a different one; after the change it returns the operator's token
- verified in containers built from this tree: an operator token that used to be discarded now authenticates (401 without it, 200 with it), and an unusable one answers 401 to an anonymous caller where it previously answered 200
- full local suite: 2999 passed, 6 skipped, 0 failed
- bandit identical to main (36 medium / 2 high, all pre-existing); `test_issue108_bearer_token_env.py` went from 11 style violations to 6

Touches `modules/`, so the release gate requires the real-certificate E2E before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)