### PR TITLE
refactor: move the backup endpoints out of the closure

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -18,10 +18,14 @@ import os
 import io
 from pathlib import Path
 from flask import send_file, after_this_request, current_app, request, jsonify, Response
-from flask_restx import Resource, fields
+from flask_restx import Resource
 
 from ..core.constants import CERTIFICATE_FILES, iter_cert_domain_dirs
 from .resources_cache import create_cache_resources
+from .resources_backup import create_backup_resources
+# Re-exported: it moved to resources_backup with the endpoints that use it,
+# and tests import it from here.
+from .resources_backup import _validate_backup_filename  # noqa: F401
 from .resources_health import create_health_resources
 from .resource_context import (
     build_context, wants_async, job_accepted, check_domain_scope,
@@ -29,7 +33,6 @@ from .resource_context import (
 )
 from ..core.utils import utc_now_iso, classify_renewal_error
 from ..core.certificates import DomainOperationInProgress
-from ..core.file_operations import RestoreIncompleteError
 from ..core.cert_service import DomainOutOfScope
 from ..core.audit_context import audit_context_from_request
 from ..core.inventory_view import build_inventory_view
@@ -37,17 +40,6 @@ from ..core.inventory_view import build_inventory_view
 _DOMAIN_RE = re.compile(r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$')
 
 
-def _validate_backup_filename(filename):
-    """Reject path traversal attempts in backup filenames. Returns error string or None."""
-    if not filename:
-        return 'Filename is required'
-    if '..' in filename or '/' in filename or '\\' in filename or '\x00' in filename:
-        return 'Invalid filename'
-    # .zip = cleartext backup, .zip.enc = encrypted-at-rest backup
-    # (CERTMATE_BACKUP_PASSPHRASE).
-    if not (filename.endswith('.zip') or filename.endswith('.zip.enc')):
-        return 'Invalid backup file format'
-    return None
 
 
 def _validate_domain_path(domain, cert_base_dir):
@@ -353,6 +345,7 @@ def create_api_resources(api, models, managers):
     extracted = {
         **create_cache_resources(api, models, ctx),
         **create_health_resources(api, models, ctx),
+        **create_backup_resources(api, models, ctx),
     }
     auth_manager = ctx.auth
     settings_manager = ctx.settings
@@ -2281,109 +2274,7 @@ def create_api_resources(api, models, managers):
             return summary, 200
 
     # Backup endpoints (Unified backup system for atomic consistency)
-    class BackupList(Resource):
-        @api.doc(security='Bearer')
-        @api.marshal_with(models['backup_list_model'])
-        @auth_manager.require_role('viewer')
-        def get(self):
-            """List all available backups"""
-            try:
-                backups = file_ops.list_backups()
-                return backups
-            except Exception as e:
-                logger.error(f"Error listing backups: {e}")
-                return {'error': 'Failed to list backups'}, 500
 
-    class BackupCreate(Resource):
-        @api.doc(security='Bearer')
-        @api.expect(api.model('BackupCreateRequest', {
-            'type': fields.String(required=True, enum=['unified', 'settings', 'certificates', 'both'],
-                                  description='Type of backup to create (unified recommended for data consistency)'),
-            'reason': fields.String(description='Reason for backup creation', default='manual'),
-            'include_secrets': fields.Boolean(
-                description=(
-                    'Default false: every secret-bearing field is replaced '
-                    'with the mask sentinel in the resulting zip, so the '
-                    'file is safe to share. true: produces a plaintext '
-                    'snapshot for disaster-recovery restore; the resulting '
-                    'file on disk now contains every credential and a '
-                    'dedicated audit-log entry records the opt-in.'
-                ),
-                default=False,
-            ),
-        }))
-        @auth_manager.require_role('admin')
-        def post(self):
-            """Create a new backup (unified format recommended)"""
-            try:
-                data = api.payload
-                backup_type = data.get('type', 'unified')  # Default to unified
-                reason = data.get('reason', 'manual')
-                # `include_secrets` decides between a share-safe masked archive
-                # and a plaintext dump of every credential and private key, so
-                # it MUST be a real JSON boolean. bool() coercion was the trap:
-                # bool("false") is True, so a client sending the value as a
-                # string — trivial in a shell or an untyped template —
-                # asked for masked and got the plaintext dump. Accept only a
-                # JSON boolean; anything else is refused rather than guessed,
-                # and the safe default (masked) applies only when it is absent.
-                raw_include = data.get('include_secrets', False)
-                if not isinstance(raw_include, bool):
-                    return {
-                        'error': 'include_secrets must be a JSON boolean '
-                                 '(true or false)'
-                    }, 400
-                include_secrets = raw_include
-
-                created_backups = []
-
-                # Only support unified backup (legacy removed)
-                settings = settings_manager.load_settings()
-                filename = file_ops.create_unified_backup(
-                    settings, reason, include_secrets=include_secrets,
-                )
-                if filename:
-                    created_backups.append({'type': 'unified', 'filename': filename})
-                    # Log the secret-handling MODE name, not the boolean
-                    # `include_secrets` — CodeQL's clear-text-logging rule
-                    # flags any expression named "secrets" landing in a log
-                    # line, even when the value is a True/False flag.
-                    backup_mode = 'plaintext' if include_secrets else 'masked'
-                    logger.info(f"Created unified backup: {filename} (mode={backup_mode})")
-
-                if created_backups:
-                    if audit_logger:
-                        user = getattr(request, 'current_user', None) or {}
-                        audit_logger.log_operation(
-                            operation='create',
-                            resource_type='backup',
-                            resource_id=created_backups[0].get('filename', 'unknown'),
-                            status='success',
-                            details={
-                                'type': 'unified',
-                                'reason': reason,
-                                # Pin the secret-handling mode on the
-                                # audit record so a SIEM can flag the
-                                # opt-in path (the resulting file on
-                                # disk is a credential dump).
-                                'include_secrets': include_secrets,
-                                'secrets_masked': not include_secrets,
-                            },
-                            user=user.get('username'),
-                            ip_address=request.remote_addr,
-                        )
-                    return {
-                        'message': 'Backup created successfully',
-                        'backups': created_backups,
-                        'secrets_masked': not include_secrets,
-                        'recommendation': 'Use unified backup' if backup_type != 'unified' else None,
-                    }, 201
-                else:
-                    return {'error': 'Failed to create backup'}, 500
-
-            except Exception as e:
-                logger.error(f"Error creating backup: {e}")
-                return {'error': 'Failed to create backup'}, 500
 
     # DNS Accounts management
     class DNSAccounts(Resource):
@@ -2567,248 +2458,8 @@ def create_api_resources(api, models, managers):
                     )
                 return {'error': str(e)}, 500
 
-    class BackupDownload(Resource):
-        @api.doc(security='Bearer')
-        @auth_manager.require_role('admin')
-        def get(self, backup_type, filename):
-            """Download a backup file"""
-            try:
-                if backup_type != 'unified':
-                    return {'error': 'Only unified backup download is supported'}, 400
 
-                err = _validate_backup_filename(filename)
-                if err:
-                    return {'error': err}, 400
 
-                backup_path = Path(file_ops.backup_dir) / backup_type / filename
-
-                if not backup_path.exists():
-                    return {'error': 'Backup file not found'}, 404
-
-                # Security check
-                if not str(backup_path.resolve()).startswith(str(Path(file_ops.backup_dir).resolve())):
-                    if audit_logger:
-                        user = getattr(request, 'current_user', None) or {}
-                        audit_logger.log_operation(
-                            operation='download',
-                            resource_type='backup',
-                            resource_id=filename,
-                            status='denied',
-                            details={
-                                'backup_type': backup_type,
-                                'reason': 'Path traversal attempt'
-                            },
-                            user=user.get('username'),
-                            ip_address=request.remote_addr,
-                        )
-                    return {'error': 'Access denied'}, 403
-
-                if audit_logger:
-                    user = getattr(request, 'current_user', None) or {}
-                    audit_logger.log_operation(
-                        operation='download',
-                        resource_type='backup',
-                        resource_id=filename,
-                        status='success',
-                        details={
-                            'backup_type': backup_type
-                        },
-                        user=user.get('username'),
-                        ip_address=request.remote_addr,
-                    )
-
-                return send_file(
-                    str(backup_path.resolve()),
-                    as_attachment=True,
-                    download_name=filename,
-                    mimetype='application/octet-stream'
-                )
-
-            except FileNotFoundError:
-                return {'error': 'Backup file not found'}, 404
-            except PermissionError:
-                return {'error': 'Access denied to backup file'}, 403
-            except Exception as e:
-                logger.error(f"Error downloading backup: {e}")
-                return {'error': 'Failed to download backup'}, 500
-
-    class BackupRestore(Resource):
-        @api.doc(security='Bearer')
-        @api.expect(api.model('BackupRestoreRequest', {
-            'filename': fields.String(required=True, description='Backup filename to restore from'),
-            'create_backup_before_restore': fields.Boolean(description='Create backup before restore', default=True)
-        }))
-        @auth_manager.require_role('admin')
-        def post(self, backup_type):
-            """Restore from a unified backup file (only unified backups supported)"""
-            try:
-                if backup_type != 'unified':
-                    return {'error': 'Only unified backup restoration is supported'}, 400
-
-                data = api.payload
-                filename = data.get('filename')
-                create_backup = data.get('create_backup_before_restore', True)
-
-                err = _validate_backup_filename(filename)
-                if err:
-                    return {'error': err}, 400
-
-                backup_path = Path(file_ops.backup_dir) / "unified" / filename
-
-                if not backup_path.exists():
-                    return {'error': 'Backup file not found'}, 404
-
-                # Security check
-                if not str(backup_path.resolve()).startswith(str(Path(file_ops.backup_dir).resolve())):
-                    return {'error': 'Access denied'}, 403
-
-                # Create backup of current state if requested
-                pre_restore_backup = None
-                if create_backup:
-                    current_settings = settings_manager.load_settings()
-                    # include_secrets=True: this archive exists for exactly one
-                    # purpose — putting the instance back if the restore below
-                    # goes wrong. A masked rollback cannot recover a single
-                    # credential, which makes it a file that looks like a
-                    # safety net and is not one. It never leaves the host and
-                    # is written chmod 0600, and the opt-in is audit-logged
-                    # with the restore entry below.
-                    pre_restore_backup = file_ops.create_unified_backup(
-                        current_settings, "pre_restore", include_secrets=True)
-                    # create_unified_backup returns None on failure (e.g. the
-                    # backups directory is not writable). The operator asked for
-                    # a pre-restore backup precisely so the restore is
-                    # reversible; if we cannot make one, proceeding would
-                    # overwrite settings and certificates with no way back. Fail
-                    # closed instead of silently doing the irreversible thing.
-                    if not pre_restore_backup:
-                        return {
-                            'error': 'Refusing to restore: the pre-restore '
-                                     'backup could not be created, so the '
-                                     'restore would not be reversible. Check '
-                                     'that the backup directory is writable, or '
-                                     'retry with '
-                                     'create_backup_before_restore=false to '
-                                     'proceed without a safety net.'
-                        }, 500
-                    logger.info(f"Created pre-restore backup: {pre_restore_backup}")
-
-                # Restore from unified backup
-                success = file_ops.restore_unified_backup(str(backup_path))
-                restore_msg = "Settings and certificates restored atomically"
-
-                if success:
-                    if audit_logger:
-                        user = getattr(request, 'current_user', None) or {}
-                        # Restore wholesale-replaces settings + certificates;
-                        # the audit entry must surface both source filename
-                        # and the pre-restore backup (if one was created) so
-                        # an admin can roll back via the audit trail alone.
-                        audit_logger.log_operation(
-                            operation='restore',
-                            resource_type='backup',
-                            resource_id=filename,
-                            status='success',
-                            details={
-                                'backup_type': 'unified',
-                                'pre_restore_backup': pre_restore_backup,
-                            },
-                            user=user.get('username'),
-                            ip_address=request.remote_addr,
-                        )
-                    response = {
-                        'message': f'{restore_msg} successfully from {filename}',
-                        'restored_from': filename,
-                        'backup_type': 'unified'
-                    }
-                    if pre_restore_backup:
-                        response['pre_restore_backup'] = pre_restore_backup
-                        response['note'] = 'A backup of the previous state was created before restore'
-
-                    return response, 200
-                else:
-                    reason = getattr(file_ops, 'last_restore_error', None)
-                    if reason:
-                        # The restore declined for a reason it can state
-                        # (a share-safe archive over a populated instance);
-                        # nothing was written. 409, not 500.
-                        return {'error': f'Restore refused: {reason}'}, 409
-                    return {'error': 'Failed to restore unified backup'}, 500
-
-            except FileNotFoundError:
-                return {'error': 'Backup file not found'}, 404
-            except RestoreIncompleteError as e:
-                # Some members restored, at least one did not. The failed ones
-                # kept their pre-existing files (atomic extract), so nothing was
-                # truncated — but the instance is now a mix of old and new and
-                # must not be reported as a clean restore. Name the members so
-                # the operator knows what to check before rolling back.
-                logger.error(f"Restore incomplete: {e}")
-                return {
-                    'error': 'Restore incomplete — some files could not be '
-                             'restored and were left unchanged; the instance '
-                             'is in a mixed state. Roll back with the '
-                             'pre-restore backup.',
-                    'failed': e.failed,
-                }, 500
-            except ValueError as e:
-                logger.warning(f"Backup restore validation error: {e}")
-                return {'error': 'Invalid backup data'}, 400
-            except Exception as e:
-                logger.error(f"Error restoring backup: {e}")
-                return {'error': 'Failed to restore backup'}, 500
-
-    class BackupDelete(Resource):
-        @api.doc(security='Bearer')
-        @auth_manager.require_role('admin')
-        def delete(self, backup_type, filename):
-            """Delete a unified backup file"""
-            try:
-                file_ops_manager = managers.get('file_ops')
-                if not file_ops_manager:
-                    return {'error': 'File operations manager not available'}, 503
-
-                if backup_type != 'unified':
-                    return {'error': 'Only unified backup deletion is supported'}, 400
-
-                err = _validate_backup_filename(filename)
-                if err:
-                    return {'error': err}, 400
-
-                backup_dir = file_ops_manager.backup_dir / backup_type
-                backup_path = backup_dir / filename
-
-                # Validate the backup file exists and is within the backup directory
-                if not backup_path.exists():
-                    return {'error': 'Backup file not found'}, 404
-
-                if not str(backup_path.resolve()).startswith(str(backup_dir.resolve())):
-                    return {'error': 'Invalid backup path'}, 400
-
-                # Delete the backup file
-                backup_path.unlink()
-
-                logger.info(f"Backup deleted: {backup_type}/{filename}")
-                if audit_logger:
-                    user = getattr(request, 'current_user', None) or {}
-                    audit_logger.log_operation(
-                        operation='delete',
-                        resource_type='backup',
-                        resource_id=filename,
-                        status='success',
-                        details={'backup_type': backup_type},
-                        user=user.get('username'),
-                        ip_address=request.remote_addr,
-                    )
-                return {
-                    'message': f'Backup {filename} deleted successfully',
-                    'deleted_file': filename,
-                    'backup_type': backup_type
-                }, 200
-
-            except Exception as e:
-                logger.error(f"Error deleting backup: {e}")
-                return {'error': 'Failed to delete backup'}, 500
 
     # Storage Backend Management
     class StorageBackendInfo(Resource):
@@ -3607,10 +3258,5 @@ def create_api_resources(api, models, managers):
         'CertificateJobs': CertificateJobs,
         'CertificateAutoRenew': CertificateAutoRenew,
         'CertificateRunDeploy': CertificateRunDeploy,
-        'BackupList': BackupList,
-        'BackupCreate': BackupCreate,
-        'BackupDownload': BackupDownload,
-        'BackupRestore': BackupRestore,
-        'BackupDelete': BackupDelete,
         'CAProviderTest': CAProviderTest
     }

