### PR TITLE
refactor: move health, metrics and diagnostics out of the closure

### DIFF
--- a/modules/api/resource_context.py
+++ b/modules/api/resource_context.py
@@ -50,6 +50,12 @@ class ApiContext:
     audit: Optional[Any]
     cert_service: Any
     cert_executor: Optional[Any]
+    # The full manager mapping, for the long tail a diagnostics endpoint
+    # legitimately reaches across (scheduler, storage, oidc, shell_executor...).
+    # The named fields above stay the contract for everything else: enumerating
+    # every optional manager as a field would be a fiction, since a diagnostics
+    # snapshot is by nature a view over the whole application.
+    managers: Any = None
 
 
 def build_context(managers) -> ApiContext:
@@ -86,6 +92,7 @@ def build_context(managers) -> ApiContext:
         # Absent in minimal-managers unit tests, in which case create and renew
         # stay synchronous.
         cert_executor=managers.get('cert_executor'),
+        managers=managers,
     )
 
 

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -20,9 +20,9 @@ from pathlib import Path
 from flask import send_file, after_this_request, current_app, request, jsonify, Response
 from flask_restx import Resource, fields
 
-from ..core.metrics import get_metrics_summary, is_prometheus_available
 from ..core.constants import CERTIFICATE_FILES, iter_cert_domain_dirs
 from .resources_cache import create_cache_resources
