### PR TITLE
test: keep the suite out of the checkout's runtime directories (#702)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,62 @@ import pytest
 import requests
 
 # ---------------------------------------------------------------------------
+# Test isolation
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_runtime_dirs(tmp_path_factory):
+    """Keep `create_app()` out of the checkout's real runtime directories.
+
+    `setup_directories` resolves cert/data/backup/log paths from
+    `modules.core.factory.__file__` — three levels up — and honours no
+    override. So any in-process `create_app()` reads and writes the working
+    tree's own `data/`, `certificates/`, `backups/` and `logs/`, whatever
+    tmp_path the test set up. Thirteen test files do that, and a suite run was
+    measurably changing three of those four directories (#702).
+
+    Two consequences, and the second is the dangerous one: running the tests
+    mutates the developer's instance, and a test can pass on state an earlier
+    run left behind. An assertion that passes for that reason looks exactly
+    like one that passes because the code is right.
+
+    Anchoring `__file__` at a temporary tree is the pattern this repo already
+    uses in test_csp_img_src_airgap.py and test_advertised_endpoints_exist.py;
+    doing it here applies it everywhere without touching production paths, and
+    the container image and systemd unit keep resolving exactly as before.
+
+    `templates/` and `static/` are linked back to the real ones, because the
+    same `__file__` also locates them (factory.py:1305) — an anchor without
+    them would break every test that renders a page, silently at first, since
+    a missing template directory is only a warning at startup.
+    """
+    # Applied to every test, including the container-backed ones: those talk to
+    # CertMate over HTTP and never build an app in this process, so the anchor
+    # is inert for them. An earlier version skipped `slow` tests on the
+    # assumption they were all container-backed. They are not — several run
+    # in-process, and they were the ones still writing to the checkout.
+    root = tmp_path_factory.mktemp("runtime")
+    module_dir = root / "modules" / "core"
+    module_dir.mkdir(parents=True)
+    anchor = module_dir / "factory.py"
+    anchor.write_text("# test path anchor\n", encoding="utf-8")
+    for shared in ("templates", "static"):
+        source = os.path.join(PROJECT_ROOT, shared)
+        if os.path.isdir(source):
+            os.symlink(source, root / shared)
+
+    # Session-scoped, and that is the whole point. As a function-scoped
+    # fixture this lost a race: a fixture defined in a test module runs BEFORE
+    # a function-scoped autouse fixture from conftest, so the app was already
+    # built against the real tree by the time the anchor was applied. Measured,
+    # not assumed — the two fixtures were made to print their order.
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr("modules.core.factory.__file__", str(anchor),
+                      raising=False)
+        yield
+
+
+# ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 TEST_PORT = int(os.environ.get("CERTMATE_TEST_PORT", "18888"))