--- a/modules/api/resources_backup.py
+++ b/modules/api/resources_backup.py
@@ -1,0 +1,395 @@
+"""Backup listing, creation, download, restore and deletion.
+
+Extracted from the `create_api_resources` closure (#669). The classes are
+unchanged; what used to be captured from the enclosing scope now arrives as an
+explicit `ApiContext`, which is what makes them importable — and therefore
+testable — without constructing the whole manager graph.
+
+`_validate_backup_filename` moves with them: it is used only by these five
+endpoints, and leaving it behind would have made this module import
+`resources.py`, which imports this one. `resources.py` re-exports it so the
+existing tests keep their import path.
+"""
+from pathlib import Path
+
+from flask import request, send_file
+from flask_restx import Resource, fields
+
+import logging
+
+from ..core.file_operations import RestoreIncompleteError
+from .resource_context import ApiContext
+
+logger = logging.getLogger(__name__)
+
+
+def _validate_backup_filename(filename):
+    """Reject path traversal attempts in backup filenames. Returns error string or None."""
+    if not filename:
+        return 'Filename is required'
+    if '..' in filename or '/' in filename or '\\' in filename or '\x00' in filename:
+        return 'Invalid filename'
+    # .zip = cleartext backup, .zip.enc = encrypted-at-rest backup
+    # (CERTMATE_BACKUP_PASSPHRASE).
+    if not (filename.endswith('.zip') or filename.endswith('.zip.enc')):
+        return 'Invalid backup file format'
+    return None
+
+
+def create_backup_resources(api, models, ctx: ApiContext) -> dict:
+    """Build the backup resources against *ctx*."""
+
+    class BackupList(Resource):
+        @api.doc(security='Bearer')
+        @api.marshal_with(models['backup_list_model'])
+        @ctx.auth.require_role('viewer')
+        def get(self):
+            """List all available backups"""
+            try:
+                backups = ctx.file_ops.list_backups()
+                return backups
+            except Exception as e:
+                logger.error(f"Error listing backups: {e}")
+                return {'error': 'Failed to list backups'}, 500
+
+    class BackupCreate(Resource):
+        @api.doc(security='Bearer')
+        @api.expect(api.model('BackupCreateRequest', {
+            'type': fields.String(required=True, enum=['unified', 'settings', 'certificates', 'both'],
+                                  description='Type of backup to create (unified recommended for data consistency)'),
+            'reason': fields.String(description='Reason for backup creation', default='manual'),
+            'include_secrets': fields.Boolean(
+                description=(
+                    'Default false: every secret-bearing field is replaced '
+                    'with the mask sentinel in the resulting zip, so the '
+                    'file is safe to share. true: produces a plaintext '
+                    'snapshot for disaster-recovery restore; the resulting '
+                    'file on disk now contains every credential and a '
+                    'dedicated audit-log entry records the opt-in.'
+                ),
+                default=False,
+            ),
+        }))
+        @ctx.auth.require_role('admin')
+        def post(self):
+            """Create a new backup (unified format recommended)"""
+            try:
+                data = api.payload
+                backup_type = data.get('type', 'unified')  # Default to unified
+                reason = data.get('reason', 'manual')
+                # `include_secrets` decides between a share-safe masked archive
+                # and a plaintext dump of every credential and private key, so
+                # it MUST be a real JSON boolean. bool() coercion was the trap:
+                # bool("false") is True, so a client sending the value as a
+                # string — trivial in a shell or an untyped template —
+                # asked for masked and got the plaintext dump. Accept only a
+                # JSON boolean; anything else is refused rather than guessed,
+                # and the safe default (masked) applies only when it is absent.
+                raw_include = data.get('include_secrets', False)
+                if not isinstance(raw_include, bool):
+                    return {
+                        'error': 'include_secrets must be a JSON boolean '
+                                 '(true or false)'
+                    }, 400
+                include_secrets = raw_include
+
+                created_backups = []
+
+                # Only support unified backup (legacy removed)
+                settings = ctx.settings.load_settings()
+                filename = ctx.file_ops.create_unified_backup(
+                    settings, reason, include_secrets=include_secrets,
+                )
+                if filename:
+                    created_backups.append({'type': 'unified', 'filename': filename})
+                    # Log the secret-handling MODE name, not the boolean
+                    # `include_secrets` — CodeQL's clear-text-logging rule
+                    # flags any expression named "secrets" landing in a log
+                    # line, even when the value is a True/False flag.
+                    backup_mode = 'plaintext' if include_secrets else 'masked'
+                    logger.info(f"Created unified backup: {filename} (mode={backup_mode})")
+
+                if created_backups:
+                    if ctx.audit:
+                        user = getattr(request, 'current_user', None) or {}
+                        ctx.audit.log_operation(
+                            operation='create',
+                            resource_type='backup',
+                            resource_id=created_backups[0].get('filename', 'unknown'),
+                            status='success',
+                            details={
+                                'type': 'unified',
+                                'reason': reason,
+                                # Pin the secret-handling mode on the
+                                # audit record so a SIEM can flag the
+                                # opt-in path (the resulting file on
+                                # disk is a credential dump).
+                                'include_secrets': include_secrets,
+                                'secrets_masked': not include_secrets,
+                            },
+                            user=user.get('username'),
+                            ip_address=request.remote_addr,
+                        )
+                    return {
+                        'message': 'Backup created successfully',
+                        'backups': created_backups,
+                        'secrets_masked': not include_secrets,
+                        'recommendation': 'Use unified backup' if backup_type != 'unified' else None,
+                    }, 201
+                else:
+                    return {'error': 'Failed to create backup'}, 500
+
+            except Exception as e:
+                logger.error(f"Error creating backup: {e}")
+                return {'error': 'Failed to create backup'}, 500
+
+    class BackupDownload(Resource):
+        @api.doc(security='Bearer')
+        @ctx.auth.require_role('admin')
+        def get(self, backup_type, filename):
+            """Download a backup file"""
+            try:
+                if backup_type != 'unified':
+                    return {'error': 'Only unified backup download is supported'}, 400
+
+                err = _validate_backup_filename(filename)
+                if err:
+                    return {'error': err}, 400
+
+                backup_path = Path(ctx.file_ops.backup_dir) / backup_type / filename
+
+                if not backup_path.exists():
+                    return {'error': 'Backup file not found'}, 404
+
+                # Security check
+                if not str(backup_path.resolve()).startswith(str(Path(ctx.file_ops.backup_dir).resolve())):
+                    if ctx.audit:
+                        user = getattr(request, 'current_user', None) or {}
+                        ctx.audit.log_operation(
+                            operation='download',
+                            resource_type='backup',
+                            resource_id=filename,
+                            status='denied',
+                            details={
+                                'backup_type': backup_type,
+                                'reason': 'Path traversal attempt'
+                            },
+                            user=user.get('username'),
+                            ip_address=request.remote_addr,
+                        )
+                    return {'error': 'Access denied'}, 403
+
+                if ctx.audit:
+                    user = getattr(request, 'current_user', None) or {}
+                    ctx.audit.log_operation(
+                        operation='download',
+                        resource_type='backup',
+                        resource_id=filename,
+                        status='success',
+                        details={
+                            'backup_type': backup_type
+                        },
+                        user=user.get('username'),
+                        ip_address=request.remote_addr,
+                    )
+
+                return send_file(
+                    str(backup_path.resolve()),
+                    as_attachment=True,
+                    download_name=filename,
+                    mimetype='application/octet-stream'
+                )
+
+            except FileNotFoundError:
+                return {'error': 'Backup file not found'}, 404
+            except PermissionError:
+                return {'error': 'Access denied to backup file'}, 403
+            except Exception as e:
+                logger.error(f"Error downloading backup: {e}")
+                return {'error': 'Failed to download backup'}, 500
+
+    class BackupRestore(Resource):
+        @api.doc(security='Bearer')
+        @api.expect(api.model('BackupRestoreRequest', {
+            'filename': fields.String(required=True, description='Backup filename to restore from'),
+            'create_backup_before_restore': fields.Boolean(description='Create backup before restore', default=True)
+        }))
+        @ctx.auth.require_role('admin')
+        def post(self, backup_type):
+            """Restore from a unified backup file (only unified backups supported)"""
+            try:
+                if backup_type != 'unified':
+                    return {'error': 'Only unified backup restoration is supported'}, 400
+
+                data = api.payload
+                filename = data.get('filename')
+                create_backup = data.get('create_backup_before_restore', True)
+
+                err = _validate_backup_filename(filename)
+                if err:
+                    return {'error': err}, 400
+
+                backup_path = Path(ctx.file_ops.backup_dir) / "unified" / filename
+
+                if not backup_path.exists():
+                    return {'error': 'Backup file not found'}, 404
+
+                # Security check
+                if not str(backup_path.resolve()).startswith(str(Path(ctx.file_ops.backup_dir).resolve())):
+                    return {'error': 'Access denied'}, 403
+
+                # Create backup of current state if requested
+                pre_restore_backup = None
+                if create_backup:
+                    current_settings = ctx.settings.load_settings()
+                    # include_secrets=True: this archive exists for exactly one
+                    # purpose — putting the instance back if the restore below
+                    # goes wrong. A masked rollback cannot recover a single
+                    # credential, which makes it a file that looks like a
+                    # safety net and is not one. It never leaves the host and
+                    # is written chmod 0600, and the opt-in is audit-logged
+                    # with the restore entry below.
+                    pre_restore_backup = ctx.file_ops.create_unified_backup(
+                        current_settings, "pre_restore", include_secrets=True)
+                    # create_unified_backup returns None on failure (e.g. the
+                    # backups directory is not writable). The operator asked for
+                    # a pre-restore backup precisely so the restore is
+                    # reversible; if we cannot make one, proceeding would
+                    # overwrite settings and certificates with no way back. Fail
+                    # closed instead of silently doing the irreversible thing.
+                    if not pre_restore_backup:
+                        return {
+                            'error': 'Refusing to restore: the pre-restore '
+                                     'backup could not be created, so the '
+                                     'restore would not be reversible. Check '
+                                     'that the backup directory is writable, or '
+                                     'retry with '
+                                     'create_backup_before_restore=false to '
+                                     'proceed without a safety net.'
+                        }, 500
+                    logger.info(f"Created pre-restore backup: {pre_restore_backup}")
+
+                # Restore from unified backup
+                success = ctx.file_ops.restore_unified_backup(str(backup_path))
+                restore_msg = "Settings and certificates restored atomically"
+
+                if success:
+                    if ctx.audit:
+                        user = getattr(request, 'current_user', None) or {}
+                        # Restore wholesale-replaces settings + certificates;
+                        # the audit entry must surface both source filename
+                        # and the pre-restore backup (if one was created) so
+                        # an admin can roll back via the audit trail alone.
+                        ctx.audit.log_operation(
+                            operation='restore',
+                            resource_type='backup',
+                            resource_id=filename,
+                            status='success',
+                            details={
+                                'backup_type': 'unified',
+                                'pre_restore_backup': pre_restore_backup,
+                            },
+                            user=user.get('username'),
+                            ip_address=request.remote_addr,
+                        )
+                    response = {
+                        'message': f'{restore_msg} successfully from {filename}',
+                        'restored_from': filename,
+                        'backup_type': 'unified'
+                    }
+                    if pre_restore_backup:
+                        response['pre_restore_backup'] = pre_restore_backup
+                        response['note'] = 'A backup of the previous state was created before restore'
+
+                    return response, 200
+                else:
+                    reason = getattr(ctx.file_ops, 'last_restore_error', None)
+                    if reason:
+                        # The restore declined for a reason it can state
+                        # (a share-safe archive over a populated instance);
+                        # nothing was written. 409, not 500.
+                        return {'error': f'Restore refused: {reason}'}, 409
+                    return {'error': 'Failed to restore unified backup'}, 500
+
+            except FileNotFoundError:
+                return {'error': 'Backup file not found'}, 404
+            except RestoreIncompleteError as e:
+                # Some members restored, at least one did not. The failed ones
+                # kept their pre-existing files (atomic extract), so nothing was
+                # truncated — but the instance is now a mix of old and new and
+                # must not be reported as a clean restore. Name the members so
+                # the operator knows what to check before rolling back.
+                logger.error(f"Restore incomplete: {e}")
+                return {
+                    'error': 'Restore incomplete — some files could not be '
+                             'restored and were left unchanged; the instance '
+                             'is in a mixed state. Roll back with the '
+                             'pre-restore backup.',
+                    'failed': e.failed,
+                }, 500
+            except ValueError as e:
+                logger.warning(f"Backup restore validation error: {e}")
+                return {'error': 'Invalid backup data'}, 400
+            except Exception as e:
+                logger.error(f"Error restoring backup: {e}")
+                return {'error': 'Failed to restore backup'}, 500
+
+    class BackupDelete(Resource):
+        @api.doc(security='Bearer')
+        @ctx.auth.require_role('admin')
+        def delete(self, backup_type, filename):
+            """Delete a unified backup file"""
+            try:
+                file_ops_manager = ctx.managers.get('file_ops')
+                if not file_ops_manager:
+                    return {'error': 'File operations manager not available'}, 503
+
+                if backup_type != 'unified':
+                    return {'error': 'Only unified backup deletion is supported'}, 400
+
+                err = _validate_backup_filename(filename)
+                if err:
+                    return {'error': err}, 400
+
+                backup_dir = file_ops_manager.backup_dir / backup_type
+                backup_path = backup_dir / filename
+
+                # Validate the backup file exists and is within the backup directory
+                if not backup_path.exists():
+                    return {'error': 'Backup file not found'}, 404
+
+                if not str(backup_path.resolve()).startswith(str(backup_dir.resolve())):
+                    return {'error': 'Invalid backup path'}, 400
+
+                # Delete the backup file
+                backup_path.unlink()
+
+                logger.info(f"Backup deleted: {backup_type}/{filename}")
+                if ctx.audit:
+                    user = getattr(request, 'current_user', None) or {}
+                    ctx.audit.log_operation(
+                        operation='delete',
+                        resource_type='backup',
+                        resource_id=filename,
+                        status='success',
+                        details={'backup_type': backup_type},
+                        user=user.get('username'),
+                        ip_address=request.remote_addr,
+                    )
+                return {
+                    'message': f'Backup {filename} deleted successfully',
+                    'deleted_file': filename,
+                    'backup_type': backup_type
+                }, 200
+
+            except Exception as e:
+                logger.error(f"Error deleting backup: {e}")
+                return {'error': 'Failed to delete backup'}, 500
+
+    return {
+        'BackupList': BackupList,
+        'BackupCreate': BackupCreate,
+        'BackupDownload': BackupDownload,
+        'BackupRestore': BackupRestore,
+        'BackupDelete': BackupDelete,
+    }

