### PR TITLE
fix: a not-yet-due renewal retries a stranded backend store and propagates a reconcile

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -2148,9 +2148,9 @@ class CertificateManager:
                     # because get_certificate_info reads the backend copy when a
                     # storage backend is configured, needs_renewal stayed True
                     # forever, every run landed here, and the store was never
-                    # tried again (#1). And when the reconcile above republished
+                    # tried again. And when the reconcile above republished
                     # the flat PEMs, the new generation reached /download and the
-                    # deploy hooks but not the backend or the PFX (#2). Push here
+                    # deploy hooks but not the backend or the PFX. Push here
                     # when the external copy is behind — a prior store failed
                     # (storage_warning persisted) or we just republished — so
                     # downstream is not stranded on the old certificate.

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -2140,14 +2140,51 @@ class CertificateManager:
                                 f"{domain} is serving files that do not match "
                                 f"its certificate and they could not be "
                                 f"repaired: {republish_error}") from republish_error
+                    # Reconcile the external copy too. _store_in_backend is
+                    # otherwise reached only from create and the renewed=True
+                    # branch, so a store that failed once (an expired Vault
+                    # token, a transient 5xx) was never retried: the local cert
+                    # was fresh but the backend stayed on the OLD generation, and
+                    # because get_certificate_info reads the backend copy when a
+                    # storage backend is configured, needs_renewal stayed True
+                    # forever, every run landed here, and the store was never
+                    # tried again (#1). And when the reconcile above republished
+                    # the flat PEMs, the new generation reached /download and the
+                    # deploy hooks but not the backend or the PFX (#2). Push here
+                    # when the external copy is behind — a prior store failed
+                    # (storage_warning persisted) or we just republished — so
+                    # downstream is not stranded on the old certificate.
+                    reconcile_warning = None
+                    if self.storage_manager and (stale or metadata.get('storage_warning')):
+                        cert_files = {
+                            name: (domain_dir / name).read_bytes()
+                            for name in CERTIFICATE_FILES
+                            if (domain_dir / name).exists()
+                        }
+                        reconcile_warning = self._store_in_backend(
+                            domain, cert_files, metadata)
+                        try:
+                            self._apply_storage_warning(metadata, reconcile_warning)
+                            self._save_metadata(domain, metadata)
+                        except Exception as e:
+                            logger.warning(
+                                "Failed to persist storage state for %s: %s",
+                                domain, e)
+                        if stale:
+                            # The served pair rotated a generation; rebuild the
+                            # PFX so Windows automation polling cert.pfx sees it.
+                            self._write_pfx(domain)
                     self._invalidate_certificate_info_cache(domain)
