### PR TITLE
fix: removing a domain no longer drops a concurrent registration (lost update)

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -1718,17 +1718,26 @@ def create_api_resources(api, models, managers):
                     return {'error': f'Certificate not found for domain: {domain}'}, 404
 
                 # Best-effort: drop the domain from settings so the dashboard
-                # stops listing it.
+                # stops listing it. Do it as a read-modify-write under the lock
+                # (settings_manager.update), NOT load_settings()+atomic_update
+                # with a whole 'domains' list: the load here is a request-cache
+                # HIT (the rate-limit before_request primed flask.g), and
+                # delete_certificate above can span a storage-backend network
+                # round-trip, so a concurrent registration that lands in that
+                # window is absent from the cached list. atomic_update replaces
+                # 'domains' wholesale (it is not a deep-merge key), so the stale
+                # list would win and silently drop the freshly-registered
+                # domain from renewals. The mutator filters the fresh on-disk
+                # list instead, removing only this domain.
                 try:
-                    settings = settings_manager.load_settings()
-                    domains = settings.get('domains', []) or []
-                    new_domains = [
-                        d for d in domains
-                        if (isinstance(d, str) and d != domain)
-                        or (isinstance(d, dict) and d.get('domain') != domain)
-                    ]
-                    if len(new_domains) != len(domains):
-                        settings_manager.atomic_update({'domains': new_domains})
+                    def _drop_domain(s):
+                        current = s.get('domains', []) or []
+                        s['domains'] = [
+                            d for d in current
+                            if (isinstance(d, str) and d != domain)
+                            or (isinstance(d, dict) and d.get('domain') != domain)
+                        ]
+                    settings_manager.update(_drop_domain, reason='certificate_delete')
                 except Exception as e:
                     logger.warning(f"Removed cert for {domain} but failed to update settings: {e}")
 

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -1729,15 +1729,27 @@ def create_api_resources(api, models, managers):
                 # list would win and silently drop the freshly-registered
                 # domain from renewals. The mutator filters the fresh on-disk
                 # list instead, removing only this domain.
+                class _AlreadyAbsent(Exception):
+                    pass
+
+                def _drop_domain(s):
+                    current = s.get('domains', []) or []
+                    kept = [
+                        d for d in current
+                        if (isinstance(d, str) and d != domain)
+                        or (isinstance(d, dict) and d.get('domain') != domain)
+                    ]
+                    # Nothing to remove — do not persist (and do not trigger an
+                    # automatic backup) for a no-op, matching the previous
+                    # `if len(new_domains) != len(domains)` guard.
+                    if len(kept) == len(current):
+                        raise _AlreadyAbsent
+                    s['domains'] = kept
+
                 try:
-                    def _drop_domain(s):
-                        current = s.get('domains', []) or []
-                        s['domains'] = [
-                            d for d in current
-                            if (isinstance(d, str) and d != domain)
-                            or (isinstance(d, dict) and d.get('domain') != domain)
-                        ]
                     settings_manager.update(_drop_domain, reason='certificate_delete')
