### PR TITLE
fix: give the Prometheus scrape target one coherent access model

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -477,10 +477,12 @@ def create_api_resources(api, models, managers):
 
     # Metrics endpoints
     class MetricsList(Resource):
-        # Gated like its sibling info endpoints (CacheStats, BackupList): the
-        # Prometheus scrape target is the separate public '/metrics' route —
-        # this JSON summary lives in the authenticated API and must require at
-        # least a viewer credential, not be reachable unauthenticated.
+        # Gated like its sibling info endpoints (CacheStats, BackupList).
+        # This JSON summary lives in the authenticated API and must require at
+        # least a viewer credential, not be reachable unauthenticated. The
+        # Prometheus scrape target is the separate '/metrics' route, which is
+        # NOT public: it carries the same viewer requirement, because its
+        # series enumerate every managed domain.
         @api.doc(security='Bearer')
         @auth_manager.require_role('viewer')
         def get(self):

--- a/modules/web/misc_routes.py
+++ b/modules/web/misc_routes.py
@@ -195,8 +195,15 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
             logger.error(f"Audit export API error: {e}")
             return jsonify({'error': 'Failed to export audit bundle'}), 500
 
+    # Viewer, not admin. This is a read-only scrape target whose sibling
+    # '/api/metrics' already serves the same class of information (domain
+    # names, counts, expiry) at viewer level, so requiring admin here bought
+    # no confidentiality — it only forced an operator to put ADMIN credentials
+    # into a Prometheus scrape config to collect anything at all, or to
+    # collect nothing. It is not public either: the series enumerate every
+    # managed domain, which is infrastructure disclosure.
     @app.route('/metrics')
-    @auth_manager.require_role('admin')
+    @auth_manager.require_role('viewer')
     def metrics():
         """Prometheus metrics endpoint.
 

--- a/tests/test_metrics_access_model.py
+++ b/tests/test_metrics_access_model.py
@@ -1,0 +1,79 @@
+"""The Prometheus scrape target has one declared, coherent access model.
+
+`/metrics` required the **admin** role while the sibling `/api/metrics`
+(`MetricsList`) served the same class of information — domain names, counts,
+expiry — at **viewer**, and justified its own gate in a comment that asserted
+"the Prometheus scrape target is the separate public '/metrics' route". The
+relationship was stated backwards: the scrape route was not public, it was
+stricter. The practical effect was that collecting metrics at all required
+putting ADMIN credentials into a Prometheus scrape config, or collecting
+nothing.
+
+`/metrics` now requires viewer: least privilege for a read-only endpoint, and
+consistent with the sibling that already exposes the same data. It is still
+authenticated — the series enumerate every managed domain, which is
+infrastructure disclosure (#650).
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from modules.web.misc_routes import register_misc_routes
+
+pytestmark = [pytest.mark.unit]
+
+
+def _app_recording_declared_roles():
+    """Mount the misc routes, tagging each view with the role it declared."""
+    app = Flask(__name__)
+    app.config['VERSION'] = 'test'
+
+    auth_manager = MagicMock()
+
+    def _recording_require_role(role):
+        def deco(fn):
+            fn._declared_role = role
+            return fn
+        return deco
+
+    auth_manager.require_role = _recording_require_role
+    auth_manager.is_local_auth_enabled.return_value = False
+    auth_manager.has_any_users.return_value = False
+
+    register_misc_routes(app, {}, require_web_auth=None,
+                         auth_manager=auth_manager)
+    return app
+
+
+def test_metrics_is_not_public():
+    app = _app_recording_declared_roles()
+    view = app.view_functions['metrics']
+    assert getattr(view, '_declared_role', None) is not None, (
+        "/metrics must be authenticated — its series enumerate every managed "
+        "domain, which discloses the infrastructure being protected"
+    )
+
+
+def test_metrics_requires_viewer_not_admin():
+    app = _app_recording_declared_roles()
+    assert app.view_functions['metrics']._declared_role == 'viewer', (
+        "a read-only scrape target must not demand admin: that forces admin "
+        "credentials into a Prometheus scrape config to collect anything"
+    )
+
+
+def test_metrics_matches_the_sibling_json_summary_gate():
+    """CONTROL: the two metrics surfaces must not disagree.
+
+    `/api/metrics` (MetricsList) is gated at viewer. If the scrape route drifts
+    to a different role again, one of the two comments explaining the split
+    becomes false — which is exactly the state this fixed.
+    """
+    app = _app_recording_declared_roles()
+    activity_role = app.view_functions['activity_api']._declared_role
+    metrics_role = app.view_functions['metrics']._declared_role
+    assert metrics_role == activity_role == 'viewer', (
+        "read-only informational endpoints should share one gate; "
+        f"/metrics={metrics_role} vs /api/activity={activity_role}"
+    )

--- a/tests/test_metrics_access_model.py
+++ b/tests/test_metrics_access_model.py
@@ -63,17 +63,57 @@ def test_metrics_requires_viewer_not_admin():
     )
 
 
