### PR TITLE
refactor: move the inventory endpoints out of the closure

### DIFF
--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -17,12 +17,13 @@ import zipfile
 import os
 import io
 from pathlib import Path
-from flask import send_file, after_this_request, current_app, request, jsonify, Response
+from flask import send_file, after_this_request, current_app, request, jsonify
 from flask_restx import Resource
 
 from ..core.constants import CERTIFICATE_FILES, iter_cert_domain_dirs
 from .resources_cache import create_cache_resources
 from .resources_backup import create_backup_resources
+from .resources_inventory import create_inventory_resources
 from .resources_storage import create_storage_resources
 # Re-exported: it moved to resources_backup with the endpoints that use it,
 # and tests import it from here.
@@ -36,7 +37,6 @@ from ..core.utils import utc_now_iso, classify_renewal_error
 from ..core.certificates import DomainOperationInProgress
 from ..core.cert_service import DomainOutOfScope
 from ..core.audit_context import audit_context_from_request
-from ..core.inventory_view import build_inventory_view
 
 _DOMAIN_RE = re.compile(r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$')
 
@@ -347,6 +347,7 @@ def create_api_resources(api, models, managers):
         **create_cache_resources(api, models, ctx),
         **create_health_resources(api, models, ctx),
         **create_backup_resources(api, models, ctx),
+        **create_inventory_resources(api, models, ctx),
     }
     auth_manager = ctx.auth
     settings_manager = ctx.settings
@@ -625,184 +626,10 @@ def create_api_resources(api, models, managers):
     # expose it to the dashboard (#471). cert_inventory / cert_discovery /
     # ct_monitor are optional managers (absent in minimal-manager unit setups),
     # so every handler guards for their absence with a 503.
-    class InventoryList(Resource):
-        @api.doc(security='Bearer')
-        @auth_manager.require_role('viewer')
-        def get(self):
-            """List the certificate inventory (issued + discovered) with an
-            expiry forecast. Optional filters: ?managed=true/false, ?source=."""
-            inventory = managers.get('cert_inventory')
-            if inventory is None:
-                return {'error': 'Certificate inventory not available'}, 503
-            try:
-                managed = request.args.get('managed')
-                managed_filter = None
-                if managed is not None and managed != '':
-                    managed_filter = managed.strip().lower() in ('1', 'true', 'yes', 'on')
-                source = request.args.get('source') or None
-                records = inventory.list_all(managed=managed_filter, source=source)
-                return build_inventory_view(_scope_filter_records(records))
-            except Exception as e:
-                logger.error(f"Error listing inventory: {e}")
-                return {'error': 'Failed to list inventory'}, 500
 
-    class InventoryConfig(Resource):
-        @api.doc(security='Bearer')
-        @auth_manager.require_role('viewer')
-        def get(self):
-            """Return discovery + CT-log monitoring configuration."""
-            discovery = managers.get('cert_discovery')
-            ct_monitor = managers.get('ct_monitor')
-            if discovery is None or ct_monitor is None:
-                return {'error': 'Certificate discovery not available'}, 503
-            return {
-                'discovery': discovery.get_config(),
-                'ct_monitoring': ct_monitor.get_config(),
-            }
 
-        @api.doc(security='Bearer')
-        @auth_manager.require_role('admin')
-        def post(self):
-            """Update discovery and/or CT-log monitoring configuration.
 
-            Body may carry a ``discovery`` and/or ``ct_monitoring`` object; each
-            is validated and persisted by its manager (a bad endpoint spec is a
-            400). Returns the effective configuration after the update.
-            """
-            discovery = managers.get('cert_discovery')
-            ct_monitor = managers.get('ct_monitor')
-            if discovery is None or ct_monitor is None:
-                return {'error': 'Certificate discovery not available'}, 503
-            payload = request.get_json(silent=True) or {}
-            try:
-                if isinstance(payload.get('discovery'), dict):
-                    discovery.save_config(payload['discovery'])
-                if isinstance(payload.get('ct_monitoring'), dict):
-                    ct_monitor.save_config(payload['ct_monitoring'])
-            except ValueError as e:
-                return {'error': str(e)}, 400
-            return {
-                'discovery': discovery.get_config(),
-                'ct_monitoring': ct_monitor.get_config(),
-            }
 
