### PR TITLE
fix: make the systemd deployment able to boot and to finish an issuance

### DIFF
--- a/certmate.service
+++ b/certmate.service
@@ -10,14 +10,23 @@ User=certmate
 Group=certmate
 WorkingDirectory=/opt/certmate
 Environment=PATH=/opt/certmate/venv/bin
-Environment=API_BEARER_TOKEN=change-this-secure-token
+# Worker timeout. DNS-01 issuance waits on propagation and routinely runs for
+# minutes; gunicorn's default is 30s, which reaps the worker mid-certbot and
+# fails the issuance for no reason the operator can see. The container image
+# sets the same value (Dockerfile: GUNICORN_TIMEOUT=300) — keep them in step.
+Environment=GUNICORN_TIMEOUT=300
+# Operator-supplied secrets (API_BEARER_TOKEN, provider credentials). The unit
+# ships no credential of its own: a value committed here would be identical on
+# every installation that never changed it. Leading '-' means the file is
+# optional; with no token supplied the application derives one at startup.
+EnvironmentFile=-/etc/certmate/certmate.env
 # Single worker + threads, matching the Dockerfile (#411). Sessions, session
 # revocation and the login rate limiter are per-process in-memory state: with
 # 4 workers, revoking a compromised admin's session only took effect on the
 # worker that handled the request (so ~3 requests in 4 still validated), the
 # login rate limit was multiplied by the worker count, and APScheduler ran a
 # duplicate renewal job per worker.
-ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout ${GUNICORN_TIMEOUT} app:app
 ExecReload=/bin/kill -s HUP $MAINPID
 Restart=always
 RestartSec=10
@@ -28,7 +37,11 @@ TimeoutStopSec=5
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=/opt/certmate/certificates /opt/certmate/data
+# All four directories the startup writeability probe requires. It checks
+# certificates, data, backups AND logs and raises at boot if any is not
+# writable, so omitting the last two under ProtectSystem=strict stopped the
+# service from starting at all.
+ReadWritePaths=/opt/certmate/certificates /opt/certmate/data /opt/certmate/backups /opt/certmate/logs
 PrivateTmp=true
 ProtectKernelTunables=true
 ProtectKernelModules=true

--- a/docs/de/installation.md
+++ b/docs/de/installation.md
@@ -423,7 +423,7 @@ ersten Start auf die WAL-Fallback-Zeile.
 ### Gunicorn verwenden
 
 ```bash
-gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout 300 app:app
 ```
 
 ### systemd verwenden
@@ -440,7 +440,8 @@ Type=simple
 User=certmate
 WorkingDirectory=/opt/certmate
 Environment=PATH=/opt/certmate/venv/bin
-ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+Environment=GUNICORN_TIMEOUT=300
+ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout ${GUNICORN_TIMEOUT} app:app
 Restart=always
 
 [Install]

--- a/docs/de/testing.md
+++ b/docs/de/testing.md
@@ -108,7 +108,7 @@ eingeschränkte Netzwerke), kann die Suite auf eine bereits laufende Instanz gez
 
 ```bash
 # Terminal 1: CertMate beliebig starten
-gunicorn --bind 127.0.0.1:18888 --workers 1 --threads 8 app:app
+gunicorn --bind 127.0.0.1:18888 --workers 1 --threads 8 --timeout 300 app:app
 
 # Terminal 2: auf diese Instanz zeigen (überspringt die gesamte Docker-Lifecycle-Verwaltung)
 CERTMATE_E2E_BASE_URL=http://localhost:18888 pytest -m "e2e and not ui"

--- a/docs/es/installation.md
+++ b/docs/es/installation.md
@@ -281,7 +281,7 @@ Mantenga `BEHIND_PROXY=true` en el servicio CertMate: Zion añade `X-Forwarded-F
 
 ```bash
 pip install gunicorn
-gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout 300 app:app
 ```
 
 ### Usar systemd
@@ -298,7 +298,8 @@ Type=simple
 User=certmate
 WorkingDirectory=/opt/certmate
 Environment=PATH=/opt/certmate/venv/bin
-ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+Environment=GUNICORN_TIMEOUT=300
+ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout ${GUNICORN_TIMEOUT} app:app
 Restart=always
 
 [Install]
