### PR TITLE
fix: release prepare refuses a stale local checkout so the gated tree is the released tree

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -111,6 +111,22 @@ cmd_prepare() {
   [ -z "$(git status --porcelain)" ] || die "working tree is dirty - commit or stash first"
   git fetch origin --quiet
   git rev-parse --verify origin/main >/dev/null 2>&1 || die "no origin/main"
+  # The gates below run against the CHECKED-OUT tree, but the real-cert policy
+  # is computed from origin/main and the release branch is cut from origin/main
+  # (see below). If the local checkout is behind origin/main — the ordinary
+  # state right after merging a PR on GitHub — the tree that is gated and the
+  # tree that is released are different: a commit on origin/main that is not in
+  # the local checkout is never seen by flake8/bandit/pytest/the real-cert E2E,
+  # and "ALL GATES PASSED" would then vouch for a tree no gate examined. Refuse
+  # unless HEAD is exactly origin/main so the gated tree IS the released tree.
+  local head_sha origin_sha
+  head_sha="$(git rev-parse HEAD)"
+  origin_sha="$(git rev-parse origin/main)"
+  [ "$head_sha" = "$origin_sha" ] || die "local HEAD ($head_sha) is not origin/main ($origin_sha).
+The gates run against the checked-out tree but the release is cut from origin/main,
+so they would test a different tree than the one released. Align first:
+  git checkout main && git pull --ff-only
+then re-run prepare."
   local cur; cur="$("$PY" -c 'from modules import __version__; print(__version__)')"
   version_gt "$version" "$cur" || die "version $version is not greater than current $cur"
 

--- a/tests/test_release_gate.py
+++ b/tests/test_release_gate.py
@@ -267,3 +267,27 @@ def test_release_tooling_does_not_hardcode_an_author():
         + "\nA generated commit should not claim an author the generator "
           "cannot know."
     )
+
+
+def test_prepare_refuses_a_stale_local_checkout():
+    """cmd_prepare gates the checked-out tree but cuts the release branch from
+    origin/main. If the local checkout is behind origin/main (the ordinary
+    state after merging a PR on GitHub), the gated tree and the released tree
+    differ and a commit on origin/main is never tested. prepare must refuse
+    unless HEAD == origin/main, BEFORE any gate runs.
+    """
+    src = RELEASE_SH.read_text(encoding="utf-8")
+
+    # the check compares HEAD to origin/main and dies on mismatch
+    assert 'git rev-parse HEAD' in src
+    assert 'git rev-parse origin/main' in src
+    head_check = re.search(
+        r'\[ "\$head_sha" = "\$origin_sha" \] \|\| die', src)
+    assert head_check, "no HEAD==origin/main fail-closed check in release.sh"
+
+    # and it runs before the first gate, or a stale tree would still be gated
+    check_pos = head_check.start()
+    first_gate = src.find('gate "flake8')
+    assert first_gate != -1
+    assert check_pos < first_gate, \
+        "the HEAD==origin/main check must precede the gates"


### PR DESCRIPTION
`cmd_prepare` checked only that the working tree was clean. It then computed the real-cert policy from `git diff <last_tag>..origin/main`, ran every gate (flake8, bandit, the unit/UI suites, the **mandatory real-cert E2E**, the Docker build) against whatever was checked out, and only afterwards cut the release branch with `git checkout -b <branch> origin/main`.

So the tree that is gated and the tree that is released are **different trees** whenever the local checkout is behind `origin/main` — the ordinary state right after merging a PR on GitHub. A commit on `origin/main` that is not in the local checkout is never seen by any gate, and "ALL GATES PASSED" would vouch for a tree no gate examined; the very next statement checks out `origin/main` and the release carries the untested change.

The script's own comment flags exactly this hazard and had fixed it for `publish` only.

## The fix

`prepare` now refuses, right after the fetch and before any gate, unless `HEAD` is exactly `origin/main`, with a message telling the operator to `git checkout main && git pull --ff-only` and retry. The gated tree is then the released tree.

## Verified

With a throwaway repo: the check dies when HEAD is a commit behind `origin/main` and passes once aligned. A static test pins that the check exists and runs **before** the first gate.

- `test_release_gate.py`: 39 passed

From the HIGH re-triage against current main (finding #15). This is release-tooling only (no `modules/` change), so the real-cert E2E is not required for this PR — but it hardens the gate that enforces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)