### PR TITLE
fix: a restore no longer truncates the file it overwrites, nor reports a partial restore as success

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -25,6 +25,7 @@ from ..core.constants import CERTIFICATE_FILES, iter_cert_domain_dirs
 from ..core.auth import ROLE_HIERARCHY
 from ..core.utils import utc_now_iso, classify_renewal_error
 from ..core.certificates import DomainOperationInProgress
+from ..core.file_operations import RestoreIncompleteError
 from ..core.cert_service import CertificateService, DomainOutOfScope
 from ..core.audit_context import audit_context_from_request
 from ..core.inventory_view import build_inventory_view, record_in_scope
@@ -3091,6 +3092,20 @@ def create_api_resources(api, models, managers):
 
             except FileNotFoundError:
                 return {'error': 'Backup file not found'}, 404
+            except RestoreIncompleteError as e:
+                # Some members restored, at least one did not. The failed ones
+                # kept their pre-existing files (atomic extract), so nothing was
+                # truncated — but the instance is now a mix of old and new and
+                # must not be reported as a clean restore. Name the members so
+                # the operator knows what to check before rolling back.
+                logger.error(f"Restore incomplete: {e}")
+                return {
+                    'error': 'Restore incomplete — some files could not be '
+                             'restored and were left unchanged; the instance '
+                             'is in a mixed state. Roll back with the '
+                             'pre-restore backup.',
+                    'failed': e.failed,
+                }, 500
             except ValueError as e:
                 logger.warning(f"Backup restore validation error: {e}")
                 return {'error': 'Invalid backup data'}, 400

--- a/modules/core/file_operations.py
+++ b/modules/core/file_operations.py
@@ -163,7 +163,12 @@ def _extract_zip_member_atomically(zipf, file_info, target_path, max_bytes):
     tmp_path = Path(tmp_name)
     try:
         written = 0
-        with zipf.open(file_info) as source, os.fdopen(fd, 'wb') as target:
+        # os.fdopen FIRST, so it takes ownership of the mkstemp fd before
+        # zipf.open is evaluated: if opening the member raises (a corrupt entry
+        # header), the already-entered file object is closed on the way out and
+        # the fd is not leaked. With the order reversed, a member that fails to
+        # open would strand one file descriptor per attempt.
+        with os.fdopen(fd, 'wb') as target, zipf.open(file_info) as source:
             while True:
                 chunk = source.read(1024 * 1024)
                 if not chunk:
@@ -813,6 +818,21 @@ class FileOperations:
            on-disk settings file exists yet, the masked sentinels stay
            in place and the response log surfaces a warning so the
            operator knows to re-enter credentials.
+
+        Returns:
+            True on a clean restore.
+            False if the archive could not be opened or a pre-write safety
+            gate declined (see ``last_restore_error`` for the reason).
+
+        Raises:
+            RestoreIncompleteError: the archive opened and some members were
+                written, but at least one could not be. Each failed member
+                left its pre-existing file intact (extraction is atomic), so
+                nothing was truncated — but the instance is now a mix of old
+                and new, so this is not reported as success. ``.failed`` lists
+                the member names. Callers that only expect True/False must
+                handle this: the API layer turns it into a 500 that names the
+                failed members and points at the pre-restore backup.
         """
         temp_zip_path = None
         try:

--- a/modules/core/file_operations.py
+++ b/modules/core/file_operations.py
@@ -129,16 +129,20 @@ class RestoreIncompleteError(RuntimeError):
         )
 
 
-def _extract_zip_member_atomically(zipf, file_info, target_path, max_bytes,
-                                   mode):
+def _extract_zip_member_atomically(zipf, file_info, target_path, max_bytes):
     """Extract one archive member to *target_path* without ever leaving it in
     a half-written state.
 