@@ -427,7 +428,7 @@ Si NFS es inevitable, monte con `soft,timeo=30,retrans=3` (o el equivalente de s
 ### Usar Gunicorn
 
 ```bash
-gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout 300 app:app
 ```
 
 ### Usar systemd
@@ -444,7 +445,8 @@ Type=simple
 User=certmate
 WorkingDirectory=/opt/certmate
 Environment=PATH=/opt/certmate/venv/bin
-ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+Environment=GUNICORN_TIMEOUT=300
+ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout ${GUNICORN_TIMEOUT} app:app
 Restart=always
 
 [Install]

--- a/docs/es/testing.md
+++ b/docs/es/testing.md
@@ -108,7 +108,7 @@ redes restringidas), apunte la suite a una instancia ya en ejecución:
 
 ```bash
 # Terminal 1: ejecute CertMate como prefiera
-gunicorn --bind 127.0.0.1:18888 --workers 1 --threads 8 app:app
+gunicorn --bind 127.0.0.1:18888 --workers 1 --threads 8 --timeout 300 app:app
 
 # Terminal 2: apunte a esa instancia (omite toda la gestión del ciclo de vida Docker)
 CERTMATE_E2E_BASE_URL=http://localhost:18888 pytest -m "e2e and not ui"

--- a/docs/fr/installation.md
+++ b/docs/fr/installation.md
@@ -281,7 +281,7 @@ Gardez `BEHIND_PROXY=true` sur le service CertMate : Zion ajoute `X-Forwarded-Fo
 
 ```bash
 pip install gunicorn
-gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout 300 app:app
 ```
 
 ### Utiliser systemd
@@ -298,7 +298,8 @@ Type=simple
 User=certmate
 WorkingDirectory=/opt/certmate
 Environment=PATH=/opt/certmate/venv/bin
-ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+Environment=GUNICORN_TIMEOUT=300
+ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout ${GUNICORN_TIMEOUT} app:app
 Restart=always
 
 [Install]
@@ -428,7 +429,7 @@ Si NFS est inévitable, montez avec `soft,timeo=30,retrans=3` (ou l'équivalent 
 ### Utiliser Gunicorn
 
 ```bash
-gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout 300 app:app
 ```
 
 ### Utiliser systemd
@@ -445,7 +446,8 @@ Type=simple
 User=certmate
 WorkingDirectory=/opt/certmate
 Environment=PATH=/opt/certmate/venv/bin
-ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+Environment=GUNICORN_TIMEOUT=300
+ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout ${GUNICORN_TIMEOUT} app:app
 Restart=always
 
 [Install]

--- a/docs/fr/testing.md
+++ b/docs/fr/testing.md
@@ -108,7 +108,7 @@ réseaux restreints), pointez la suite vers une instance déjà en cours :
 
 ```bash
 # Terminal 1 : lancez CertMate comme vous le souhaitez
-gunicorn --bind 127.0.0.1:18888 --workers 1 --threads 8 app:app
+gunicorn --bind 127.0.0.1:18888 --workers 1 --threads 8 --timeout 300 app:app
 
 # Terminal 2 : ciblez cette instance (ignore toute la gestion du cycle de vie Docker)
 CERTMATE_E2E_BASE_URL=http://localhost:18888 pytest -m "e2e and not ui"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -432,7 +432,7 @@ after first start.
 ### Using Gunicorn
 
 ```bash
-gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout 300 app:app
 ```
 
 ### Using systemd
@@ -449,7 +449,8 @@ Type=simple
 User=certmate
 WorkingDirectory=/opt/certmate
 Environment=PATH=/opt/certmate/venv/bin
-ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+Environment=GUNICORN_TIMEOUT=300
+ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout ${GUNICORN_TIMEOUT} app:app
 Restart=always
 
 [Install]

--- a/docs/it/installation.md
+++ b/docs/it/installation.md
@@ -281,7 +281,7 @@ Mantenere `BEHIND_PROXY=true` sul servizio CertMate: Zion aggiunge `X-Forwarded-
 
 ```bash
 pip install gunicorn
-gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout 300 app:app
 ```
 
 ### Usare systemd
@@ -298,7 +298,8 @@ Type=simple
 User=certmate
 WorkingDirectory=/opt/certmate
 Environment=PATH=/opt/certmate/venv/bin
-ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+Environment=GUNICORN_TIMEOUT=300
+ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout ${GUNICORN_TIMEOUT} app:app
 Restart=always
 
 [Install]
@@ -428,7 +429,7 @@ Se NFS è inevitabile, montare con `soft,timeo=30,retrans=3` (o l'equivalente de
 ### Usare Gunicorn
 
 ```bash
-gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout 300 app:app
 ```
 
 ### Usare systemd
@@ -445,7 +446,8 @@ Type=simple
 User=certmate
 WorkingDirectory=/opt/certmate
 Environment=PATH=/opt/certmate/venv/bin
-ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 app:app
+Environment=GUNICORN_TIMEOUT=300
+ExecStart=/opt/certmate/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 8 --timeout ${GUNICORN_TIMEOUT} app:app
 Restart=always
 
 [Install]

--- a/docs/it/testing.md
+++ b/docs/it/testing.md
@@ -108,7 +108,7 @@ reti con restrizioni), puntare la suite su un'istanza già in esecuzione:
 
 ```bash
 # Terminale 1: avviare CertMate come si preferisce
-gunicorn --bind 127.0.0.1:18888 --workers 1 --threads 8 app:app
+gunicorn --bind 127.0.0.1:18888 --workers 1 --threads 8 --timeout 300 app:app
 
 # Terminale 2: puntare all'istanza (ignora tutta la gestione del ciclo di vita Docker)
 CERTMATE_E2E_BASE_URL=http://localhost:18888 pytest -m "e2e and not ui"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -108,7 +108,7 @@ restricted networks), point the suite at an already-running instance:
 
 ```bash
 # Terminal 1: run CertMate however you like
-gunicorn --bind 127.0.0.1:18888 --workers 1 --threads 8 app:app
+gunicorn --bind 127.0.0.1:18888 --workers 1 --threads 8 --timeout 300 app:app
 
 # Terminal 2: target it (skips all Docker lifecycle management)
 CERTMATE_E2E_BASE_URL=http://localhost:18888 pytest -m "e2e and not ui"

--- a/tests/test_systemd_unit_can_actually_run.py
+++ b/tests/test_systemd_unit_can_actually_run.py
@@ -15,6 +15,7 @@ and nothing ran it. It had drifted into a state where it could not work:
 These tests pin the unit against the application's own requirements rather than
 against a copy of them (#653, #654).
 """
+import ast
 import re
 from pathlib import Path
 
@@ -47,11 +48,30 @@ def _dirs_the_startup_probe_requires():
     Read from the application rather than restated here: if a fifth directory
     is ever added to that probe, this test fails until the unit grants it,
     which is the drift that stopped the service booting.
+
+    Parsed with ast rather than a regex so that reformatting the source (quote
+    style, wrapping) cannot make this silently stop deriving the real list.
     """
-    src = FACTORY.read_text(encoding='utf-8')
-    block = re.search(r'required = \[(.*?)\]', src, re.S)
-    assert block, "could not find the startup writeability probe's directory list"
-    return re.findall(r"\('([a-z_]+)',", block.group(1))
+    tree = ast.parse(FACTORY.read_text(encoding='utf-8'))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == 'required'
+                   for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.List):
+            continue
+        labels = [
+            elt.elts[0].value
+            for elt in node.value.elts
+            if isinstance(elt, ast.Tuple) and elt.elts
+            and isinstance(elt.elts[0], ast.Constant)
+            and isinstance(elt.elts[0].value, str)
+        ]
+        if labels:
+            return labels
+    raise AssertionError(
+        "could not find the startup writeability probe's directory list")
 
 
 def test_gunicorn_is_given_a_timeout_long_enough_for_issuance():
@@ -62,27 +82,56 @@ def test_gunicorn_is_given_a_timeout_long_enough_for_issuance():
     )
 
 
