### PR TITLE
deps: stop the optional storage sets resolving a cryptography that breaks certbot

### DIFF
--- a/requirements-azure-storage.txt
+++ b/requirements-azure-storage.txt
@@ -3,10 +3,16 @@ azure-keyvault-secrets>=4.11.1
 azure-keyvault-certificates>=4.11.1
 azure-identity>=1.25.3
 
-# pyca/cryptography is already pulled in by the main requirements files
-# (certbot needs it), but the Certificate-object code path uses
-# `load_pem_x509_certificates` (plural form, added in 36.0) and the
-# PKCS12 builder. Pin a floor explicitly here so a layered install that
-# starts from a stripped-down base fails loudly with a clear constraint
-# error rather than an opaque ImportError at runtime.
-cryptography>=41.0.0
+# Floor: the Azure Key Vault Certificate-object path uses
+# `load_pem_x509_certificates` (plural, added in 36.0) and the PKCS12 builder,
+# so a layered install onto a stripped-down base should fail with a clear
+# constraint error rather than an opaque ImportError at runtime.
+#
+# Ceiling: the ACME stack holds cryptography below 47 (pyopenssl==26.0.0
+# requires cryptography>=46.0.0,<47; above it, `certbot --version` dies). This
+# file is documented as installable on its own, and standalone nothing else
+# constrains cryptography — it would resolve to the newest release and break
+# issuance. Until now that only held by accident of Docker's install order.
+# The authoritative reason for the hold lives beside the pin in
+# requirements.txt; raise this ceiling only when that moves (#103).
+cryptography>=41.0.0,<47

--- a/requirements-storage-all.txt
+++ b/requirements-storage-all.txt
@@ -6,9 +6,19 @@ azure-keyvault-secrets>=4.11.1
 azure-keyvault-certificates>=4.11.1
 azure-identity>=1.25.3
 
-# Needed by the Azure KV Certificate-object code path
-# (`load_pem_x509_certificates` + PKCS12 builder).
-cryptography>=41.0.0
+# Floor: the Azure Key Vault Certificate-object path uses
+# `load_pem_x509_certificates` (plural, added in 36.0) and the PKCS12 builder,
+# so a layered install onto a stripped-down base should fail with a clear
+# constraint error rather than an opaque ImportError at runtime.
+#
+# Ceiling: the ACME stack holds cryptography below 47 (pyopenssl==26.0.0
+# requires cryptography>=46.0.0,<47; above it, `certbot --version` dies). This
+# file is documented as installable on its own, and standalone nothing else
+# constrains cryptography — it would resolve to the newest release and break
+# issuance. Until now that only held by accident of Docker's install order.
+# The authoritative reason for the hold lives beside the pin in
+# requirements.txt; raise this ceiling only when that moves (#103).
+cryptography>=41.0.0,<47
 
 # AWS Secrets Manager
 boto3>=1.43.87

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -21,3 +21,9 @@ playwright
 # ModuleNotFoundError the day any of those drops it — for reasons having
 # nothing to do with what it checks.
 PyYAML==6.0.3
+
+# Read by tests/test_no_requirements_file_can_break_the_acme_stack.py to compare
+# version specifiers. Same reasoning as PyYAML above: it arrives transitively
+# today (pip, build tooling), so relying on that would break the test the day
+# something drops it, for reasons unrelated to what it checks.
+packaging==26.2

--- a/tests/test_no_requirements_file_can_break_the_acme_stack.py
+++ b/tests/test_no_requirements_file_can_break_the_acme_stack.py
@@ -1,0 +1,87 @@
+"""No requirements file may admit a cryptography the ACME stack rejects.
+
+`cryptography` is held at an exact version because moving it kills
+`certbot --version`: the versions that clear the open advisories need
+pyopenssl>=26.2.0, which removes `OpenSSL.crypto.X509Extension` that acme
+evaluates at import.
+
+The optional storage sets carried a bare floor (`cryptography>=41.0.0`) with no
+ceiling. They are documented as installable on their own, and standalone
+nothing else constrains the package — it resolves to the newest release, which
+breaks issuance. That it had not yet bitten was an accident of Docker's install
+order (the main file goes first, and the held version already satisfies the
+floor), not a property anything enforced (#658).
+
+This checks the property directly: every constraint in every requirements file
+must accept the held version and reject the versions known to break the stack.
+"""
+import re
+from pathlib import Path
+
+import pytest
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+pytestmark = [pytest.mark.unit]
+
+ROOT = Path(__file__).resolve().parent.parent
+PACKAGE = 'cryptography'
+
+# Versions that are known to kill `certbot --version` through the pyopenssl
+# route. If the stack is ever moved (#103) these stop being forbidden — which
+# is a deliberate change, and this list is where it gets made.
+BREAKS_THE_STACK = ['47.0.0', '48.0.1', '49.0.0', '50.0.0']
+
+
+def _requirements_files():
+    return sorted(ROOT.glob('requirements*.txt'))
+
+
+def _constraint(path):
+    """The cryptography specifier declared in *path*, or None."""
+    for line in path.read_text(encoding='utf-8').splitlines():
+        line = line.split('#', 1)[0].strip()
+        match = re.match(rf'^{PACKAGE}\s*(.+)$', line, re.IGNORECASE)
+        if match:
+            return SpecifierSet(match.group(1))
+    return None
+
+
+def _held_version():
+    spec = _constraint(ROOT / 'requirements.txt')
+    assert spec is not None, "requirements.txt no longer constrains cryptography"
+    pinned = [s.version for s in spec if s.operator == '==']
+    assert pinned, "cryptography is no longer held at an exact version"
+    return pinned[0]
+
+
+@pytest.mark.parametrize('path', _requirements_files(), ids=lambda p: p.name)
+def test_every_file_accepts_the_held_version(path):
+    """A file that rejects the held version cannot be installed alongside the
+    others, whatever the order."""
+    spec = _constraint(path)
+    if spec is None:
+        pytest.skip(f'{path.name} does not constrain {PACKAGE}')
+    held = _held_version()
+    assert spec.contains(Version(held)), (
+        f"{path.name} declares {PACKAGE}{spec}, which excludes the held "
+        f"version {held}"
+    )
+
+
+@pytest.mark.parametrize('path', _requirements_files(), ids=lambda p: p.name)
+def test_no_file_admits_a_version_that_breaks_issuance(path):
+    """The real defect: a floor with no ceiling.
+
+    Installed on its own — a documented path for the storage sets — such a
+    file resolves to the newest release and `certbot --version` dies.
+    """
+    spec = _constraint(path)
+    if spec is None:
+        pytest.skip(f'{path.name} does not constrain {PACKAGE}')
+    admitted = [v for v in BREAKS_THE_STACK if spec.contains(Version(v))]
+    assert not admitted, (
+        f"{path.name} declares {PACKAGE}{spec}, which would resolve to "
+        f"{admitted} when this file is installed on its own — versions that "
+        f"install cleanly and then kill `certbot --version`"
+    )

