### PR TITLE
fix: actually emit renewal telemetry so a stopped sweep is detectable

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -195,6 +195,33 @@ class CertificateManager:
         except Exception:  # pragma: no cover - defensive
             logger.debug("Failed to emit scheduled-renew audit for a domain")
 
+    def _record_renewal_metrics(self, domain, cert_info, success, duration,
+                                error=None):
+        """Emit renewal outcome + duration to the Prometheus collector.
+
+        The collector has always exposed certmate_certificate_renewals_total
+        and the renewal duration histogram, but nothing incremented them, so
+        every renewal series was permanently empty: a scheduler that had
+        silently stopped renewing looked exactly like one that was working.
+        Recording here — where check_renewals already knows the outcome —
+        keeps it out of the issuance hot path and off its many return points.
+
+        Never raises: telemetry must not be the reason a renewal run aborts.
+        """
+        try:
+            from .metrics import metrics_collector
+            provider = (cert_info or {}).get('dns_provider') or 'unknown'
+            metrics_collector.record_certificate_renewal(
+                domain, provider, success)
+            metrics_collector.record_certificate_renewal_time(
+                provider, duration)
+            if not success:
+                metrics_collector.record_acme_error(
+                    type(error).__name__ if error else 'unknown',
+                    domain, provider)
+        except Exception:  # pragma: no cover - defensive
+            logger.debug("Failed to record renewal metrics for a domain")
+
     @staticmethod
     def _certificate_info_cache_ttl() -> int:
         try:
@@ -2371,6 +2398,7 @@ class CertificateManager:
 
                 if cert_info and cert_info.get('needs_renewal'):
                     logger.info(f"Renewing certificate for {domain}")
+                    renew_started = time.time()
                     try:
                         res = self.renew_certificate(domain)
                         # certbot can report "not yet due" (renewed=False) when
@@ -2383,6 +2411,9 @@ class CertificateManager:
                         else:
                             summary['renewed'] += 1
                             logger.info(f"Successfully renewed certificate for {domain}")
+                            self._record_renewal_metrics(
+                                domain, cert_info, True,
+                                time.time() - renew_started)
                             self._audit_scheduled_renew(domain, 'success')
                             # Fire deploy hooks for background renewals too (#329):
                             # the manual path publishes this via the executor, the
@@ -2391,6 +2422,9 @@ class CertificateManager:
                     except Exception as e:
                         summary['failed'] += 1
                         logger.error(f"Failed to renew certificate for {domain}: {e}")
+                        self._record_renewal_metrics(
+                            domain, cert_info, False,
+                            time.time() - renew_started, error=e)
                         self._audit_scheduled_renew(domain, 'failure', error=e)
                         # Notify (#417): without this the operator's configured
                         # email/Slack channels stay silent while the cert

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -21,6 +21,7 @@ from modules.core import (
     RateLimitConfig, SimpleRateLimiter,
     get_certmate_logger
 )
+from modules.core.metrics import metrics_collector
 from modules.core.shell import ShellExecutor
 from modules.core.notifier import Notifier
 from modules.core.events import EventBus
@@ -653,6 +654,14 @@ def _run_manager_job(manager_key: str, method_name: str):
                 manager_key=manager_key,
             )
             return
+        # Record that this job actually ran, on both the success and the
+        # failure path. Without this the renewal sweep is unobservable: the
+        # collector exposes certmate_background_job_last_run_timestamp but
+        # nothing ever set it, so a scheduler that silently stopped looked
+        # identical to one that was working, and the single alert an operator
+        # most needs ("the sweep has not run in N days") could not be written.
+        job_type = f"{manager_key}.{method_name}"
+        started = time.time()
         try:
             getattr(manager, method_name)()
         except Exception:
@@ -661,6 +670,14 @@ def _run_manager_job(manager_key: str, method_name: str):
                 manager_key=manager_key,
                 method_name=method_name,
             )
+        finally:
+            try:
+                metrics_collector.record_background_job(
+                    job_type, time.time() - started)
+            except Exception:
+                # Telemetry must never be the reason a renewal run is lost.
+                logger.debug("Failed to record background-job metrics",
+                             job_type=job_type)
 
 
 @contextmanager