--- a/tests/test_the_suite_leaves_the_checkout_alone.py
+++ b/tests/test_the_suite_leaves_the_checkout_alone.py
@@ -1,0 +1,158 @@
+"""Running the tests must not modify the working tree's runtime directories.
+
+`setup_directories` resolves `certificates/`, `data/`, `backups/` and `logs/`
+from `modules.core.factory.__file__` — three levels up — and honours no
+override. So any in-process `create_app()` reads and writes the checkout's own
+directories, whatever `tmp_path` or env var the test set up. Thirteen test
+files do that, and several believed they were isolated: they set `DATA_DIR`,
+`CERTMATE_DATA_DIR`, `CERTMATE_LOGS_DIR`, none of which that function reads.
+
+Two consequences, and the second is the one that matters:
+
+* running the suite mutates the developer's own instance, and
+* a test can pass on state an earlier run left behind — an assertion that
+  passes for that reason looks exactly like one that passes because the code
+  is right.
+
+`tests/conftest.py` anchors `factory.__file__` at a temporary tree for the
+whole session, which is how the rest of this repo already isolates
+(test_csp_img_src_airgap.py, test_advertised_endpoints_exist.py). This file
+guards that anchor, because the property is invisible: it regresses silently
+the moment a fixture builds an app before the anchor is in place, which is
+exactly how it was broken to begin with (#702).
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RUNTIME_DIRS = ('certificates', 'data', 'backups', 'logs')
+
+
+def _build_an_app(tmp_path):
+    """Whatever this leaves behind is what a test leaves behind."""
+    from modules.core import factory
+    factory._flask_app = None
+    app, container = factory.create_app(test_config={'TESTING': True})
+    if container.scheduler:
+        container.scheduler.shutdown(wait=False)
+    return container
+
+
+def test_building_an_app_stays_out_of_the_checkout(tmp_path):
+    """The property itself, asserted on the paths the app actually resolves.
+
+    Cheaper and far more specific than diffing directory trees: if these point
+    inside the working copy, everything else in this file is academic.
+    """
+    container = _build_an_app(tmp_path)
+
+    for attribute in ('cert_dir', 'data_dir', 'backup_dir', 'logs_dir'):
+        resolved = getattr(container, attribute, None)
+        assert resolved, f'container exposes no {attribute}'
+        resolved = Path(resolved).resolve()
+        assert REPO_ROOT not in resolved.parents and resolved != REPO_ROOT, (
+            f'{attribute} resolved to {resolved}, inside the checkout — '
+            f'running the suite would read and write the developer\'s own '
+            f'instance'
+        )
+
+
+def test_the_anchor_is_actually_in_place():
+    """CONTROL: names the mechanism, so a failure says what to fix.
+
+    Without this, the check above could pass because `create_app` changed
+    rather than because the isolation works, and the next person would have no
+    idea where to look.
+    """
+    from modules.core import factory
+
+    anchored = Path(factory.__file__).resolve()
+    assert REPO_ROOT not in anchored.parents, (
+        f'modules.core.factory.__file__ is {anchored} — the session anchor in '
+        f'tests/conftest.py is not in effect, so every in-process create_app() '
+        f'is writing to the working tree'
+    )
+
+
+def test_the_templates_the_anchor_points_at_still_exist():
+    """The anchor relocates more than the data directories.
+
+    `factory.__file__` also locates `templates/` and `static/` (factory.py
+    around :1305). An anchor without them breaks every page-rendering test —
+    and only warns at startup, so the first symptom is a confusing failure
+    somewhere else entirely.
+    """
+    root = Path(__file__).resolve()
+    from modules.core import factory
+    anchored_root = Path(factory.__file__).resolve().parent.parent.parent
+
+    for shared in ('templates', 'static'):
+        assert (anchored_root / shared).is_dir(), (
+            f'{shared}/ is missing from the anchored tree at {anchored_root}; '
+            f'template rendering will fail in a way that does not name this '
+            f'as the cause'
+        )
+    assert root.exists()
+
+
+def test_the_runtime_directories_are_git_ignored():
+    """Belt and braces for the day the anchor is broken again.
+
+    If these were tracked, a broken anchor would not merely dirty the working
+    copy — it would put test output in a commit.
+    """
+    import subprocess
+
+    for name in RUNTIME_DIRS:
+        target = REPO_ROOT / name
+        if not target.exists():
+            continue
+        result = subprocess.run(
+            ['git', 'check-ignore', '-q', str(target)],
+            cwd=str(REPO_ROOT), capture_output=True)
+        assert result.returncode == 0, (
+            f'{name}/ is not git-ignored; anything a test writes there can be '
+            f'committed by accident'
+        )
+        assert os.path.isdir(target)
+
+
+def test_the_isolation_fixture_is_session_scoped():
+    """CONTROL for the regression that actually happened.
+
+    The checks above pass from inside a file whose own fixtures do not race the
+    anchor — so they cannot see the failure mode this had: as a FUNCTION-scoped
+    autouse fixture, a fixture defined in a test module runs first, and the app
+    is built against the real tree before the anchor is applied. Measured, not
+    assumed, by making the two print their order.
+
+    Nothing in a per-test assertion can observe that from a file that is not
+    itself affected, so the scope is pinned directly. If it is ever loosened,
+    this says why it must not be.
+    """
+    from tests import conftest as suite_conftest
+
+    fixture = getattr(suite_conftest, '_isolate_runtime_dirs')
+    # pytest 9 exposes the marker as `_fixture_function_marker`; older
+    # versions used `_pytestfixturefunction`. Read whichever is there rather
+    # than pinning one, so this guard survives a pytest upgrade instead of
+    # turning into a false alarm about the thing it is guarding.
+    marker = (getattr(fixture, '_fixture_function_marker', None)
+              or getattr(fixture, '_pytestfixturefunction', None))
+    assert marker is not None, (
+        f'_isolate_runtime_dirs is no longer a recognisable pytest fixture '
+        f'({type(fixture).__name__}); this guard cannot see its scope'
+    )
+    assert marker.scope == 'session', (
+        f'the runtime-directory anchor is {marker.scope}-scoped. At function '
+        f'scope it loses to fixtures defined in test modules, which then build '
+        f'the app against the checkout before the anchor exists — the exact '
+        f'shape of #702.'
+    )
+    assert marker.autouse is True, (
+        'the anchor must be autouse; a fixture nobody requests protects nothing'
+    )


### PR DESCRIPTION
Closes #702.

`setup_directories` resolves `certificates/`, `data/`, `backups/` and `logs/` from
`modules.core.factory.__file__` and honours no override, so any in-process
`create_app()` reads and writes the **working tree's own** directories. Thirteen test
files do that — and several believed they were isolated: they set `DATA_DIR`,
`CERTMATE_DATA_DIR`, `CERTMATE_LOGS_DIR`, none of which that function reads.

**Measured before and after.** A full run was changing `data/`, `backups/` and `logs/`.
It now leaves all four **byte-identical**.

### No production path changes

`conftest` anchors `factory.__file__` at a temporary tree for the session — the pattern
this repo already uses in `test_csp_img_src_airgap.py` and
`test_advertised_endpoints_exist.py`. The container image and the systemd unit resolve
exactly as before, which is the caution the issue itself raised about the obvious
env-var fix.

### Two things had to be right, both found by measurement

**The fixture must be session-scoped.** At function scope it *lost a race*: a fixture
defined in a test module runs before a function-scoped autouse fixture from conftest, so
the app was already built against the real tree by the time the anchor applied. Both were
made to print their order to establish that, rather than reasoning about pytest's rules.

**The anchored tree needs `templates/` and `static/` linked in**, because the same
`__file__` locates those too (`factory.py:1305`). Without them page rendering fails
somewhere else entirely — and a missing template directory is only a *warning* at startup.

### The guard, and why one of its checks looks odd

The property is invisible: it regresses silently the moment a fixture builds an app before
the anchor exists. Three mutations are covered — removing the anchor, loosening the scope,
dropping autouse.

The scope check pins the fixture's declaration directly, which normally I would avoid as
testing the mechanism rather than the behaviour. It is there because **the first version of
this guard passed with the bug reintroduced**: a per-test assertion cannot observe the
ordering failure from a file whose own fixtures do not race it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)