+from .resources_health import create_health_resources
 from .resource_context import (
     build_context, wants_async, job_accepted, check_domain_scope,
     is_record_in_scope, scope_filter_records, user_has_role,
@@ -350,7 +350,10 @@ def create_api_resources(api, models, managers):
     ctx = build_context(managers)
     # Groups that have moved into modules of their own build here and
     # are merged into the returned mapping below (#669).
-    extracted = create_cache_resources(api, models, ctx)
+    extracted = {
+        **create_cache_resources(api, models, ctx),
+        **create_health_resources(api, models, ctx),
+    }
     auth_manager = ctx.auth
     settings_manager = ctx.settings
     certificate_manager = ctx.certificates
@@ -379,73 +382,8 @@ def create_api_resources(api, models, managers):
         return scope_filter_records(ctx, records)
 
     # Health check endpoint
-    class HealthCheck(Resource):
-        def get(self):
-            """Health check: settings readable + background scheduler running."""
-            checks = {}
-            overall = 'healthy'
-            try:
-                settings_manager.load_settings()
-                checks['settings'] = 'ok'
-            except Exception as e:
-                logger.error(f"Health check failed (settings): {e}")
-                checks['settings'] = 'error'
-                overall = 'unhealthy'
-
-            scheduler = managers.get('scheduler')
-            scheduler_running = bool(scheduler and getattr(scheduler, 'running', False))
-            checks['scheduler'] = 'running' if scheduler_running else 'not_running'
-            if not scheduler_running:
-                # The scheduler being down means renewals stop firing — surface it
-                # as 'degraded' so monitoring catches it without flapping liveness.
-                if overall == 'healthy':
-                    overall = 'degraded'
-
-            # Surface a storage-backend fallback: if the configured cloud/remote
-            # backend failed to initialise, CertMate silently uses local disk —
-            # the operator thinks certs are in Azure/Vault/S3 but they are not.
-            # Only a log line signalled this before; make monitoring see it.
-            storage = managers.get('storage')
-            if storage is not None and hasattr(storage, 'get_fallback_backend'):
-                try:
-                    fell_back_from = storage.get_fallback_backend()
-                except Exception:
-                    fell_back_from = None
-                if fell_back_from:
-                    checks['storage'] = f'fallback_to_local (configured backend: {fell_back_from})'
-                    if overall == 'healthy':
-                        overall = 'degraded'
-                else:
-                    checks['storage'] = 'ok'
-
-            status_code = 200 if overall != 'unhealthy' else 500
-            return {'status': overall, 'checks': checks}, status_code
 
     # Metrics endpoints
-    class MetricsList(Resource):
-        # Gated like its sibling info endpoints (CacheStats, BackupList).
-        # This JSON summary lives in the authenticated API and must require at
-        # least a viewer credential, not be reachable unauthenticated. The
-        # Prometheus scrape target is the separate '/metrics' route, which is
-        # NOT public: it carries the same viewer requirement, because its
-        # series enumerate every managed domain.
-        @api.doc(security='Bearer')
-        @auth_manager.require_role('viewer')
-        def get(self):
-            """Get available metrics information"""
-            try:
-                if not is_prometheus_available():
-                    return {'error': 'Prometheus metrics not available'}, 503
-
-                summary = get_metrics_summary()
-                return {
-                    'available': True,
-                    'metrics_endpoint': '/metrics',
-                    'summary': summary
-                }
-            except Exception as e:
-                logger.error(f"Error getting metrics info: {e}")
-                return {'error': 'Failed to get metrics information'}, 500
 
     # Diagnostic snapshot endpoint — closes #150. Powers the "Report this
     # issue" button in the error toast: when an admin hits a recoverable
@@ -463,252 +401,6 @@ def create_api_resources(api, models, managers):
     # Sanitization is enforced inline in this handler, not deferred to a
     # generic mask helper, so a future contributor adding a field is
     # forced to think about whether to include it.
-    class DiagnosticsSnapshot(Resource):
-        @api.doc(security='Bearer')
-        @auth_manager.require_role('admin')
-        def get(self):
-            """Build a sanitized diagnostic snapshot for bug-report use."""
-            import platform
-            import shutil
-            import sys
-            import os
-            import ssl
-            import json
-
-            from .. import __version__ as _certmate_version
-
-            errors = {}
-
-            # --- System info ---
-            cryptography_version = None
-            try:
-                import cryptography
-                cryptography_version = cryptography.__version__
-            except Exception as e:
-                logger.warning(f"Diagnostic: failed to read cryptography version: {e}")
-                errors['cryptography_version'] = 'unavailable'
-
-            openssl_version = None
-            try:
-                openssl_version = ssl.OPENSSL_VERSION
-            except Exception as e:
-                logger.warning(f"Diagnostic: failed to read OpenSSL version: {e}")
-                errors['openssl_version'] = 'unavailable'
-
-            shell_executor = managers.get('shell_executor') or (certificate_manager and getattr(certificate_manager, 'shell_executor', None))
-            certbot_version = None
-            if shell_executor:
-                try:
-                    res = shell_executor.run(['.venv/bin/certbot', '--version'], timeout=5)
-                    if res and hasattr(res, 'stdout') and isinstance(res.stdout, str):
-                        stdout_str = res.stdout or ''
-                        stderr_str = res.stderr or '' if isinstance(res.stderr, str) else ''
-                        out = stdout_str + stderr_str
-                        if out.strip():
-                            certbot_version = out.strip()
-                except Exception as e:
-                    logger.debug("Failed to run .venv/bin/certbot --version: %s", e)
-                if not certbot_version:
-                    try:
-                        res = shell_executor.run(['certbot', '--version'], timeout=5)
-                        if res and hasattr(res, 'stdout') and isinstance(res.stdout, str):
-                            stdout_str = res.stdout or ''
-                            stderr_str = res.stderr or '' if isinstance(res.stderr, str) else ''
-                            out = stdout_str + stderr_str
-                            if out.strip():
-                                certbot_version = out.strip()
-                    except Exception as e:
-                        logger.debug("Failed to run certbot --version fallback: %s", e)
-            if not certbot_version:
-                errors['certbot_version'] = 'unavailable'
-
-            # --- Storage health ---
-            cert_dir = getattr(certificate_manager, 'cert_dir', None)
-            data_dir = current_app.config.get('DATA_DIR') or '.'
-
-            cert_dir_path = cert_dir if isinstance(cert_dir, (str, Path)) else None
-            data_dir_path = data_dir if isinstance(data_dir, (str, Path)) else None
-
-            storage_permissions = {
-                'cert_dir_readable': os.access(str(cert_dir_path), os.R_OK) if cert_dir_path else False,
-                'cert_dir_writable': os.access(str(cert_dir_path), os.W_OK) if cert_dir_path else False,
-                'data_dir_readable': os.access(str(data_dir_path), os.R_OK) if data_dir_path else False,
-                'data_dir_writable': os.access(str(data_dir_path), os.W_OK) if data_dir_path else False,
-            }
-
-            # --- Application / runtime identity ---
-            payload = {
-                'certmate_version': _certmate_version,
-                'python_version': sys.version.split()[0],
-                'os_platform': platform.platform(),
-                'container': Path('/.dockerenv').exists(),
-                'cryptography_version': cryptography_version,
-                'openssl_version': openssl_version,
-                'certbot_version': certbot_version,
-                'storage_permissions': storage_permissions,
-            }
-
-            # --- Background scheduler liveness ---
-            scheduler = managers.get('scheduler')
-            payload['scheduler_running'] = bool(
-                scheduler and getattr(scheduler, 'running', False)
-            )
-
-            # --- Certificate inventory cardinality ---
-            # Count on-disk cert stores the same way the rest of the codebase
-            # discovers them. CertificateManager has no list_certificates()
-            # method (that lives on storage backends), so the old call always
-            # raised and reported a null count.
-            try:
-                payload['certificate_count'] = sum(
-                    1 for _ in iter_cert_domain_dirs(certificate_manager.cert_dir)
-                )
-            except Exception as e:
-                logger.warning(f"Diagnostic: failed to count certificates: {e}")
-                payload['certificate_count'] = None
-                errors['certificate_count'] = 'failed_to_enumerate'
-
-            # --- Configuration scalars & summary ---
-            try:
-                settings = settings_manager.load_settings() or {}
-                payload['dns_provider'] = settings.get('dns_provider')
-                payload['default_ca'] = settings.get('default_ca')
-                payload['challenge_type'] = settings.get('challenge_type')
-                cert_storage = settings.get('certificate_storage') or {}
-                payload['storage_backend'] = cert_storage.get('backend')
-                payload['configured_domains_count'] = len(settings.get('domains', [])) if isinstance(settings.get('domains'), list) else 0
-
-                # Active DNS providers (by type, with credentials omitted)
-                active_dns_providers = {}
-                dns_providers = settings.get('dns_providers', {})
-                if isinstance(dns_providers, dict):
-                    for provider_name, provider_config in dns_providers.items():
-                        if not provider_config or not isinstance(provider_config, dict):
-                            continue
-                        accounts_list = []
-                        if 'accounts' in provider_config and isinstance(provider_config['accounts'], dict):
-                            for acc_id, acc_config in provider_config['accounts'].items():
-                                if isinstance(acc_config, dict):
-                                    accounts_list.append({
-                                        'id': acc_id,
-                                        'name': acc_config.get('name', acc_id),
-                                        'description': acc_config.get('description', '')
-                                    })
-                        else:
-                            accounts_list.append({
-                                'id': 'default',
-                                'name': provider_config.get('name', 'Default Account'),
-                                'description': provider_config.get('description', 'Legacy single-account config')
-                            })
-                        if accounts_list:
-                            active_dns_providers[provider_name] = accounts_list
-                payload['active_dns_providers'] = active_dns_providers
-
-            except Exception as e:
-                logger.warning(f"Diagnostic: failed to read settings scalars: {e}")
-                errors['settings'] = 'failed_to_read'
-
-            # SSO / OIDC status
-            try:
-                oidc_manager = managers.get('oidc')
-                if oidc_manager:
-                    enabled_val = oidc_manager.is_enabled()
-                    payload['sso_oidc_enabled'] = bool(enabled_val) if isinstance(enabled_val, bool) else False
-                else:
-                    payload['sso_oidc_enabled'] = False
-            except Exception as e:
-                logger.warning(f"Diagnostic: failed to query OIDC status: {e}")
-                payload['sso_oidc_enabled'] = False
-                errors['sso_oidc'] = 'failed_to_query'
-
-            # --- Free disk on the data partition ---
-            try:
-                data_dir_path = current_app.config.get('DATA_DIR') or '.'
-                usage = shutil.disk_usage(str(data_dir_path))
-                payload['disk_free_bytes'] = usage.free
-                payload['disk_total_bytes'] = usage.total
-            except Exception as e:
-                logger.warning(f"Diagnostic: disk_usage failed: {e}")
-                payload['disk_free_bytes'] = None
-                payload['disk_total_bytes'] = None
-                errors['disk_usage'] = 'permission_or_path_unavailable'
-
-            # --- Backup history ---
-            backup_count = 0
-            backup_total_size = 0
-            file_ops = managers.get('file_ops')
-            if file_ops:
-                try:
-                    backups = file_ops.list_backups()
-                    if isinstance(backups, dict):
-                        unified_list = backups.get('unified', [])
-                        if isinstance(unified_list, list):
-                            backup_count = len(unified_list)
-                            backup_total_size = sum(item.get('metadata', {}).get('size', 0) for item in unified_list if isinstance(item, dict))
-                except Exception as e:
-                    logger.warning(f"Diagnostic: failed to read backup metrics: {e}")
-                    errors['backups'] = 'failed_to_list'
-            payload['backup_count'] = backup_count
-            payload['backup_total_size'] = backup_total_size
-
-            # --- Sanitized Logs (last 50 lines) ---
-            sanitized_logs = []
-            if file_ops and getattr(file_ops, 'logs_dir', None) and isinstance(file_ops.logs_dir, (str, Path)):
-                try:
-                    log_file = file_ops.logs_dir / 'certmate.log'
-                    if log_file.exists() and log_file.is_file():
-                        from collections import deque
-                        with open(log_file, 'r', encoding='utf-8') as f:
-                            last_lines = list(deque(f, maxlen=50))
-                        
-                        from modules.core.structured_logging import JSONFormatter
-                        formatter = JSONFormatter()
-                        
-                        for line in last_lines:
-                            line_str = line.strip()
-                            if not line_str:
-                                continue
-                            try:
-                                parsed = json.loads(line_str)
-                                sanitized_parsed = formatter.sanitize_data(parsed)
-                                sanitized_logs.append(sanitized_parsed)
-                            except Exception:
-                                sanitized_str = formatter.sanitize_data(line_str)
-                                sanitized_logs.append(sanitized_str)
-                except Exception as e:
-                    logger.warning(f"Diagnostic: failed to read sanitized logs: {e}")
-                    errors['sanitized_logs'] = 'failed_to_read'
-            payload['sanitized_logs'] = sanitized_logs
-
-            # --- Recent audit (sanitized: identifiers stripped) ---
-            # Only timestamp / operation / resource_type / status survive
-            # the round-trip. Domain names, usernames, IP addresses, and
-            # the audit details payload are all dropped before
-            # serialization. Anyone reading the resulting bug report
-            # sees operational tempo without learning who did what to
-            # which domain from which IP.
-            try:
-                raw_entries = audit_logger.get_recent_entries(limit=5) if audit_logger else []
-                if isinstance(raw_entries, list):
-                    payload['recent_audit'] = [
-                        {
-                            'timestamp': (e or {}).get('timestamp'),
-                            'operation': (e or {}).get('operation'),
-                            'resource_type': (e or {}).get('resource_type'),
-                            'status': (e or {}).get('status'),
-                        }
-                        for e in raw_entries[:5] if isinstance(e, dict)
-                    ]
-                else:
-                    payload['recent_audit'] = []
-            except Exception as e:
-                logger.warning(f"Diagnostic: audit log read failed: {e}")
-                payload['recent_audit'] = []
-                errors['recent_audit'] = 'failed_to_read'
-
-            if errors:
-                payload['errors'] = errors
-            return payload, 200
 
     # Settings endpoints
     class Settings(Resource):
@@ -3892,9 +3584,6 @@ def create_api_resources(api, models, managers):
     # Return all resource classes (CA provider test will be registered in app.py)
     return {
         **extracted,
-        'HealthCheck': HealthCheck,
-        'MetricsList': MetricsList,
-        'DiagnosticsSnapshot': DiagnosticsSnapshot,
         'Settings': Settings,
         'DNSProviders': DNSProviders,
         'CertificateList': CertificateList,

--- a/modules/api/resources_health.py
+++ b/modules/api/resources_health.py
@@ -1,0 +1,342 @@
+"""Liveness, metrics and the diagnostics snapshot.
+
+Extracted from the `create_api_resources` closure (#669). The classes are
+unchanged; the managers they used to capture now arrive as an explicit
+`ApiContext`, which is what lets them be imported — and tested — without
+building the whole graph.
+"""
+import logging
+from pathlib import Path
+
+from flask import current_app
+from flask_restx import Resource
+
+from ..core.constants import iter_cert_domain_dirs
+from ..core.metrics import get_metrics_summary, is_prometheus_available
+from .resource_context import ApiContext
+
+logger = logging.getLogger(__name__)
+
+
+def create_health_resources(api, models, ctx: ApiContext) -> dict:
+    """Build the health, metrics and diagnostics resources against *ctx*."""
+
+    class HealthCheck(Resource):
+        def get(self):
+            """Health check: settings readable + background scheduler running."""
+            checks = {}
+            overall = 'healthy'
+            try:
+                ctx.settings.load_settings()
+                checks['settings'] = 'ok'
+            except Exception as e:
+                logger.error(f"Health check failed (settings): {e}")
+                checks['settings'] = 'error'
+                overall = 'unhealthy'
+
+            scheduler = ctx.managers.get('scheduler')
+            scheduler_running = bool(scheduler and getattr(scheduler, 'running', False))
+            checks['scheduler'] = 'running' if scheduler_running else 'not_running'
+            if not scheduler_running:
+                # The scheduler being down means renewals stop firing — surface it
+                # as 'degraded' so monitoring catches it without flapping liveness.
+                if overall == 'healthy':
+                    overall = 'degraded'
+
+            # Surface a storage-backend fallback: if the configured cloud/remote
+            # backend failed to initialise, CertMate silently uses local disk —
+            # the operator thinks certs are in Azure/Vault/S3 but they are not.
+            # Only a log line signalled this before; make monitoring see it.
+            storage = ctx.managers.get('storage')
+            if storage is not None and hasattr(storage, 'get_fallback_backend'):
+                try:
+                    fell_back_from = storage.get_fallback_backend()
+                except Exception:
+                    fell_back_from = None
+                if fell_back_from:
+                    checks['storage'] = f'fallback_to_local (configured backend: {fell_back_from})'
+                    if overall == 'healthy':
+                        overall = 'degraded'
+                else:
+                    checks['storage'] = 'ok'
+
+            status_code = 200 if overall != 'unhealthy' else 500
+            return {'status': overall, 'checks': checks}, status_code
+
+    class MetricsList(Resource):
+        # Gated like its sibling info endpoints (CacheStats, BackupList).
+        # This JSON summary lives in the authenticated API and must require at
+        # least a viewer credential, not be reachable unauthenticated. The
+        # Prometheus scrape target is the separate '/metrics' route, which is
+        # NOT public: it carries the same viewer requirement, because its
+        # series enumerate every managed domain.
+        @api.doc(security='Bearer')
+        @ctx.auth.require_role('viewer')
+        def get(self):
+            """Get available metrics information"""
+            try:
+                if not is_prometheus_available():
+                    return {'error': 'Prometheus metrics not available'}, 503
+
+                summary = get_metrics_summary()
+                return {
+                    'available': True,
+                    'metrics_endpoint': '/metrics',
+                    'summary': summary
+                }
+            except Exception as e:
+                logger.error(f"Error getting metrics info: {e}")
+                return {'error': 'Failed to get metrics information'}, 500
+
+    class DiagnosticsSnapshot(Resource):
+        @api.doc(security='Bearer')
+        @ctx.auth.require_role('admin')
+        def get(self):
+            """Build a sanitized diagnostic snapshot for bug-report use."""
+            import platform
+            import shutil
+            import sys
+            import os
+            import ssl
+            import json
+
+            from .. import __version__ as _certmate_version
+
+            errors = {}
+
+            # --- System info ---
+            cryptography_version = None
+            try:
+                import cryptography
+                cryptography_version = cryptography.__version__
+            except Exception as e:
+                logger.warning(f"Diagnostic: failed to read cryptography version: {e}")
+                errors['cryptography_version'] = 'unavailable'
+
+            openssl_version = None
+            try:
+                openssl_version = ssl.OPENSSL_VERSION
+            except Exception as e:
+                logger.warning(f"Diagnostic: failed to read OpenSSL version: {e}")
+                errors['openssl_version'] = 'unavailable'
+
+            shell_executor = ctx.managers.get('shell_executor') or (ctx.certificates and getattr(ctx.certificates, 'shell_executor', None))
+            certbot_version = None
+            if shell_executor:
+                try:
+                    res = shell_executor.run(['.venv/bin/certbot', '--version'], timeout=5)
+                    if res and hasattr(res, 'stdout') and isinstance(res.stdout, str):
+                        stdout_str = res.stdout or ''
+                        stderr_str = res.stderr or '' if isinstance(res.stderr, str) else ''
+                        out = stdout_str + stderr_str
+                        if out.strip():
+                            certbot_version = out.strip()
+                except Exception as e:
+                    logger.debug("Failed to run .venv/bin/certbot --version: %s", e)
+                if not certbot_version:
+                    try:
+                        res = shell_executor.run(['certbot', '--version'], timeout=5)
+                        if res and hasattr(res, 'stdout') and isinstance(res.stdout, str):
+                            stdout_str = res.stdout or ''
+                            stderr_str = res.stderr or '' if isinstance(res.stderr, str) else ''
+                            out = stdout_str + stderr_str
+                            if out.strip():
+                                certbot_version = out.strip()
+                    except Exception as e:
+                        logger.debug("Failed to run certbot --version fallback: %s", e)
+            if not certbot_version:
+                errors['certbot_version'] = 'unavailable'
+
+            # --- Storage health ---
+            cert_dir = getattr(ctx.certificates, 'cert_dir', None)
+            data_dir = current_app.config.get('DATA_DIR') or '.'
+
+            cert_dir_path = cert_dir if isinstance(cert_dir, (str, Path)) else None
+            data_dir_path = data_dir if isinstance(data_dir, (str, Path)) else None
+
+            storage_permissions = {
+                'cert_dir_readable': os.access(str(cert_dir_path), os.R_OK) if cert_dir_path else False,
+                'cert_dir_writable': os.access(str(cert_dir_path), os.W_OK) if cert_dir_path else False,
+                'data_dir_readable': os.access(str(data_dir_path), os.R_OK) if data_dir_path else False,
+                'data_dir_writable': os.access(str(data_dir_path), os.W_OK) if data_dir_path else False,
+            }
+
+            # --- Application / runtime identity ---
+            payload = {
+                'certmate_version': _certmate_version,
+                'python_version': sys.version.split()[0],
+                'os_platform': platform.platform(),
+                'container': Path('/.dockerenv').exists(),
+                'cryptography_version': cryptography_version,
+                'openssl_version': openssl_version,
+                'certbot_version': certbot_version,
+                'storage_permissions': storage_permissions,
+            }
+
+            # --- Background scheduler liveness ---
+            scheduler = ctx.managers.get('scheduler')
+            payload['scheduler_running'] = bool(
+                scheduler and getattr(scheduler, 'running', False)
+            )
+
+            # --- Certificate inventory cardinality ---
+            # Count on-disk cert stores the same way the rest of the codebase
+            # discovers them. CertificateManager has no list_certificates()
+            # method (that lives on storage backends), so the old call always
+            # raised and reported a null count.
+            try:
+                payload['certificate_count'] = sum(
+                    1 for _ in iter_cert_domain_dirs(ctx.certificates.cert_dir)
+                )
+            except Exception as e:
+                logger.warning(f"Diagnostic: failed to count certificates: {e}")
+                payload['certificate_count'] = None
+                errors['certificate_count'] = 'failed_to_enumerate'
+
+            # --- Configuration scalars & summary ---
+            try:
+                settings = ctx.settings.load_settings() or {}
+                payload['dns_provider'] = settings.get('dns_provider')
+                payload['default_ca'] = settings.get('default_ca')
+                payload['challenge_type'] = settings.get('challenge_type')
+                cert_storage = settings.get('certificate_storage') or {}
+                payload['storage_backend'] = cert_storage.get('backend')
+                payload['configured_domains_count'] = len(settings.get('domains', [])) if isinstance(settings.get('domains'), list) else 0
+
+                # Active DNS providers (by type, with credentials omitted)
+                active_dns_providers = {}
+                dns_providers = settings.get('dns_providers', {})
+                if isinstance(dns_providers, dict):
+                    for provider_name, provider_config in dns_providers.items():
+                        if not provider_config or not isinstance(provider_config, dict):
+                            continue
+                        accounts_list = []
+                        if 'accounts' in provider_config and isinstance(provider_config['accounts'], dict):
+                            for acc_id, acc_config in provider_config['accounts'].items():
+                                if isinstance(acc_config, dict):
+                                    accounts_list.append({
+                                        'id': acc_id,
+                                        'name': acc_config.get('name', acc_id),
+                                        'description': acc_config.get('description', '')
+                                    })
+                        else:
+                            accounts_list.append({
+                                'id': 'default',
+                                'name': provider_config.get('name', 'Default Account'),
+                                'description': provider_config.get('description', 'Legacy single-account config')
+                            })
+                        if accounts_list:
+                            active_dns_providers[provider_name] = accounts_list
+                payload['active_dns_providers'] = active_dns_providers
+
+            except Exception as e:
+                logger.warning(f"Diagnostic: failed to read settings scalars: {e}")
+                errors['settings'] = 'failed_to_read'
+
+            # SSO / OIDC status
+            try:
+                oidc_manager = ctx.managers.get('oidc')
+                if oidc_manager:
+                    enabled_val = oidc_manager.is_enabled()
+                    payload['sso_oidc_enabled'] = bool(enabled_val) if isinstance(enabled_val, bool) else False
+                else:
+                    payload['sso_oidc_enabled'] = False
+            except Exception as e:
+                logger.warning(f"Diagnostic: failed to query OIDC status: {e}")
+                payload['sso_oidc_enabled'] = False
+                errors['sso_oidc'] = 'failed_to_query'
+
+            # --- Free disk on the data partition ---
+            try:
+                data_dir_path = current_app.config.get('DATA_DIR') or '.'
+                usage = shutil.disk_usage(str(data_dir_path))
+                payload['disk_free_bytes'] = usage.free
+                payload['disk_total_bytes'] = usage.total
+            except Exception as e:
+                logger.warning(f"Diagnostic: disk_usage failed: {e}")
+                payload['disk_free_bytes'] = None
+                payload['disk_total_bytes'] = None
+                errors['disk_usage'] = 'permission_or_path_unavailable'
+
+            # --- Backup history ---
+            backup_count = 0
+            backup_total_size = 0
+            file_ops = ctx.managers.get('file_ops')
+            if file_ops:
+                try:
+                    backups = ctx.file_ops.list_backups()
+                    if isinstance(backups, dict):
+                        unified_list = backups.get('unified', [])
+                        if isinstance(unified_list, list):
+                            backup_count = len(unified_list)
+                            backup_total_size = sum(item.get('metadata', {}).get('size', 0) for item in unified_list if isinstance(item, dict))
+                except Exception as e:
+                    logger.warning(f"Diagnostic: failed to read backup metrics: {e}")
+                    errors['backups'] = 'failed_to_list'
+            payload['backup_count'] = backup_count
+            payload['backup_total_size'] = backup_total_size
+
+            # --- Sanitized Logs (last 50 lines) ---
+            sanitized_logs = []
+            if file_ops and getattr(ctx.file_ops, 'logs_dir', None) and isinstance(ctx.file_ops.logs_dir, (str, Path)):
+                try:
+                    log_file = ctx.file_ops.logs_dir / 'certmate.log'
+                    if log_file.exists() and log_file.is_file():
+                        from collections import deque
+                        with open(log_file, 'r', encoding='utf-8') as f:
+                            last_lines = list(deque(f, maxlen=50))
+
+                        from modules.core.structured_logging import JSONFormatter
+                        formatter = JSONFormatter()
+
+                        for line in last_lines:
+                            line_str = line.strip()
+                            if not line_str:
+                                continue
+                            try:
+                                parsed = json.loads(line_str)
+                                sanitized_parsed = formatter.sanitize_data(parsed)
+                                sanitized_logs.append(sanitized_parsed)
+                            except Exception:
+                                sanitized_str = formatter.sanitize_data(line_str)
+                                sanitized_logs.append(sanitized_str)
+                except Exception as e:
+                    logger.warning(f"Diagnostic: failed to read sanitized logs: {e}")
+                    errors['sanitized_logs'] = 'failed_to_read'
+            payload['sanitized_logs'] = sanitized_logs
+
+            # --- Recent audit (sanitized: identifiers stripped) ---
+            # Only timestamp / operation / resource_type / status survive
+            # the round-trip. Domain names, usernames, IP addresses, and
+            # the audit details payload are all dropped before
+            # serialization. Anyone reading the resulting bug report
+            # sees operational tempo without learning who did what to
+            # which domain from which IP.
+            try:
+                raw_entries = ctx.audit.get_recent_entries(limit=5) if ctx.audit else []
+                if isinstance(raw_entries, list):
+                    payload['recent_audit'] = [
+                        {
+                            'timestamp': (e or {}).get('timestamp'),
+                            'operation': (e or {}).get('operation'),
+                            'resource_type': (e or {}).get('resource_type'),
+                            'status': (e or {}).get('status'),
+                        }
+                        for e in raw_entries[:5] if isinstance(e, dict)
+                    ]
+                else:
+                    payload['recent_audit'] = []
+            except Exception as e:
+                logger.warning(f"Diagnostic: audit log read failed: {e}")
+                payload['recent_audit'] = []
+                errors['recent_audit'] = 'failed_to_read'
+
+            if errors:
+                payload['errors'] = errors
+            return payload, 200
+
+    return {
+        'HealthCheck': HealthCheck,
+        'MetricsList': MetricsList,
+        'DiagnosticsSnapshot': DiagnosticsSnapshot,
+    }

--- a/tests/test_api_group_modules_are_standalone.py
+++ b/tests/test_api_group_modules_are_standalone.py
@@ -17,6 +17,7 @@ from flask_restx import Api, Resource
 
 from modules.api.resource_context import ApiContext
 from modules.api.resources_cache import create_cache_resources
+from modules.api.resources_health import create_health_resources
 
 pytestmark = [pytest.mark.unit]
 
@@ -67,3 +68,29 @@ def test_the_cache_group_needs_no_certificate_manager(api):
     ctx = _minimal_context(cache=MagicMock(), certificates=None)
     resources = create_cache_resources(api, models, ctx)
     assert resources, 'the group must build with no certificate manager at all'
+
+
+def test_the_health_group_builds_from_a_minimal_context(api):
+    """Diagnostics reaches across the application by nature, so its context
+    carries the manager mapping — but it must still build without the closure.
+    """
+    models = {'health_model': MagicMock(), 'metrics_model': MagicMock()}
+    ctx = _minimal_context(
+        settings=MagicMock(), certificates=MagicMock(), file_ops=MagicMock(),
+        managers={},
+    )
+    resources = create_health_resources(api, models, ctx)
+
+    assert set(resources) == {
+        'HealthCheck', 'MetricsList', 'DiagnosticsSnapshot'}
+    for name, cls in resources.items():
+        assert issubclass(cls, Resource), f'{name} is not a Resource'
+
+
+def test_the_health_group_tolerates_an_empty_manager_mapping(api):
+    """CONTROL: the long-tail managers are optional, as they were in the
+    closure — a diagnostics endpoint must degrade, not refuse to build."""
+    models = {'health_model': MagicMock(), 'metrics_model': MagicMock()}
+    ctx = _minimal_context(settings=MagicMock(), certificates=MagicMock(),
+                           file_ops=MagicMock(), managers={})
+    assert create_health_resources(api, models, ctx)


### PR DESCRIPTION
Third step of #669. Stacked on #692 (cache group), which is stacked on #691.

`HealthCheck`, `MetricsList` and `DiagnosticsSnapshot` move into
`modules/api/resources_health.py`, built by `create_health_resources(api, models, ctx)`.

### What this buys

These three are the endpoints most worth testing directly and the ones that were
hardest to reach: getting at `/api/health` meant constructing the entire manager
graph, because the class only existed inside `create_api_resources`. They can now
be built on their own.

Closure complexity is down to 485 (from 559 at the start of #669), and
`resources.py` is 3616 lines (from 4040).

### The one thing worth a reviewer's attention

`ApiContext` gains a `managers` field holding the full mapping. `DiagnosticsSnapshot`
legitimately reaches `scheduler`, `storage`, `oidc` and `shell_executor`, and
enumerating each as a named field would be a fiction — a diagnostics snapshot is by
nature a view over the whole application. The ten named fields remain the contract
for everything else.

This was caught the honest way: the extraction initially passed the contract test
while the code raised `NameError` at request time, because the classes used
`managers` directly along with `current_app`, `Path` and `iter_cert_domain_dirs`.
Thirteen tests failed. `test_api_group_modules_are_standalone.py` now builds each
extracted group without the manager graph, so a group that only *looks* extracted
fails the build rather than the first request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)