-def test_metrics_matches_the_sibling_json_summary_gate():
-    """CONTROL: the two metrics surfaces must not disagree.
+def _metrics_list_declared_role():
+    """The role `/api/metrics` (MetricsList) declares.
 
-    `/api/metrics` (MetricsList) is gated at viewer. If the scrape route drifts
-    to a different role again, one of the two comments explaining the split
-    becomes false — which is exactly the state this fixed.
+    MetricsList is defined inside create_api_resources, so reaching it means
+    constructing the whole resource graph — there is no cheaper way in, which
+    is itself the point of #669.
+    """
+    from flask_restx import Api
+
+    from modules.api.models import create_api_models
+    from modules.api.resources import create_api_resources
+
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    api = Api(app, prefix='/api')
+
+    auth_manager = MagicMock()
+
+    def _recording_require_role(role):
+        def deco(fn):
+            fn._declared_role = role
+            return fn
+        return deco
+
+    auth_manager.require_role = _recording_require_role
+
+    class _Managers(dict):
+        """Supplies a stub for any manager the closure reaches for, so the
+        test does not have to enumerate the whole graph."""
+
+        def __missing__(self, key):
+            value = MagicMock()
+            self[key] = value
+            return value
+
+    managers = _Managers(auth=auth_manager)
+    resources = create_api_resources(api, create_api_models(api), managers)
+    return resources['MetricsList'].get._declared_role
+
+
+def test_the_two_metrics_surfaces_declare_the_same_gate():
+    """CONTROL: the scrape route and the JSON summary must not disagree.
+
+    They serve the same class of information. When they drifted apart, the
+    comment on one of them explaining the split became false — which is the
+    state this change fixed, so it is the state worth pinning.
     """
     app = _app_recording_declared_roles()
-    activity_role = app.view_functions['activity_api']._declared_role
-    metrics_role = app.view_functions['metrics']._declared_role
-    assert metrics_role == activity_role == 'viewer', (
-        "read-only informational endpoints should share one gate; "
-        f"/metrics={metrics_role} vs /api/activity={activity_role}"
+    scrape_role = app.view_functions['metrics']._declared_role
+    json_role = _metrics_list_declared_role()
+    assert scrape_role == json_role == 'viewer', (
+        "the two metrics surfaces must declare one gate; "
+        f"/metrics={scrape_role} vs /api/metrics={json_role}"
     )


### PR DESCRIPTION
Closes #650.

## What the review found, and what turned out to be worse
The issue was filed as "the route is admin-gated but documented as public". Reading both surfaces, the contradiction is sharper than that:

- `/metrics` (scrape target) required **admin**.
- `/api/metrics` (`MetricsList`, the JSON summary) requires **viewer** — and its comment justified that gate by asserting *"the Prometheus scrape target is the separate **public** '/metrics' route"*.

The relationship was stated **backwards**. `/metrics` was not public; it was stricter than the endpoint whose comment used it as the permissive counterexample. So one of the two comments explaining the split was simply false, and an operator following it would configure a scrape that returns 401.

## Change
`/metrics` now requires **viewer**, matching the sibling that already serves the same data at that level, and the false comment is corrected.

**This is an access-control change (admin → viewer) — flagging it explicitly for veto.** The reasoning:
- It does **not** widen the class of information exposed: a viewer already reaches `/api/metrics` (same data, JSON) and the certificate list.
- Requiring admin bought no confidentiality, but did force admin credentials into a Prometheus scrape config to collect anything — a strictly worse outcome than a viewer-scoped key.
- It stays authenticated. Making it genuinely public would disclose every managed domain, which is infrastructure disclosure for the thing being protected.

## Verification
Three tests pin the **declared gate on the route object**, not the source text (the review flagged source-substring assertions as brittle), plus a control that the read-only informational endpoints do not drift apart again. Two-sided: the viewer assertions fail against the pre-change code. Full suite green (3124 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)