-    class InventoryScan(Resource):
-        @api.doc(security='Bearer')
-        @auth_manager.require_role('admin')
-        def post(self):
-            """Run a discovery sweep and a CT-log poll now, returning their
-            summaries. Both are failure-isolated and no-ops when disabled."""
-            discovery = managers.get('cert_discovery')
-            ct_monitor = managers.get('ct_monitor')
-            if discovery is None or ct_monitor is None:
-                return {'error': 'Certificate discovery not available'}, 503
-            result = {}
-            try:
-                result['discovery'] = discovery.run_discovery()
-            except Exception as e:
-                logger.error(f"Discovery scan failed: {e}")
-                result['discovery'] = {'error': 'discovery failed'}
-            try:
-                result['ct_monitoring'] = ct_monitor.run_poll()
-            except Exception as e:
-                logger.error(f"CT-log poll failed: {e}")
-                result['ct_monitoring'] = {'error': 'ct poll failed'}
-            return result
-
-    class InventoryCryptoReport(Resource):
-        @api.doc(security='Bearer')
-        @auth_manager.require_role('viewer')
-        def get(self):
-            """Cryptographic algorithm inventory & readiness report over every
-            managed + discovered certificate. ``?format=csv`` downloads a CSV;
-            otherwise JSON is returned."""
-            from ..core.crypto_report import build_crypto_report, report_to_csv
-            inventory = managers.get('cert_inventory')
-            if inventory is None:
-                return {'error': 'Certificate inventory not available'}, 503
-            try:
-                records = _scope_filter_records(inventory.list_all())
-                report = build_crypto_report(records, generated_at=utc_now_iso())
-            except Exception as e:
-                logger.error(f"Error building crypto report: {e}")
-                return {'error': 'Failed to build crypto report'}, 500
-
-            if request.args.get('format', '').strip().lower() == 'csv':
-                return Response(
-                    report_to_csv(report),
-                    mimetype='text/csv',
-                    headers={'Content-Disposition':
-                             'attachment; filename=crypto-readiness-report.csv'},
-                )
-            return report
-
-    class InventoryAdopt(Resource):
-        @api.doc(security='Bearer')
-        @auth_manager.require_role('viewer')
-        def get(self, fingerprint):
-            """Return the adoption plan for a discovered certificate: the
-            pre-filled create parameters and whether adoption is possible."""
-            from ..core.cert_adopt import build_adoption_plan
-            inventory = managers.get('cert_inventory')
-            dns_mgr = managers.get('dns')
-            if inventory is None or dns_mgr is None:
-                return {'error': 'Certificate inventory not available'}, 503
-            record = inventory.get(fingerprint)
-            if record is None or not _record_in_scope(record):
-                return {'error': 'Certificate not found in inventory'}, 404
-            return build_adoption_plan(record, dns_mgr)
-
-        @api.doc(security='Bearer')
-        @auth_manager.require_role('operator')
-        def post(self, fingerprint):
-            """Adopt a discovered certificate: issue/manage it from the observed
-            metadata, then flag the inventory record managed. Refuses (400) when
-            the domain cannot be validated (no DNS credentials / no email)."""
-            from ..core.cert_adopt import build_adoption_plan
-            inventory = managers.get('cert_inventory')
-            dns_mgr = managers.get('dns')
-            svc = managers.get('cert_service')
-            if inventory is None or dns_mgr is None or svc is None:
-                return {'error': 'Certificate adoption not available'}, 503
-
-            record = inventory.get(fingerprint)
-            if record is None or not _record_in_scope(record):
-                return {'error': 'Certificate not found in inventory'}, 404
-
-            plan = build_adoption_plan(record, dns_mgr)
-            if not plan['available']:
-                return {'error': plan['reason'], 'code': 'ADOPTION_UNAVAILABLE'}, 400
-
-            # Scope check: the caller's API key must cover the adopted domain.
-            denied = _check_domain_scope(plan['domain'], 'adopt')
-            if denied is not None:
-                return denied
-
-            try:
-                svc.create(
-                    domain=plan['domain'],
-                    san_domains=plan['san_domains'],
-                    dns_provider=plan['dns_provider'],
-                    key_type=plan['key_type'],
-                    key_size=plan['key_size'],
-                    elliptic_curve=plan['elliptic_curve'],
-                    user=getattr(request, 'current_user', None),
-                    ip_address=request.remote_addr,
-                    audit_ctx=audit_context_from_request(),
-                )
-            except DomainOutOfScope as e:
-                return {'error': str(e), 'code': 'DOMAIN_OUT_OF_SCOPE'}, 403
-            except DomainOperationInProgress:
-                return {'error': 'An operation is already in progress for this domain'}, 409
-            except ValueError as e:
-                return {'error': str(e)}, 400
-            except Exception as e:
-                logger.error(f"Adoption issuance failed for {plan['domain']}: {e}")
-                return {'error': 'Adoption failed during issuance'}, 500
-
-            inventory.mark_managed(fingerprint, plan['domain'])
-            return {'status': 'adopted', 'domain': plan['domain'],
-                    'managed': True}, 201
 
     class CreateCertificate(Resource):
         @api.doc(security='Bearer')
