### PR TITLE
fix: the deploy-failure alert is always delivered, whatever the event filter

### DIFF
--- a/modules/core/notifier.py
+++ b/modules/core/notifier.py
@@ -78,6 +78,12 @@ def _webhook_url_is_internal(url: str) -> bool:
 # Every secret-bearing field name matches the settings secret regex (token,
 # password), so it is masked on GET and restored on a round-trip save.
 
+# Events that are always delivered, whatever the operator's event filter, because
+# they report a failure the operator must not be able to silence by accident.
+# deploy_hook_failed is the one that motivated this: it is not among the five
+# certificate_* events the UI offers, so any filter drops it — see notify().
+_ALWAYS_NOTIFY_EVENTS = frozenset({'deploy_hook_failed'})
+
 WEBHOOK_METHODS = ('POST', 'PUT', 'PATCH')
 WEBHOOK_AUTH_TYPES = ('none', 'bearer', 'basic', 'header')
 WEBHOOK_DEFAULT_TIMEOUT = 10
@@ -273,8 +279,18 @@ class Notifier:
         if not config.get('enabled', False):
             return {'skipped': 'notifications disabled'}
 
+        # Critical failure events bypass the event filter. deploy_hook_failed is
+        # the silent-deploy alarm: a renewal succeeds but its deploy hook (nginx
+        # reload, LB push) exits non-zero, so the service keeps serving the OLD
+        # certificate while the dashboard says success. The events UI only
+        # offers the five certificate_* events, so an operator who ticks any of
+        # them sets a filter that does not include deploy_hook_failed and
+        # permanently silences exactly the alert it exists to raise — with no way
+        # to re-enable it. An operator must never be able to filter away a
+        # failure they need to see, so these are always delivered.
         events_filter = config.get('events', [])
-        if events_filter and event not in events_filter:
+        if (events_filter and event not in events_filter
+                and event not in _ALWAYS_NOTIFY_EVENTS):
             return {'skipped': 'event not in filter'}
 
         results = {}
@@ -289,9 +305,11 @@ class Notifier:
         for wh in channels.get('webhooks', []):
             if not wh.get('enabled', False):
                 continue
-            # Per-webhook event filtering
+            # Per-webhook event filtering — same critical-event exemption as
+            # the global filter above.
             wh_events = wh.get('events', [])
-            if wh_events and event not in wh_events:
+            if (wh_events and event not in wh_events
+                    and event not in _ALWAYS_NOTIFY_EVENTS):
                 continue
             name = wh.get('name', 'webhook')
             results[name] = self._send_webhook_with_retry(wh, event, title, message, details)

--- a/tests/test_deploy_failure_alert_is_deliverable.py
+++ b/tests/test_deploy_failure_alert_is_deliverable.py
@@ -1,0 +1,69 @@
+"""deploy_hook_failed must reach the operator even with an event filter set.
+
+deploy_hook_failed is the silent-deploy alarm: a renewal succeeds but its deploy
+hook (nginx reload, LB push) exits non-zero, so the service keeps serving the OLD
+certificate while the dashboard says success. The events UI offers only the five
+certificate_* events, so an operator who ticks any of them sets a filter that
+does not include deploy_hook_failed and permanently silences exactly the alert it
+exists to raise. Critical failure events now bypass both the global and the
+per-webhook event filter.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.notifier import Notifier, _ALWAYS_NOTIFY_EVENTS
+
+pytestmark = [pytest.mark.unit]
+
+
+def _notifier(config):
+    n = Notifier(settings_manager=MagicMock(), data_dir='/nonexistent')
+    n._get_config = lambda: config
+    sent = []
+    n._send_webhook_with_retry = (
+        lambda *a, **k: sent.append(a[1]) or {'success': True})
+    n._send_email_with_retry = (
+        lambda *a, **k: sent.append(a[1]) or {'success': True})
+    return n, sent
+
+
+_WH = {'name': 'w', 'enabled': True, 'type': 'generic', 'url': 'https://x'}
+
+
+def test_deploy_hook_failed_bypasses_a_global_filter():
+    n, sent = _notifier({'enabled': True, 'events': ['certificate_renewed'],
+                         'channels': {'webhooks': [dict(_WH)]}})
+    n.notify('deploy_hook_failed', 't', 'm', {})
+    assert 'deploy_hook_failed' in sent
+
+
+def test_deploy_hook_failed_bypasses_a_per_webhook_filter():
+    wh = dict(_WH, events=['certificate_renewed'])
+    n, sent = _notifier({'enabled': True, 'events': [],
+                         'channels': {'webhooks': [wh]}})
+    n.notify('deploy_hook_failed', 't', 'm', {})
+    assert 'deploy_hook_failed' in sent
+
+
+def test_a_non_critical_event_still_honours_the_filter():
+    """CONTROL: the exemption is narrow — an ordinary event the operator
+    filtered out stays filtered."""
+    n, sent = _notifier({'enabled': True, 'events': ['certificate_renewed'],
+                         'channels': {'webhooks': [dict(_WH)]}})
+    r = n.notify('certificate_created', 't', 'm', {})
+    assert r.get('skipped') == 'event not in filter'
+    assert 'certificate_created' not in sent
+
+
+def test_the_master_switch_still_wins():
+    """CONTROL: 'notifications disabled' is not bypassed — a critical event is
+    silenced when the whole system is off, unlike a mere filter."""
+    n, sent = _notifier({'enabled': False})
+    r = n.notify('deploy_hook_failed', 't', 'm', {})
+    assert 'skipped' in r
+    assert sent == []
+
+
+def test_deploy_hook_failed_is_in_the_always_notify_set():
+    assert 'deploy_hook_failed' in _ALWAYS_NOTIFY_EVENTS


### PR DESCRIPTION
`deploy_hook_failed` is the silent-deploy alarm: a renewal succeeds but its deploy hook (nginx reload, LB push) exits non-zero, so the service keeps serving the **old** certificate while the dashboard and the renewal API both report success. The notifier publishes `deploy_hook_failed` specifically so an operator hears about that.

But `notify()` drops any event not in the configured `events` filter, and the events UI offers only the five `certificate_*` events — so an operator who ticks any of them sets a filter that does not include `deploy_hook_failed` and **permanently silences exactly the alert it exists to raise**, with no UI control to re-enable it. The per-webhook filter had the same gap.

## The fix

Critical failure events (`deploy_hook_failed`) now bypass both the global and the per-webhook filter: an operator must never be able to filter away a failure they need to see. The master switch still wins — a disabled notifications config sends nothing — and ordinary events are still filtered normally.

## Verified

By execution with controls: with a global filter of `[certificate_renewed]`, main returns `{'skipped': 'event not in filter'}` for `deploy_hook_failed` and sends nothing; the fix delivers it. A per-webhook filter is bypassed the same way. A non-critical filtered event stays filtered, and notifications-disabled silences even the critical event.

- 5 new tests
- full local suite: 3080 passed, 0 failed

From the HIGH re-triage against current main (finding #10). Touches `modules/`, so the release gate requires the real-cert E2E before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)