### PR TITLE
deps: pin acme, the package the rest of the pins reason about

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -8,6 +8,10 @@ flask-restx==1.3.2
 
 # Certificate management
 certbot==2.10.0
+# The ACME protocol client. certbot declares it without a version bound,
+# so unpinned it is whatever PyPI serves — and the pyopenssl pin below
+# justifies itself against a specific acme version. See requirements.txt.
+acme==3.3.0
 josepy==1.13.0
 certbot-dns-cloudflare==2.10.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,17 @@ flask-restx==1.3.2
 
 # Certificate management
 certbot==2.10.0
+# acme is the ACME protocol client itself — the most protocol- and
+# security-sensitive package in the tree. certbot 2.10.0 declares a bare,
+# unbounded `Requires: acme`, so until this line existed the version was
+# whatever PyPI happened to serve, and a clean install was not guaranteed to
+# reproduce the one that was tested. That is load-bearing rather than tidy:
+# the rationale written on the cryptography and pyopenssl pins below is stated
+# in terms of acme 3.3.0 (which import-evaluates OpenSSL.crypto.X509Extension),
+# so the two most carefully reasoned pins in this file depended on a version
+# nothing enforced. Pinned to the version those pins were reasoned against and
+# the published image ships. Moving it is part of #103, not a routine bump.
+acme==3.3.0
 josepy==1.13.0
 
 # DNS provider plugins - Major cloud providers

--- a/tests/test_acme_pin_matches_its_rationale.py
+++ b/tests/test_acme_pin_matches_its_rationale.py
@@ -56,10 +56,15 @@ def test_the_dependency_rationale_names_the_version_that_is_pinned(path):
     acme_version = _pinned_version('acme', path)
     assert acme_version, "acme must be pinned before this can be checked"
 
+    # Case-insensitive throughout: 'PyOpenSSL' and 'pyopenssl' are the same
+    # requirement, and a rationale that said 'ACME' would be just as binding.
+    # A guard that silently stops matching on a capitalisation change is the
+    # kind of instrument this milestone exists to remove.
     text = path.read_text(encoding='utf-8')
     rationale_lines = [
         line for line in text.splitlines()
-        if line.startswith(('cryptography==', 'pyopenssl==')) and 'acme' in line
+        if re.match(r'^(cryptography|pyopenssl)==', line, re.IGNORECASE)
+        and 'acme' in line.lower()
     ]
     assert rationale_lines, (
         "the cryptography/pyopenssl pins no longer explain themselves in terms "
@@ -67,9 +72,11 @@ def test_the_dependency_rationale_names_the_version_that_is_pinned(path):
         "deliberately rather than letting it pass vacuously"
     )
 