@@ -2772,11 +2599,6 @@ def create_api_resources(api, models, managers):
         'Settings': Settings,
         'DNSProviders': DNSProviders,
         'CertificateList': CertificateList,
-        'InventoryList': InventoryList,
-        'InventoryConfig': InventoryConfig,
-        'InventoryScan': InventoryScan,
-        'InventoryCryptoReport': InventoryCryptoReport,
-        'InventoryAdopt': InventoryAdopt,
         'CreateCertificate': CreateCertificate,
         'ZombieScan': ZombieScan,
         'CheckDNSAlias': CheckDNSAlias,

--- a/modules/api/resources_inventory.py
+++ b/modules/api/resources_inventory.py
@@ -1,0 +1,231 @@
+"""Certificate discovery and inventory: listing, scanning, adoption.
+
+Extracted from the `create_api_resources` closure (#669). The classes are
+unchanged; what used to be captured from the enclosing scope now arrives as an
+explicit `ApiContext`, which is what makes them importable — and therefore
+testable — without constructing the whole manager graph.
+
+This is the first group whose classes use the scope helpers. Those are already
+module-level functions taking a context, but they take it as their first
+argument, so the thin wrappers the closure prologue defines are reproduced here
+rather than rewriting every call site — the call sites move verbatim, which is
+the property that makes an extraction reviewable.
+"""
+from flask import Response, request
+from flask_restx import Resource
+
+import logging
+
+from ..core.audit_context import audit_context_from_request
+from ..core.cert_service import DomainOutOfScope
+from ..core.certificates import DomainOperationInProgress
+from ..core.inventory_view import build_inventory_view
+from ..core.utils import utc_now_iso
+from .resource_context import (
+    ApiContext,
+    check_domain_scope,
+    is_record_in_scope,
+    scope_filter_records,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def create_inventory_resources(api, models, ctx: ApiContext) -> dict:
+    """Build the inventory resources against *ctx*."""
+
+    def _check_domain_scope(domain, operation):
+        return check_domain_scope(ctx, domain, operation)
+
+    def _record_in_scope(record):
+        return is_record_in_scope(ctx, record)
+
+    def _scope_filter_records(records):
+        return scope_filter_records(ctx, records)
+
+    class InventoryList(Resource):
+        @api.doc(security='Bearer')
+        @ctx.auth.require_role('viewer')
+        def get(self):
+            """List the certificate inventory (issued + discovered) with an
+            expiry forecast. Optional filters: ?managed=true/false, ?source=."""
+            inventory = ctx.managers.get('cert_inventory')
+            if inventory is None:
+                return {'error': 'Certificate inventory not available'}, 503
+            try:
+                managed = request.args.get('managed')
+                managed_filter = None
+                if managed is not None and managed != '':
+                    managed_filter = managed.strip().lower() in ('1', 'true', 'yes', 'on')
+                source = request.args.get('source') or None
+                records = inventory.list_all(managed=managed_filter, source=source)
+                return build_inventory_view(_scope_filter_records(records))
+            except Exception as e:
+                logger.error(f"Error listing inventory: {e}")
+                return {'error': 'Failed to list inventory'}, 500
+
+    class InventoryConfig(Resource):
+        @api.doc(security='Bearer')
+        @ctx.auth.require_role('viewer')
+        def get(self):
+            """Return discovery + CT-log monitoring configuration."""
+            discovery = ctx.managers.get('cert_discovery')
+            ct_monitor = ctx.managers.get('ct_monitor')
+            if discovery is None or ct_monitor is None:
+                return {'error': 'Certificate discovery not available'}, 503
+            return {
+                'discovery': discovery.get_config(),
+                'ct_monitoring': ct_monitor.get_config(),
+            }
+
+        @api.doc(security='Bearer')
+        @ctx.auth.require_role('admin')
+        def post(self):
+            """Update discovery and/or CT-log monitoring configuration.
+
+            Body may carry a ``discovery`` and/or ``ct_monitoring`` object; each
+            is validated and persisted by its manager (a bad endpoint spec is a
+            400). Returns the effective configuration after the update.
+            """
+            discovery = ctx.managers.get('cert_discovery')
+            ct_monitor = ctx.managers.get('ct_monitor')
+            if discovery is None or ct_monitor is None:
+                return {'error': 'Certificate discovery not available'}, 503
+            payload = request.get_json(silent=True) or {}
+            try:
+                if isinstance(payload.get('discovery'), dict):
+                    discovery.save_config(payload['discovery'])
+                if isinstance(payload.get('ct_monitoring'), dict):
+                    ct_monitor.save_config(payload['ct_monitoring'])
+            except ValueError as e:
+                return {'error': str(e)}, 400
+            return {
+                'discovery': discovery.get_config(),
+                'ct_monitoring': ct_monitor.get_config(),
+            }
+
+    class InventoryScan(Resource):
+        @api.doc(security='Bearer')
+        @ctx.auth.require_role('admin')
+        def post(self):
+            """Run a discovery sweep and a CT-log poll now, returning their
+            summaries. Both are failure-isolated and no-ops when disabled."""
+            discovery = ctx.managers.get('cert_discovery')
+            ct_monitor = ctx.managers.get('ct_monitor')
+            if discovery is None or ct_monitor is None:
+                return {'error': 'Certificate discovery not available'}, 503
+            result = {}
+            try:
+                result['discovery'] = discovery.run_discovery()
+            except Exception as e:
+                logger.error(f"Discovery scan failed: {e}")
+                result['discovery'] = {'error': 'discovery failed'}
+            try:
+                result['ct_monitoring'] = ct_monitor.run_poll()
+            except Exception as e:
+                logger.error(f"CT-log poll failed: {e}")
+                result['ct_monitoring'] = {'error': 'ct poll failed'}
+            return result
+
+    class InventoryCryptoReport(Resource):
+        @api.doc(security='Bearer')
+        @ctx.auth.require_role('viewer')
+        def get(self):
+            """Cryptographic algorithm inventory & readiness report over every
+            managed + discovered certificate. ``?format=csv`` downloads a CSV;
+            otherwise JSON is returned."""
+            from ..core.crypto_report import build_crypto_report, report_to_csv
+            inventory = ctx.managers.get('cert_inventory')
+            if inventory is None:
+                return {'error': 'Certificate inventory not available'}, 503
+            try:
+                records = _scope_filter_records(inventory.list_all())
+                report = build_crypto_report(records, generated_at=utc_now_iso())
+            except Exception as e:
+                logger.error(f"Error building crypto report: {e}")
+                return {'error': 'Failed to build crypto report'}, 500
+
+            if request.args.get('format', '').strip().lower() == 'csv':
+                return Response(
+                    report_to_csv(report),
+                    mimetype='text/csv',
+                    headers={'Content-Disposition':
+                             'attachment; filename=crypto-readiness-report.csv'},
+                )
+            return report
+
+    class InventoryAdopt(Resource):
+        @api.doc(security='Bearer')
+        @ctx.auth.require_role('viewer')
+        def get(self, fingerprint):
+            """Return the adoption plan for a discovered certificate: the
+            pre-filled create parameters and whether adoption is possible."""
+            from ..core.cert_adopt import build_adoption_plan
+            inventory = ctx.managers.get('cert_inventory')
+            dns_mgr = ctx.managers.get('dns')
+            if inventory is None or dns_mgr is None:
+                return {'error': 'Certificate inventory not available'}, 503
+            record = inventory.get(fingerprint)
+            if record is None or not _record_in_scope(record):
+                return {'error': 'Certificate not found in inventory'}, 404
+            return build_adoption_plan(record, dns_mgr)
+
+        @api.doc(security='Bearer')
+        @ctx.auth.require_role('operator')
+        def post(self, fingerprint):
+            """Adopt a discovered certificate: issue/manage it from the observed
+            metadata, then flag the inventory record managed. Refuses (400) when
+            the domain cannot be validated (no DNS credentials / no email)."""
+            from ..core.cert_adopt import build_adoption_plan
+            inventory = ctx.managers.get('cert_inventory')
+            dns_mgr = ctx.managers.get('dns')
+            svc = ctx.managers.get('cert_service')
+            if inventory is None or dns_mgr is None or svc is None:
+                return {'error': 'Certificate adoption not available'}, 503
+
+            record = inventory.get(fingerprint)
+            if record is None or not _record_in_scope(record):
+                return {'error': 'Certificate not found in inventory'}, 404
+
+            plan = build_adoption_plan(record, dns_mgr)
+            if not plan['available']:
+                return {'error': plan['reason'], 'code': 'ADOPTION_UNAVAILABLE'}, 400
+
+            # Scope check: the caller's API key must cover the adopted domain.
+            denied = _check_domain_scope(plan['domain'], 'adopt')
+            if denied is not None:
+                return denied
+
+            try:
+                svc.create(
+                    domain=plan['domain'],
+                    san_domains=plan['san_domains'],
+                    dns_provider=plan['dns_provider'],
+                    key_type=plan['key_type'],
+                    key_size=plan['key_size'],
+                    elliptic_curve=plan['elliptic_curve'],
+                    user=getattr(request, 'current_user', None),
+                    ip_address=request.remote_addr,
+                    audit_ctx=audit_context_from_request(),
+                )
+            except DomainOutOfScope as e:
+                return {'error': str(e), 'code': 'DOMAIN_OUT_OF_SCOPE'}, 403
+            except DomainOperationInProgress:
+                return {'error': 'An operation is already in progress for this domain'}, 409
+            except ValueError as e:
+                return {'error': str(e)}, 400
+            except Exception as e:
+                logger.error(f"Adoption issuance failed for {plan['domain']}: {e}")
+                return {'error': 'Adoption failed during issuance'}, 500
+
+            inventory.mark_managed(fingerprint, plan['domain'])
+            return {'status': 'adopted', 'domain': plan['domain'],
+                    'managed': True}, 201
+
+    return {
+        'InventoryList': InventoryList,
+        'InventoryConfig': InventoryConfig,
+        'InventoryScan': InventoryScan,
+        'InventoryCryptoReport': InventoryCryptoReport,
+        'InventoryAdopt': InventoryAdopt,
+    }

--- a/tests/test_api_group_modules_are_standalone.py
+++ b/tests/test_api_group_modules_are_standalone.py
@@ -19,6 +19,7 @@ from modules.api.resource_context import ApiContext
 from modules.api.resources_backup import create_backup_resources
 from modules.api.resources_cache import create_cache_resources
 from modules.api.resources_health import create_health_resources
+from modules.api.resources_inventory import create_inventory_resources
 from modules.api.resources_storage import create_storage_resources
 
 pytestmark = [pytest.mark.unit]
@@ -219,3 +220,61 @@ def test_the_storage_group_reaches_the_storage_manager_by_the_right_name(api):
         f'mapping, so its lookup key is wrong: {body}'
     )
     assert body['current_backend'] == 'local_filesystem'