--- a/modules/api/resources_backup.py
+++ b/modules/api/resources_backup.py
@@ -29,6 +29,15 @@ def _validate_backup_filename(filename):
         return 'Filename is required'
     if '..' in filename or '/' in filename or '\\' in filename or '\x00' in filename:
         return 'Invalid filename'
+    # NUL was rejected above but the other control characters were not, so a
+    # name like "x\nFORGED.zip" passed and reached the log lines that report
+    # the filename back — under the non-JSON log format that forges a record.
+    # Every backup this application writes is named backup_<timestamp>.zip, so
+    # a control character in one is never legitimate: refuse it here, at the
+    # single point all five endpoints already go through, rather than scrubbing
+    # each log site and waiting for the next one to be added without it.
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in filename):
+        return 'Invalid filename'
     # .zip = cleartext backup, .zip.enc = encrypted-at-rest backup
     # (CERTMATE_BACKUP_PASSPHRASE).
     if not (filename.endswith('.zip') or filename.endswith('.zip.enc')):

--- a/tests/test_api_group_modules_are_standalone.py
+++ b/tests/test_api_group_modules_are_standalone.py
@@ -16,6 +16,7 @@ from flask import Flask
 from flask_restx import Api, Resource
 
 from modules.api.resource_context import ApiContext
