### PR TITLE
fix: jitter the renewal sweeps so installs don't all hit the CA at once

### DIFF
--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -836,14 +836,24 @@ def setup_scheduler(container: AppContainer):
         scheduler = BackgroundScheduler(jobstores=jobstores, job_defaults=job_defaults)
         scheduler.start()
 
+        # Spread the renewal sweeps across a window instead of firing every
+        # instance at exactly HH:00:00. Without this, every CertMate in the
+        # world hits its ACME CA at the same wall-clock second, a synchronised
+        # load spike the CA has to absorb; Let's Encrypt asks integrators to
+        # renew at randomised times for precisely this reason. APScheduler's
+        # cron `jitter` adds a random +/- offset (seconds) to each fire, so the
+        # 02:00 certificate sweep lands anywhere in 01:00-03:00 and the 03:00
+        # client-certificate sweep in 02:00-04:00 — the same overnight window,
+        # de-synchronised. It composes with the misfire grace above.
+        renewal_jitter = 3600  # +/- 1 hour
         scheduler.add_job(
             func=_certificate_renewal_job,
-            trigger="cron", hour=2, minute=0,
+            trigger="cron", hour=2, minute=0, jitter=renewal_jitter,
             id='certificate_renewal_check', replace_existing=True
         )
         scheduler.add_job(
             func=_client_certificate_renewal_job,
-            trigger="cron", hour=3, minute=0,
+            trigger="cron", hour=3, minute=0, jitter=renewal_jitter,
             id='client_certificate_renewal_check', replace_existing=True
         )
         scheduler.add_job(

--- a/tests/test_renewal_reliability_hardening.py
+++ b/tests/test_renewal_reliability_hardening.py
@@ -222,6 +222,13 @@ def test_scheduler_renewal_jobs_have_misfire_grace(monkeypatch, tmp_path):
                 f"APScheduler 1s default that silently drops a missed day"
             )
             assert job.coalesce is True
+            # Renewal sweeps must be jittered, not fire at exactly HH:00:00 on
+            # every install at once — a synchronised load spike on the ACME CA
+            # that Let's Encrypt asks integrators to avoid.
+            assert getattr(job.trigger, 'jitter', None) == 3600, (
+                f"{job_id} must carry cron jitter to de-synchronise renewals "
+                f"across installs"
+            )
     finally:
         if container.scheduler:
             container.scheduler.shutdown(wait=False)


### PR DESCRIPTION
## What

The certificate (`02:00`) and client-certificate (`03:00`) renewal cron jobs fired at exactly the top of the hour on every install. Every CertMate in the world therefore hit its ACME CA at the same wall-clock second — a synchronised load spike. [Let's Encrypt asks integrators](https://letsencrypt.org/docs/integration-guide/) to renew at randomised times for precisely this reason.

## Change

Add APScheduler cron `jitter` (±1 hour) to both renewal jobs:
- `certificate_renewal_check`: 02:00 → lands in 01:00–03:00
- `client_certificate_renewal_check`: 03:00 → lands in 02:00–04:00

Same overnight window, de-synchronised across installs. Composes with the existing 6-hour misfire grace and `coalesce=True`.

## Test

`test_scheduler_renewal_jobs_have_misfire_grace` now also asserts both jobs carry the jitter (verified two-sided: the assertion fails against the pre-change scheduler). Full local suite green (3115 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)