+def _effective_exec_start_timeout():
+    """The timeout ExecStart actually passes to gunicorn.
+
+    Resolves a ${VAR} reference through the unit's own Environment=, because
+    asserting only that the variable is declared would pass while ExecStart
+    hard-coded a different value and left the service misconfigured.
+    """
+    directives = _unit_directives()
+    exec_start = directives['ExecStart'][0]
+    match = re.search(r'--timeout\s+(\S+)', exec_start)
+    assert match, "ExecStart passes no --timeout"
+    value = match.group(1)
+
+    ref = re.fullmatch(r'\$\{(\w+)\}|\$(\w+)', value)
+    if ref:
+        name = ref.group(1) or ref.group(2)
+        for env in directives.get('Environment', []):
+            key, _, env_value = env.partition('=')
+            if key.strip() == name:
+                return env_value.strip()
+        raise AssertionError(
+            f"ExecStart references ${{{name}}} but the unit never sets it, so "
+            f"gunicorn would receive an empty timeout"
+        )
+    return value
+
+
 def test_the_unit_timeout_matches_the_container():
     """CONTROL: the two deployment surfaces must not disagree on this value."""
-    directives = _unit_directives()
-    unit_timeout = None
-    for env in directives.get('Environment', []):
-        if env.startswith('GUNICORN_TIMEOUT='):
-            unit_timeout = env.split('=', 1)[1].strip()
-    assert unit_timeout, "the unit should state its worker timeout explicitly"
+    unit_timeout = _effective_exec_start_timeout()
 
     dockerfile = (ROOT / 'Dockerfile').read_text(encoding='utf-8')
     container_timeout = re.search(r'ENV GUNICORN_TIMEOUT=(\d+)', dockerfile)
     assert container_timeout, "Dockerfile no longer states GUNICORN_TIMEOUT"
     assert unit_timeout == container_timeout.group(1), (
-        f"systemd says {unit_timeout}, the image says "
+        f"systemd effectively passes {unit_timeout}, the image says "
         f"{container_timeout.group(1)} — the same workload needs the same "
         f"budget on both surfaces"
     )
 
 
 def test_readwritepaths_covers_every_directory_the_app_requires_at_boot():