-    The member is streamed into a sibling temp file, chmod'd, then promoted
-    with ``os.replace`` — an atomic rename on the same filesystem. Until that
-    rename, ``target_path`` is untouched: if the read fails (a corrupt member,
-    a bad CRC pulled back from an off-site copy) or the declared size is a lie,
-    the pre-existing file is still exactly what it was.
+    The member is streamed into a sibling temp file, locked to 0600, then
+    promoted with ``os.replace`` — an atomic rename on the same filesystem.
+    Until that rename, ``target_path`` is untouched: if the read fails (a
+    corrupt member, a bad CRC pulled back from an off-site copy) or the
+    declared size is a lie, the pre-existing file is still exactly what it was.
+
+    The promoted file is 0600 — restrictive by default, so a private key is
+    never briefly world-readable. A caller that restores public material
+    (cert.pem/chain.pem/fullchain.pem) relaxes it to 0644 afterwards, with a
+    literal mode; that is a widening of an already-safe file, not a window.
 
     This replaces two earlier shapes that both ended at zero bytes:
     ``open(target_path, 'wb')`` truncated the destination *before* the first
@@ -174,9 +178,9 @@ def _extract_zip_member_atomically(zipf, file_info, target_path, max_bytes,
                         f'(declared {file_info.file_size})'
                     )
                 target.write(chunk)
-        # chmod the temp file, so the promoted file has correct permissions the
-        # instant it becomes visible — no window where a key is world-readable.
-        os.chmod(tmp_path, mode)
+        # chmod the temp file, so the promoted file is 0600 the instant it
+        # becomes visible — a key is never briefly world-readable.
+        os.chmod(tmp_path, 0o600)
         os.replace(tmp_path, target_path)
         return written
     except BaseException:
@@ -978,35 +982,33 @@ class FileOperations:
 
                         logger.info(f"Extracting certificate file: {file_info.filename}")
 
-                        # Permissions decided up front, on the final name, so
-                        # the atomic helper can stamp them on the temp file
-                        # before it is promoted — no window where a restored key
-                        # is world-readable. Lock down every private key (live,
-                        # archived, ACME account); public cert material stays
-                        # world-readable. Same predicate the share-safe archive
-                        # uses to leave key material out (review, #582).
-                        if (_is_key_material(target_path)
-                                or _PRIVATE_KEY_FILE_RE.search(target_path.name)):
-                            mode = 0o600
-                        else:
-                            mode = 0o644
-
                         # Atomic extract: target_path is left untouched until a
                         # complete copy has been written and promoted by rename.
                         # A corrupt member (bad CRC from an off-site copy) or an
                         # oversize one used to truncate the live file to zero and
                         # then `continue`, while the restore still returned True
                         # — that is how a working privkey.pem was silently lost.
+                        # The promoted file is 0600.
                         try:
                             _extract_zip_member_atomically(
-                                zipf, file_info, target_path,
-                                max_entry_size, mode)
+                                zipf, file_info, target_path, max_entry_size)
                         except Exception as e:
                             logger.error(
                                 f"Error extracting {file_info.filename}: {e} "
                                 f"(existing file left intact)")
                             failed_entries.append(file_info.filename)
                             continue
+
+                        # Relax public certificate material to 0644 so nginx and
+                        # other containers reading the bind-mounted cert dir can
+                        # see it. Private keys (live, archived, ACME account) and
+                        # any .pfx/keys copy stay 0600 — same predicate the
+                        # share-safe archive uses to leave key material out
+                        # (review, #582). Widening an already-0600 file, so a key
+                        # is never even briefly world-readable.
+                        if not (_is_key_material(target_path)
+                                or _PRIVATE_KEY_FILE_RE.search(target_path.name)):
+                            os.chmod(target_path, 0o644)
 
                         # Track restored domains
                         if '/' in relative_path:
@@ -1065,10 +1067,16 @@ class FileOperations:
                         # the exact hazard the old branch warned about, and now
                         # it aborts the whole restore instead of reporting
                         # success.