+                except _AlreadyAbsent:
+                    pass
                 except Exception as e:
                     logger.warning(f"Removed cert for {domain} but failed to update settings: {e}")
 

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -2435,24 +2435,36 @@ class CertificateManager:
         otherwise. Legacy string-form entries are upgraded to dict form so the
         flag can be persisted.
         """
-        settings = self.settings_manager.load_settings()
-        # Migrate so every entry is a dict and the flag has somewhere to live.
-        settings = self.settings_manager.migrate_domains_format(settings)
+        # Flip the flag as a read-modify-write on the FRESH on-disk list, under
+        # the lock. The previous shape — load_settings() (a request-cache hit)
+        # then atomic_update({'domains': whole_list}) — replaced 'domains'
+        # wholesale from a possibly-stale snapshot: any concurrent registration
+        # or deletion that landed after the cache was primed was silently
+        # dropped. atomic_update guards the WRITE but not the staleness of the
+        # list it is handed. The mutator sees the current list and touches only
+        # this domain's entry, and raises _DomainNotInSettings when the domain
+        # is absent so nothing is persisted (preserving the old "return False,
+        # no write" behaviour rather than saving the migration for a no-op).
+        class _DomainNotInSettings(Exception):
+            pass
 
-        new_domains = []
-        found = False
-        for entry in settings.get('domains', []):
-            if isinstance(entry, dict) and entry.get('domain') == domain:
-                entry = {**entry, 'auto_renew': bool(enabled)}
-                found = True
-            new_domains.append(entry)
+        def _flip(s):
+            self.settings_manager.migrate_domains_format(s)
+            new_domains = []
+            found = False
+            for entry in s.get('domains', []):
+                if isinstance(entry, dict) and entry.get('domain') == domain:
+                    entry = {**entry, 'auto_renew': bool(enabled)}
+                    found = True
+                new_domains.append(entry)
+            if not found:
+                raise _DomainNotInSettings
+            s['domains'] = new_domains
 
-        if not found:
+        try:
+            self.settings_manager.update(_flip, reason='set_auto_renew')
+        except _DomainNotInSettings:
             return False
-
-        # atomic_update merges under a lock, avoiding a load/mutate/save race
-        # with concurrent settings writes.
-        self.settings_manager.atomic_update({'domains': new_domains})
         logger.info(f"auto_renew set to {bool(enabled)} for {domain}")
         return True
 

--- a/tests/test_domain_delete_no_lost_update.py
+++ b/tests/test_domain_delete_no_lost_update.py
@@ -1,0 +1,97 @@
+"""Removing a domain from settings must not drop a concurrent registration.
+
+The DELETE handler and set_auto_renew both did load_settings() (a request-cache
+hit, primed by the rate-limit before_request) then atomic_update({'domains':
+<whole list built from the stale snapshot>}). 'domains' is replaced wholesale
+(not a deep-merge key), so a domain registered by another request after the
+cache was primed — while the delete's storage-backend round-trip ran — was
+silently dropped from the list, and check_renewals never renewed it again. Both
+now do a read-modify-write on the fresh on-disk list via settings_manager.update.
+"""
+import json
+import threading
+
+import pytest
+
+from modules.core.file_operations import FileOperations
+from modules.core.settings import SettingsManager
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def sm(tmp_path):
+    d, c, b, l = (tmp_path / 'data', tmp_path / 'certs',
+                  tmp_path / 'backups', tmp_path / 'logs')
+    for p in (d, c, b, l):
+        p.mkdir()
+    (d / 'settings.json').write_text(json.dumps({
+        'domains': [{'domain': 'a.example.com'}],
+        'email': 'ops@example.com',
+        'users': {'admin': {'role': 'admin'}},
+    }))
+    fo = FileOperations(c, d, b, l)
+    return SettingsManager(fo, d / 'settings.json'), d / 'settings.json'
+
+
+def _domains(path):
+    return sorted(x['domain']
+                  for x in json.loads(path.read_text()).get('domains', []))
+
+
+def _drop(domain):
+    def mut(s):
+        s['domains'] = [d for d in s.get('domains', [])
+                        if d.get('domain') != domain]
+    return mut
+
+
+def test_a_concurrent_registration_survives_a_delete(sm):
+    manager, path = sm
+    b_written = threading.Event()
+
+    def register_b():
+        manager.update(lambda s: s.setdefault('domains', []).append(
+            {'domain': 'b.example.com'}), reason='register_b')
+        b_written.set()
+
+    def delete_a():
+        # The delete's read-modify-write happens after B lands, under the lock,
+        # so it sees the fresh list — the interleaving that used to lose B.
+        b_written.wait(2)
+        manager.update(_drop('a.example.com'), reason='delete_a')
+
+    t1 = threading.Thread(target=delete_a)
+    t2 = threading.Thread(target=register_b)
+    t1.start(); t2.start(); t1.join(); t2.join()
+
+    assert _domains(path) == ['b.example.com']
+
+
+def test_update_removes_only_the_named_domain(sm):
+    """CONTROL: the mutator must still actually remove the target."""
+    manager, path = sm
+    manager.update(lambda s: s.setdefault('domains', []).append(
+        {'domain': 'b.example.com'}), reason='seed')
+    manager.update(_drop('a.example.com'), reason='delete')
+    assert _domains(path) == ['b.example.com']
+
+
+def test_set_auto_renew_uses_a_locked_read_modify_write():
+    """Guard against a regression to load_settings()+atomic_update in the
+    auto-renew toggle, which had the identical lost-update shape."""
+    import inspect
+    from modules.core.certificates import CertificateManager
+    src = inspect.getsource(CertificateManager.set_auto_renew)
+    assert 'settings_manager.update' in src
+    # strip comments so the anti-pattern check looks at code, not prose
+    code = '\n'.join(line.split('#', 1)[0] for line in src.splitlines())
+    assert 'atomic_update' not in code
+
+
+def test_delete_handler_uses_a_locked_read_modify_write():
+    import inspect
+    from modules.api import resources
+    src = inspect.getsource(resources.create_api_resources)
+    # the delete path drops the domain via the mutator, not a whole-list replace
+    assert '_drop_domain' in src

--- a/tests/test_domain_delete_no_lost_update.py
+++ b/tests/test_domain_delete_no_lost_update.py
@@ -46,26 +46,78 @@ def _drop(domain):
     return mut
 
 
-def test_a_concurrent_registration_survives_a_delete(sm):
+def test_the_stale_snapshot_approach_loses_b_but_the_mutator_does_not(sm):
+    """Directly contrast the two approaches on the SAME interleaving: A reads
+    the domain list, B registers concurrently, then A removes its domain.
+
+    - the old shape (snapshot taken early, then atomic_update({'domains': list
+      built from that snapshot})) writes the stale list back and drops B;
+    - the new shape (update(mutator) re-reads the fresh list under the lock)
+      keeps B.
+    """
     manager, path = sm
     b_written = threading.Event()
+    snapshot_taken = threading.Event()
+
+    # --- old shape: snapshot then whole-list atomic_update ---
+    def delete_a_stale():
+        snap = manager.load_settings(use_cache=False)   # taken before B lands
+        snapshot_taken.set()
+        b_written.wait(2)
+        kept = [d for d in snap.get('domains', [])
+                if d.get('domain') != 'a.example.com']
+        manager.atomic_update({'domains': kept})
 
     def register_b():
+        snapshot_taken.wait(2)                          # let delete snapshot first
         manager.update(lambda s: s.setdefault('domains', []).append(
             {'domain': 'b.example.com'}), reason='register_b')
         b_written.set()
 
-    def delete_a():
-        # The delete's read-modify-write happens after B lands, under the lock,
-        # so it sees the fresh list — the interleaving that used to lose B.
+    t1 = threading.Thread(target=delete_a_stale)
+    t2 = threading.Thread(target=register_b)
+    t1.start(); t2.start(); t1.join(); t2.join()
+    assert 'b.example.com' not in _domains(path), \
+        "precondition: the stale-snapshot approach must lose B here"
+
+    # reset and run the SAME interleaving with the mutator (the fix)
+    (path).write_text(json.dumps({
+        'domains': [{'domain': 'a.example.com'}], 'email': 'ops@example.com',
+        'users': {'admin': {'role': 'admin'}}}))
+    b_written.clear()
+
+    def delete_a_mutator():
         b_written.wait(2)
         manager.update(_drop('a.example.com'), reason='delete_a')
 
-    t1 = threading.Thread(target=delete_a)
-    t2 = threading.Thread(target=register_b)
-    t1.start(); t2.start(); t1.join(); t2.join()
+    t3 = threading.Thread(target=delete_a_mutator)
+    t4 = threading.Thread(target=register_b)
+    t3.start(); t4.start(); t3.join(); t4.join()
+    assert _domains(path) == ['b.example.com'], \
+        "the mutator re-reads under the lock and keeps B"
 
-    assert _domains(path) == ['b.example.com']
+
+def test_a_no_op_delete_does_not_persist(sm):
+    """Removing a domain that is not present must not write settings (nor
+    trigger an automatic backup) — a no-op stays a no-op."""
+    manager, path = sm
+    manager.load_settings(use_cache=False)   # let any migration settle first
+    before = path.read_text()
+
+    class _AlreadyAbsent(Exception):
+        pass
+
+    def guarded(s):
+        current = s.get('domains', []) or []
+        kept = [d for d in current if d.get('domain') != 'zzz.example.com']
+        if len(kept) == len(current):
+            raise _AlreadyAbsent
+        s['domains'] = kept
+
+    with pytest.raises(_AlreadyAbsent):
+        manager.update(guarded, reason='noop')
+    # the mutator raised before save_settings, so the file is byte-identical
+    assert path.read_text() == before, "a no-op delete must not rewrite settings"
 
 
 def test_update_removes_only_the_named_domain(sm):


### PR DESCRIPTION
`DELETE /api/certificates/<domain>` and `CertificateManager.set_auto_renew` both did `load_settings()` then `atomic_update({'domains': <whole list built from that snapshot>})`. Two problems compound:

- the load is a request-cache **hit** — `flask.g` is primed by the rate-limit `before_request` hook on every request, so the handler reads a snapshot taken at request start, not current state;
- `'domains'` is replaced wholesale (not a deep-merge key), so `atomic_update`'s fresh on-disk read cannot rescue it. The stale list wins.

The window is real: `delete_certificate` runs a storage-backend delete (a Vault/AWS/Azure round-trip) before the settings write, and `set_auto_renew` has the identical shape. A domain registered by another request during that window is absent from the snapshot and silently dropped from `settings['domains']`; `check_renewals` iterates only that list, so the dropped domain is never renewed and expires ~90 days later with no error anywhere.

## The fix

Both now do the read-modify-write on the **fresh on-disk list** via `settings_manager.update(mutator)`, which reads under the lock with `use_cache=False` and touches only the target domain's entry. `set_auto_renew` keeps its "return False, no write" behaviour for an unknown domain via a sentinel exception, so a no-op does not persist the migration.

## Verified

Behavioural control with two real threads on a real `SettingsManager`: deleting A while B registers concurrently, main ends with `domains=[]` (B lost); the fix ends with `domains=[b]` (A removed, B kept).

- 4 new tests, plus regression guards that both sites use the locked read-modify-write (comment-stripped, so the check looks at code not prose)
- full local suite: 3054 passed, 0 failed

From the HIGH re-triage against current main (finding #5, and the `set_auto_renew` twin it names). Touches `modules/`, so the release gate requires the real-cert E2E before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)