--- a/tests/test_renewal_metrics_are_emitted.py
+++ b/tests/test_renewal_metrics_are_emitted.py
@@ -1,0 +1,179 @@
+"""Renewal telemetry must actually be emitted, not merely defined.
+
+The collector has always exposed `certmate_background_job_last_run_timestamp`,
+`certmate_certificate_renewals_total` and the renewal duration histogram, but
+nothing in the application ever called the `record_*` methods that feed them.
+Every one of those series was permanently empty, so the single alert an
+operator most needs for a certificate manager — "the renewal sweep has not run
+in N days" / "renewals are failing" — could not be written: a scheduler that
+had silently stopped looked exactly like one that was working.
+
+These tests assert the signals move on the real code paths (#649).
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+from prometheus_client import REGISTRY
+
+from modules.core import factory
+from modules.core.certificates import CertificateManager
+
+pytestmark = [pytest.mark.unit]
+
+LAST_RUN = 'certmate_background_job_last_run_timestamp'
+RENEWALS = 'certmate_certificate_renewals_total'
+ACME_ERRORS = 'certmate_acme_errors_total'
+
+
+def _sample(name, labels):
+    return REGISTRY.get_sample_value(name, labels)
+
+
+def _run_job(manager, key='certificates', method='check_renewals'):
+    app = Flask(__name__)
+    app.config['MANAGERS'] = {key: manager}
+    with patch.object(factory, '_flask_app', app):
+        factory._run_manager_job(key, method)
+
+
+# --------------------------------------------------------------------------
+# The scheduled-job wrapper stamps that the sweep ran
+# --------------------------------------------------------------------------
+
+def test_a_scheduled_job_stamps_its_last_run_timestamp():
+    labels = {'job_type': 'certificates.check_renewals'}
+    before = _sample(LAST_RUN, labels)
+    _run_job(MagicMock())
+    after = _sample(LAST_RUN, labels)
+
+    assert after is not None, (
+        "the renewal sweep ran but left no last-run timestamp — an operator "
+        "cannot distinguish a working scheduler from a dead one"
+    )
+    if before is not None:
+        assert after >= before
+
+
+def test_a_failing_job_still_stamps_that_it_ran():
+    """CONTROL: liveness and success are different questions.
+
+    A sweep that raised still *ran*; the failure counters say it failed. If
+    only successful runs stamped, a permanently-failing scheduler would be
+    indistinguishable from a stopped one.
+    """
+    labels = {'job_type': 'certificates.check_renewals'}
+    _run_job(MagicMock())
+    before = _sample(LAST_RUN, labels)
+
+    failing = MagicMock()
+    failing.check_renewals.side_effect = RuntimeError("sweep exploded")
+    _run_job(failing)
+
+    after = _sample(LAST_RUN, labels)
+    assert after > before, "a failed sweep must still record that it executed"
+
+
+# --------------------------------------------------------------------------
+# check_renewals records the outcome of each renewal
+# --------------------------------------------------------------------------
+
+def _mgr_with_one_due_domain(tmp_path, domain):
+    settings_mgr = MagicMock()
+    settings_mgr.load_settings.return_value = {
+        'auto_renew': True,
+        'domains': [{'domain': domain, 'auto_renew': True}],
+    }
+    # check_renewals passes settings through migrate_domains_format; a bare
+    # MagicMock there would swallow the domain list and the loop would see
+    # nothing to renew.
+    settings_mgr.migrate_domains_format.side_effect = lambda s: s
+    mgr = CertificateManager(
+        cert_dir=tmp_path,
+        settings_manager=settings_mgr,
+        dns_manager=MagicMock(),
+        storage_manager=None,
+        ca_manager=None,
+        shell_executor=MagicMock(),
+    )
+    mgr.get_certificate_info = MagicMock(return_value={
+        'needs_renewal': True, 'dns_provider': 'cloudflare',
+    })
+    mgr._audit_scheduled_renew = MagicMock()
+    mgr._publish_renewed_event = MagicMock()
+    mgr._publish_failed_event = MagicMock()
+    return mgr
+
+
+def test_a_successful_renewal_increments_the_success_counter(tmp_path):
+    domain = 'metrics-ok.example.com'
+    labels = {'domain': domain, 'dns_provider': 'cloudflare',
+              'status': 'success'}
+    before = _sample(RENEWALS, labels) or 0.0
+
+    mgr = _mgr_with_one_due_domain(tmp_path, domain)
+    mgr.renew_certificate = MagicMock(return_value={'renewed': True})
+    summary = mgr.check_renewals()
+
+    assert summary['renewed'] == 1
+    assert (_sample(RENEWALS, labels) or 0.0) == before + 1, (
+        "a renewal succeeded but certmate_certificate_renewals_total did not "
+        "move — the success rate is unobservable"
+    )
+
+
+def test_a_failed_renewal_increments_the_failure_counter_and_an_acme_error(
+        tmp_path):
+    domain = 'metrics-fail.example.com'
+    fail_labels = {'domain': domain, 'dns_provider': 'cloudflare',
+                   'status': 'failure'}
+    err_labels = {'error_type': 'RuntimeError', 'domain': domain,
+                  'dns_provider': 'cloudflare'}
+    before = _sample(RENEWALS, fail_labels) or 0.0
+    before_err = _sample(ACME_ERRORS, err_labels) or 0.0
+
+    mgr = _mgr_with_one_due_domain(tmp_path, domain)
+    mgr.renew_certificate = MagicMock(side_effect=RuntimeError("CA said no"))
+    summary = mgr.check_renewals()
+
+    assert summary['failed'] == 1
+    assert (_sample(RENEWALS, fail_labels) or 0.0) == before + 1, (
+        "a renewal failed but the failure counter did not move"
+    )
+    assert (_sample(ACME_ERRORS, err_labels) or 0.0) == before_err + 1
+
+
+def test_a_not_yet_due_result_is_not_counted_as_a_renewal(tmp_path):
+    """CONTROL: certbot reporting 'not yet due' is not a renewal.
+
+    Counting it would inflate the success rate and hide a sweep that is
+    renewing nothing.
+    """
+    domain = 'metrics-notdue.example.com'
+    labels = {'domain': domain, 'dns_provider': 'cloudflare',
+              'status': 'success'}
+    before = _sample(RENEWALS, labels) or 0.0
+
+    mgr = _mgr_with_one_due_domain(tmp_path, domain)
+    mgr.renew_certificate = MagicMock(return_value={'renewed': False})
+    summary = mgr.check_renewals()
+
+    assert summary['skipped_not_due'] == 1
+    assert (_sample(RENEWALS, labels) or 0.0) == before, (
+        "a 'not yet due' result must not count as a successful renewal"
+    )
+
+
+def test_telemetry_failure_never_breaks_a_renewal(tmp_path):
+    """CONTROL: metrics are not allowed to cost a certificate."""
+    mgr = _mgr_with_one_due_domain(tmp_path, 'metrics-boom.example.com')
+    mgr.renew_certificate = MagicMock(return_value={'renewed': True})
+
+    with patch('modules.core.metrics.metrics_collector'
+               '.record_certificate_renewal',
+               side_effect=RuntimeError("collector down")):
+        summary = mgr.check_renewals()
+
+    assert summary['renewed'] == 1, (
+        "a telemetry error must not turn a successful renewal into a failure"
+    )


### PR DESCRIPTION
Closes #649. First item of the review milestone, and deliberately first overall: you cannot repair what you cannot measure.

## The problem
The collector defines `certmate_background_job_last_run_timestamp`, `certmate_certificate_renewals_total`, `certmate_acme_errors_total` and the renewal duration histogram — and **nothing ever called the `record_*` methods that feed them**. Every renewal series was permanently empty. A scheduler that had silently stopped renewing looked identical to one that was working, and the single most important alert for a certificate manager could not be written. Only the scrape-time inventory gauges populated: inventory, not liveness.

## The change
Wired at the two points that already know the answer, rather than inside the F(115)/F(62) issuance functions and their many return paths:

- **`_run_manager_job`** (the single wrapper for every scheduled job) stamps last-run + duration in a `finally`, so a sweep that **raised** still records that it executed. Liveness and success are different questions: the timestamp says the scheduler is alive, the counters say whether it is succeeding.
- **`check_renewals`** records per-domain success/failure, renewal duration, and an `acme_errors` entry on failure, where the outcome is already computed.

Telemetry is defensive on both paths — a collector error can never cost a renewal.

## Verification
Six tests, including three controls:
- a failing sweep still stamps that it ran;
- a certbot "not yet due" result is **not** counted as a renewal (counting it would inflate the success rate and hide a sweep that renews nothing);
- a telemetry failure does not turn a successful renewal into a failure.

Two-sided: the four behavioural assertions fail against the pre-change code and pass with it. Full local suite green (3121 passed, 6 skipped).

Note: `certificate_renewals_total` carries a per-domain label, so this activates cardinality that was previously dormant. The gauges already label per domain, so the order of magnitude is unchanged; the label-set design is a separate question and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)