+
+
+def test_the_inventory_group_builds_from_a_minimal_context(api):
+    ctx = _minimal_context(managers={})
+    resources = create_inventory_resources(api, {}, ctx)
+
+    assert set(resources) == {
+        'InventoryList', 'InventoryConfig', 'InventoryScan',
+        'InventoryCryptoReport', 'InventoryAdopt'}
+    for name, cls in resources.items():
+        assert issubclass(cls, Resource), f'{name} is not a Resource'
+
+
+def test_the_inventory_group_applies_scope_through_the_shared_helper(api):
+    """The first group whose classes use the scope helpers.
+
+    The closure defined thin wrappers over the context-taking functions in
+    resource_context; this module reproduces them so the call sites could move
+    verbatim. If a wrapper were wired to the wrong function — or dropped so a
+    call resolved to the module-level one with the wrong arity — the endpoint
+    would either crash or, far worse, stop filtering and return the whole
+    inventory to a scoped caller. So this calls it and checks what comes back.
+    """
+    inventory = MagicMock()
+    inventory.list_all.return_value = [
+        {'subject_cn': 'mine.example.com', 'sans': []},
+        {'subject_cn': 'theirs.example.net', 'sans': []},
+    ]
+    ctx = _minimal_context(managers={'cert_inventory': inventory})
+    # Scope the caller to one of the two records.
+    ctx.auth.domain_matches_scope = lambda domain, scope: (
+        scope is None or domain in scope)
+
+    resources = create_inventory_resources(api, {}, ctx)
+    app = Flask(__name__)
+    with app.test_request_context('/'):
+        from flask import request as flask_request
+        flask_request.current_user = {
+            'username': 'someone', 'allowed_domains': ['mine.example.com']}
+        result = resources['InventoryList']().get()
+
+    status = result[1] if isinstance(result, tuple) else 200
+    body = result[0] if isinstance(result, tuple) else result
+    assert status != 503, f'the inventory manager was not resolved: {body}'
+
+    # Read the subjects out of the response rather than searching its repr: a
+    # substring match would also be satisfied by a domain that merely contains
+    # the expected one, and would report the wrong thing when it failed.
+    returned = sorted(
+        entry.get('subject_cn')
+        for group in body.values() if isinstance(group, list)
+        for entry in group if isinstance(entry, dict)
+    )
+    assert returned == ['mine.example.com'], (
+        f'the scoped caller should see exactly its own record; got {returned}. '
+        f'Anything else means the scope helper is not being applied — which '
+        f'would hand a restricted caller the whole inventory.'
+    )


### PR DESCRIPTION
Sixth group of #669. Stacked on #695 (storage).

`InventoryList`, `InventoryConfig`, `InventoryScan`, `InventoryCryptoReport` and
`InventoryAdopt` move into `modules/api/resources_inventory.py`.

Closure complexity **372 → 335**; `resources.py` **2796 → 2618** lines.
Since #669 started: **559 → 335**, and **4040 → 2618**.

### The first group that uses the scope helpers

Those already exist as module-level functions in `resource_context`, but they take
the context as their **first argument** — so rewriting every call site would have
changed the code being moved. The thin wrappers the closure prologue defines are
reproduced in the group factory instead, and the call sites move verbatim, which is
the property that makes an extraction reviewable at all.

That wiring is worth a test rather than a glance. A wrapper pointed at the wrong
function would either crash or — far worse — silently stop filtering and hand a
scoped caller the entire inventory. The new case builds the group with a scoped
caller and two records, calls `InventoryList`, and asserts the out-of-scope one is
absent. Verified by dropping the filter from that call: it fails.

### The generic guard paid for itself

`test_manager_lookup_keys_are_real` (added in #695) validated this group's five
`managers.get(...)` keys with no new test written for them. That was the point of
writing it statically over `modules/api` rather than per endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)