--- a/tests/test_no_requirements_file_can_break_the_acme_stack.py
+++ b/tests/test_no_requirements_file_can_break_the_acme_stack.py
@@ -30,7 +30,7 @@ PACKAGE = 'cryptography'
 # Versions that are known to kill `certbot --version` through the pyopenssl
 # route. If the stack is ever moved (#103) these stop being forbidden — which
 # is a deliberate change, and this list is where it gets made.
-BREAKS_THE_STACK = ['47.0.0', '48.0.1', '49.0.0', '50.0.0']
+BREAKS_THE_STACK = ['47.0.0', '48.0.1', '49.0.0', '50.0.0', '50.0.1']
 
 
 def _requirements_files():
@@ -66,6 +66,26 @@ def test_every_file_accepts_the_held_version(path):
     assert spec.contains(Version(held)), (
         f"{path.name} declares {PACKAGE}{spec}, which excludes the held "
         f"version {held}"
+    )
+
+
+@pytest.mark.parametrize('path', _requirements_files(), ids=lambda p: p.name)
+def test_every_constraint_is_bounded_above(path):
+    """The defect class, independent of which versions exist today.
+
+    Listing known-bad versions can only describe the past: a release published
+    tomorrow would slip through an unbounded floor while this file still looked
+    green. What made the storage sets dangerous was not version 50 in
+    particular, it was `>=41` with nothing on the right-hand side.
+    """
+    spec = _constraint(path)
+    if spec is None:
+        pytest.skip(f'{path.name} does not constrain {PACKAGE}')
+    bounded = any(s.operator in ('==', '<', '<=', '~=') for s in spec)
+    assert bounded, (
+        f"{path.name} declares {PACKAGE}{spec} with no upper bound, so it "
+        f"resolves to whatever is newest — including releases that do not "
+        f"exist yet and cannot be listed here"
     )
 
 


### PR DESCRIPTION
Closes #658.

## Measured, not argued
Both Azure Key Vault storage sets declared `cryptography>=41.0.0` — a floor with **no ceiling** — and both are documented as installable on their own (`# Install with: pip install -r requirements-storage-all.txt`).

Resolving that file standalone:

| | resolves cryptography to |
|---|---|
| as on `main` | **50.0.1** |
| with this change | **46.0.7** (the held version) |

50.0.1 is the exact version `SECURITY.md` records as *installing cleanly and then killing `certbot --version`*. **The documented install path produces a broken issuance stack today.**

That it had not yet bitten was an accident of Docker's layer order — the main file installs first and the held version already satisfies `>=41`. Nothing enforced it; `pip install -U` or the standalone path walks straight past it.

## Change
The floor stays — it is deliberate and documented (the Certificate-object path needs `load_pem_x509_certificates` and the PKCS12 builder, and should fail with a clear constraint error rather than an opaque runtime `ImportError`). What is added is the ceiling the stack itself imposes: `pyopenssl==26.0.0` requires `cryptography>=46.0.0,<47`.

The authoritative reason for the hold stays in exactly one place, beside the pin in `requirements.txt` — following this repo's own rule that what sits next to a pin is a *pointer*, not a copy that goes stale.

## New guard
Rather than trusting install order, a test checks the property directly across **every** requirements file: each must accept the held version, and none may admit a version known to break issuance. It catches both files exactly as they were on `main`, and the forbidden-version list is where a deliberate stack move (#103) gets made.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)