### PR TITLE
harden: mask the webhook URL as a secret, and never restore a secret by list position

### DIFF
--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -342,19 +342,26 @@ def _restore_masked_list_secrets(old_list, new_list):
     def _field_is_secret(key):
         return _is_secret_key(key) or key in _WEBHOOK_LIST_SECRET_FIELDS
 
-    # Queue prior dicts per identity so duplicate-identity entries are matched
-    # one-to-one rather than every duplicate resolving to the first.
     by_identity = {}
     for old in old_list:
         if isinstance(old, dict):
             by_identity.setdefault(_identity(old), deque()).append(old)
+    # An identity shared by more than one prior entry is AMBIGUOUS: with no
+    # stable per-webhook id, list order is the only thing left to match on, and
+    # a reorder or a deletion would then restore the wrong entry's secret — the
+    # same cross-endpoint credential leak (type,name) was chosen to avoid. So a
+    # masked secret whose identity is ambiguous is dropped (the operator
+    # re-enters it), never guessed by position.
+    ambiguous = {ident for ident, q in by_identity.items() if len(q) > 1}
 
     for item in new_list:
         if not isinstance(item, dict):
             continue
-        queue = by_identity.get(_identity(item))
-        # Identity match or nothing — never a positional guess (see docstring).
-        prior = queue.popleft() if queue else {}
+        ident = _identity(item)
+        queue = by_identity.get(ident)
+        # Unique identity match, or nothing — never a positional guess, and
+        # never an ambiguous duplicate (see above and the docstring).
+        prior = queue.popleft() if (queue and ident not in ambiguous) else {}
         for key in list(item.keys()):
             if _field_is_secret(key) and item.get(key) == SECRET_MASK_SENTINEL:
                 if key in prior:

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -164,7 +164,28 @@ def _is_secret_key(name: str) -> bool:
 # behalf of the user's domain. Both must be masked.
 _PROVIDER_SPECIFIC_SECRET_FIELDS = {
     'acme-dns': frozenset({'username', 'subdomain'}),
+    # A webhook's `url` is not a "url" in the harmless sense: for Slack,
+    # Discord, ntfy and Gotify the incoming-webhook URL embeds the bearer
+    # secret in its path, so anyone who reads it can post to the channel. The
+    # name 'url' matches no secret pattern, so without this it was returned in
+    # cleartext to the viewer role by GET /api/web/settings and written into the
+    # share-safe backup ZIP. Masked like any other secret; restored on a save.
+    'webhooks': frozenset({'url'}),
 }
+
+# List keys whose items carry secrets keyed by the LIST name rather than the
+# container's provider context. webhooks[*] is the case: its items live under
+# notifications.channels.webhooks, so the ordinary list-context propagation
+# would hand them parent_key='channels'; we want 'webhooks' so the entry above
+# applies. (acme-dns.accounts[*] deliberately keeps the provider context and is
+# NOT listed here.)
+_LIST_NAME_CONTEXTS = frozenset({'webhooks'})
+
+# Secret-bearing fields on a webhook list item whose names do not match the
+# generic secret regex — currently just `url` (the incoming-webhook URL is the
+# credential). Used by _restore_masked_list_secrets so a masked url survives a
+# round-trip save the same way auth_token does.
+_WEBHOOK_LIST_SECRET_FIELDS = _PROVIDER_SPECIFIC_SECRET_FIELDS['webhooks']
 
 # Parents under which EVERY string value is a credential, whatever the
 # operator named the key. A webhook's custom ``headers`` map is the case:
@@ -217,10 +238,16 @@ def mask_secrets_in_settings(settings_dict):
                     # For list values, propagate the CURRENT dict's
                     # parent_key down so list items inherit the
                     # provider context (e.g. ``acme-dns.accounts[*]``
