### PR TITLE
docs: release notes for v2.26.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,27 @@
+## v2.26.3 (Renewals stop arriving at the certificate authority all at once)
+
+A patch release. One change, and it is about timing, not correctness.
+
+### The renewal sweeps are now jittered across a window
+
+The scheduled renewal jobs fired on a fixed cron: the certificate sweep at
+exactly 02:00:00, the client-certificate sweep at 03:00:00. On a single
+instance that is unremarkable. Across every CertMate in the world it means each
+one contacts its ACME certificate authority at the same wall-clock second, a
+synchronised load spike the CA has to absorb every hour on the hour. Let's
+Encrypt asks integrators to renew at randomised times for exactly this reason.
+
+Both renewal jobs now carry a cron jitter of plus-or-minus one hour, so the
+02:00 certificate sweep lands somewhere in 01:00-03:00 and the 03:00
+client-certificate sweep in 02:00-04:00 — the same overnight window, but
+de-synchronised across installs. It composes with the six-hour misfire grace
+and the coalescing already in place, so a sweep that is delayed or missed while
+the instance was unavailable still runs, once, on catch-up. Nothing about which
+certificates are renewed, or when they become due, changes; only the moment the
+sweep begins.
+
+---
+
 ## v2.26.2 (A security-hardening patch: seventeen fixes)
 
 A patch release. It adds no features and changes nothing about how you operate

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,8 +8,9 @@ The scheduled renewal jobs fired on a fixed cron: the certificate sweep at
 exactly 02:00:00, the client-certificate sweep at 03:00:00. On a single
 instance that is unremarkable. Across every CertMate in the world it means each
 one contacts its ACME certificate authority at the same wall-clock second, a
-synchronised load spike the CA has to absorb every hour on the hour. Let's
-Encrypt asks integrators to renew at randomised times for exactly this reason.
+synchronised load spike the CA has to absorb at those two fixed times every
+day. Let's Encrypt asks integrators to renew at randomised times for exactly
+this reason.
 
 Both renewal jobs now carry a cron jitter of plus-or-minus one hour, so the
 02:00 certificate sweep lands somewhere in 01:00-03:00 and the 03:00


### PR DESCRIPTION
Release notes for the v2.26.3 patch — a single change: cron jitter on the renewal sweeps (#633) so installs stop hitting the ACME CA at the same wall-clock second.

Lands before the version-bump release PR, per the two-PR release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)