### PR TITLE
fix: DNS default account selection and notifications load-error handling

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -2829,11 +2829,17 @@ def create_api_resources(api, models, managers):
                 name = data.get('name') or data.get('account_id')
                 req_provider = provider or data.get('provider')
                 config = data.get('config', {})
+                set_as_default = data.get('set_as_default', False)
 
                 if not name or not req_provider:
                     return {'error': 'Account name and provider required'}, 400
 
                 if dns_manager.add_account(name, req_provider, config):
+                    # Honour the operator's explicit "set as default" choice on
+                    # create, mirroring the update path — the flag the UI sends
+                    # was previously dropped here.
+                    if set_as_default:
+                        dns_manager.set_default_account(req_provider, name)
                     if audit_logger:
                         user = getattr(request, 'current_user', None) or {}
                         audit_logger.log_operation(

--- a/modules/core/dns_providers.py
+++ b/modules/core/dns_providers.py
@@ -308,10 +308,25 @@ class DNSManager:
                     provider_config['accounts'] = {}
                 provider_config['accounts'][account_id] = account_config
 
-                # First account for this provider becomes the default.
+                # Claim the default slot for the first REAL account. The
+                # first-run migration pre-seeds default_accounts[provider] =
+                # 'default' pointing at the empty scaffolded placeholder, so
+                # `provider not in default_accounts` was never true after that
+                # and a real account added later never became the default —
+                # issuance then resolved the empty placeholder and handed certbot
+                # a blank credential. Promote the new account when there is
+                # no default, or the current default points at an account that
+                # is not actually configured, provided the new one is.
                 if 'default_accounts' not in settings:
                     settings['default_accounts'] = {}
-                if provider not in settings['default_accounts']:
+                accounts = provider_config['accounts']
+                current_default = settings['default_accounts'].get(provider)
+                current_cfg = (accounts.get(current_default)
+                               if current_default else None)
+                if not current_default or (
+                        not self._account_has_credentials(provider, current_cfg)
+                        and self._account_has_credentials(
+                            provider, account_config)):
                     settings['default_accounts'][provider] = account_id
 
             success = self.settings_manager.update(

--- a/modules/web/settings_routes.py
+++ b/modules/web/settings_routes.py
@@ -321,11 +321,17 @@ def register_settings_routes(app, managers, require_web_auth, auth_manager,
             name = data.get('name') or data.get('account_id')
             req_provider = provider or data.get('provider')
             config = data.get('config', {})
+            set_as_default = data.get('set_as_default', False)
 
             if not name or not req_provider:
                 return jsonify({'error': 'Account name and provider required'}), 400
 
             if dns_manager.add_account(name, req_provider, config):
+                # Honour the operator's explicit "set as default" choice on
+                # create, mirroring the update path — the flag the UI sends was
+                # previously dropped here.
+                if set_as_default:
+                    dns_manager.set_default_account(req_provider, name)
                 if audit_logger:
                     user = getattr(request, 'current_user', None) or {}
                     audit_logger.log_operation(

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -178,7 +178,12 @@
             var content = document.getElementById('notifContent');
             content.setAttribute('aria-busy', 'true');
             fetch('/api/certificates', { credentials: 'same-origin' })
-                .then(function(r) { return r.ok ? r.json() : []; })
+                // An HTTP error (401/403/500) must NOT become an empty list —
+                // render() would paint "All certificates are healthy." over a
+                // failed load, on the one page whose job is to warn about
+                // expiring certs. Reject so the .catch shows the load failed.
+                // Same pattern as crypto_report.html / inventory.js.
+                .then(function(r) { return r.ok ? r.json() : Promise.reject(r.status); })
                 .then(function(certs) {
                     _certs = Array.isArray(certs) ? certs : [];
                     render();

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -189,7 +189,15 @@
                     render();
                 })
                 .catch(function() {
-                    document.getElementById('notifContent').innerHTML =
+                    // Reset the same busy/summary state render() would have —
+                    // otherwise the failure path leaves aria-busy="true" and
+                    // the summary strip stuck on "Loading…", stale to both
+                    // sighted users and assistive tech.
+                    var node = document.getElementById('notifContent');
+                    node.setAttribute('aria-busy', 'false');
+                    document.getElementById('notifSummary').innerHTML =
+                        '<i class="fas fa-triangle-exclamation text-gray-400 mr-2"></i>Could not load certificates.';
+                    node.innerHTML =
                         '<div class="px-6 py-12 flex flex-col items-center gap-3 text-muted"><i class="fas fa-triangle-exclamation text-2xl text-gray-300 dark:text-gray-600" aria-hidden="true"></i><p>Could not load certificates.</p></div>';
                 });
         };

--- a/tests/test_dns_account_create_honours_set_as_default.py
+++ b/tests/test_dns_account_create_honours_set_as_default.py
@@ -1,0 +1,66 @@
+"""Creating a DNS account with set_as_default=true makes it the default.
+
+The create route dropped the set_as_default flag the settings UI sends (only
+the update route honoured it), so an operator ticking "set as default" while
+adding an account had no effect (#13). This exercises the wiring end-to-end.
+"""
+from pathlib import Path
+
+import pytest
+
+from modules.core.factory import create_app
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def app_container(tmp_path, monkeypatch):
+    project_root = tmp_path / "certmate"
+    module_dir = project_root / "modules" / "core"
+    module_dir.mkdir(parents=True)
+    (module_dir / "factory.py").write_text("# test path anchor\n")
+    monkeypatch.setattr("modules.core.factory.__file__",
+                        str(module_dir / "factory.py"))
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.setenv("TESTING", "true")
+    application, container = create_app()
+    assert Path(container.cert_dir).resolve().is_relative_to(tmp_path)
+    return application, container
+
+
+@pytest.fixture
+def client(app_container):
+    return app_container[0].test_client()
+
+
+@pytest.fixture
+def container(app_container):
+    return app_container[1]
+
+
+def _default(container, provider='cloudflare'):
+    settings = container.managers['settings'].load_settings()
+    return (settings.get('default_accounts') or {}).get(provider)
+
+
+def test_set_as_default_on_create_promotes_the_new_account(client, container):
+    r = client.post('/api/dns/cloudflare/accounts', json={
+        'name': 'production',
+        'config': {'api_token': 'REAL-TOKEN'},
+        'set_as_default': True,
+    })
+    assert r.status_code == 200, r.get_data(as_text=True)
+    assert _default(container) == 'production'
+
+
+def test_without_the_flag_a_real_account_still_promotes_over_placeholder(
+        client, container):
+    """CONTROL: even without the flag, the first real account claims the
+    default over the empty migrated placeholder (the auto-promotion half of
+    #13)."""
+    r = client.post('/api/dns/cloudflare/accounts', json={
+        'name': 'production',
+        'config': {'api_token': 'REAL-TOKEN'},
+    })
+    assert r.status_code == 200, r.get_data(as_text=True)
+    assert _default(container) == 'production'

--- a/tests/test_dns_default_promotes_over_placeholder.py
+++ b/tests/test_dns_default_promotes_over_placeholder.py
@@ -1,0 +1,56 @@
+"""Adding a real DNS account claims the default slot over an empty placeholder.
+
+The first-run migration pre-seeds default_accounts[provider] = 'default'
+pointing at the empty scaffolded placeholder account. create_dns_account only
+claimed the default when `provider not in default_accounts`, which was never
+true after that, so a real account added later never became the default —
+issuance then resolved the empty placeholder and handed certbot a blank
+credential (#13). The new account now claims the slot when the current default
+is unconfigured.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.dns_providers import DNSManager
+
+pytestmark = [pytest.mark.unit]
+
+
+def _dm(state):
+    sm = MagicMock()
+    sm.migrate_dns_providers_to_multi_account = lambda s: s
+    sm.update = lambda mut, reason: (mut(state), True)[1]
+    return DNSManager(sm)
+
+
+def test_a_real_account_promotes_over_the_empty_placeholder():
+    state = {
+        'dns_providers': {'cloudflare': {'accounts': {
+            'default': {'api_token': ''}}}},
+        'default_accounts': {'cloudflare': 'default'},
+    }
+    _dm(state).create_dns_account(
+        'cloudflare', 'production', {'api_token': 'REAL', 'name': 'Production'})
+    assert state['default_accounts']['cloudflare'] == 'production'
+
+
+def test_a_valid_default_is_not_overridden():
+    """CONTROL: a second real account must not steal the default from a
+    configured one."""
+    state = {
+        'dns_providers': {'cloudflare': {'accounts': {
+            'production': {'api_token': 'REAL'}}}},
+        'default_accounts': {'cloudflare': 'production'},
+    }
+    _dm(state).create_dns_account(
+        'cloudflare', 'staging', {'api_token': 'REAL2', 'name': 'Staging'})
+    assert state['default_accounts']['cloudflare'] == 'production'
+
+
+def test_the_first_account_still_becomes_default():
+    """CONTROL: with no default set yet, the first account claims the slot."""
+    state = {'dns_providers': {'cloudflare': {'accounts': {}}}}
+    _dm(state).create_dns_account(
+        'cloudflare', 'production', {'api_token': 'REAL'})
+    assert state['default_accounts']['cloudflare'] == 'production'

--- a/tests/test_notifications_page_does_not_hide_errors.py
+++ b/tests/test_notifications_page_does_not_hide_errors.py
@@ -26,3 +26,13 @@ def test_an_http_error_rejects_instead_of_becoming_an_empty_list():
 def test_the_catch_branch_reports_the_failure():
     src = TEMPLATE.read_text(encoding='utf-8')
     assert 'Could not load certificates.' in src
+
+
+def test_the_catch_branch_clears_the_loading_state():
+    """The failure path must reset the same busy/summary state render() does,
+    or the page is left with aria-busy="true" and the summary stuck on
+    'Loading…' (both stale to assistive tech)."""
+    src = TEMPLATE.read_text(encoding='utf-8')
+    catch = src.split('.catch(', 1)[1].split('});', 1)[0]
+    assert "setAttribute('aria-busy', 'false')" in catch
+    assert 'notifSummary' in catch

--- a/tests/test_notifications_page_does_not_hide_errors.py
+++ b/tests/test_notifications_page_does_not_hide_errors.py
@@ -1,0 +1,28 @@
+"""The /notifications page must not paint 'all healthy' on an HTTP error.
+
+loadNotifications did `r.ok ? r.json() : []`, turning a 401/403/500 into an
+empty certificate list, which render() reads as 'nothing needs attention' — on
+the one page whose job is to warn about expiring certs. It now rejects on an
+HTTP error so the .catch shows the load failed (the pattern crypto_report.html
+and inventory.js already use).
+"""
+import pathlib
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+TEMPLATE = (pathlib.Path(__file__).resolve().parent.parent
+            / 'templates' / 'notifications.html')
+
+
+def test_an_http_error_rejects_instead_of_becoming_an_empty_list():
+    src = TEMPLATE.read_text(encoding='utf-8')
+    assert 'r.ok ? r.json() : []' not in src, \
+        "an HTTP error must not silently become an empty certificate list"
+    assert 'r.ok ? r.json() : Promise.reject(r.status)' in src
+
+
+def test_the_catch_branch_reports_the_failure():
+    src = TEMPLATE.read_text(encoding='utf-8')
+    assert 'Could not load certificates.' in src


### PR DESCRIPTION
Two independent reliability fixes.

## DNS default account
- The first-run migration pre-seeds `default_accounts[provider]` pointing at the empty scaffolded placeholder account, so `create_dns_account`'s "first account becomes default" guard (`provider not in default_accounts`) never fired again. A real account added afterwards never became the default, and issuance resolved the empty placeholder. The new account now claims the default slot whenever the current default points at an unconfigured account and the new one is configured.
- Both create handlers (the API resource and the web settings route) now honour the `set_as_default` flag the settings UI already sends on the add-account form. Previously only the **update** path honoured it, so ticking "set as default" while *adding* an account had no effect.

## Notifications page
- `loadNotifications` turned an HTTP error (401/403/500) into an empty certificate list, which the page renders as "All certificates are healthy." — on the one page whose job is to surface expiring certs. It now rejects on an HTTP error so the failure surfaces, matching the pattern already used in the crypto report and inventory views.

## Tests
- `test_dns_default_promotes_over_placeholder` — promotion + two controls (a valid default is not overridden; the first account still claims the slot).
- `test_dns_account_create_honours_set_as_default` — route-level `set_as_default` on create, plus a control for auto-promotion without the flag.
- `test_notifications_page_does_not_hide_errors` — template guard.

Full local suite green (3111 passed, 6 skipped); each fix verified by execution with a two-sided control against `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)