+from modules.api.resources_backup import create_backup_resources
 from modules.api.resources_cache import create_cache_resources
 from modules.api.resources_health import create_health_resources
 
@@ -94,3 +95,76 @@ def test_the_health_group_tolerates_an_empty_manager_mapping(api):
     ctx = _minimal_context(settings=MagicMock(), certificates=MagicMock(),
                            file_ops=MagicMock(), managers={})
     assert create_health_resources(api, models, ctx)
+
+
+BACKUP_MODELS = {'backup_model': MagicMock(), 'backup_list_model': MagicMock()}
+
+
+def test_the_backup_group_builds_from_a_minimal_context(api):
+    ctx = _minimal_context(settings=MagicMock(), file_ops=MagicMock(),
+                           audit=MagicMock(), managers={})
+    resources = create_backup_resources(api, BACKUP_MODELS, ctx)
+
+    assert set(resources) == {
+        'BackupList', 'BackupCreate', 'BackupDownload', 'BackupRestore',
+        'BackupDelete'}
+    for name, cls in resources.items():
+        assert issubclass(cls, Resource), f'{name} is not a Resource'
+
+
+def test_the_backup_group_needs_no_certificate_manager(api):
+    """CONTROL: backups are taken through file_ops, not the cert manager.
+
+    In the closure every class could reach `certificate_manager` regardless of
+    whether it used one, so this coupling was invisible. If it returns, the
+    group stops being movable and this fails.
+    """
+    ctx = _minimal_context(settings=MagicMock(), file_ops=MagicMock(),
+                           audit=MagicMock(), certificates=None, managers={})
+    assert create_backup_resources(api, BACKUP_MODELS, ctx)
+
+
+def test_the_backup_group_resolves_the_managers_it_looks_up_by_name(api, tmp_path):
+    """Building a group proves nothing about the names it reads at request time.
+
+    BackupDelete does not use the named `file_ops` field; it looks the manager
+    up out of the mapping by string key, and answers 503 when that lookup comes
+    back empty. Every test above would pass with that key misspelt, because
+    none of them call the method — which is exactly how a broken key survived
+    the move here once already.
+
+    So this one calls it, with a real file to delete, and asserts the endpoint
+    actually did the work.
+    """
+    backup_dir = tmp_path / 'unified'
+    backup_dir.mkdir()
+    victim = backup_dir / 'backup_20260101_120000.zip'
+    victim.write_bytes(b'PK\x03\x04')
+
+    file_ops = MagicMock()
+    file_ops.backup_dir = tmp_path
+    ctx = _minimal_context(settings=MagicMock(), file_ops=file_ops,
+                           audit=None, managers={'file_ops': file_ops})
+
+    resources = create_backup_resources(api, BACKUP_MODELS, ctx)
+    app = Flask(__name__)
+    with app.test_request_context('/'):
+        body, status = resources['BackupDelete']().delete(
+            'unified', 'backup_20260101_120000.zip')
+
+    assert status != 503, (
+        f'the endpoint could not find the file_ops manager in the context '
+        f'mapping, so a lookup key is wrong: {body}'
+    )
+    assert status == 200, f'expected the delete to succeed, got {status}: {body}'
+    assert not victim.exists(), 'the endpoint returned 200 without deleting'
+
+
+def test_the_backup_group_builds_without_an_audit_logger(api):
+    """CONTROL: the audit logger is optional in the manager set, and the
+    closure guarded every use with `if audit_logger`. Building without one has
+    to keep working, or the extraction changed behaviour rather than location.
+    """
+    ctx = _minimal_context(settings=MagicMock(), file_ops=MagicMock(),
+                           audit=None, managers={})
+    assert create_backup_resources(api, BACKUP_MODELS, ctx)

