### PR TITLE
ci: publish an SBOM and build provenance with the image

### DIFF
--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -25,8 +25,10 @@ env:
 
 # Default to read-only. The build job authenticates to Docker Hub via the
 # DOCKERHUB_TOKEN secret, not the workflow GITHUB_TOKEN, so no write
-# permission on the repo is needed for the push. If we ever add SLSA
-# attestation here (Phase 2), `id-token: write` lands at the job level.
+# permission on the repo is needed for the push. The build publishes BuildKit
+# SBOM and provenance attestations, which travel with the image in the registry
+# and need no extra token; a keyless-signing scheme (cosign / GitHub
+# attestations) would be what requires `id-token: write` at the job level.
 permissions: read-all
 
 jobs:
@@ -137,6 +139,23 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        # A bill of materials and build provenance, pushed alongside the image
+        # as OCI attestations. Without them the published artefact says nothing
+        # about what is inside it or where it came from, which for a container
+        # that custodies private keys is the one artefact most worth being able
+        # to audit after the fact. `mode=max` records the full build context
+        # (base image digests, build args, the source commit) rather than the
+        # minimal summary.
+        #
+        # Inspect a published tag with:
+        #   docker buildx imagetools inspect <image> --format '{{ json .SBOM }}'
+        #   docker buildx imagetools inspect <image> --format '{{ json .Provenance }}'
+        #
+        # BuildKit writes these as extra manifests in the image index. The
+        # image is already a multi-arch index, so this is additive: `docker
+        # pull` and `--platform` selection are unaffected.
+        sbom: true
+        provenance: mode=max
         build-args: |
           REQUIREMENTS_FILE=requirements.txt
           


### PR DESCRIPTION
Addresses part of #659 — deliberately **not** all of it (see below).

## What
The published image said nothing about what is inside it or where it came from. For a container that custodies TLS private keys, ACME account keys and DNS-provider credentials, that is the artefact most worth auditing after the fact — and the workflow carried only a comment *deferring* it: *"if we ever add SLSA attestation here (Phase 2)"*.

BuildKit emits both natively, so this is `sbom: true` + `provenance: mode=max` on the publish step. **No new token needed** — the attestations travel with the image in the registry as extra manifests.

## Verified by building it, not by trusting the flags
Built locally with the same flags and read the exported OCI layout:

- the index gains an **attestation-manifest** beside the image;
- the **SBOM is SPDX with 272 packages**, and genuinely contains `certbot`, `acme` and `cryptography` — so the image can finally answer *"which cryptography is in here?"* without pulling and running it, which is the question the whole of phase-2 has been about;
- the **provenance is `slsa.dev/provenance/v1`**, and its `resolvedDependencies` record the **base image digest** the build actually used — directly relevant to the reproducibility concern in the issue.

The image is already a multi-arch index, so the extra manifests are additive: `docker pull` and `--platform` selection are unaffected.

## What this does NOT do, and why I did not bundle it
`#659` packages three things with very different cost and risk. Closing it on the strength of this one would be the same overstatement this milestone keeps finding:

1. **`apt-get upgrade -y`** — removing it buys reproducibility and gives up automatic OS security pickup between base-image bumps. That is a policy decision, not a cleanup, and it is the maintainer's call.
2. **`--require-hashes`** — a large change that conflicts with the layered `EXTRA_REQUIREMENTS` install model the Dockerfile depends on. Worth its own issue and its own design.

I will split those out rather than leave `#659` half-satisfied and looking done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)