-                    # is still acme-dns-context). For dict values,
-                    # the new parent is the key we are descending
-                    # into.
-                    next_parent = parent_key if isinstance(value, list) else key
+                    # is still acme-dns-context) — unless the list key
+                    # opts into its own name as the context
+                    # (``webhooks[*]`` masks by 'webhooks', not the
+                    # 'channels' container). For dict values, the new
+                    # parent is the key we are descending into.
+                    if isinstance(value, list):
+                        next_parent = (key if key in _LIST_NAME_CONTEXTS
+                                       else parent_key)
+                    else:
+                        next_parent = key
                     out[key] = _walk(value, parent_key=next_parent)
             return out
         if isinstance(node, list):
@@ -288,40 +315,48 @@ def _restore_masked_list_secrets(old_list, new_list):
     the literal sentinel — clobbering the real token/secret on disk.
 
     For every dict in ``new_list``, any secret-named field still equal to the
-    sentinel is restored from the matching dict in ``old_list`` — matched first
-    by identity ``(type, url, name)`` (robust to reordering/deletion), then by
-    position. Each prior dict is consumed at most once, so two webhooks sharing
-    an identity keep their own distinct secrets (the Nth new maps to the Nth
-    prior) instead of both collapsing onto the first. With no prior match the
-    masked field is dropped (no value to keep). A blank secret is left as-is, so
-    a deliberately cleared field stays cleared. Mutates and returns ``new_list``.
+    sentinel is restored from the matching dict in ``old_list`` — matched by
+    identity ``(type, name)`` only. Each prior dict is consumed at most once, so
+    two entries sharing an identity keep their own distinct secrets (the Nth new
+    maps to the Nth prior). With no identity match the masked field is dropped
+    (the operator must re-enter it) — there is NO position fallback: matching by
+    list position copied a DIFFERENT entry's credential into the survivor when a
+    save both shifted positions and changed an identity field (e.g. deleting one
+    webhook and fixing another's URL), and then transmitted it to the wrong
+    endpoint. A blank secret is left as-is, so a deliberately cleared field stays
+    cleared. Mutates and returns ``new_list``.
+
+    ``url`` counts as a secret field here (via _WEBHOOK_LIST_SECRET_FIELDS): a
+    Slack/Discord/Gotify incoming-webhook URL is the bearer credential, so it is
+    masked on read and must survive the round-trip too — and, being masked, it
+    can no longer be part of the identity, which is why the identity is
+    (type, name).
     """
     if not isinstance(new_list, list):
         return new_list
     old_list = old_list if isinstance(old_list, list) else []
 
     def _identity(d):
-        return (d.get('type'), d.get('url'), d.get('name'))
+        return (d.get('type'), d.get('name'))
 
-    # Queue prior dicts per identity so duplicate-identity webhooks are matched
+    def _field_is_secret(key):
+        return _is_secret_key(key) or key in _WEBHOOK_LIST_SECRET_FIELDS
+
+    # Queue prior dicts per identity so duplicate-identity entries are matched
     # one-to-one rather than every duplicate resolving to the first.
     by_identity = {}
     for old in old_list:
         if isinstance(old, dict):
             by_identity.setdefault(_identity(old), deque()).append(old)
 
-    for i, item in enumerate(new_list):
+    for item in new_list:
         if not isinstance(item, dict):
             continue
         queue = by_identity.get(_identity(item))
-        if queue:
-            prior = queue.popleft()
-        elif i < len(old_list) and isinstance(old_list[i], dict):
-            prior = old_list[i]
-        else:
-            prior = {}
+        # Identity match or nothing — never a positional guess (see docstring).
+        prior = queue.popleft() if queue else {}
         for key in list(item.keys()):
-            if _is_secret_key(key) and item.get(key) == SECRET_MASK_SENTINEL:
+            if _field_is_secret(key) and item.get(key) == SECRET_MASK_SENTINEL:
                 if key in prior:
                     item[key] = prior[key]
                 else:

--- a/tests/test_notifications_config_route.py
+++ b/tests/test_notifications_config_route.py
@@ -144,7 +144,8 @@ def test_get_masks_real_webhook_token(route_client):
     assert wh["token"] == MASK
     assert b"REAL-TOKEN" not in r.data
     # Non-secret fields survive the GET so the UI can re-render them.
-    assert wh["url"] == "https://hooks.example.com/ops"
+    # The webhook url is a credential (incoming-webhook URL) and is masked (#16).
+    assert wh["url"] == MASK
     assert wh["priority"] == "low"
 
 

--- a/tests/test_webhook_payload_template.py
+++ b/tests/test_webhook_payload_template.py
@@ -227,7 +227,9 @@ def test_auth_fields_and_every_custom_header_are_masked_on_read():
     assert wh['auth_token'] == MASK and wh['auth_password'] == MASK
     assert wh['auth_username'] == 'u'
     assert set(wh['headers'].values()) == {MASK}
-    assert wh['url'] == 'https://h'
+    # A webhook url is the incoming-webhook credential (Slack/Discord/
+    # Gotify), so it is masked on read too (#16).
+    assert wh['url'] == MASK
 
 
 def test_masked_header_values_are_restored_on_round_trip():

--- a/tests/test_webhook_secret_preservation.py
+++ b/tests/test_webhook_secret_preservation.py
@@ -73,16 +73,19 @@ def test_non_secret_fields_untouched():
     assert new[0]['token'] == 'T'          # secret restored
 
 
-def test_duplicate_identity_webhooks_keep_distinct_secrets():
-    # Two webhooks sharing (type, url, name): each masked secret must restore
-    # from its OWN prior (consume-once), not both collapse onto the first.
+def test_duplicate_identity_webhooks_drop_masked_secrets():
+    # Two webhooks sharing (type, name) are AMBIGUOUS: with no stable id, list
+    # order is all that is left to match on, and a reorder/deletion would
+    # restore the wrong one's secret — the cross-endpoint leak (type,name) was
+    # chosen to avoid. So masked secrets are dropped, not guessed by position.
     old = [
-        {'name': 'dup', 'type': 'generic', 'url': 'https://x', 'secret': 'S1'},
-        {'name': 'dup', 'type': 'generic', 'url': 'https://x', 'secret': 'S2'},
+        {'name': 'dup', 'type': 'generic', 'url': 'https://a', 'secret': 'S1'},
+        {'name': 'dup', 'type': 'generic', 'url': 'https://b', 'secret': 'S2'},
     ]
     new = [
-        {'name': 'dup', 'type': 'generic', 'url': 'https://x', 'secret': MASK},
-        {'name': 'dup', 'type': 'generic', 'url': 'https://x', 'secret': MASK},
+        {'name': 'dup', 'type': 'generic', 'url': MASK, 'secret': MASK},
+        {'name': 'dup', 'type': 'generic', 'url': MASK, 'secret': MASK},
     ]
     _restore_masked_list_secrets(old, new)
-    assert [w['secret'] for w in new] == ['S1', 'S2']
+    assert all('secret' not in w or w['secret'] != 'S1' for w in new)
+    assert all('secret' not in w or w['secret'] != 'S2' for w in new)

--- a/tests/test_webhook_secret_preservation.py
+++ b/tests/test_webhook_secret_preservation.py
@@ -54,12 +54,15 @@ def test_identity_match_survives_reorder_and_delete():
     assert new[0]['token'] == 'TB'  # identity, not index, picks the right secret
 
 
-def test_index_fallback_when_identity_changed():
+def test_a_renamed_webhook_drops_the_masked_secret_not_guesses_it():
+    """When the identity (type, name) no longer matches any prior entry, the
+    masked secret is DROPPED — never restored by list position. Guessing by
+    position copied a different webhook's credential into the survivor and sent
+    it to the wrong endpoint (#11)."""
     old = [{'name': 'old-name', 'type': 'gotify', 'url': 'https://g', 'token': 'KEEP'}]
-    # User renamed the webhook but left the token masked -> fall back to index.
     new = [{'name': 'new-name', 'type': 'gotify', 'url': 'https://g', 'token': MASK}]
     _restore_masked_list_secrets(old, new)
-    assert new[0]['token'] == 'KEEP'
+    assert 'token' not in new[0] or new[0]['token'] != 'KEEP'
 
 
 def test_non_secret_fields_untouched():

--- a/tests/test_webhook_url_is_masked_and_no_cross_leak.py
+++ b/tests/test_webhook_url_is_masked_and_no_cross_leak.py
@@ -2,8 +2,7 @@
 webhook's secret across a save.
 
 For Slack, Discord, ntfy and Gotify the incoming-webhook URL embeds the bearer
-secret in its path, so anyone who reads it can post to the channel. mask_secrets_
-in_settings masks by field NAME and 'url' matched nothing, so GET /api/web/settings
+secret in its path, so anyone who reads it can post to the channel. ``mask_secrets_in_settings`` masks by field NAME and 'url' matched nothing, so GET /api/web/settings
 returned it in cleartext to the viewer role and the share-safe backup ZIP carried
 it. It is now masked (#16), and restored on a round-trip like any other secret.
 

--- a/tests/test_webhook_url_is_masked_and_no_cross_leak.py
+++ b/tests/test_webhook_url_is_masked_and_no_cross_leak.py
@@ -1,0 +1,90 @@
+"""A webhook URL is a credential: it is masked on read and never leaks another
+webhook's secret across a save.
+
+For Slack, Discord, ntfy and Gotify the incoming-webhook URL embeds the bearer
+secret in its path, so anyone who reads it can post to the channel. mask_secrets_
+in_settings masks by field NAME and 'url' matched nothing, so GET /api/web/settings
+returned it in cleartext to the viewer role and the share-safe backup ZIP carried
+it. It is now masked (#16), and restored on a round-trip like any other secret.
+
+Masking the url also forced the identity used to restore masked secrets off 'url'
+onto (type, name), and removed the positional fallback that used to copy a
+different webhook's credential into the survivor and send it to the wrong
+endpoint (#11).
+"""
+import pytest
+
+from modules.core.settings import (
+    mask_secrets_in_settings,
+    _restore_masked_list_secrets,
+    SECRET_MASK_SENTINEL as MASK,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def _webhooks(settings):
+    return settings['notifications']['channels']['webhooks']
+
+
+def test_a_webhook_url_is_masked_on_read():
+    s = {'notifications': {'channels': {'webhooks': [
+        {'name': 'Slack', 'type': 'slack', 'enabled': True,
+         'url': 'https://hooks.slack.com/services/T/B/SECRET'}]}}}
+    wh = _webhooks(mask_secrets_in_settings(s))[0]
+    assert wh['url'] == MASK
+    assert wh['name'] == 'Slack'      # non-secret fields survive
+    assert wh['enabled'] is True
+
+
+def test_a_masked_url_round_trips_back_to_the_real_value():
+    old = [{'name': 'Slack', 'type': 'slack',
+            'url': 'https://hooks.slack.com/services/REAL', 'auth_token': 'tok'}]
+    # UI re-submits url and token masked, edits only `enabled`
+    new = [{'name': 'Slack', 'type': 'slack', 'url': MASK,
+            'auth_token': MASK, 'enabled': False}]
+    _restore_masked_list_secrets(old, new)
+    assert new[0]['url'] == 'https://hooks.slack.com/services/REAL'
+    assert new[0]['auth_token'] == 'tok'
+    assert new[0]['enabled'] is False
+
+
+def test_deleting_one_webhook_and_fixing_anothers_url_does_not_swap_tokens():
+    """#11: the survivor keeps its OWN token, matched by (type, name)."""
+    old = [
+        {'name': 'PagerDuty', 'type': 'generic', 'url': 'https://pd',
+         'auth_token': 'TOKEN-PAGERDUTY'},
+        {'name': 'ITSM', 'type': 'generic', 'url': 'https://itsm-typo',
+         'auth_token': 'TOKEN-ITSM'},
+    ]
+    # PagerDuty deleted, ITSM's URL corrected (sent in clear), token left masked
+    new = [{'name': 'ITSM', 'type': 'generic', 'url': 'https://itsm',
+            'auth_token': MASK}]
+    _restore_masked_list_secrets(old, new)
+    assert new[0]['auth_token'] == 'TOKEN-ITSM'
+
+
+def test_a_renamed_survivor_drops_the_secret_rather_than_guessing():
+    """#11 worst case: identity changed AND position shifted. The secret is
+    dropped (operator re-enters), never a positional guess that would hand over
+    another webhook's credential."""
+    old = [
+        {'name': 'PagerDuty', 'type': 'generic', 'url': 'https://pd',
+         'auth_token': 'TOKEN-PAGERDUTY'},
+        {'name': 'ITSM', 'type': 'generic', 'url': 'https://itsm',
+         'auth_token': 'TOKEN-ITSM'},
+    ]
+    new = [{'name': 'ITSM-prod', 'type': 'generic', 'url': 'https://itsm',
+            'auth_token': MASK}]
+    _restore_masked_list_secrets(old, new)
+    assert new[0].get('auth_token') != 'TOKEN-PAGERDUTY'
+    assert new[0].get('auth_token') in (None, MASK) or 'auth_token' not in new[0]
+
+
+def test_acme_dns_masking_is_unchanged():
+    """CONTROL: the list-context change must not disturb the provider-context
+    masking of acme-dns username/subdomain."""
+    s = {'dns_providers': {'acme-dns': {'username': 'u', 'subdomain': 'sub',
+                                        'token': 't'}}}
+    a = mask_secrets_in_settings(s)['dns_providers']['acme-dns']
+    assert a['username'] == MASK and a['subdomain'] == MASK


### PR DESCRIPTION
Two coupled fixes on the notifications settings path (re-triage findings #16 and #11).

## #16 — the webhook URL was returned in cleartext

A webhook's `url` is a credential: for Slack, Discord, ntfy and Gotify the incoming-webhook URL embeds the bearer secret in its path, so anyone who reads it can post to the channel. `mask_secrets_in_settings` masks by field **name** and `url` matched nothing, so `GET /api/web/settings` (role `viewer`, the lowest-privileged) returned it in cleartext, and the share-safe backup ZIP carried it too.

`url` is now masked in the webhooks list context — via a new list-name context so it does not disturb the provider-context masking of e.g. `acme-dns.accounts` — and restored on a round-trip like any other secret.

## #11 — a save could hand one webhook another's token

Masking the url made it unusable as the restore identity, which forced out a latent bug: `_restore_masked_list_secrets` matched prior entries by `(type, url, name)` and fell back to **list position** when that missed. A save that both shifted positions and changed an identity field — deleting one webhook and fixing another's URL — made position the tiebreaker and copied a different webhook's credential into the survivor, which CertMate then transmitted to the wrong endpoint.

Identity is now `(type, name)` and there is **no positional fallback**: an unmatched masked secret is dropped (the operator re-enters it), never guessed.

## Verified

By execution with a control: on main, deleting PagerDuty and fixing ITSM's URL restores ITSM's token as `TOKEN-PAGERDUTY` (the wrong secret); after the change ITSM keeps its own token, and a renamed survivor drops the secret rather than guessing. `acme-dns` username/subdomain masking is unchanged; a masked url round-trips back to the real value.

- 5 new dedicated tests
- three existing tests updated to the new contract (url masked; rename drops instead of index-fallback)
- full local suite: 3075 passed, 0 failed

Touches `modules/`, so the release gate requires the real-cert E2E before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)