-    granted = ' '.join(_unit_directives().get('ReadWritePaths', []))
+    # Whole paths, not substrings: granting only /opt/certmate/backups/unified
+    # would satisfy a substring check while the directory the probe actually
+    # writes to stayed read-only.
+    granted = {
+        Path(token).name
+        for directive in _unit_directives().get('ReadWritePaths', [])
+        for token in directive.split()
+    }
     missing = [d for d in _dirs_the_startup_probe_requires()
                if d not in granted]
     assert not missing, (

--- a/tests/test_systemd_unit_can_actually_run.py
+++ b/tests/test_systemd_unit_can_actually_run.py
@@ -1,0 +1,103 @@
+"""The shipped systemd unit must be able to boot and to finish an issuance.
+
+Docker is the exercised deployment surface; the systemd unit ships alongside it
+and nothing ran it. It had drifted into a state where it could not work:
+
+* gunicorn was started with no ``--timeout``, so it used the 30-second default
+  while DNS-01 issuance routinely runs for minutes — certbot was reaped
+  mid-issuance. The container image sets 300 for exactly this reason.
+* ``ProtectSystem=strict`` with a ``ReadWritePaths`` covering only two of the
+  four directories the startup writeability probe requires, so the service
+  raised at boot instead of starting.
+* It shipped a placeholder credential, identical on every installation that
+  never changed it.
+
+These tests pin the unit against the application's own requirements rather than
+against a copy of them (#653, #654).
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+ROOT = Path(__file__).resolve().parent.parent
+UNIT = ROOT / 'certmate.service'
+FACTORY = ROOT / 'modules' / 'core' / 'factory.py'
+
+
+def _unit_directives():
+    """Map directive -> list of values, ignoring comments."""
+    out = {}
+    for raw in UNIT.read_text(encoding='utf-8').splitlines():
+        line = raw.strip()
+        if not line or line.startswith('#') or line.startswith('['):
+            continue
+        if '=' not in line:
+            continue
+        key, _, value = line.partition('=')
+        out.setdefault(key.strip(), []).append(value.strip())
+    return out
+
+
+def _dirs_the_startup_probe_requires():
+    """The directory labels factory.py's boot writeability probe checks.
+
+    Read from the application rather than restated here: if a fifth directory
+    is ever added to that probe, this test fails until the unit grants it,
+    which is the drift that stopped the service booting.
+    """
+    src = FACTORY.read_text(encoding='utf-8')
+    block = re.search(r'required = \[(.*?)\]', src, re.S)
+    assert block, "could not find the startup writeability probe's directory list"
+    return re.findall(r"\('([a-z_]+)',", block.group(1))
+
+
+def test_gunicorn_is_given_a_timeout_long_enough_for_issuance():
+    exec_start = _unit_directives()['ExecStart'][0]
+    assert '--timeout' in exec_start, (
+        "gunicorn defaults to a 30s worker timeout; DNS-01 issuance takes "
+        "minutes, so without an explicit --timeout certbot is killed mid-run"
+    )
+
+
+def test_the_unit_timeout_matches_the_container():
+    """CONTROL: the two deployment surfaces must not disagree on this value."""
+    directives = _unit_directives()
+    unit_timeout = None
+    for env in directives.get('Environment', []):
+        if env.startswith('GUNICORN_TIMEOUT='):
+            unit_timeout = env.split('=', 1)[1].strip()
+    assert unit_timeout, "the unit should state its worker timeout explicitly"
+
+    dockerfile = (ROOT / 'Dockerfile').read_text(encoding='utf-8')
+    container_timeout = re.search(r'ENV GUNICORN_TIMEOUT=(\d+)', dockerfile)
+    assert container_timeout, "Dockerfile no longer states GUNICORN_TIMEOUT"
+    assert unit_timeout == container_timeout.group(1), (
+        f"systemd says {unit_timeout}, the image says "
+        f"{container_timeout.group(1)} — the same workload needs the same "
+        f"budget on both surfaces"
+    )
+
+
+def test_readwritepaths_covers_every_directory_the_app_requires_at_boot():
+    granted = ' '.join(_unit_directives().get('ReadWritePaths', []))
+    missing = [d for d in _dirs_the_startup_probe_requires()
+               if d not in granted]
+    assert not missing, (
+        f"ProtectSystem=strict makes everything else read-only, and the boot "
+        f"probe raises RuntimeError when a required directory is not writable. "
+        f"Not granted: {missing}"
+    )
+
+
+def test_the_unit_ships_no_credential_value():
+    """A credential committed here is identical on every install that never
+    changed it."""
+    for env in _unit_directives().get('Environment', []):
+        key, _, value = env.partition('=')
+        assert 'TOKEN' not in key.upper() or not value.strip(), (
+            f"{key} carries a value in the shipped unit; secrets belong in an "
+            f"operator-owned EnvironmentFile"
+        )


### PR DESCRIPTION
Closes #653. Closes #654. First of phase-1 — what is broken in production now.

Docker is the exercised surface. The systemd unit ships alongside it, nothing ever ran it, and it had drifted into a state where it **could not work**.

## Three defects in one artefact

**1. certbot was being reaped mid-issuance.** gunicorn was started with no `--timeout`, so it used the **30-second default** — while DNS-01 issuance waits on propagation and routinely runs for minutes. The operator saw a failed issuance with no visible cause. The container image sets `GUNICORN_TIMEOUT=300` for precisely this reason; the unit now states the same value, and a test pins the two surfaces together so they cannot drift apart again.

**2. The service could not start at all.** `ProtectSystem=strict` makes everything outside `ReadWritePaths` read-only, but `ReadWritePaths` granted only `certificates` and `data`. The startup writeability probe requires **four** directories — certificates, data, **backups and logs** — and raises `RuntimeError` when one is not writable. All four are now granted.

The test for this derives the required list **from the probe in `factory.py`** rather than restating it, so if a fifth directory is ever added the test fails until the unit grants it. That is the drift that produced this bug.

**3. The unit shipped a credential value inline**, identical on every installation that never changed it. Secrets now come from an operator-owned `EnvironmentFile`; with none supplied the application derives a token at startup.

## The defect was not only in the unit
The same missing timeout appeared in **13 further places**: the unit is duplicated inline in the installation docs, and the manual production and test `gunicorn` invocations carried it too — across all five languages. All corrected. (`es`/`fr`/`it` each held *two* copies of the inline unit, which is the documentation-sprawl problem in #674 showing up as a correctness bug rather than a tidiness one.)

## Verification
Four tests, all four failing against the pre-change unit and passing after — including the `ReadWritePaths` one, whose failure on `main` is the direct evidence the service could not boot. Full suite green (3128 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)