### PR TITLE
ci: ratchet the coverage floor to 75 so it can actually catch a regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,12 +105,14 @@ jobs:
         # --cov-fail-under is a FLOOR, not a target (#428): before it, project
         # and patch statuses were both informational and fail_ci_if_error was
         # false, so coverage could fall to zero with CI still green.
-        # RATCHET IT UP, NEVER DOWN to make a red build pass. It sat at 65
-        # while the real number was 77, so twelve points of coverage — entire
-        # modules losing their tests — could evaporate with CI still green,
-        # which is the one thing a coverage floor exists to prevent (#651).
-        # 75 keeps a small margin for run-to-run skip variance while leaving
-        # no room for a module to go dark unnoticed.
+        # RATCHET IT UP, NEVER DOWN to make a red build pass. It had been
+        # left far below the coverage actually achieved, so entire modules
+        # could lose their tests with CI still green — the one thing a
+        # coverage floor exists to prevent (#651). Keep it just under the
+        # measured number: close enough to catch a module going dark, with a
+        # small margin for run-to-run skip variance. Re-measure and raise it
+        # when coverage climbs; do not record the measurement here, where it
+        # would age into a false claim.
         # `not network`: the CA-reachability checks in
         # tests/test_ca_endpoints_are_live.py fetch five external ACME
         # directories. They found two real defects (a DigiCert host that no

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,9 +104,13 @@ jobs:
         # into the number, inflating it and hiding the real app coverage.
         # --cov-fail-under is a FLOOR, not a target (#428): before it, project
         # and patch statuses were both informational and fail_ci_if_error was
-        # false, so coverage could fall to zero with CI still green. 65 is
-        # comfortably below the current number; raise it as a ratchet, never
-        # lower it to make a red build pass.
+        # false, so coverage could fall to zero with CI still green.
+        # RATCHET IT UP, NEVER DOWN to make a red build pass. It sat at 65
+        # while the real number was 77, so twelve points of coverage — entire
+        # modules losing their tests — could evaporate with CI still green,
+        # which is the one thing a coverage floor exists to prevent (#651).
+        # 75 keeps a small margin for run-to-run skip variance while leaving
+        # no room for a module to go dark unnoticed.
         # `not network`: the CA-reachability checks in
         # tests/test_ca_endpoints_are_live.py fetch five external ACME
         # directories. They found two real defects (a DigiCert host that no
@@ -114,7 +118,7 @@ jobs:
         # another name) — but as a required check they would turn every PR red
         # on someone else's outage. They run on the weekly schedule below
         # instead, where a failure is news rather than a blocked merge.
-        pytest -v --tb=short --cov=modules --cov-report=xml --cov-report=html --cov-fail-under=65 -m "not ui and not network"
+        pytest -v --tb=short --cov=modules --cov-report=xml --cov-report=html --cov-fail-under=75 -m "not ui and not network"
 
     - name: Upload coverage reports
       if: matrix.python-version == '3.12'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ catch something:
 |---|---|
 | Syntax + bug-class lint (**fails CI**) | `flake8 . --count --select=E9,F63,F7,F82,F811,F632,E711,E712,E713,E714 --show-source` |
 | Security scan (**fails CI**) | `bandit -r modules/ app.py --severity-level medium` |
-| Tests + coverage floor of 65% on `modules/` | `pytest -m "not ui" --cov=modules --cov-fail-under=65` |
+| Tests + coverage floor of 75% on `modules/` | `pytest -m "not ui" --cov=modules --cov-fail-under=75` |
 | Theme tokens | `python3 scripts/theme_codemod.py --check` |
 | CSS bundle freshness | `npm ci && npm run css:build`, then commit `static/css/tailwind.min.css` |
 | No emoji in `RELEASE_NOTES.md` | `.github/workflows/lint-emoji.yml` |

--- a/docs/de/testing.md
+++ b/docs/de/testing.md
@@ -272,7 +272,7 @@ Hooks umfassen: Code-Formatierung (black, isort), Linting (flake8), Sicherheitsp
 
 ## Coverage-Anforderungen
 
-- Die CI erzwingt eine Untergrenze von **65%** über `modules/`
+- Die CI erzwingt eine Untergrenze von **75%** über `modules/`
   (`--cov-fail-under`, eine Ratsche: anheben, niemals senken, damit ein Build
   durchgeht). Der aktuelle Wert liegt komfortabel darüber.
 - Alle neuen Funktionen müssen Tests enthalten.

--- a/docs/es/testing.md
+++ b/docs/es/testing.md
@@ -272,7 +272,7 @@ Los hooks incluyen: formateo de código (black, isort), linting (flake8), verifi
 
 ## Requisitos de cobertura
 
-- CI impone un mínimo del **65%** sobre `modules/` (`--cov-fail-under`, un
+- CI impone un mínimo del **75%** sobre `modules/` (`--cov-fail-under`, un
   trinquete: súbalo, nunca lo baje para que pase una build). El número actual
   está cómodamente por encima.
 - Todas las funcionalidades nuevas deben incluir tests.

--- a/docs/fr/testing.md
+++ b/docs/fr/testing.md
@@ -272,7 +272,7 @@ Les hooks incluent : formatage de code (black, isort), linting (flake8), vérifi
 
 ## Exigences de couverture
 
-- La CI impose un plancher de **65%** sur `modules/` (`--cov-fail-under`, un
+- La CI impose un plancher de **75%** sur `modules/` (`--cov-fail-under`, un
   cliquet : à relever, jamais à abaisser pour faire passer une build). Le
   chiffre actuel est confortablement au-dessus.
 - Toutes les nouvelles fonctionnalités doivent inclure des tests.

--- a/docs/it/testing.md
+++ b/docs/it/testing.md
@@ -272,7 +272,7 @@ Gli hook includono: formattazione del codice (black, isort), linting (flake8), v
 
 ## Requisiti di copertura
 
-- La CI impone un minimo del **65%** su `modules/` (`--cov-fail-under`, un
+- La CI impone un minimo del **75%** su `modules/` (`--cov-fail-under`, un
   cricchetto: alzarlo, mai abbassarlo per far passare una build). Il numero
   attuale è comodamente sopra.
 - Tutte le nuove funzionalità devono includere test.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -266,7 +266,7 @@ real certificate issued against Let's Encrypt staging, and a Docker build.
 
 ## Coverage Requirements
 
-- CI enforces a floor of **65%** over `modules/` (`--cov-fail-under`, a ratchet
+- CI enforces a floor of **75%** over `modules/` (`--cov-fail-under`, a ratchet
   — raise it, never lower it to make a build pass). The number today is
   comfortably above it.
 - All new features must include tests.


### PR DESCRIPTION
Closes #651.

Measured actual branch coverage over `modules/` with the exact selection CI uses (`-m "not ui and not network"`): **77%** (15,262 statements, 3,506 missed). The floor was **65**.

That is twelve points of slack — enough for entire modules to lose their tests with CI still green, which is the single outcome a coverage floor exists to prevent. The comment beside the setting already said *"raise it as a ratchet, never lower it"*; it was never raised.

Set to **75**: a small margin for run-to-run skip variance (e2e/live skip in the unit job without Docker credentials), and no room for a module to go dark unnoticed.

This PR's own CI run is the verification — if 75 were above the number CI actually measures, this build goes red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)