### PR TITLE
refactor: give the API resources an explicit context, and pin their contract

### DIFF
--- a/modules/api/resource_context.py
+++ b/modules/api/resource_context.py
@@ -23,6 +23,7 @@ from flask import request
 from modules.core.auth import ROLE_HIERARCHY
 from modules.core.cert_service import CertificateService
 from modules.core.inventory_view import record_in_scope
+from modules.core.structured_logging import scrub_log_value
 import logging
 
 logger = logging.getLogger(__name__)
@@ -119,9 +120,14 @@ def check_domain_scope(ctx: ApiContext, domain, operation):
     user = getattr(request, 'current_user', None) or {}
     if ctx.auth.user_can_access_domain(user, domain):
         return None
+    # Scrubbed exactly as cert_service does for the same denial log: the
+    # username can carry a newline (create_user does not constrain it, and the
+    # OIDC path takes it from an IdP claim), which under the non-JSON log
+    # format forges a second, fully attacker-chosen record.
     logger.warning(
         "Scope denial: user=%s op=%s domain=%s scope=%s",
-        user.get('username'), operation, domain, user.get('allowed_domains'),
+        scrub_log_value(user.get('username')), scrub_log_value(operation),
+        scrub_log_value(domain), scrub_log_value(user.get('allowed_domains')),
     )
     if ctx.audit:
         ctx.audit.log_authz_denied(

--- a/modules/api/resource_context.py
+++ b/modules/api/resource_context.py
@@ -1,0 +1,165 @@
+"""The shared state and helpers the API resources need, made explicit.
+
+`create_api_resources` is a single function holding 41 resource classes as
+closures over ten managers and a handful of helpers. Nothing in it can be
+imported on its own, which is why the HTTP layer is both the largest module in
+the project and the least covered: reaching one route means constructing the
+whole graph (#669).
+
+This is the first step out of that: the state those classes capture becomes an
+object that can be built and inspected, and the helpers that captured it become
+functions that take it. Resource classes can then move into modules of their
+own without each one dragging the closure along.
+
+Nothing here changes behaviour. `build_context` reproduces exactly the lookups
+and fallbacks the closure performed, including the `CertificateService`
+fallback that lets tests pass a minimal manager dict.
+"""
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from flask import request
+
+from modules.core.auth import ROLE_HIERARCHY
+from modules.core.cert_service import CertificateService
+from modules.core.inventory_view import record_in_scope
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Values the ``async`` flag accepts in a request body. Kept with the helper
+# that reads it rather than loose in the closure.
+ASYNC_TRUTHY = (True, 1, '1', 'true', 'yes', 'on')
+
+
+@dataclass(frozen=True)
+class ApiContext:
+    """The managers the API resources operate through.
+
+    Frozen: resources read this, they do not reconfigure the application.
+    """
+
+    auth: Any
+    settings: Any
+    certificates: Any
+    file_ops: Any
+    cache: Any
+    dns: Any
+    deployer: Optional[Any]
+    audit: Optional[Any]
+    cert_service: Any
+    cert_executor: Optional[Any]
+
+
+def build_context(managers) -> ApiContext:
+    """Resolve the manager set exactly as the closure used to.
+
+    The required managers are looked up with ``[]`` and the optional ones with
+    ``.get()``, preserving which absences are a programming error and which are
+    a supported configuration.
+    """
+    auth = managers['auth']
+    settings = managers['settings']
+    certificates = managers['certificates']
+    audit = managers.get('audit')
+
+    # Shared create/renew orchestration. Production wires a single instance via
+    # the container (factory.py); the fallback builds one from the manager set
+    # so tests that call the factory with a minimal managers dict (no
+    # 'cert_service'/'events') keep working.
+    cert_service = managers.get('cert_service') or CertificateService(
+        certificates, settings, auth, audit_logger=audit,
+    )
+
+    return ApiContext(
+        auth=auth,
+        settings=settings,
+        certificates=certificates,
+        file_ops=managers['file_ops'],
+        cache=managers['cache'],
+        dns=managers['dns'],
+        deployer=managers.get('deployer'),
+        audit=audit,
+        cert_service=cert_service,
+        # Optional async issuance executor (single-instance, in-process).
+        # Absent in minimal-managers unit tests, in which case create and renew
+        # stay synchronous.
+        cert_executor=managers.get('cert_executor'),
+    )
+
+
+def wants_async(payload) -> bool:
+    """True when the caller opted into async issuance via the ``async`` body
+    flag or the ``?async=`` query param."""
+    if isinstance(payload, dict) and payload.get('async') in ASYNC_TRUTHY:
+        return True
+    return request.args.get('async', '').strip().lower() in (
+        '1', 'true', 'yes', 'on')
+
+
+def job_accepted(job_id, operation, domain, status_url) -> dict:
+    """The 202 body for an accepted async job."""
+    return {
+        'job_id': job_id,
+        'status': 'queued',
+        'operation': operation,
+        'domain': domain,
+        'status_url': status_url,
+    }
+
+
+def check_domain_scope(ctx: ApiContext, domain, operation):
+    """Reject the request if the caller's API-key allowed_domains does not
+    cover *domain*. Returns (body, status) on denial, or None when permitted.
+
+    Sessions and legacy bearer tokens have no allowed_domains on
+    request.current_user, so they are unrestricted; only scoped API keys, which
+    carry an allowed_domains list, can reach a 403.
+    """
+    user = getattr(request, 'current_user', None) or {}
+    if ctx.auth.user_can_access_domain(user, domain):
+        return None
+    logger.warning(
+        "Scope denial: user=%s op=%s domain=%s scope=%s",
+        user.get('username'), operation, domain, user.get('allowed_domains'),
+    )
+    if ctx.audit:
+        ctx.audit.log_authz_denied(
+            operation=operation,
+            resource_type='certificate',
+            resource_id=domain,
+            reason='domain outside scoped key allowed_domains',
+            user=user.get('username'),
+            ip_address=request.remote_addr,
+        )
+    return {
+        'error': f'API key not authorized for domain {domain}',
+        'code': 'DOMAIN_OUT_OF_SCOPE',
+    }, 403
+
+
+def is_record_in_scope(ctx: ApiContext, record) -> bool:
+    """True if the caller's scope covers any domain the inventory *record*
+    names (subject CN or a SAN).
+
+    Matches CertificateList exactly: scope comes from allowed_domains and is
+    fed to domain_matches_scope, so an unrestricted caller (scope None,
+    including a request whose current_user is unset) sees everything. Using
+    user_can_access_domain here instead would be a regression — it returns
+    False for an empty user dict and would hide the WHOLE inventory from a
+    legitimate unrestricted caller.
+    """
+    user = getattr(request, 'current_user', None) or {}
+    scope = user.get('allowed_domains')
+    return record_in_scope(
+        record, lambda d: ctx.auth.domain_matches_scope(d, scope)
+    )
+
+
+def scope_filter_records(ctx: ApiContext, records):
+    return [r for r in records if is_record_in_scope(ctx, r)]
+
+
+def user_has_role(user, min_role) -> bool:
+    level = ROLE_HIERARCHY.get((user or {}).get('role'), -1)
+    return level >= ROLE_HIERARCHY.get(min_role, 999)

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -22,13 +22,16 @@ from flask_restx import Resource, fields
 
 from ..core.metrics import get_metrics_summary, is_prometheus_available
 from ..core.constants import CERTIFICATE_FILES, iter_cert_domain_dirs
-from ..core.auth import ROLE_HIERARCHY
+from .resource_context import (
+    build_context, wants_async, job_accepted, check_domain_scope,
+    is_record_in_scope, scope_filter_records, user_has_role,
+)
 from ..core.utils import utc_now_iso, classify_renewal_error
 from ..core.certificates import DomainOperationInProgress
 from ..core.file_operations import RestoreIncompleteError
-from ..core.cert_service import CertificateService, DomainOutOfScope
+from ..core.cert_service import DomainOutOfScope
 from ..core.audit_context import audit_context_from_request
-from ..core.inventory_view import build_inventory_view, record_in_scope
+from ..core.inventory_view import build_inventory_view
 
 _DOMAIN_RE = re.compile(r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$')
 
@@ -338,98 +341,38 @@ def create_api_resources(api, models, managers):
         managers: Dictionary of manager instances (auth, settings, certificates, etc.)
     """
 
-    auth_manager = managers['auth']
-    settings_manager = managers['settings']
-    certificate_manager = managers['certificates']
-    file_ops = managers['file_ops']
-    cache_manager = managers['cache']
-    dns_manager = managers['dns']
-    deploy_manager = managers.get('deployer')
-    audit_logger = managers.get('audit')
-    # Shared create/renew orchestration. Production wires a single instance via
-    # the container (factory.py); the ``or`` fallback builds one from the
-    # manager set so tests that call create_api_resources with a minimal
-    # managers dict (no 'cert_service'/'events') keep working.
-    cert_service = managers.get('cert_service') or CertificateService(
-        certificate_manager, settings_manager, auth_manager,
-        audit_logger=audit_logger,
-    )
-    # Optional async issuance executor (single-instance, in-process). Absent in
-    # minimal-managers unit tests, in which case create/renew stay synchronous.
-    cert_executor = managers.get('cert_executor')
-
-    _ASYNC_TRUTHY = (True, 1, '1', 'true', 'yes', 'on')
+    # The manager set and the helpers that used to be captured here now live
+    # in modules/api/resource_context.py, so a resource class can be moved into
+    # a module of its own without dragging this closure with it (#669). The
+    # local names below are aliases kept during the decomposition: call sites
+    # move group by group, not all at once.
+    ctx = build_context(managers)
+    auth_manager = ctx.auth
+    settings_manager = ctx.settings
+    certificate_manager = ctx.certificates
+    file_ops = ctx.file_ops
+    cache_manager = ctx.cache
+    dns_manager = ctx.dns
+    deploy_manager = ctx.deployer
+    audit_logger = ctx.audit
+    cert_service = ctx.cert_service
+    cert_executor = ctx.cert_executor
 
     def _wants_async(payload):
-        """True when the caller opted into async issuance via the ``async``
-        body flag or the ``?async=`` query param."""
-        if isinstance(payload, dict) and payload.get('async') in _ASYNC_TRUTHY:
-            return True
-        return request.args.get('async', '').strip().lower() in ('1', 'true', 'yes', 'on')
+        return wants_async(payload)
 
     def _job_accepted(job_id, operation, domain):
-        return {
-            'job_id': job_id,
-            'status': 'queued',
-            'operation': operation,
-            'domain': domain,
-            'status_url': f'/api/certificates/jobs/{job_id}',
-        }
+        return job_accepted(job_id, operation, domain,
+                            f'/api/certificates/jobs/{job_id}')
 
     def _check_domain_scope(domain, operation):
-        """Reject the request if the caller's API-key allowed_domains does
-        not cover *domain*. Returns (response_body, http_status) on denial,
-        or None when access is permitted.
-
-        Sessions and legacy bearer tokens have no allowed_domains set on
-        request.current_user → unrestricted (existing behavior preserved).
-        Only scoped API keys, which now carry an allowed_domains list,
-        will hit a 403.
-        """
-        user = getattr(request, 'current_user', None) or {}
-        if auth_manager.user_can_access_domain(user, domain):
-            return None
-        logger.warning(
-            "Scope denial: user=%s op=%s domain=%s scope=%s",
-            user.get('username'), operation, domain,
-            user.get('allowed_domains'),
-        )
-        if audit_logger:
-            audit_logger.log_authz_denied(
-                operation=operation,
-                resource_type='certificate',
-                resource_id=domain,
-                reason='domain outside scoped key allowed_domains',
-                user=user.get('username'),
-                ip_address=request.remote_addr,
-            )
-        return {
-            'error': f'API key not authorized for domain {domain}',
-            'code': 'DOMAIN_OUT_OF_SCOPE',
-        }, 403
+        return check_domain_scope(ctx, domain, operation)
 
     def _record_in_scope(record):
-        """True if the caller's API-key scope covers any domain the inventory
-        *record* names (subject CN or a SAN). Unrestricted callers (sessions,
-        legacy tokens, unscoped keys) always pass; a scoped key only sees
-        discovered/managed certs within its allowed_domains, matching the
-        boundary CertificateList already enforces. A record with no names is
-        visible only to unrestricted callers.
-
-        Matches CertificateList exactly: scope comes from the user's
-        allowed_domains and is fed to domain_matches_scope, so an unrestricted
-        caller (scope None — including a request whose current_user is unset)
-        sees everything. Using user_can_access_domain here instead would be a
-        regression: it returns False for an empty user dict and would hide the
-        WHOLE inventory from a legitimate unrestricted caller."""
-        user = getattr(request, 'current_user', None) or {}
-        scope = user.get('allowed_domains')
-        return record_in_scope(
-            record, lambda d: auth_manager.domain_matches_scope(d, scope)
-        )
+        return is_record_in_scope(ctx, record)
 
     def _scope_filter_records(records):
-        return [r for r in records if _record_in_scope(r)]
+        return scope_filter_records(ctx, records)
 
     # Health check endpoint
     class HealthCheck(Resource):
@@ -1791,8 +1734,7 @@ def create_api_resources(api, models, managers):
     _PUBLIC_DOWNLOAD_FILES = frozenset({'cert.pem', 'chain.pem', 'fullchain.pem'})
 
     def _user_has_role(user, min_role):
-        level = ROLE_HIERARCHY.get((user or {}).get('role'), -1)
-        return level >= ROLE_HIERARCHY.get(min_role, 999)
+        return user_has_role(user, min_role)
 
     class CertificateDeploymentStatus(Resource):
         @api.doc(security='Bearer')

--- a/modules/core/cert_service.py
+++ b/modules/core/cert_service.py
@@ -17,18 +17,15 @@ adapters map to HTTP 403.
 """
 import logging
 
+from .structured_logging import scrub_log_value
 from .utils import validate_domain, validate_key_options
 
 logger = logging.getLogger(__name__)
 
 
-def _scrub_log(value):
-    """Strip CR/LF from a value before it goes into a log line, so a crafted
-    domain / username / scope cannot forge or inject log entries
-    (CodeQL py/log-injection)."""
-    if value is None:
-        return value
-    return str(value).replace('\r', '').replace('\n', '')
+# Kept as a local alias: this module's call sites read better with the short
+# name, but the implementation now lives once, in the logging module.
+_scrub_log = scrub_log_value
 
 
 class DomainOutOfScope(PermissionError):

--- a/modules/core/structured_logging.py
+++ b/modules/core/structured_logging.py
@@ -107,6 +107,26 @@ def sanitize_text(s: str) -> str:
     return s
 
 
+def scrub_log_value(value):
+    """Strip CR/LF from an attacker-influenced value bound into a log message,
+    so it cannot forge a second log record (CodeQL py/log-injection).
+
+    Lives here, in the logging module, because it was previously an idiom
+    copy-pasted inline at a dozen call sites — and the one denial path that did
+    not receive the copy is exactly the one code scanning flagged.
+
+    Note this is NOT made unnecessary by the JSON formatter. JSON escapes a
+    newline inside a string, so the default configuration is immune; but
+    ``CERTMATE_LOG_JSON=false`` (app.py) selects a plain line formatter where a
+    newline in a username produces a fully attacker-chosen log line, timestamp
+    and level included. The defence has to sit at the call site, not in one of
+    the two formatters.
+    """
+    if value is None:
+        return value
+    return str(value).replace('\r', '').replace('\n', '')
+
+
 class JSONFormatter(logging.Formatter):
     """JSON log formatter for structured logging"""
     

--- a/tests/test_api_resource_contract.py
+++ b/tests/test_api_resource_contract.py
@@ -1,0 +1,111 @@
+"""The set of API resource classes is a contract, pinned before it is moved.
+
+`create_api_resources` is a single 3,700-line function holding 41 classes as
+closures, which is why no route can be imported or tested without constructing
+the whole manager graph — and therefore why the HTTP layer is the least covered
+code in the project (#662, #669).
+
+Breaking it up moves thousands of lines. This exists so that the move is
+verifiable rather than hopeful: whatever the internal arrangement, the factory
+must keep returning exactly the same resource names, and every one must still
+be a usable Flask-RESTX resource. Written before the first line is moved, so
+the net is in place during the work rather than after it.
+"""
+import inspect
+
+import pytest
+from flask import Flask
+from flask_restx import Api, Resource
+
+from modules.api.models import create_api_models
+from modules.api.resources import create_api_resources
+
+pytestmark = [pytest.mark.unit]
+
+# The names the factory returned before any decomposition. Adding a resource is
+# a deliberate change to this list; losing one silently is the failure this
+# guards against.
+EXPECTED_RESOURCES = {
+    'HealthCheck', 'MetricsList', 'DiagnosticsSnapshot',
+    'Settings', 'DNSProviders', 'CAProviderTest',
+    'CacheStats', 'CacheClear',
+    'CertificateList', 'CreateCertificate', 'CertificateDetail',
+    'CertificateDeploymentStatus', 'CertificateDeploymentBrowserReports',
+    'DownloadCertificate', 'DownloadCertificateFile',
+    'RenewCertificate', 'CertificateReissue',
+    'CertificateJob', 'CertificateJobs', 'CertificateAutoRenew',
+    'CertificateRunDeploy', 'CheckDNSAlias', 'CertificateDNSAliasCheck',
+    'InventoryList', 'InventoryConfig', 'InventoryScan',
+    'InventoryCryptoReport', 'InventoryAdopt', 'ZombieScan',
+    'BackupList', 'BackupCreate', 'BackupDownload', 'BackupRestore',
+    'BackupDelete',
+}
+
+
+class _Managers(dict):
+    """Supplies a stub for any manager the factory reaches for."""
+
+    def __missing__(self, key):
+        from unittest.mock import MagicMock
+        value = MagicMock()
+        self[key] = value
+        return value
+
+
+@pytest.fixture(scope='module')
+def resources():
+    from unittest.mock import MagicMock
+
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    api = Api(app, prefix='/api')
+
+    auth_manager = MagicMock()
+    auth_manager.require_role = lambda role: (lambda fn: fn)
+
+    return create_api_resources(api, create_api_models(api),
+                                _Managers(auth=auth_manager))
+
+
+def test_the_factory_returns_exactly_the_expected_resources(resources):
+    returned = set(resources)
+    missing = sorted(EXPECTED_RESOURCES - returned)
+    added = sorted(returned - EXPECTED_RESOURCES)
+    assert not missing, (
+        f'these resources are no longer returned, so their routes cannot be '
+        f'registered and the endpoints disappear silently: {missing}'
+    )
+    assert not added, (
+        f'these resources are new; if that is intended, add them to '
+        f'EXPECTED_RESOURCES deliberately: {added}'
+    )
+
+
+def test_every_returned_resource_is_a_usable_flask_restx_resource(resources):
+    """CONTROL: the names alone are not the contract.
+
+    A decomposition that returned the right keys pointing at something that is
+    not a Resource would satisfy a name-only check and still break every route.
+    """
+    wrong = sorted(
+        name for name, cls in resources.items()
+        if not (inspect.isclass(cls) and issubclass(cls, Resource))
+    )
+    assert not wrong, f'not Flask-RESTX Resource subclasses: {wrong}'
+
+
+def test_every_resource_exposes_at_least_one_http_verb(resources):
+    """A Resource with no verb registers a route that answers 405 to everything.
+
+    Moving code between modules is exactly how a method ends up outside the
+    class it belonged to.
+    """
+    verbs = ('get', 'post', 'put', 'patch', 'delete', 'head', 'options')
+    verbless = sorted(
+        name for name, cls in resources.items()
+        if not any(callable(getattr(cls, verb, None)) for verb in verbs)
+    )
+    assert not verbless, (
+        f'these resources define no HTTP verb, so their routes would answer '
+        f'405 to every request: {verbless}'
+    )

--- a/tests/test_log_values_cannot_forge_a_record.py
+++ b/tests/test_log_values_cannot_forge_a_record.py
@@ -1,0 +1,145 @@
+"""Values bound into a log message must not be able to become a log *record*.
+
+The scope-denial log binds caller-supplied values (username, domain, scope)
+into a message. The JSON formatter escapes a newline inside a string, so the
+default configuration is unaffected — which is precisely why this was easy to
+believe settled. It is not: `CERTMATE_LOG_JSON=false` (app.py) selects a plain
+line formatter, and there a newline in a bound value ends the record and starts
+another one whose timestamp and level the value chooses.
+
+So the property under test is not "the formatter escapes it". It is that the
+values are scrubbed at the call site, under EITHER formatter.
+
+Two-sided on purpose: the control below feeds the same value through an
+unscrubbed message and proves the harness can actually observe forging. Without
+it, a test that only ever sees one line cannot distinguish a working defence
+from a blind assertion.
+"""
+import logging
+from io import StringIO
+
+import pytest
+
+from modules.core.structured_logging import JSONFormatter, scrub_log_value
+
+pytestmark = [pytest.mark.unit]
+
+# The plain formatter app.py selects when CERTMATE_LOG_JSON is not 'true'.
+PLAIN = logging.Formatter(
+    '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S',
+)
+
+# A value carrying a line break plus a complete, well-formed second record.
+HOSTILE = 'someone\n2026-01-01 00:00:00 - modules.core.auth - INFO - forged'
+
+
+def _emit(formatter, message, *args):
+    """Emit one log call and return the physical lines it produced."""
+    stream = StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(formatter)
+    logger = logging.getLogger(f'probe.{id(stream)}')
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+    logger.warning(message, *args)
+    return [line for line in stream.getvalue().strip().splitlines()
+            if line.strip()]
+
+
+@pytest.mark.parametrize('formatter,label', [
+    (PLAIN, 'plain'), (JSONFormatter(), 'json'),
+])
+def test_a_scrubbed_value_stays_inside_one_record(formatter, label):
+    lines = _emit(formatter, 'denial: user=%s', scrub_log_value(HOSTILE))
+    assert len(lines) == 1, (
+        f'under the {label} formatter a scrubbed value still produced '
+        f'{len(lines)} records; a caller-supplied value must never be able to '
+        f'append an entry of its own choosing to the log'
+    )
+
+
+def test_the_harness_can_actually_observe_forging():
+    """CONTROL: the same value, unscrubbed, must break the record in two.
+
+    If this ever stops producing a second line, the assertions above are
+    passing because nothing can forge here, not because the scrub works.
+    """
+    lines = _emit(PLAIN, 'denial: user=%s', HOSTILE)
+    assert len(lines) == 2, (
+        'the plain formatter no longer splits on a newline, so the test above '
+        'proves nothing — re-derive what it should assert'
+    )
+
+
+def test_the_json_formatter_alone_is_not_the_defence():
+    """Records why the scrub is required even though JSON escapes newlines.
+
+    JSON output is immune on its own, so a reader may reasonably conclude the
+    call-site scrub is redundant and remove it. It is not redundant: the plain
+    formatter is operator-selectable, and the control above shows what it does.
+    """
+    assert len(_emit(JSONFormatter(), 'denial: user=%s', HOSTILE)) == 1
+    assert len(_emit(PLAIN, 'denial: user=%s', HOSTILE)) == 2
+
+
+def test_the_denial_path_itself_scrubs_what_it_logs():
+    """The one that guards the actual code.
+
+    Everything above tests the helper and the formatters; none of it would
+    notice the scrub being dropped from the denial path, which is where the
+    values are bound. This drives `check_domain_scope` and counts the records
+    the plain formatter produces.
+    """
+    from flask import Flask
+
+    from modules.api.resource_context import ApiContext
+    from modules.api import resource_context as rc
+
+    stream = StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(PLAIN)
+    rc.logger.handlers = [handler]
+    rc.logger.propagate = False
+    rc.logger.setLevel(logging.INFO)
+
+    class _DenyAll:
+        def user_can_access_domain(self, user, domain):
+            return False
+
+    ctx = ApiContext(
+        auth=_DenyAll(), settings=None, certificates=None, file_ops=None,
+        cache=None, dns=None, deployer=None, audit=None, cert_service=None,
+        cert_executor=None,
+    )
+
+    app = Flask(__name__)
+    with app.test_request_context('/'):
+        from flask import request
+        request.current_user = {'username': HOSTILE, 'allowed_domains': ['x']}
+        body, status = check_scope(ctx)
+
+    assert status == 403, 'the request must still be denied'
+    lines = [line for line in stream.getvalue().strip().splitlines()
+             if line.strip()]
+    assert len(lines) == 1, (
+        f'the scope-denial log emitted {len(lines)} records for one denial; '
+        f'a caller-supplied username must not be able to append a record of '
+        f'its own to the log'
+    )
+
+
+def check_scope(ctx):
+    from modules.api.resource_context import check_domain_scope
+    return check_domain_scope(ctx, 'blocked.example.com', 'renew')
+
+
+def test_scrub_preserves_values_it_has_no_business_changing():
+    """A scrub that mangles ordinary values would only be found in
+    production."""
+    assert scrub_log_value('alice') == 'alice'
+    assert scrub_log_value('*.example.com') == '*.example.com'
+    assert scrub_log_value(['a.example.com', 'b.example.com']) == \
+        "['a.example.com', 'b.example.com']"
+    assert scrub_log_value(None) is None


### PR DESCRIPTION
Refs #669. **Step 1 of the decomposition**, pulled ahead of #662 deliberately.

## Why this comes before the coverage work
`#662` asks for coverage on the HTTP layer (39–60%). But no route can be imported without constructing the entire manager graph, because all 41 classes live inside one 3,700-line closure. I hit this earlier in the milestone: asserting the declared role of **one** route required instantiating the whole factory.

Raising coverage first would mean writing tests against that constraint and rewriting them immediately after. So the split comes first.

## The net before the move
A contract test pins what must survive the refactor, and it was written **before** a line was moved:

- the **34 resource names** the factory returns;
- each is a real Flask-RESTX `Resource`;
- each exposes **at least one HTTP verb** — moving code between modules is exactly how a method ends up outside the class it belonged to, and a verbless Resource answers 405 to everything.

Verified by mutation: dropping a key is caught by name; pointing a key at a non-`Resource` is caught by name.

## The step itself
`build_context` resolves the manager set exactly as the closure did — preserving which absences are a programming error (required, `[]`) and which are a supported configuration (optional, `.get()`), including the `CertificateService` fallback that lets tests pass a minimal manager dict. The six closure helpers become functions taking that context.

**None of the 41 classes is touched here.** The local names stay as aliases delegating to the shared module. This step creates the seam; the classes move group by group, each with the contract test underneath.

## Measurable, not asserted
Closure complexity: **559 → 556**. Small — the helpers were only 69 lines — but 559 is precisely the number the phase-0 complexity ratchet pins, so from here the decomposition reports its own progress. That ratchet comes down as the groups land.

The phase-0 lint gate also caught three imports this refactor orphaned, which is the first time the instruments built earlier in the milestone have policed later work on it.

Full suite green (3175).

🤖 Generated with [Claude Code](https://claude.com/claude-code)