### PR TITLE
docs: the API decomposition is #667, not #669

### DIFF
--- a/modules/api/resource_context.py
+++ b/modules/api/resource_context.py
@@ -4,7 +4,7 @@
 closures over ten managers and a handful of helpers. Nothing in it can be
 imported on its own, which is why the HTTP layer is both the largest module in
 the project and the least covered: reaching one route means constructing the
-whole graph (#669).
+whole graph (#667).
 
 This is the first step out of that: the state those classes capture becomes an
 object that can be built and inspected, and the helpers that captured it become

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -339,12 +339,12 @@ def create_api_resources(api, models, managers):
 
     # The manager set and the helpers that used to be captured here now live
     # in modules/api/resource_context.py, so a resource class can be moved into
-    # a module of its own without dragging this closure with it (#669). The
+    # a module of its own without dragging this closure with it (#667). The
     # local names below are aliases kept during the decomposition: call sites
     # move group by group, not all at once.
     ctx = build_context(managers)
     # Groups that have moved into modules of their own build here and
-    # are merged into the returned mapping below (#669).
+    # are merged into the returned mapping below (#667).
     settings_resources = create_settings_resources(api, models, ctx)
     extracted = {
         # Only the two factory.py registers from the returned mapping; the
@@ -1980,12 +1980,12 @@ def create_api_resources(api, models, managers):
     # Register storage backend endpoints. Unlike the health, cache and backup
     # groups — which factory.py registers from the returned mapping — these
     # build their namespace here, so the classes are taken from `extracted`
-    # rather than from the local scope they no longer occupy (#669).
+    # rather than from the local scope they no longer occupy (#667).
     # Built here rather than merged into `extracted` above: unlike the health,
     # cache and backup groups, these are registered on a namespace of their own
     # right here instead of by factory.py from the returned mapping. Adding
     # them to that mapping would change what create_api_resources hands back,
-    # which the resource contract test pins deliberately (#669).
+    # which the resource contract test pins deliberately (#667).
     storage_resources = create_storage_resources(api, models, ctx)
     storage_ns = api.namespace('storage', description='Storage Backend Operations')
     storage_ns.add_resource(storage_resources['StorageBackendInfo'], '/info')

--- a/modules/api/resources_backup.py
+++ b/modules/api/resources_backup.py
@@ -1,6 +1,6 @@
 """Backup listing, creation, download, restore and deletion.
 
-Extracted from the `create_api_resources` closure (#669). The classes are
+Extracted from the `create_api_resources` closure (#667). The classes are
 unchanged; what used to be captured from the enclosing scope now arrives as an
 explicit `ApiContext`, which is what makes them importable — and therefore
 testable — without constructing the whole manager graph.

--- a/modules/api/resources_ca.py
+++ b/modules/api/resources_ca.py
@@ -1,6 +1,6 @@
 """ACME CA provider connectivity checks.
 
-Extracted from the `create_api_resources` closure (#669). The class is
+Extracted from the `create_api_resources` closure (#667). The class is
 unchanged; what used to be captured from the enclosing scope now arrives as an
 explicit `ApiContext`, which is what makes it importable — and therefore
 testable — without constructing the whole manager graph.

--- a/modules/api/resources_cache.py
+++ b/modules/api/resources_cache.py
@@ -1,6 +1,6 @@
 """Cache inspection and invalidation endpoints.
 
-Extracted from the `create_api_resources` closure (#669). The classes are
+Extracted from the `create_api_resources` closure (#667). The classes are
 unchanged; what used to be captured from the enclosing scope now arrives as an
 explicit `ApiContext`, which is what makes them importable — and therefore
 testable — without constructing the whole manager graph.

--- a/modules/api/resources_health.py
+++ b/modules/api/resources_health.py
@@ -1,6 +1,6 @@
 """Liveness, metrics and the diagnostics snapshot.
 
-Extracted from the `create_api_resources` closure (#669). The classes are
+Extracted from the `create_api_resources` closure (#667). The classes are
 unchanged; the managers they used to capture now arrive as an explicit
 `ApiContext`, which is what lets them be imported — and tested — without
 building the whole graph.

--- a/modules/api/resources_inventory.py
+++ b/modules/api/resources_inventory.py
@@ -1,6 +1,6 @@
 """Certificate discovery and inventory: listing, scanning, adoption.
 
-Extracted from the `create_api_resources` closure (#669). The classes are
+Extracted from the `create_api_resources` closure (#667). The classes are
 unchanged; what used to be captured from the enclosing scope now arrives as an
 explicit `ApiContext`, which is what makes them importable — and therefore
 testable — without constructing the whole manager graph.

--- a/modules/api/resources_settings.py
+++ b/modules/api/resources_settings.py
@@ -1,6 +1,6 @@
 """Application settings and DNS provider account management.
 
-Extracted from the `create_api_resources` closure (#669). The classes are
+Extracted from the `create_api_resources` closure (#667). The classes are
 unchanged; what used to be captured from the enclosing scope now arrives as an
 explicit `ApiContext`, which is what makes them importable — and therefore
 testable — without constructing the whole manager graph.

--- a/modules/api/resources_storage.py
+++ b/modules/api/resources_storage.py
@@ -1,6 +1,6 @@
 """Certificate storage backends: inspection, configuration, migration.
 
-Extracted from the `create_api_resources` closure (#669). The classes are
+Extracted from the `create_api_resources` closure (#667). The classes are
 unchanged; what used to be captured from the enclosing scope now arrives as an
 explicit `ApiContext`, which is what makes them importable — and therefore
 testable — without constructing the whole manager graph.

--- a/tests/test_api_group_modules_are_standalone.py
+++ b/tests/test_api_group_modules_are_standalone.py
@@ -3,7 +3,7 @@
 That is the entire point of the decomposition. While all 41 classes lived
 inside `create_api_resources`, reaching one route meant constructing every
 manager, which is why the HTTP layer ended up both the largest module and the
-least covered (#662, #669).
+least covered (#662, #667).
 
 This asserts the property directly for each group as it moves out, so a later
 change that quietly reintroduces a dependency on the full graph fails here

--- a/tests/test_api_resource_contract.py
+++ b/tests/test_api_resource_contract.py
@@ -3,7 +3,7 @@
 `create_api_resources` is a single 3,700-line function holding 41 classes as
 closures, which is why no route can be imported or tested without constructing
 the whole manager graph — and therefore why the HTTP layer is the least covered
-code in the project (#662, #669).
+code in the project (#662, #667).
 
 Breaking it up moves thousands of lines. This exists so that the move is
 verifiable rather than hopeful: whatever the internal arrangement, the factory

--- a/tests/test_metrics_access_model.py
+++ b/tests/test_metrics_access_model.py
@@ -68,7 +68,7 @@ def _metrics_list_declared_role():
 
     MetricsList is defined inside create_api_resources, so reaching it means
     constructing the whole resource graph — there is no cheaper way in, which
-    is itself the point of #669.
+    is itself the point of #667.
     """
     from flask_restx import Api
 


### PR DESCRIPTION
Every module and test from the decomposition cites **#669**. That issue is *"settings.json has no schema_version; migrations sniff data shape"* — nothing to do with it. The work belongs to **#667**, *"create_api_resources is a 3,708-line function holding 42 Resource classes"*.

Fifteen references across twelve files. Each was checked to be about the decomposition before being changed, rather than replaced blind.

The eight merged PR titles keep the wrong number — rewriting merged history is worse than a footnote. The progress comment has been moved to #667 with the mistake noted, and the one left on #669 now says only that it was posted there in error, so nobody reads it as work started on that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)