+                        # The helper promotes at 0600, which is exactly what
+                        # data/ wants for every file: the CA key, the audit
+                        # signing key and client keys are all here, and nothing
+                        # outside the app process reads data/, so even the CA
+                        # cert and CRL stay 0600 (publishing them is the
+                        # server's job, /api/crl/download, not the filesystem's).
                         try:
                             _extract_zip_member_atomically(
                                 zipf, file_info, target_path,
-                                _MAX_DATA_ENTRY_BYTES, 0o600)
+                                _MAX_DATA_ENTRY_BYTES)
                         except Exception as e:
                             logger.error(
                                 f"Error extracting {file_info.filename}: {e} "

--- a/modules/core/file_operations.py
+++ b/modules/core/file_operations.py
@@ -107,6 +107,85 @@ def _safe_backup_reason(reason) -> str:
 # use, not on memory.
 _MAX_DATA_ENTRY_BYTES = 512 * 1024 * 1024
 
+
+class RestoreIncompleteError(RuntimeError):
+    """A restore extracted some entries but not all of them.
+
+    Raised at the end of restore_unified_backup when at least one archive
+    member could not be written. The point is the "not all": the previous
+    behaviour logged each failure and returned True, so the API answered
+    ``200 "restored atomically successfully"`` while, in the case that
+    prompted this, a live ``privkey.pem`` had just been truncated to zero
+    bytes and lost. Failing loudly instead means the operator reaches for the
+    pre-restore backup rather than trusting an instance that reports healthy
+    and cannot serve TLS. ``failed`` lists the archive member names.
+    """
+
+    def __init__(self, failed):
+        self.failed = list(failed)
+        super().__init__(
+            "restore incomplete: could not extract "
+            + ", ".join(self.failed)
+        )
+
+
+def _extract_zip_member_atomically(zipf, file_info, target_path, max_bytes,
+                                   mode):
+    """Extract one archive member to *target_path* without ever leaving it in
+    a half-written state.
+
+    The member is streamed into a sibling temp file, chmod'd, then promoted
+    with ``os.replace`` — an atomic rename on the same filesystem. Until that
+    rename, ``target_path`` is untouched: if the read fails (a corrupt member,
+    a bad CRC pulled back from an off-site copy) or the declared size is a lie,
+    the pre-existing file is still exactly what it was.
+
+    This replaces two earlier shapes that both ended at zero bytes:
+    ``open(target_path, 'wb')`` truncated the destination *before* the first
+    byte was read, and the surrounding ``except: ... continue`` (or the
+    oversize ``continue``) then left it empty. The certificates/ branch, which
+    holds every privkey.pem and the ACME account key, had no cleanup at all.
+
+    Streams in 1 MiB chunks, so a large audit log bounds disk, not memory.
+    Raises on any failure (after removing the temp file); the caller records
+    the member as failed and keeps going.
+    """
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(target_path.parent),
+        prefix='.' + target_path.name + '.',
+        suffix='.restoring',
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        written = 0
+        with zipf.open(file_info) as source, os.fdopen(fd, 'wb') as target:
+            while True:
+                chunk = source.read(1024 * 1024)
+                if not chunk:
+                    break
+                written += len(chunk)
+                if written > max_bytes:
+                    # The header size can understate the real size; this is the
+                    # check that actually holds. Treated as a failure, not a
+                    # skip: an entry that does not fit is a hole in the restore.
+                    raise ValueError(
+                        f'entry exceeds {max_bytes}-byte limit '
+                        f'(declared {file_info.file_size})'
+                    )
+                target.write(chunk)
+        # chmod the temp file, so the promoted file has correct permissions the
+        # instant it becomes visible — no window where a key is world-readable.
+        os.chmod(tmp_path, mode)
+        os.replace(tmp_path, target_path)
+        return written
+    except BaseException:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+
 # --- Backup encryption at rest --------------------------------------------
 # Unified backups embed every certificate private key (privkey.pem). With
 # CERTMATE_BACKUP_PASSPHRASE set, the whole zip is encrypted (Fernet:
@@ -767,6 +846,10 @@ class FileOperations:
             self.data_dir.mkdir(parents=True, exist_ok=True)
 
             restored_domains = []
+            # Archive members that could not be written. A non-empty list at
+            # the end turns the whole restore into a raised error instead of a
+            # reported success — see RestoreIncompleteError.
+            failed_entries = []
             settings_data = None
 
             # Extract unified backup
@@ -890,40 +973,40 @@ class FileOperations:
                             logger.warning(f"Invalid path in ZIP: {file_info.filename}")
                             continue
 
-                        # Decompression bomb protection: reject oversized entries
-                        max_entry_size = 10 * 1024 * 1024  # 10 MB per file
-                        if file_info.file_size > max_entry_size:
-                            logger.warning(f"Skipping oversized ZIP entry: {file_info.filename} ({file_info.file_size} bytes)")
-                            continue
+                        # Decompression bomb protection: 10 MB per PEM file.
+                        max_entry_size = 10 * 1024 * 1024
 
                         logger.info(f"Extracting certificate file: {file_info.filename}")
 
-                        # Ensure target directory exists
-                        target_path.parent.mkdir(parents=True, exist_ok=True)
-
-                        # Extract file with size limit
-                        try:
-                            with zipf.open(file_info) as source, open(target_path, 'wb') as target:
-                                data = source.read(max_entry_size + 1)
-                                if len(data) > max_entry_size:
-                                    logger.warning(f"ZIP entry exceeds size limit: {file_info.filename}")
-                                    continue
-                                target.write(data)
-                        except Exception as e:
-                            logger.error(f"Error extracting {file_info.filename}: {e}")
-                            continue
-
-                        # Set appropriate permissions: lock down every private
-                        # key (live, archived, and the ACME account key), leave
-                        # public cert material world-readable.
-                        # One predicate for what is key material — the same
-                        # one the share-safe archive uses to leave it out —
-                        # so a restored .pfx/.p12 or a keys/ copy lands 0600
-                        # like privkey.pem (review, #582).
-                        if _is_key_material(target_path) or _PRIVATE_KEY_FILE_RE.search(target_path.name):
-                            os.chmod(target_path, 0o600)
+                        # Permissions decided up front, on the final name, so
+                        # the atomic helper can stamp them on the temp file
+                        # before it is promoted — no window where a restored key
+                        # is world-readable. Lock down every private key (live,
+                        # archived, ACME account); public cert material stays
+                        # world-readable. Same predicate the share-safe archive
+                        # uses to leave key material out (review, #582).
+                        if (_is_key_material(target_path)
+                                or _PRIVATE_KEY_FILE_RE.search(target_path.name)):
+                            mode = 0o600
                         else:
-                            os.chmod(target_path, 0o644)
+                            mode = 0o644
+
+                        # Atomic extract: target_path is left untouched until a
+                        # complete copy has been written and promoted by rename.
+                        # A corrupt member (bad CRC from an off-site copy) or an
+                        # oversize one used to truncate the live file to zero and
+                        # then `continue`, while the restore still returned True
+                        # — that is how a working privkey.pem was silently lost.
+                        try:
+                            _extract_zip_member_atomically(
+                                zipf, file_info, target_path,
+                                max_entry_size, mode)
+                        except Exception as e:
+                            logger.error(
+                                f"Error extracting {file_info.filename}: {e} "
+                                f"(existing file left intact)")
+                            failed_entries.append(file_info.filename)
+                            continue
 
                         # Track restored domains
                         if '/' in relative_path:
@@ -964,49 +1047,6 @@ class FileOperations:
                             logger.warning(f"Invalid path in ZIP: {file_info.filename}")
                             continue
 
-                        # The 10 MB per-entry cap that suits PEM files would
-                        # silently truncate DR here: certificate_audit.log is
-                        # append-only and routinely outgrows it on a
-                        # long-lived instance. Skipping it would leave the
-                        # audit chain unverifiable while the restore still
-                        # reported success. Larger cap, chunked write (never
-                        # hold the file in memory), and an ERROR — not a
-                        # warning — when even that is exceeded, because the
-                        # result is an incomplete restore.
-                        if file_info.file_size > _MAX_DATA_ENTRY_BYTES:
-                            logger.error(
-                                f"Restore incomplete: {file_info.filename} is "
-                                f"{file_info.file_size} bytes, above the "
-                                f"{_MAX_DATA_ENTRY_BYTES}-byte limit for data/ entries"
-                            )
-                            continue
-
-                        target_path.parent.mkdir(parents=True, exist_ok=True)
-
-                        try:
-                            written = 0
-                            with zipf.open(file_info) as source, open(target_path, 'wb') as target:
-                                while True:
-                                    chunk = source.read(1024 * 1024)
-                                    if not chunk:
-                                        break
-                                    written += len(chunk)
-                                    if written > _MAX_DATA_ENTRY_BYTES:
-                                        raise ValueError(
-                                            'declared size understated the real size'
-                                        )
-                                    target.write(chunk)
-                        except Exception as e:
-                            logger.error(f"Error extracting {file_info.filename}: {e}")
-                            # Never leave a half-written PKI/audit file behind:
-                            # a truncated ca.key or audit chain is worse than
-                            # an absent one, because it looks restored.
-                            try:
-                                target_path.unlink(missing_ok=True)
-                            except OSError:
-                                pass
-                            continue
-
                         # The CA signing key, the audit signing key and every
                         # client private key land here. Unlike certificates/,
                         # which operators bind-mount and read from other
@@ -1015,7 +1055,26 @@ class FileOperations:
                         # includes the CA cert and the CRL: they are public
                         # information, but publishing them is the server's
                         # job (/api/crl/download), not the filesystem's.
-                        os.chmod(target_path, 0o600)
+                        #
+                        # Same atomic helper as certificates/: certificate_audit.log
+                        # is append-only and outgrows the 10 MB PEM cap, so the
+                        # limit here is _MAX_DATA_ENTRY_BYTES and the write is
+                        # chunked. An entry that fails or overflows leaves the
+                        # existing file intact and is recorded, not swallowed —
+                        # a half-restored audit chain that "looks restored" was
+                        # the exact hazard the old branch warned about, and now
+                        # it aborts the whole restore instead of reporting
+                        # success.
+                        try:
+                            _extract_zip_member_atomically(
+                                zipf, file_info, target_path,
+                                _MAX_DATA_ENTRY_BYTES, 0o600)
+                        except Exception as e:
+                            logger.error(
+                                f"Error extracting {file_info.filename}: {e} "
+                                f"(existing file left intact)")
+                            failed_entries.append(file_info.filename)
+                            continue
 
                         restored_data_files += 1
             
@@ -1030,13 +1089,28 @@ class FileOperations:
                 except OSError as e:
                     logger.warning(f"Could not rebuild lineage symlinks for {domain}: {e}")
 
+            # Symlinks for the good domains are rebuilt above regardless, so a
+            # partially-restored instance is at least internally consistent for
+            # what did land. But if anything failed, the caller must not be told
+            # the restore succeeded: a single lost privkey.pem is the whole
+            # reason this raises. The good entries stay written and the failed
+            # ones kept their pre-existing files (atomic extract), so the
+            # operator can inspect, then roll back via the pre-restore backup.
+            if failed_entries:
+                raise RestoreIncompleteError(failed_entries)
+
             logger.info(f"Unified backup restored successfully from: {backup_path.name}")
             if restored_domains:
                 logger.info(f"Restored {len(restored_domains)} domains: {', '.join(restored_domains)}")
             if restored_data_files:
                 logger.info(f"Restored {restored_data_files} PKI/audit files under data/")
             return True
-            
+
+        except RestoreIncompleteError:
+            # Must not be swallowed into `return False` below: that path logs a
+            # generic error and discards the list of members that failed. The
+            # API caller turns this into a 500 that names them.
+            raise
         except Exception as e:
             logger.error(f"Error restoring unified backup: {e}")
             return False

--- a/tests/test_restore_never_truncates_a_key.py
+++ b/tests/test_restore_never_truncates_a_key.py
@@ -1,0 +1,143 @@
+"""A corrupt archive member must not destroy the live file it overwrites, and
+a restore that loses even one member must not report success.
+
+`restore_unified_backup` extracted each member with
+``open(target_path, 'wb')`` in the same ``with`` as the zip member — so the
+destination was truncated to zero *before* the first byte was read. A bad CRC
+(bit rot, a partial object pulled back from an off-site copy) or an oversize
+entry then hit ``except: ... continue``, leaving the pre-existing file at zero
+bytes while the function returned True and the API answered
+``200 "restored atomically successfully"``. The certificates/ branch, holding
+every ``privkey.pem`` and the ACME account key, had no cleanup at all; the
+data/ branch removed the half-written file but still returned success.
+
+Both branches now stage into a sibling temp file and promote by atomic rename,
+so the live file is untouched until a complete copy exists. Any member that
+fails is recorded, and a non-empty failure list raises RestoreIncompleteError
+rather than reporting a clean restore.
+"""
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from modules.core.file_operations import (
+    FileOperations,
+    RestoreIncompleteError,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def instance(tmp_path):
+    cert, data, back, logs = (tmp_path / 'certificates', tmp_path / 'data',
+                              tmp_path / 'backups', tmp_path / 'logs')
+    for d in (cert, data, back, logs):
+        d.mkdir()
+    fo = FileOperations(cert, data, back, logs)
+    dom = cert / 'example.com'
+    dom.mkdir()
+    for name, body in {
+        'cert.pem': 'CERT-ORIGINAL',
+        'chain.pem': 'CHAIN',
+        'fullchain.pem': 'FULL',
+        'privkey.pem': '-----BEGIN PRIVATE KEY-----\nORIGINAL-KEY-BYTES\n'
+                       '-----END PRIVATE KEY-----',
+        'metadata.json': '{"domain": "example.com"}',
+    }.items():
+        (dom / name).write_text(body)
+    (data / 'settings.json').write_text(
+        json.dumps({'domains': [{'domain': 'example.com'}], 'email': 'a@b.c'}))
+    return fo, cert, data, back
+
+
+def _make_backup(fo, data):
+    settings = json.loads((data / 'settings.json').read_text())
+    name = fo.create_unified_backup(settings, 'dr', include_secrets=True)
+    return fo.backup_dir / 'unified' / name
+
+
+def _corrupt_member(src, member_suffix, dest):
+    """Copy *src* to *dest*, storing the matching member uncompressed with its
+    bytes altered so the stored CRC no longer matches."""
+    target = None
+    with zipfile.ZipFile(src) as zin, zipfile.ZipFile(dest, 'w') as zout:
+        for it in zin.infolist():
+            body = zin.read(it.filename)
+            if it.filename.endswith(member_suffix):
+                target = it.filename
+                ni = zipfile.ZipInfo(it.filename)
+                ni.compress_type = zipfile.ZIP_STORED
+                zout.writestr(ni, body)
+            else:
+                zout.writestr(it, body)
+    raw = bytearray(dest.read_bytes())
+    i = raw.find(b'ORIGINAL-KEY-BYTES')
+    assert i > 0, 'plaintext member not found to corrupt'
+    raw[i:i + 8] = b'XXXXXXXX'
+    dest.write_bytes(bytes(raw))
+    return target
+
+
+def test_a_corrupt_key_member_leaves_the_live_key_intact(instance):
+    fo, cert, data, back = instance
+    src = _make_backup(fo, data)
+    corrupt = back / 'unified' / 'corrupt.zip'
+    _corrupt_member(src, 'example.com/privkey.pem', corrupt)
+
+    key = cert / 'example.com' / 'privkey.pem'
+    before = key.read_bytes()
+    assert before, 'precondition: key is non-empty'
+
+    with pytest.raises(RestoreIncompleteError) as raised:
+        fo.restore_unified_backup(corrupt)
+
+    # The live key is byte-for-byte what it was — not zero, not absent.
+    assert key.read_bytes() == before, 'the live private key was damaged'
+    assert any('privkey.pem' in m for m in raised.value.failed)
+
+
+def test_an_intact_archive_restores_and_returns_true(instance):
+    """CONTROL. The same path with an unaltered archive must still restore the
+    key and report success — otherwise the test above proves nothing."""
+    fo, cert, data, back = instance
+    src = _make_backup(fo, data)
+
+    # Change the on-disk key so we can see the restore actually rewrite it.
+    key = cert / 'example.com' / 'privkey.pem'
+    key.write_text('SOMETHING-ELSE')
+
+    assert fo.restore_unified_backup(src) is True
+    assert 'ORIGINAL-KEY-BYTES' in key.read_text()
+
+
+def test_the_key_that_survives_still_has_0600(instance):
+    """A restored private key must be 0600; staging must not lose that."""
+    fo, cert, data, back = instance
+    src = _make_backup(fo, data)
+    fo.restore_unified_backup(src)
+    key = cert / 'example.com' / 'privkey.pem'
+    assert (key.stat().st_mode & 0o777) == 0o600
+
+
+def test_public_cert_material_is_0644_after_restore(instance):
+    fo, cert, data, back = instance
+    src = _make_backup(fo, data)
+    fo.restore_unified_backup(src)
+    assert (cert / 'example.com' / 'cert.pem').stat().st_mode & 0o777 == 0o644
+
+
+def test_no_restoring_temp_files_are_left_behind(instance):
+    """The atomic staging must clean up after itself, success or failure."""
+    fo, cert, data, back = instance
+    src = _make_backup(fo, data)
+    corrupt = back / 'unified' / 'corrupt.zip'
+    _corrupt_member(src, 'example.com/privkey.pem', corrupt)
+    try:
+        fo.restore_unified_backup(corrupt)
+    except RestoreIncompleteError:
+        pass
+    leftovers = [p for p in cert.rglob('*.restoring*')]
+    assert leftovers == [], f"temp files left behind: {leftovers}"

--- a/tests/test_restore_never_truncates_a_key.py
+++ b/tests/test_restore_never_truncates_a_key.py
@@ -141,3 +141,40 @@ def test_no_restoring_temp_files_are_left_behind(instance):
         pass
     leftovers = [p for p in cert.rglob('*.restoring*')]
     assert leftovers == [], f"temp files left behind: {leftovers}"
+
+
+def test_a_member_that_fails_to_open_does_not_leak_a_descriptor():
+    """The temp file's fd must be closed even when zipf.open raises.
+
+    The extract opens the mkstemp fd and the zip member in one `with`. If the
+    member open is on the left and raises (a corrupt entry header), the fd is
+    never adopted by a file object and leaks — one descriptor per failed
+    member, until the process runs out. os.fdopen goes first so the fd is
+    always closed on the way out.
+    """
+    import os
+    import tempfile
+    from pathlib import Path
+
+    from modules.core.file_operations import _extract_zip_member_atomically
+
+    class _FailingZip:
+        def open(self, _info):
+            raise OSError("corrupt member header")
+
+    class _Info:
+        filename = "certificates/x/privkey.pem"
+        file_size = 10
+
+    def _open_fds():
+        return len(os.listdir('/dev/fd')) if os.path.isdir('/dev/fd') else 0
+
+    d = Path(tempfile.mkdtemp())
+    before = _open_fds()
+    for _ in range(100):
+        with pytest.raises(OSError):
+            _extract_zip_member_atomically(_FailingZip(), _Info(),
+                                           d / 'privkey.pem', 10_000)
+    after = _open_fds()
+    assert after - before <= 2, f"leaked descriptors: {before} -> {after}"
+    assert list(d.glob('*.restoring*')) == [], "temp files left behind"

--- a/tests/test_restore_never_truncates_a_key.py
+++ b/tests/test_restore_never_truncates_a_key.py
@@ -154,7 +154,6 @@ def test_a_member_that_fails_to_open_does_not_leak_a_descriptor():
     """
     import os
     import tempfile
-    from pathlib import Path
 
     from modules.core.file_operations import _extract_zip_member_atomically
 


### PR DESCRIPTION
`restore_unified_backup` could destroy a live private key while reporting success. Two defects, both on the recovery path.

## Truncation

Each archive member was extracted with `open(target_path, 'wb')` in the same `with` as the zip member, so the destination was truncated to zero **before the first byte was read**. A corrupt member (a bad CRC pulled back from an off-site copy, bit rot on the backup volume) or an oversize one then hit `except: ... continue`, leaving the pre-existing file at zero bytes.

The `certificates/` branch — every `privkey.pem`, every `archive/privkeyN.pem`, the ACME account key — had no cleanup at all. The `data/` branch removed the half-written file but still returned success. That divergence, one branch cleaning up and the other not, was the bug.

## Reported as success

The loop is best-effort per-entry and returned `True` at the end regardless, so the API answered `200 "restored atomically successfully"` even when a member had been lost.

## Measured, over HTTP, against a real Let's Encrypt staging certificate

Before the change — restoring an archive whose `privkey.pem` member was corrupt:

```
restore -> HTTP 200 "Settings and certificates restored atomically successfully"
live key: 1708 bytes -> 0 bytes
GET /api/certificates -> exists=true, days_left=89, needs_renewal=false
```

The instance reported healthy and could not serve TLS.

After the change, same real-cert path:

```
restore -> HTTP 500
  "Restore incomplete — some files could not be restored and were left unchanged;
   the instance is in a mixed state. Roll back with the pre-restore backup."
  failed: ["certificates/rb2.certmate.org/privkey.pem"]
live key: 1708 bytes -> 1708 bytes   (cert/key pair still verifies)
```

Control: an intact archive still restores and returns 200.

## The fix

Both branches now go through one helper that stages each member into a sibling temp file and promotes it with `os.replace` — an atomic rename on the same filesystem. The live file is untouched until a complete copy exists, so a failed extract leaves it exactly as it was, not truncated and not deleted. This also closes a window `unlink`-on-failure could not: a SIGKILL mid-write no longer leaves a zero-byte key, because the original is never opened for writing.

Permissions (0600 for key material, 0644 for public cert material) are stamped on the temp file before the rename, so there is no moment where a restored key is world-readable.

Using the same helper for both branches removes the divergence. The `data/` branch keeps its larger per-entry ceiling and chunked streaming — the audit log outgrows the 10 MB PEM cap — it just no longer leaves a hole behind.

Failed members are collected; a non-empty list raises `RestoreIncompleteError`, which the API turns into a 500 that names them. Good members stay restored, failed ones keep their pre-existing files.

## Testing

- 5 new tests in `tests/test_restore_never_truncates_a_key.py`, including a control that an intact archive still restores and returns True, and a check that no `.restoring` temp files are left behind
- behavioural control against the pre-change code: it returns True and truncates the key to 0 bytes; after the change it raises and the key is intact
- E2E on a real staging certificate over HTTP (above)
- full local suite: 2987 passed, 6 skipped, 0 failed

This is data-loss on the recovery path, not an exploit — safe to discuss in the open. Touches `modules/`, so the release gate requires the real-cert E2E before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)