-                    return {
+                    result = {
                         'success': True,
                         'renewed': False,
                         'domain': domain,
                         'repaired': stale or None,
                         'message': 'Certificate not yet due for renewal',
                     }
+                    if reconcile_warning:
+                        result['storage_warning'] = reconcile_warning
+                    return result
 
                 # Copy renewed certificates from the correct live directory
                 src_dir = domain_dir / 'live' / domain

--- a/tests/test_renew_reconciles_backend_when_not_yet_due.py
+++ b/tests/test_renew_reconciles_backend_when_not_yet_due.py
@@ -5,16 +5,15 @@ store that failed once (expired Vault token, transient 5xx) was never retried:
 the local cert was fresh but the backend stayed on the OLD generation, and
 because get_certificate_info reads the backend copy when a backend is
 configured, needs_renewal stayed True forever — every run landed in the
-not-yet-due branch, which never touched the backend (#1). And when that branch
+not-yet-due branch, which never touched the backend. And when that branch
 republished the flat PEMs, the new generation reached /download and the deploy
-hooks but not the backend or the PFX (#2).
+hooks but not the backend or the PFX.
 
 The not-yet-due branch now pushes to the backend when the external copy is
 behind (a prior store failed, or the flats were just republished), clearing the
 storage_warning on success.
 """
 import json
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_renew_reconciles_backend_when_not_yet_due.py
+++ b/tests/test_renew_reconciles_backend_when_not_yet_due.py
@@ -1,0 +1,111 @@
+"""A not-yet-due renewal retries a failed backend store and rebuilds downstream.
+
+_store_in_backend was reached only from create and the renewed=True branch. A
+store that failed once (expired Vault token, transient 5xx) was never retried:
+the local cert was fresh but the backend stayed on the OLD generation, and
+because get_certificate_info reads the backend copy when a backend is
+configured, needs_renewal stayed True forever — every run landed in the
+not-yet-due branch, which never touched the backend (#1). And when that branch
+republished the flat PEMs, the new generation reached /download and the deploy
+hooks but not the backend or the PFX (#2).
+
+The not-yet-due branch now pushes to the backend when the external copy is
+behind (a prior store failed, or the flats were just republished), clearing the
+storage_warning on success.
+"""
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modules.core.certificates import CertificateManager
+from modules.core.constants import CERTIFICATE_FILES
+from modules.core.shell import MockShellExecutor
+
+pytestmark = [pytest.mark.unit]
+
+
+class _NotYetDueExecutor(MockShellExecutor):
+    """certbot exits 0 and prints the not-yet-due sentinel; produces no new
+    live files, so renew_certificate concludes renewed=False."""
+    def run(self, cmd, **kwargs):
+        self.set_next_result(returncode=0,
+                             stdout='Certificate not yet due for renewal')
+        return super().run(cmd, **kwargs)
+
+
+def _mgr(tmp_path, storage):
+    sm = MagicMock()
+    sm.load_settings.return_value = {
+        'default_ca': 'letsencrypt', 'challenge_type': 'dns-01',
+        'default_key_type': 'ecdsa', 'default_elliptic_curve': 'secp384r1',
+    }
+    sm.get_domain_dns_provider.return_value = 'duckdns'
+    dns = MagicMock()
+    dns.get_dns_provider_account_config.return_value = (
+        {'api_token': 'duck-token'}, 'default')
+    return CertificateManager(
+        cert_dir=tmp_path, settings_manager=sm, dns_manager=dns,
+        storage_manager=storage, ca_manager=None,
+        shell_executor=_NotYetDueExecutor())   # no-op: prints not-yet-due
+
+
+def _seed(tmp_path, domain, metadata):
+    d = tmp_path / domain
+    (d / 'live' / domain).mkdir(parents=True)
+    for name in CERTIFICATE_FILES:
+        (d / name).write_bytes(b'flat-' + name.encode())
+        (d / 'live' / domain / name).write_bytes(b'flat-' + name.encode())
+    (d / 'metadata.json').write_text(json.dumps(metadata))
+    return d
+
+
+def _renew(mgr, domain):
+    with patch('modules.core.certificates.check_certbot_plugin_installed',
+               return_value=True), \
+         patch.object(CertificateManager, '_write_pfx', return_value=None):
+        return mgr.renew_certificate(domain)
+
+
+def test_a_persisted_storage_warning_makes_the_not_yet_due_branch_retry(tmp_path):
+    domain = 'retry.example.duckdns.org'
+    storage = MagicMock()
+    storage.get_backend_name.return_value = 'vault'
+    storage.store_certificate.return_value = True   # succeeds this time
+    mgr = _mgr(tmp_path, storage)
+    _seed(tmp_path, domain, {'domain': domain,
+                             'storage_warning': 'previous store failed'})
+
+    result = _renew(mgr, domain)
+
+    assert result['renewed'] is False               # not yet due
+    storage.store_certificate.assert_called_once()  # but the backend was retried
+    # and the warning is cleared on success
+    meta = json.loads((tmp_path / domain / 'metadata.json').read_text())
+    assert 'storage_warning' not in meta
+
+
+def test_no_warning_and_no_stale_does_not_touch_the_backend(tmp_path):
+    """CONTROL: a healthy not-yet-due run (external copy already current) must
+    not push on every daily check."""
+    domain = 'healthy.example.duckdns.org'
+    storage = MagicMock()
+    storage.get_backend_name.return_value = 'vault'
+    mgr = _mgr(tmp_path, storage)
+    _seed(tmp_path, domain, {'domain': domain})   # no storage_warning
+
+    result = _renew(mgr, domain)
+
+    assert result['renewed'] is False
+    storage.store_certificate.assert_not_called()
+
+
+def test_no_backend_configured_still_returns_not_yet_due(tmp_path):
+    """CONTROL: with no storage backend the branch behaves as before."""
+    domain = 'nobackend.example.duckdns.org'
+    mgr = _mgr(tmp_path, None)
+    _seed(tmp_path, domain, {'domain': domain,
+                             'storage_warning': 'stale'})
+    result = _renew(mgr, domain)
+    assert result['renewed'] is False


### PR DESCRIPTION
`_store_in_backend` was reached only from create and the `renewed=True` branch of `renew_certificate`, so a store that failed once (an expired Vault token, a transient 5xx) was **never retried**.

The local certificate was fresh but the external copy stayed on the OLD generation — and because `get_certificate_info` reads the backend copy when a storage backend is configured, `needs_renewal` stayed True forever: every daily run reached the not-yet-due branch, which never touched the backend, so the store was never tried again and the external consumer (nginx, k8s, the DR site) served an expiring then expired certificate **with CertMate reporting no failure** (#1).

Separately, when that branch republished the flat PEMs after an interrupted publish, the new generation reached `/download` and the deploy hooks but not the backend or the PFX (#2).

## The fix

The not-yet-due branch now pushes to the backend when the external copy is behind — a prior store failed (`storage_warning` persisted) or the flats were just republished — clearing the `storage_warning` on success, and rebuilds the PFX when the served pair rotated. A healthy not-yet-due run (no warning, no stale) still does not touch the backend, so the daily check is not amplified.

## Verified

Behavioural control against the pre-change code: with a persisted `storage_warning` and certbot reporting not-yet-due, main never calls `store_certificate`; the fix retries it once and clears the warning. Controls: a healthy run does not push, and a no-backend instance still returns not-yet-due.

- 3 new tests driving the real `renew_certificate` with a not-yet-due executor
- full local suite: 3107 passed, 0 failed

From the HIGH re-triage against current main (findings #1 and #2). Touches `modules/`, so the release gate requires the real-cert E2E before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)