### PR TITLE
harden: constrain usernames where they are created

### DIFF
--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -56,6 +56,38 @@ def _bcrypt_input(password):
     """The bytes bcrypt will actually consider, whatever the caller passed."""
     return password.encode()[:_BCRYPT_MAX_BYTES]
 
+
+# A username is a key in settings['users']; it is also rendered in the UI, put
+# in audit records, and interpolated into log messages. Nothing constrained it,
+# and the OIDC path takes it from an IdP claim rather than from an operator.
+USERNAME_MAX_LENGTH = 256
+
+
+def validate_username(username):
+    """Normalise and check a username. Returns ``(clean, error)``.
+
+    Deliberately narrow. It rejects control characters and nothing else about
+    the character set: an IdP legitimately issues addresses, dots, apostrophes
+    and non-ASCII names as ``preferred_username``, and an allowlist would lock
+    real people out of a working SSO deployment to prevent a problem they do
+    not cause. No name a person chooses contains a control character.
+
+    Surrounding whitespace is stripped rather than refused. Nobody intends a
+    trailing space as part of their identity, and normalising means " alice "
+    now collides with an existing "alice" instead of creating a second,
+    visually identical account.
+    """
+    if not isinstance(username, str):
+        return None, 'Username is required'
+    clean = username.strip()
+    if not clean:
+        return None, 'Username is required'
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in clean):
+        return None, 'Username cannot contain control characters'
+    if len(clean) > USERNAME_MAX_LENGTH:
+        return None, f'Username cannot exceed {USERNAME_MAX_LENGTH} characters'
+    return clean, None
+
 class AuthManager:
     """Class to handle authentication and authorization"""
     
@@ -609,6 +641,10 @@ class AuthManager:
     def create_user(self, username, password, role='operator', email=None):
         """Create a new user"""
         try:
+            username, err = validate_username(username)
+            if err:
+                return False, err
+
             users = self._get_users()
 
             if username in users:

--- a/modules/core/oidc.py
+++ b/modules/core/oidc.py
@@ -33,6 +33,7 @@ from urllib.parse import urlparse, urlencode
 
 from flask import session as flask_session
 
+from .auth import validate_username
 from .settings import _strip_masked_values
 from .utils import utc_now
 
@@ -420,6 +421,13 @@ class OIDCManager:
         email_claim = cfg.get('email_claim') or 'email'
         username_value = claims.get(username_claim) or claims.get('preferred_username') \
             or claims.get('email') or sub
+        # This is the one username CertMate does not get from an operator, so
+        # it is the one that has to be checked. A claim carrying control
+        # characters would become a key in settings['users'], a name in the UI
+        # and a value in every audit record written for that session.
+        username_value, username_err = validate_username(username_value)
+        if username_err:
+            return None, 'invalid_username'
         email = claims.get(email_claim) or claims.get('email') or ''
         # OIDC Core §5.1 specifies ``email_verified`` as a boolean. Some
         # IdPs serialise it as the string "true"/"false"; accept either