--- a/tests/test_backup_filename_is_a_real_gate.py
+++ b/tests/test_backup_filename_is_a_real_gate.py
@@ -1,0 +1,150 @@
+"""What a backup filename is allowed to be, proved by trying to break it.
+
+Code scanning reports five paths through the backup endpoints where a request
+value reaches a filesystem path or a log line. Four of them were already
+defended and one was not, and the only way to tell those apart is to run them.
+
+The four path-expression reports are guarded three deep: `backup_type` must
+equal the literal 'unified', the filename goes through
+`_validate_backup_filename`, and the resolved path must still sit under the
+backup directory. This exercises that end to end rather than asserting it from
+reading, because "the validator handles it" is exactly the claim that turns out
+to be wrong when it is wrong.
+
+The fifth needed work: the validator rejected NUL but no other control
+character, and a filename is reported back in log output. Control characters
+are now refused at the validator rather than handled at each log site, since it
+is the single point all five endpoints already go through.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+from flask_restx import Api
+
+from modules.api.resource_context import ApiContext
+from modules.api.resources_backup import (
+    _validate_backup_filename,
+    create_backup_resources,
+)
+
+pytestmark = [pytest.mark.unit]
+
+TRAVERSAL = [
+    '../../etc/passwd',
+    '..%2f..%2fetc%2fpasswd.zip',
+    'sub/dir/backup.zip',
+    '..\\..\\windows\\system32.zip',
+    'backup.zip\x00.png',
+    '....//backup.zip',
+]
+
+CONTROL_CHARS = [
+    'x\nSECOND.zip',
+    'x\rSECOND.zip',
+    'x\tSECOND.zip',
+    'x\x1bSECOND.zip',
+    'x\x7fSECOND.zip',
+]
+
+LEGITIMATE = [
+    'backup_20260101_120000.zip',
+    'backup_20260101_120000.zip.enc',
+    'certmate-backup.zip',
+]
+
+
+@pytest.mark.parametrize('filename', TRAVERSAL)
+def test_traversal_shapes_are_refused(filename):
+    assert _validate_backup_filename(filename) is not None, (
+        f'{filename!r} was accepted as a backup filename'
+    )
+
+
+@pytest.mark.parametrize('filename', CONTROL_CHARS)
+def test_control_characters_are_refused(filename):
+    assert _validate_backup_filename(filename) is not None, (
+        f'{filename!r} was accepted; a control character in a filename reaches '
+        f'the log output that reports it back'
+    )
+
+
+@pytest.mark.parametrize('filename', LEGITIMATE)
+def test_the_names_this_application_actually_writes_are_accepted(filename):
+    """CONTROL: a validator that rejects everything would pass every test above
+    while breaking backups entirely."""
+    assert _validate_backup_filename(filename) is None, (
+        f'{filename!r} is a name CertMate itself writes and it was refused'
+    )
+
+
+def _download_endpoint(tmp_path):
+    file_ops = MagicMock()
+    file_ops.backup_dir = tmp_path
+    ctx = ApiContext(
+        auth=MagicMock(), settings=MagicMock(), certificates=None,
+        file_ops=file_ops, cache=None, dns=None, deployer=None, audit=None,
+        cert_service=None, cert_executor=None, managers={'file_ops': file_ops},
+    )
+    ctx.auth.require_role = lambda role: (lambda fn: fn)
+    app = Flask(__name__)
+    api = Api(app, prefix='/api')
+    models = {'backup_model': MagicMock(), 'backup_list_model': MagicMock()}
+    return app, create_backup_resources(api, models, ctx)['BackupDownload']
+
+
+@pytest.mark.parametrize('filename', TRAVERSAL + CONTROL_CHARS)
+def test_the_download_endpoint_refuses_them_too(tmp_path, filename):
+    """The reports are against the endpoint, so the endpoint is what is tested.
+
+    A validator can be correct and still be bypassed by a caller reaching the
+    path expression another way, which is the shape code scanning warns about.
+    """
+    app, endpoint = _download_endpoint(tmp_path)
+    with app.test_request_context('/'):
+        result = endpoint().get('unified', filename)
+
+    status = result[1] if isinstance(result, tuple) else 200
+    assert status in (400, 403, 404), (
+        f'{filename!r} produced {status}; a traversal or control-character '
+        f'name must be refused, not served'
+    )
+
+
+def test_the_download_endpoint_pins_the_backup_type(tmp_path):
+    """CONTROL: the filename is only half of the path expression.
+
+    `backup_type` is also interpolated into it. It is pinned to one literal, so
+    it cannot carry a traversal — if that check is ever relaxed, the filename
+    validation above stops being sufficient on its own.
+    """
+    app, endpoint = _download_endpoint(tmp_path)
+    with app.test_request_context('/'):
+        result = endpoint().get('../../etc', 'backup_20260101_120000.zip')
+
+    status = result[1] if isinstance(result, tuple) else 200
+    assert status == 400, (
+        f'a backup_type other than "unified" produced {status}; it is '
+        f'interpolated straight into the path'
+    )
+
+
+def test_a_legitimate_name_that_is_absent_reaches_the_not_found_path(tmp_path):
+    """CONTROL: proves the refusals above are refusals, not a dead endpoint.
+
+    Without this, an endpoint that returned 404 unconditionally — because the
+    resource never built, or every call raised — would satisfy every assertion
+    above while testing nothing.
+    """
+    app, endpoint = _download_endpoint(tmp_path)
+    (tmp_path / 'unified').mkdir()
+    (tmp_path / 'unified' / 'backup_20260101_120000.zip').write_bytes(b'PK')
+
+    with app.test_request_context('/'):
+        result = endpoint().get('unified', 'backup_20260101_120000.zip')
+
+    status = result[1] if isinstance(result, tuple) else 200
+    assert status == 200, (
+        f'a real backup file was not served ({status}); the endpoint refuses '
+        f'everything, so the refusal tests above prove nothing'
+    )


### PR DESCRIPTION
Fourth group of #669. Stacked on #693 (health), which is stacked on #692 (cache).

`BackupList`, `BackupCreate`, `BackupDownload`, `BackupRestore` and `BackupDelete`
move into `modules/api/resources_backup.py`, built by
`create_backup_resources(api, models, ctx)`.

`_validate_backup_filename` moves with them: it is used only by these five
endpoints, and leaving it in `resources.py` would have made this module import the
one that imports it. `resources.py` re-exports it so the existing tests keep their
import path.

Closure complexity **485 → 439**; `resources.py` **3616 → 3262** lines.

### How the grouping was chosen

By asking the AST which names each class captures from the enclosing scope, rather
than by reading them. All five need only `auth`, `settings`, `file_ops`, `audit`
and the manager mapping.

The same analysis says **18 of the 36 remaining classes are already buildable from
the context alone**, and the rest need only the thin helper wrappers the prologue
defines (`_check_domain_scope`, `_wants_async`, `_job_accepted`, …), which are
already module-level functions in `resource_context.py`. So the remaining groups
are mechanical.

### One thing a reviewer should know went wrong

Rewriting the captured names to `ctx.*` went through a regex that did not respect
string boundaries, and turned `managers.get('file_ops')` into
`managers.get('ctx.file_ops')`. `BackupDelete` then answered 503 to every request.

**Every build-only test still passed**, because none of them call the method — the
same shape of gap that let the health group pass its contract test while raising
`NameError` at request time. The full suite caught it.

`test_api_group_modules_are_standalone.py` therefore gains a case that calls
`BackupDelete` against a real file and asserts it actually deleted it, so a wrong
lookup key fails at the group level rather than surviving to the suite. Verified by
reintroducing that exact corruption: the new case fails, the build-only cases stay
green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)