-    stale = [line.split('#', 1)[0].strip() for line in rationale_lines
+    # Report the WHOLE line, comment included. Stripping the comment would hide
+    # the stale rationale — the one thing a reader needs to fix this.
+    stale = [line.strip() for line in rationale_lines
              if acme_version not in line]
     assert not stale, (
         f"acme is pinned to {acme_version} but these pins justify themselves "
-        f"against a different acme version: {stale}"
+        f"against a different acme version:\n  " + "\n  ".join(stale)
     )

--- a/tests/test_acme_pin_matches_its_rationale.py
+++ b/tests/test_acme_pin_matches_its_rationale.py
@@ -1,0 +1,75 @@
+"""The ACME protocol client must be pinned, and the pins that reason about it
+must reason about the version actually pinned.
+
+``acme`` is the most protocol- and security-sensitive package in the tree, and
+certbot 2.10.0 declares a bare unbounded ``Requires: acme`` — so its version was
+whatever PyPI happened to serve, and a clean install was not guaranteed to
+reproduce the one that had been tested.
+
+That is load-bearing rather than tidy. The rationale written on the
+``cryptography`` and ``pyopenssl`` pins is stated in terms of a specific acme
+version (it import-evaluates ``OpenSSL.crypto.X509Extension``, which is why
+pyopenssl may not move). So the two most carefully reasoned pins in the file
+depended on a version nothing enforced, and a silent acme bump would have
+invalidated their reasoning while leaving the prose looking authoritative
+(#657).
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+ROOT = Path(__file__).resolve().parent.parent
+REQUIREMENTS = ROOT / 'requirements.txt'
+# Both published sets carry the pin and the rationale, so both are checked.
+REQUIREMENT_FILES = [REQUIREMENTS, ROOT / 'requirements-minimal.txt']
+
+
+def _pinned_version(package, path=None):
+    """The exact version pinned for *package*, or None if it is not pinned."""
+    pattern = re.compile(
+        rf'^{re.escape(package)}==([0-9][^\s#]*)', re.IGNORECASE | re.MULTILINE)
+    match = pattern.search((path or REQUIREMENTS).read_text(encoding='utf-8'))
+    return match.group(1) if match else None
+
+
+@pytest.mark.parametrize('path', REQUIREMENT_FILES, ids=lambda p: p.name)
+def test_acme_is_pinned(path):
+    assert _pinned_version('acme', path) is not None, (
+        "acme is the ACME protocol client; certbot declares it without a "
+        "version bound, so leaving it unpinned means a clean install can "
+        "resolve a version that was never tested"
+    )
+
+
+@pytest.mark.parametrize('path', REQUIREMENT_FILES, ids=lambda p: p.name)
+def test_the_dependency_rationale_names_the_version_that_is_pinned(path):
+    """The prose explaining why cryptography and pyopenssl are held must refer
+    to the acme version actually enforced.
+
+    If acme is bumped and the rationale is not, the comments keep asserting a
+    constraint about a version that is no longer installed — authoritative
+    prose describing a stack that no longer exists.
+    """
+    acme_version = _pinned_version('acme', path)
+    assert acme_version, "acme must be pinned before this can be checked"
+
+    text = path.read_text(encoding='utf-8')
+    rationale_lines = [
+        line for line in text.splitlines()
+        if line.startswith(('cryptography==', 'pyopenssl==')) and 'acme' in line
+    ]
+    assert rationale_lines, (
+        "the cryptography/pyopenssl pins no longer explain themselves in terms "
+        "of acme; if that coupling really is gone, remove this guard "
+        "deliberately rather than letting it pass vacuously"
+    )
+
+    stale = [line.split('#', 1)[0].strip() for line in rationale_lines
+             if acme_version not in line]
+    assert not stale, (
+        f"acme is pinned to {acme_version} but these pins justify themselves "
+        f"against a different acme version: {stale}"
+    )

--- a/tests/test_dependabot_holds_the_stack.py
+++ b/tests/test_dependabot_holds_the_stack.py
@@ -53,14 +53,23 @@ HELD = {
     "cryptography": 'SECURITY.md "Known dependency constraint"',
     "dns-lexicon": "dns-lexicon",
     "cloudflare": "#568",
+    # Promoted from DEFENSIVE (#657). It used to arrive only as certbot's own
+    # dependency, and certbot bounds it not at all — so the version was
+    # whatever PyPI served, while the pyopenssl and cryptography reasons above
+    # are stated in terms of a specific acme version. The two most carefully
+    # reasoned pins in the tree rested on a number nothing enforced.
+    "acme": "ACME protocol client",
 }
 
-# Ignored defensively rather than held: `acme` is not pinned anywhere — it
-# arrives as certbot's own dependency — but an entry costs nothing and stops a
-# future direct pin from being bumped past the stack the moment it is added.
-# Kept separate from HELD so the "still pinned" check does not fail on it, and
-# so nobody reads it as a pin that exists.
-DEFENSIVE = {"acme"}
+# Ignored defensively rather than held: entries for packages that carry no
+# direct pin of their own. An entry costs nothing and stops a future direct pin
+# from being bumped past the stack the moment it is added. Kept separate from
+# HELD so the "still pinned" check does not fail on them.
+#
+# Empty since acme was promoted to HELD (#657): it acquired a direct pin, which
+# is exactly the transition test_a_defensive_entry_really_is_unpinned exists to
+# force rather than let happen silently.
+DEFENSIVE: set = set()
 
 # Wildcards cover a family; each needs at least one pinned member to be real.
 HELD_FAMILIES = {

--- a/tests/test_requirements_sets.py
+++ b/tests/test_requirements_sets.py
@@ -32,6 +32,7 @@ BOOT_CRITICAL = {
     "flask-cors",
     "flask-restx",
     "certbot",
+    "acme",           # the protocol client; certbot bounds it not at all
     "cryptography",
     "requests",
     "urllib3",


### PR DESCRIPTION
Closes #657. First of phase-2.

## Sharper than the issue as filed
The issue said "acme is unpinned". Reading the file, it is worse than that:

- `cryptography==46.0.7` justifies itself with *"every version that clears the open advisories needs pyopenssl>=26.2.0, which breaks **acme 3.3.0** at import"*.
- `pyopenssl==26.0.0` justifies itself with *"do not bump to 26.2.0+: it removes `OpenSSL.crypto.X509Extension`, which **acme==3.3.0** evaluates at import time"*.

**The two most carefully reasoned pins in the tree state their reason in terms of a version that nothing enforced.** certbot 2.10.0 declares a bare unbounded `Requires: acme`, so the number those pins depend on was whatever PyPI served that day. A silent acme bump would have invalidated both rationales while leaving the prose looking authoritative.

## Change
`acme==3.3.0` in **both** published requirement sets — the version those pins were reasoned against and the image already ships. Moving it belongs to #103, not to a routine bump.

Then the follow-through the pin implies:
- **`acme` joins `BOOT_CRITICAL`**, so the existing guard against pins drifting between `requirements.txt` and `requirements-minimal.txt` now covers it.
- **`acme` moves from `DEFENSIVE` to `HELD`** in the Dependabot hold list. That file *already demanded this*: `test_a_defensive_entry_really_is_unpinned` says a defensive entry acquiring a direct pin must be promoted with a reason written beside it — and it failed until I did. The guard worked exactly as designed, which is worth saying out loud given the milestone is about instruments that do not.

## New guard
A test ties the prose to the pin: bump acme without updating the cryptography/pyopenssl rationale and the build fails, naming both stale lines. Verified by mutation (`acme==4.0.0` → fails naming both) and against the pre-change tree (unpinned → fails).

Full suite green (3141 passed), lint gate clean, `certbot --version` still answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)