--- a/tests/test_username_is_validated_at_the_two_write_points.py
+++ b/tests/test_username_is_validated_at_the_two_write_points.py
@@ -1,0 +1,178 @@
+"""A username is checked where it enters, and only for what actually harms.
+
+A username is a key in `settings['users']`, a name rendered in the UI, and a
+value written into every audit record for that session. Nothing constrained it,
+and one of the two ways it can be created is not an operator typing it: the
+OIDC path takes it from an IdP claim.
+
+The risk in a check like this is not that it is too weak, it is that it is too
+strong. An allowlist would lock real people out of a working SSO deployment —
+IdPs legitimately issue addresses, dots, apostrophes and non-ASCII names as
+`preferred_username`. So the rule is narrow: control characters, which no
+person's name contains, and a length cap. The bulk of this file is the evidence
+that legitimate names still get through, because that is the failure mode with
+real users on the other side of it.
+
+Validation is at write time only. Existing rows are left alone deliberately:
+renaming or dropping an account that is already there would be destructive, and
+the log paths that consume a username scrub their own values anyway.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.auth import USERNAME_MAX_LENGTH, validate_username
+
+pytestmark = [pytest.mark.unit]
+
+# Names an IdP really does put in preferred_username, or a person really picks.
+LEGITIMATE = [
+    'alice',
+    'alice@example.com',
+    'alice.smith',
+    'alice-smith_1',
+    "O'Brien",
+    'José',
+    'Ævar',
+    '张伟',
+    'Müller',
+    'user+tag@example.com',
+    'CN=alice,OU=staff',
+    'a' * USERNAME_MAX_LENGTH,
+]
+
+HOSTILE = [
+    'alice\nbob',
+    'alice\rbob',
+    'alice\tbob',
+    'alice\x00bob',
+    'alice\x1bbob',
+    'alice\x7fbob',
+    '\n',
+]
+
+EMPTY = ['', '   ', '\t\n', None, 42, [], {}]
+
+
+@pytest.mark.parametrize('name', LEGITIMATE)
+def test_names_real_people_and_idps_use_are_accepted(name):
+    """The assertion that matters: this check must not lock anyone out."""
+    clean, err = validate_username(name)
+    assert err is None, f'{name!r} was refused: {err}'
+    assert clean == name
+
+
+@pytest.mark.parametrize('name', HOSTILE)
+def test_control_characters_are_refused(name):
+    clean, err = validate_username(name)
+    assert err is not None, f'{name!r} was accepted'
+    assert clean is None
+
+
+@pytest.mark.parametrize('name', EMPTY)
+def test_nothing_is_not_a_username(name):
+    clean, err = validate_username(name)
+    assert err is not None, f'{name!r} was accepted as a username'
+
+
+def test_surrounding_whitespace_is_normalised_not_refused():
+    """Stripping rather than rejecting is the deliberate choice.
+
+    Nobody intends a trailing space as part of their identity, and normalising
+    means the padded form now collides with the existing account instead of
+    creating a second, visually identical one.
+    """
+    assert validate_username('  alice  ') == ('alice', None)
+
+
+def test_a_name_one_character_over_the_cap_is_refused():
+    """CONTROL: the cap has to be a boundary, not decoration. The accepted case
+    at exactly the limit is in LEGITIMATE above."""
+    clean, err = validate_username('a' * (USERNAME_MAX_LENGTH + 1))
+    assert err is not None and clean is None
+
+
+# ---------------------------------------------------------------------------
+# The two write points
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def auth(tmp_path):
+    """A real AuthManager over a settings file of our own.
+
+    Built directly rather than through `create_app`: `setup_directories`
+    resolves the data directory from the package location, not from DATA_DIR,
+    so a factory-built manager reads and writes the checkout's real
+    `data/settings.json`. A test that asserted on the stored user list that way
+    would be reading whatever a previous run left behind — and did, before this
+    fixture was rewritten.
+    """
+    from modules.core.auth import AuthManager
+    from modules.core.file_operations import FileOperations
+    from modules.core.settings import SettingsManager
+
+    dirs = [tmp_path / n for n in ('certificates', 'data', 'backups', 'logs')]
+    for directory in dirs:
+        directory.mkdir()
+    settings = SettingsManager(file_ops=FileOperations(*dirs),
+                               settings_file=dirs[1] / 'settings.json')
+    settings.load_settings()
+    manager = AuthManager(settings)
+    manager.set_hmac_key('test-secret-for-hmac')
+    return manager
+
+
+def test_create_user_refuses_a_control_character(auth):
+    ok, msg = auth.create_user('bad\nname', 'S0me-Long-Passw0rd!')
+    assert ok is False, f'the account was created: {msg}'
+    assert not any('\n' in key for key in auth._get_users()), (
+        'a username containing a newline was stored as a key in settings'
+    )
+
+
+def test_create_user_still_creates_ordinary_accounts(auth):
+    """CONTROL: proves the refusal above is a refusal and not a broken path."""
+    ok, msg = auth.create_user('alice@example.com', 'S0me-Long-Passw0rd!')
+    assert ok is True, f'a legitimate account was refused: {msg}'
+    assert 'alice@example.com' in auth._get_users()
+
+
+def test_create_user_normalises_before_the_exists_check(auth):
+    """The padded form must not become a second, visually identical account."""
+    assert auth.create_user('alice', 'S0me-Long-Passw0rd!')[0] is True
+    ok, msg = auth.create_user('  alice  ', 'An0ther-Long-Passw0rd!')
+    assert ok is False and 'exists' in msg.lower(), (
+        f'a second account was created for a padded name: {msg}'
+    )
+
+
+def _oidc_manager():
+    from modules.core.oidc import OIDCManager
+    settings = MagicMock()
+    settings.load_settings.return_value = {
+        'oidc': {'enabled': True, 'issuer_url': 'https://idp.example.com',
+                 'client_id': 'x', 'auto_provision': True},
+        'users': {},
+    }
+    manager = OIDCManager.__new__(OIDCManager)
+    manager.settings_manager = settings
+    return manager
+
+
+def test_the_idp_claim_is_checked_too():
+    """The one username CertMate does not get from an operator.
+
+    Refused rather than sanitised: a claim carrying a control character is a
+    misconfigured or hostile IdP, and quietly rewriting the identity it asserts
+    would be worse than declining the login.
+    """
+    manager = _oidc_manager()
+    username, err = manager.resolve_or_provision_user({
+        'sub': 'subject-1',
+        'preferred_username': 'evil\nname',
+        'iss': 'https://idp.example.com',
+    })
+    assert username is None
+    assert err == 'invalid_username', (
+        f'expected the login to be declined with a nameable reason, got {err!r}'
+    )


### PR DESCRIPTION
A username is a key in `settings['users']`, a name rendered in the UI, and a value
written into every audit record for that session. Nothing constrained it — and one of
the two ways one can be created is not an operator typing it: the OIDC path derives it
from an IdP claim, so on an IdP with permissive self-registration the value is chosen
by whoever signs up.

### The check is narrow on purpose

The risk in a rule like this is being **too strict**, not too weak. It rejects control
characters — which no person's name contains — plus empties, and caps the length.

There is deliberately **no character allowlist**. IdPs legitimately issue addresses,
dots, apostrophes and non-ASCII names as `preferred_username`; an allowlist would lock
real people out of a working SSO deployment to prevent a problem they do not cause.
Most of the new test file is evidence that legitimate names still pass — `O'Brien`,
`José`, `张伟`, `user+tag@example.com`, `CN=alice,OU=staff` — because that is the
failure mode with real users on the other side of it.

Surrounding whitespace is stripped rather than refused: nobody intends a trailing space
as part of their identity, and normalising means the padded form now collides with the
existing account instead of creating a second, visually identical one.

### Scope

Applied at the two write points only — `create_user` and OIDC provisioning. **Existing
rows are left alone deliberately**: renaming or dropping an account that is already
there would be destructive, and the log paths that consume a username scrub their own
values. The OIDC path declines with `invalid_username`, which the callback already
turns into an audit failure and a nameable redirect, so an operator sees *why* instead
of a login that silently does not work.

### One thing found on the way

The new fixture builds `AuthManager` directly instead of through `create_app`.
`setup_directories` resolves the data directory from the package location and **ignores
`DATA_DIR`**, so a factory-built manager reads and writes the checkout's real
`data/settings.json`. An assertion about the stored user list made that way reads
whatever an earlier run left behind — which is exactly what happened here before the
fixture was rewritten. Worth a separate look; it means any test going through
`create_app` is not hermetic.

Both write points are mutation-verified: removing either check fails the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)