### PR TITLE
refactor: unblock and extract the certificate download endpoints (#667)

### DIFF
--- a/modules/api/path_validation.py
+++ b/modules/api/path_validation.py
@@ -1,0 +1,46 @@
+"""Turning a caller-supplied domain into a path, safely.
+
+Extracted from `resources.py` (#667). It sat there because that is where the
+endpoints are, and it is called from thirteen of them — which is exactly why it
+had to move: a resource group in a module of its own could not reach it without
+importing `resources.py`, which imports the group back.
+
+Nothing here is new. The rules are the ones the endpoints have always applied,
+in the order they applied them: reject the separators and NUL outright, then
+require a plausible domain, then confirm the resolved path is still under the
+certificate directory. The last check is the one that matters — the first two
+can be reasoned about, while `resolve()` is what actually answers the question
+after symlinks and `..` have been taken into account.
+"""
+import os
+import re
+from pathlib import Path
+
+# Kept identical to the expression the endpoints used. Note the leading
+# `*.` alternative: a wildcard certificate's directory is named for the
+# wildcard, so refusing it here would make those certificates unreachable.
+DOMAIN_RE = re.compile(
+    r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$')
+
+
+def validate_domain_path(domain, cert_base_dir):
+    """Validate a domain used as a directory name. Returns ``(Path, error)``.
+
+    On refusal the path is ``None`` and the caller must not fall back to
+    building one itself — that is the whole point of returning a pair.
+    """
+    if not domain or '..' in domain or '/' in domain or '\\' in domain \
+            or '\x00' in domain:
+        return None, 'Invalid domain name'
+    if not DOMAIN_RE.match(domain):
+        return None, 'Invalid domain format'
+    cert_dir = Path(cert_base_dir) / domain
+    try:
+        resolved = cert_dir.resolve()
+        base_resolved = Path(cert_base_dir).resolve()
+        if not str(resolved).startswith(str(base_resolved) + os.sep) \
+                and resolved != base_resolved:
+            return None, 'Invalid domain path'
+    except (OSError, ValueError):
+        return None, 'Invalid domain path'
+    return cert_dir, None

--- a/modules/api/path_validation.py
+++ b/modules/api/path_validation.py
@@ -16,11 +16,19 @@ import os
 import re
 from pathlib import Path
 
-# Kept identical to the expression the endpoints used. Note the leading
-# `*.` alternative: a wildcard certificate's directory is named for the
-# wildcard, so refusing it here would make those certificates unreachable.
+# Note the leading `*.` alternative: a wildcard certificate's directory is
+# named for the wildcard, so refusing it here would make those certificates
+# unreachable.
+#
+# `\Z`, not `$`. In Python `$` also matches immediately BEFORE a trailing
+# newline, so the previous expression accepted "example.com\n" as a valid
+# domain — and the character check below does not screen newlines either,
+# so nothing else caught it. That name is not a traversal (the resolved path
+# still sits under the certificate directory) but it is not a domain, and a
+# validator that reports "Invalid domain format" for everything else should
+# not make an exception for it.
 DOMAIN_RE = re.compile(
-    r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$')
+    r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}\Z')
 
 
 def validate_domain_path(domain, cert_base_dir):

--- a/modules/api/resources.py
+++ b/modules/api/resources.py
@@ -6,24 +6,21 @@ Defines Flask-RESTX Resource classes for REST API endpoints
 import base64
 import http.client
 import logging
-import re
 import socket
 import ssl
-import tempfile
 import time
 import urllib.parse
 import urllib.request
-import zipfile
 import os
-import io
 from pathlib import Path
-from flask import send_file, after_this_request, current_app, request, jsonify
+from flask import current_app, request
 from flask_restx import Resource
 
-from ..core.constants import CERTIFICATE_FILES, iter_cert_domain_dirs
+from ..core.constants import iter_cert_domain_dirs
 from .resources_cache import create_cache_resources
 from .resources_backup import create_backup_resources
 from .resources_inventory import create_inventory_resources
+from .resources_downloads import create_download_resources
 from .resources_ca import create_ca_resources
 from .resources_settings import create_settings_resources
 from .resources_storage import create_storage_resources
@@ -33,33 +30,20 @@ from .resources_backup import _validate_backup_filename  # noqa: F401
 from .resources_health import create_health_resources
 from .resource_context import (
     build_context, wants_async, job_accepted, check_domain_scope,
-    is_record_in_scope, scope_filter_records, user_has_role,
+    is_record_in_scope, scope_filter_records,
 )
 from ..core.utils import utc_now_iso, classify_renewal_error
 from ..core.certificates import DomainOperationInProgress
 from ..core.cert_service import DomainOutOfScope
 from ..core.audit_context import audit_context_from_request
+from .path_validation import DOMAIN_RE, validate_domain_path
 
-_DOMAIN_RE = re.compile(r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$')
-
-
-
-
-def _validate_domain_path(domain, cert_base_dir):
-    """Validate domain name to prevent path traversal. Returns (Path, error_msg)."""
-    if not domain or '..' in domain or '/' in domain or '\\' in domain or '\x00' in domain:
-        return None, 'Invalid domain name'
-    if not _DOMAIN_RE.match(domain):
-        return None, 'Invalid domain format'
-    cert_dir = Path(cert_base_dir) / domain
-    try:
-        resolved = cert_dir.resolve()
-        base_resolved = Path(cert_base_dir).resolve()
-        if not str(resolved).startswith(str(base_resolved) + os.sep) and resolved != base_resolved:
-            return None, 'Invalid domain path'
-    except (OSError, ValueError):
-        return None, 'Invalid domain path'
-    return cert_dir, None
+# Moved to path_validation so a resource group in its own module can reach it
+# without importing this one, which imports the group back (#667). Re-exported
+# under the old names: thirteen call sites below and the existing tests use
+# them, and renaming those is churn with no reader.
+_DOMAIN_RE = DOMAIN_RE
+_validate_domain_path = validate_domain_path
 
 
 def _certificate_fingerprint(cert_bytes):
@@ -357,6 +341,7 @@ def create_api_resources(api, models, managers):
         **create_backup_resources(api, models, ctx),
         **create_inventory_resources(api, models, ctx),
         **create_ca_resources(api, models, ctx),
+        **create_download_resources(api, models, ctx, _privkey_to_pkcs1),
     }
     auth_manager = ctx.auth
     settings_manager = ctx.settings
@@ -1051,11 +1036,7 @@ def create_api_resources(api, models, managers):
     # therefore also operator-gated. (2026-05-12 API auth audit
     # follow-up: viewer-can-pull-privkey was an information-disclosure
     # surface that the original endpoint exposed.)
-    _PRIVATE_KEY_FILES = frozenset({'privkey.pem', 'combined.pem', 'cert.pfx'})
-    _PUBLIC_DOWNLOAD_FILES = frozenset({'cert.pem', 'chain.pem', 'fullchain.pem'})
 
-    def _user_has_role(user, min_role):
-        return user_has_role(user, min_role)
 
     class CertificateDeploymentStatus(Resource):
         @api.doc(security='Bearer')
@@ -1272,351 +1253,7 @@ def create_api_resources(api, models, managers):
                 'count': len(updated),
             }, 200
 
-    class DownloadCertificate(Resource):
-        @api.doc(security='Bearer')
-        @auth_manager.require_role('viewer')
-        def get(self, domain):
-            """Download certificate files as ZIP, JSON, or individual file.
 
-            Role gating is per-file: viewers can pull public material
-            (cert.pem, chain.pem, fullchain.pem) and the public-only ZIP
-            (?include_private=0); anything that exposes the private key
-            (privkey.pem, combined.pem, format=json, default ZIP)
-            requires operator role.
-
-            ?file=privkey.pem&key_format=pkcs1 serves the key in legacy
-            PKCS#1/SEC1 form for stacks that reject certbot's PKCS#8
-            (issue #233); the default is the on-disk PKCS#8.
-
-            ?format=json&key_format=pkcs1 adds private_key_pkcs1_pem to the
-            JSON alongside the untouched private_key_pem, so an automation
-            can pull everything it needs in one call instead of downloading
-            the key a second time as a file (issue #398). The field is named
-            for the encoding, not RSA: for an ECDSA key the traditional form
-            is SEC1 ("BEGIN EC PRIVATE KEY"), and CertMate issues ECDSA by
-            default.
-
-            ?file=cert.pfx serves the encrypted PKCS#12 bundle when a PFX
-            export password is configured (issue #230); 404 otherwise. It
-            contains the private key, so it requires operator role.
-            """
-            try:
-                scope_err = _check_domain_scope(domain, 'download')
-                if scope_err:
-                    return scope_err
-                cert_dir, err = _validate_domain_path(domain, file_ops.cert_dir)
-                if err:
-                    return {'error': err}, 400
-                if not cert_dir.exists():
-                    return {'error': f'Certificate not found for domain: {domain}'}, 404
-
-                user = getattr(request, 'current_user', None) or {}
-                download_format = request.args.get('format')
-                # Check for the optional 'file' parameter
-                requested_file = request.args.get('file')
-                include_private = str(request.args.get('include_private', '1')).lower() not in ('0', 'false', 'no', 'off')
-
-                if download_format and download_format not in ['json']:
-                    return {'error': 'Invalid format requested.'}, 400
-
-                # Optional private-key serialization. Certbot stores PKCS#8
-                # ("BEGIN PRIVATE KEY"); some older stacks need the legacy
-                # PKCS#1 form ("BEGIN RSA PRIVATE KEY"). Convert on download
-                # rather than duplicating key material on disk (issue #233).
-                key_format = request.args.get('key_format')
-                if key_format is not None and key_format not in ('pkcs1', 'pkcs8'):
-                    return {'error': "Invalid key_format; use 'pkcs1' or 'pkcs8'."}, 400
-                if key_format and download_format != 'json' and requested_file != 'privkey.pem':
-                    return {
-                        'error': 'key_format applies to ?file=privkey.pem or ?format=json.'
-                    }, 400
-
-                def _privkey_denied(file_label):
-                    """Emit audit + return 403 for viewer trying to pull privkey."""
-                    if audit_logger:
-                        audit_logger.log_authz_denied(
-                            operation='download',
-                            resource_type='certificate',
-                            resource_id=domain,
-                            reason=f'viewer cannot download private-key material ({file_label})',
-                            user=user.get('username'),
-                            ip_address=request.remote_addr,
-                        )
-                    return {
-                        'error': 'operator role required to download private key material',
-                        'code': 'PRIVKEY_REQUIRES_OPERATOR',
-                        'hint': f'Use ?file=fullchain.pem or ?include_private=0 to download public material as a viewer.',
-                    }, 403
-
-                if download_format == 'json':
-                    # format=json always returns private_key_pem inline.
-                    # Restrict to operator+; viewer must use ?file=... for
-                    # the specific public-material file they need.
-                    if not _user_has_role(user, 'operator'):
-                        return _privkey_denied('format=json')
-                    if requested_file:
-                        return {'error': 'format=json cannot be combined with file.'}, 400
-
-                    required_files = {
-                        'cert_pem': 'cert.pem',
-                        'chain_pem': 'chain.pem',
-                        'fullchain_pem': 'fullchain.pem',
-                        'private_key_pem': 'privkey.pem',
-                    }
-
-                    try:
-                        payload = {'domain': domain}
-                        for response_key, filename in required_files.items():
-                            file_path = cert_dir / filename
-                            if not file_path.exists():
-                                return {'error': f'Required cert file not found for domain {domain}: {filename}'}, 404
-                            payload[response_key] = file_path.read_text(encoding='utf-8')
-
-                        # ?key_format=pkcs1 adds the legacy/traditional form
-                        # ALONGSIDE private_key_pem rather than replacing it,
-                        # so an existing consumer of format=json is unaffected
-                        # (issue #398). Converted from the bytes just read —
-                        # no second file read, no second path to validate.
-                        # pkcs8 is what is already on disk, so asking for it
-                        # here is a no-op by design.
-                        if key_format == 'pkcs1':
-                            try:
-                                payload['private_key_pkcs1_pem'] = _privkey_to_pkcs1(
-                                    payload['private_key_pem'].encode('utf-8')
-                                ).decode('utf-8')
-                            except (ValueError, TypeError) as e:
-                                # The message is included, not just the type:
-                                # cryptography emits static, descriptive text
-                                # ("Password was not given but private key is
-                                # encrypted", "format is invalid with this
-                                # key") that carries no key material and tells
-                                # an operator which of several very different
-                                # problems they have. CR/LF scrubbed like every
-                                # other interpolated value here.
-                                logger.error(
-                                    "Failed to convert private key to PKCS#1: %s: %s",
-                                    type(e).__name__,
-                                    str(e).replace('\r', ' ').replace('\n', ' '),
-                                )
-                                return {
-                                    'error': 'Could not convert the private key to PKCS#1 '
-                                             '(the key type may not support it).'
-                                }, 422
-
-                        return jsonify(payload)
-                    except FileNotFoundError:
-                        return {'error': f'Required cert file not found for domain {domain}'}, 404
-
-                if requested_file:
-                    # Security check: only allow specific certificate files
-                    allowed_files = _PUBLIC_DOWNLOAD_FILES | _PRIVATE_KEY_FILES
-                    if requested_file not in allowed_files:
-                        return {'error': 'Invalid file requested.'}, 400
-
-                    # Private-key files require operator+; public files
-                    # remain viewer-accessible.
-                    if requested_file in _PRIVATE_KEY_FILES and not _user_has_role(user, 'operator'):
-                        return _privkey_denied(requested_file)
-
-                    if requested_file == 'combined.pem':
-                        try:
-                            # Read both files and join them
-                            fullchain = (cert_dir / 'fullchain.pem').read_text(encoding='utf-8')
-                            privkey = (cert_dir / 'privkey.pem').read_text(encoding='utf-8')
-                            combined_data = io.BytesIO(f"{fullchain}{privkey}".encode())
-
-                            return send_file(
-                                combined_data,
-                                as_attachment=True,
-                                download_name=f'{domain}_combined.pem',
-                                mimetype='application/x-pem-file'
-                            )
-                        except FileNotFoundError:
-                            return {'error': f'Required cert files not found for domain {domain}'}, 404
-
-                    file_path = cert_dir / requested_file
-                    if not file_path.exists():
-                        return {'error': f'File {requested_file} not found for domain {domain}'}, 404
-
-                    if requested_file == 'privkey.pem' and key_format == 'pkcs1':
-                        # Re-resolve with a constant filename and confirm the
-                        # path stays inside the (already validated) domain dir
-                        # before reading — defense in depth, and keeps the new
-                        # file read off any tainted path component.
-                        key_path = os.path.realpath(cert_dir / 'privkey.pem')
-                        if not key_path.startswith(os.path.realpath(cert_dir) + os.sep):
-                            return {'error': 'Invalid path'}, 400
-                        try:
-                            with open(key_path, 'rb') as fh:
-                                pkcs1_pem = _privkey_to_pkcs1(fh.read())
-                        except (ValueError, TypeError) as e:
-                            # Same reasoning as the format=json branch above:
-                            # the message is safe and diagnostic. Kept identical
-                            # so the two conversion sites do not drift.
-                            logger.error(
-                                "Failed to convert private key to PKCS#1: %s: %s",
-                                type(e).__name__,
-                                str(e).replace('\r', ' ').replace('\n', ' '),
-                            )
-                            return {
-                                'error': 'Could not convert the private key to PKCS#1 '
-                                         '(the key type may not support it).'
-                            }, 422
-                        return send_file(
-                            io.BytesIO(pkcs1_pem),
-                            as_attachment=True,
-                            download_name=f'{domain}_privkey_pkcs1.pem',
-                            mimetype='application/x-pem-file',
-                        )
-
-                    file_mimetype = (
-                        'application/x-pkcs12' if requested_file.endswith('.pfx')
-                        else 'application/x-pem-file'
-                    )
-                    return send_file(
-                        file_path,
-                        as_attachment=True,
-                        download_name=f'{domain}_{requested_file}',
-                        mimetype=file_mimetype
-                    )
-
-                # Fallback ZIP. Two flavors:
-                #   include_private=1 (default)  -> all 4 PEMs, operator+
-                #   include_private=0            -> public material only,
-                #                                   safe for viewer
-                if include_private and not _user_has_role(user, 'operator'):
-                    return _privkey_denied('default ZIP')
-
-                files_to_zip = (
-                    CERTIFICATE_FILES if include_private
-                    else tuple(f for f in CERTIFICATE_FILES if f not in _PRIVATE_KEY_FILES)
-                )
-                # The encrypted PKCS#12 bundle (only present when a PFX password
-                # is configured, #230/#465) is key-bearing, so it rides only in
-                # the private ZIP. The loop below writes it only if it exists.
-                if include_private:
-                    files_to_zip = files_to_zip + ('cert.pfx',)
-                zip_suffix = 'certificates' if include_private else 'certificates_public'
-
-                # Create temporary ZIP file
-                with tempfile.NamedTemporaryFile(delete=False, suffix='.zip') as tmp_file:
-                    tmp_path = tmp_file.name
-                    with zipfile.ZipFile(tmp_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
-                        for cert_file in files_to_zip:
-                            file_path = cert_dir / cert_file
-                            if file_path.exists():
-                                zipf.write(file_path, cert_file)
-
-                    @after_this_request
-                    def remove_file(response):
-                        try:
-                            os.remove(tmp_path)
-                        except Exception as e:
-                            logger.debug(f"Could not remove temp file {tmp_path}: {e}")
-                        return response
-
-                    return send_file(
-                        tmp_path,
-                        as_attachment=True,
-                        download_name=f'{domain}_{zip_suffix}.zip',
-                        mimetype='application/zip'
-                    )
-
-            except Exception as e:
-                logger.error(f"Error downloading certificate for {domain}: {e}")
-                return {'error': 'Failed to download certificate'}, 500
-
-    class DownloadCertificateFile(Resource):
-        # Path-style alias for the query-string form on DownloadCertificate.
-        # Documented in discussion #183 as the canonical scripting URL
-        # (curl ... /api/certificates/<domain>/download/fullchain). Without
-        # this route the documented URL returned 404 (issue #212).
-        #
-        # Short names map 1:1 to the on-disk filenames. The role gate and
-        # path-traversal guards mirror the ?file= branch in
-        # DownloadCertificate.get() — keep the two in sync.
-        _SHORT_NAME_TO_FILE = {
-            'cert': 'cert.pem',
-            'chain': 'chain.pem',
-            'fullchain': 'fullchain.pem',
-            'privkey': 'privkey.pem',
-            'combined': 'combined.pem',
-        }
-
-        @api.doc(security='Bearer')
-        @auth_manager.require_role('viewer')
-        def get(self, domain, file_type):
-            """Download a single certificate file by short name.
-
-            Path-style equivalent of ``?file=<name>.pem`` on the parent
-            ``/download`` route. ``file_type`` is one of ``cert``,
-            ``chain``, ``fullchain``, ``privkey``, ``combined``.
-
-            Role gating: viewers can pull public material (cert, chain,
-            fullchain); ``privkey`` and ``combined`` require operator+.
-            """
-            requested_file = self._SHORT_NAME_TO_FILE.get(file_type)
-            if requested_file is None:
-                return {
-                    'error': f'Invalid file type: {file_type}',
-                    'hint': f"Allowed: {sorted(self._SHORT_NAME_TO_FILE)}",
-                }, 400
-
-            try:
-                scope_err = _check_domain_scope(domain, 'download')
-                if scope_err:
-                    return scope_err
-                cert_dir, err = _validate_domain_path(domain, file_ops.cert_dir)
-                if err:
-                    return {'error': err}, 400
-                if not cert_dir.exists():
-                    return {'error': f'Certificate not found for domain: {domain}'}, 404
-
-                user = getattr(request, 'current_user', None) or {}
-
-                if requested_file in _PRIVATE_KEY_FILES and not _user_has_role(user, 'operator'):
-                    if audit_logger:
-                        audit_logger.log_authz_denied(
-                            operation='download',
-                            resource_type='certificate',
-                            resource_id=domain,
-                            reason=f'viewer cannot download private-key material ({requested_file})',
-                            user=user.get('username'),
-                            ip_address=request.remote_addr,
-                        )
-                    return {
-                        'error': 'operator role required to download private key material',
-                        'code': 'PRIVKEY_REQUIRES_OPERATOR',
-                        'hint': 'Use /download/fullchain to pull public material as a viewer.',
-                    }, 403
-
-                if requested_file == 'combined.pem':
-                    try:
-                        fullchain = (cert_dir / 'fullchain.pem').read_text(encoding='utf-8')
-                        privkey = (cert_dir / 'privkey.pem').read_text(encoding='utf-8')
-                        combined_data = io.BytesIO(f"{fullchain}{privkey}".encode())
-                        return send_file(
-                            combined_data,
-                            as_attachment=True,
-                            download_name=f'{domain}_combined.pem',
-                            mimetype='application/x-pem-file'
-                        )
-                    except FileNotFoundError:
-                        return {'error': f'Required cert files not found for domain {domain}'}, 404
-
-                file_path = cert_dir / requested_file
-                if not file_path.exists():
-                    return {'error': f'File {requested_file} not found for domain {domain}'}, 404
-
-                return send_file(
-                    file_path,
-                    as_attachment=True,
-                    download_name=f'{domain}_{requested_file}',
-                    mimetype='application/x-pem-file'
-                )
-            except Exception as e:
-                logger.error(f"Error downloading {file_type} for {domain}: {e}")
-                return {'error': 'Failed to download certificate file'}, 500
 
     class RenewCertificate(Resource):
         @api.doc(security='Bearer')
@@ -2012,8 +1649,6 @@ def create_api_resources(api, models, managers):
         'CertificateDetail': CertificateDetail,
         'CertificateDeploymentStatus': CertificateDeploymentStatus,
         'CertificateDeploymentBrowserReports': CertificateDeploymentBrowserReports,
-        'DownloadCertificate': DownloadCertificate,
-        'DownloadCertificateFile': DownloadCertificateFile,
         'RenewCertificate': RenewCertificate,
         'CertificateReissue': CertificateReissue,
         'CertificateJob': CertificateJob,

--- a/modules/api/resources_downloads.py
+++ b/modules/api/resources_downloads.py
@@ -1,0 +1,405 @@
+"""Certificate downloads, and who is allowed to receive a private key.
+
+Extracted from the `create_api_resources` closure (#667). The classes are
+unchanged; what used to be captured from the enclosing scope now arrives as an
+explicit `ApiContext`.
+
+This group was the one the decomposition could not reach: both classes call
+`_validate_domain_path`, which lived in `resources.py` alongside thirteen other
+callers, so a module here could not use it without an import cycle. Moving that
+helper to `path_validation.py` is what unblocked this.
+
+The two sets below are the access rule, and they are the reason this group is
+worth having on its own: `_PRIVATE_KEY_FILES` decides which downloads require
+operator rather than viewer, and a viewer reaching a private key is the failure
+that matters most in this file. They travel with the endpoints that enforce
+them rather than staying behind as loose closure state.
+"""
+import io
+import logging
+import os
+import tempfile
+import zipfile
+
+from flask import after_this_request, jsonify, request, send_file
+from flask_restx import Resource
+
+from ..core.constants import CERTIFICATE_FILES
+from .path_validation import validate_domain_path as _validate_domain_path
+from .resource_context import ApiContext, check_domain_scope, user_has_role
+
+logger = logging.getLogger(__name__)
+
+# Files whose download hands over key material. Downloading one requires
+# operator; everything else is readable by a viewer.
+_PRIVATE_KEY_FILES = frozenset({'privkey.pem', 'combined.pem', 'cert.pfx'})
+_PUBLIC_DOWNLOAD_FILES = frozenset({'cert.pem', 'chain.pem', 'fullchain.pem'})
+
+
+def create_download_resources(api, models, ctx: ApiContext,
+                              privkey_to_pkcs1) -> dict:
+    """Build the certificate-download resources against *ctx*.
+
+    `privkey_to_pkcs1` is passed in rather than imported: it lives in
+    `resources.py`, whose tests import it from there, and taking it as an
+    argument avoids an import cycle without moving a second helper in the same
+    change.
+    """
+    _privkey_to_pkcs1 = privkey_to_pkcs1
+
+    def _check_domain_scope(domain, operation):
+        return check_domain_scope(ctx, domain, operation)
+
+    def _user_has_role(user, min_role):
+        return user_has_role(user, min_role)
+
+    class DownloadCertificate(Resource):
+        @api.doc(security='Bearer')
+        @ctx.auth.require_role('viewer')
+        def get(self, domain):
+            """Download certificate files as ZIP, JSON, or individual file.
+
+            Role gating is per-file: viewers can pull public material
+            (cert.pem, chain.pem, fullchain.pem) and the public-only ZIP
+            (?include_private=0); anything that exposes the private key
+            (privkey.pem, combined.pem, format=json, default ZIP)
+            requires operator role.
+
+            ?file=privkey.pem&key_format=pkcs1 serves the key in legacy
+            PKCS#1/SEC1 form for stacks that reject certbot's PKCS#8
+            (issue #233); the default is the on-disk PKCS#8.
+
+            ?format=json&key_format=pkcs1 adds private_key_pkcs1_pem to the
+            JSON alongside the untouched private_key_pem, so an automation
+            can pull everything it needs in one call instead of downloading
+            the key a second time as a file (issue #398). The field is named
+            for the encoding, not RSA: for an ECDSA key the traditional form
+            is SEC1 ("BEGIN EC PRIVATE KEY"), and CertMate issues ECDSA by
+            default.
+
+            ?file=cert.pfx serves the encrypted PKCS#12 bundle when a PFX
+            export password is configured (issue #230); 404 otherwise. It
+            contains the private key, so it requires operator role.
+            """
+            try:
+                scope_err = _check_domain_scope(domain, 'download')
+                if scope_err:
+                    return scope_err
+                cert_dir, err = _validate_domain_path(domain, ctx.file_ops.cert_dir)
+                if err:
+                    return {'error': err}, 400
+                if not cert_dir.exists():
+                    return {'error': f'Certificate not found for domain: {domain}'}, 404
+
+                user = getattr(request, 'current_user', None) or {}
+                download_format = request.args.get('format')
+                # Check for the optional 'file' parameter
+                requested_file = request.args.get('file')
+                include_private = str(request.args.get('include_private', '1')).lower() not in ('0', 'false', 'no', 'off')
+
+                if download_format and download_format not in ['json']:
+                    return {'error': 'Invalid format requested.'}, 400
+
+                # Optional private-key serialization. Certbot stores PKCS#8
+                # ("BEGIN PRIVATE KEY"); some older stacks need the legacy
+                # PKCS#1 form ("BEGIN RSA PRIVATE KEY"). Convert on download
+                # rather than duplicating key material on disk (issue #233).
+                key_format = request.args.get('key_format')
+                if key_format is not None and key_format not in ('pkcs1', 'pkcs8'):
+                    return {'error': "Invalid key_format; use 'pkcs1' or 'pkcs8'."}, 400
+                if key_format and download_format != 'json' and requested_file != 'privkey.pem':
+                    return {
+                        'error': 'key_format applies to ?file=privkey.pem or ?format=json.'
+                    }, 400
+
+                def _privkey_denied(file_label):
+                    """Emit audit + return 403 for viewer trying to pull privkey."""
+                    if ctx.audit:
+                        ctx.audit.log_authz_denied(
+                            operation='download',
+                            resource_type='certificate',
+                            resource_id=domain,
+                            reason=f'viewer cannot download private-key material ({file_label})',
+                            user=user.get('username'),
+                            ip_address=request.remote_addr,
+                        )
+                    return {
+                        'error': 'operator role required to download private key material',
+                        'code': 'PRIVKEY_REQUIRES_OPERATOR',
+                        'hint': f'Use ?file=fullchain.pem or ?include_private=0 to download public material as a viewer.',
+                    }, 403
+
+                if download_format == 'json':
+                    # format=json always returns private_key_pem inline.
+                    # Restrict to operator+; viewer must use ?file=... for
+                    # the specific public-material file they need.
+                    if not _user_has_role(user, 'operator'):
+                        return _privkey_denied('format=json')
+                    if requested_file:
+                        return {'error': 'format=json cannot be combined with file.'}, 400
+
+                    required_files = {
+                        'cert_pem': 'cert.pem',
+                        'chain_pem': 'chain.pem',
+                        'fullchain_pem': 'fullchain.pem',
+                        'private_key_pem': 'privkey.pem',
+                    }
+
+                    try:
+                        payload = {'domain': domain}
+                        for response_key, filename in required_files.items():
+                            file_path = cert_dir / filename
+                            if not file_path.exists():
+                                return {'error': f'Required cert file not found for domain {domain}: {filename}'}, 404
+                            payload[response_key] = file_path.read_text(encoding='utf-8')
+
+                        # ?key_format=pkcs1 adds the legacy/traditional form
+                        # ALONGSIDE private_key_pem rather than replacing it,
+                        # so an existing consumer of format=json is unaffected
+                        # (issue #398). Converted from the bytes just read —
+                        # no second file read, no second path to validate.
+                        # pkcs8 is what is already on disk, so asking for it
+                        # here is a no-op by design.
+                        if key_format == 'pkcs1':
+                            try:
+                                payload['private_key_pkcs1_pem'] = _privkey_to_pkcs1(
+                                    payload['private_key_pem'].encode('utf-8')
+                                ).decode('utf-8')
+                            except (ValueError, TypeError) as e:
+                                # The message is included, not just the type:
+                                # cryptography emits static, descriptive text
+                                # ("Password was not given but private key is
+                                # encrypted", "format is invalid with this
+                                # key") that carries no key material and tells
+                                # an operator which of several very different
+                                # problems they have. CR/LF scrubbed like every
+                                # other interpolated value here.
+                                logger.error(
+                                    "Failed to convert private key to PKCS#1: %s: %s",
+                                    type(e).__name__,
+                                    str(e).replace('\r', ' ').replace('\n', ' '),
+                                )
+                                return {
+                                    'error': 'Could not convert the private key to PKCS#1 '
+                                             '(the key type may not support it).'
+                                }, 422
+
+                        return jsonify(payload)
+                    except FileNotFoundError:
+                        return {'error': f'Required cert file not found for domain {domain}'}, 404
+
+                if requested_file:
+                    # Security check: only allow specific certificate files
+                    allowed_files = _PUBLIC_DOWNLOAD_FILES | _PRIVATE_KEY_FILES
+                    if requested_file not in allowed_files:
+                        return {'error': 'Invalid file requested.'}, 400
+
+                    # Private-key files require operator+; public files
+                    # remain viewer-accessible.
+                    if requested_file in _PRIVATE_KEY_FILES and not _user_has_role(user, 'operator'):
+                        return _privkey_denied(requested_file)
+
+                    if requested_file == 'combined.pem':
+                        try:
+                            # Read both files and join them
+                            fullchain = (cert_dir / 'fullchain.pem').read_text(encoding='utf-8')
+                            privkey = (cert_dir / 'privkey.pem').read_text(encoding='utf-8')
+                            combined_data = io.BytesIO(f"{fullchain}{privkey}".encode())
+
+                            return send_file(
+                                combined_data,
+                                as_attachment=True,
+                                download_name=f'{domain}_combined.pem',
+                                mimetype='application/x-pem-file'
+                            )
+                        except FileNotFoundError:
+                            return {'error': f'Required cert files not found for domain {domain}'}, 404
+
+                    file_path = cert_dir / requested_file
+                    if not file_path.exists():
+                        return {'error': f'File {requested_file} not found for domain {domain}'}, 404
+
+                    if requested_file == 'privkey.pem' and key_format == 'pkcs1':
+                        # Re-resolve with a constant filename and confirm the
+                        # path stays inside the (already validated) domain dir
+                        # before reading — defense in depth, and keeps the new
+                        # file read off any tainted path component.
+                        key_path = os.path.realpath(cert_dir / 'privkey.pem')
+                        if not key_path.startswith(os.path.realpath(cert_dir) + os.sep):
+                            return {'error': 'Invalid path'}, 400
+                        try:
+                            with open(key_path, 'rb') as fh:
+                                pkcs1_pem = _privkey_to_pkcs1(fh.read())
+                        except (ValueError, TypeError) as e:
+                            # Same reasoning as the format=json branch above:
+                            # the message is safe and diagnostic. Kept identical
+                            # so the two conversion sites do not drift.
+                            logger.error(
+                                "Failed to convert private key to PKCS#1: %s: %s",
+                                type(e).__name__,
+                                str(e).replace('\r', ' ').replace('\n', ' '),
+                            )
+                            return {
+                                'error': 'Could not convert the private key to PKCS#1 '
+                                         '(the key type may not support it).'
+                            }, 422
+                        return send_file(
+                            io.BytesIO(pkcs1_pem),
+                            as_attachment=True,
+                            download_name=f'{domain}_privkey_pkcs1.pem',
+                            mimetype='application/x-pem-file',
+                        )
+
+                    file_mimetype = (
+                        'application/x-pkcs12' if requested_file.endswith('.pfx')
+                        else 'application/x-pem-file'
+                    )
+                    return send_file(
+                        file_path,
+                        as_attachment=True,
+                        download_name=f'{domain}_{requested_file}',
+                        mimetype=file_mimetype
+                    )
+
+                # Fallback ZIP. Two flavors:
+                #   include_private=1 (default)  -> all 4 PEMs, operator+
+                #   include_private=0            -> public material only,
+                #                                   safe for viewer
+                if include_private and not _user_has_role(user, 'operator'):
+                    return _privkey_denied('default ZIP')
+
+                files_to_zip = (
+                    CERTIFICATE_FILES if include_private
+                    else tuple(f for f in CERTIFICATE_FILES if f not in _PRIVATE_KEY_FILES)
+                )
+                # The encrypted PKCS#12 bundle (only present when a PFX password
+                # is configured, #230/#465) is key-bearing, so it rides only in
+                # the private ZIP. The loop below writes it only if it exists.
+                if include_private:
+                    files_to_zip = files_to_zip + ('cert.pfx',)
+                zip_suffix = 'certificates' if include_private else 'certificates_public'
+
+                # Create temporary ZIP file
+                with tempfile.NamedTemporaryFile(delete=False, suffix='.zip') as tmp_file:
+                    tmp_path = tmp_file.name
+                    with zipfile.ZipFile(tmp_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
+                        for cert_file in files_to_zip:
+                            file_path = cert_dir / cert_file
+                            if file_path.exists():
+                                zipf.write(file_path, cert_file)
+
+                    @after_this_request
+                    def remove_file(response):
+                        try:
+                            os.remove(tmp_path)
+                        except Exception as e:
+                            logger.debug(f"Could not remove temp file {tmp_path}: {e}")
+                        return response
+
+                    return send_file(
+                        tmp_path,
+                        as_attachment=True,
+                        download_name=f'{domain}_{zip_suffix}.zip',
+                        mimetype='application/zip'
+                    )
+
+            except Exception as e:
+                logger.error(f"Error downloading certificate for {domain}: {e}")
+                return {'error': 'Failed to download certificate'}, 500
+
+    class DownloadCertificateFile(Resource):
+        # Path-style alias for the query-string form on DownloadCertificate.
+        # Documented in discussion #183 as the canonical scripting URL
+        # (curl ... /api/certificates/<domain>/download/fullchain). Without
+        # this route the documented URL returned 404 (issue #212).
+        #
+        # Short names map 1:1 to the on-disk filenames. The role gate and
+        # path-traversal guards mirror the ?file= branch in
+        # DownloadCertificate.get() — keep the two in sync.
+        _SHORT_NAME_TO_FILE = {
+            'cert': 'cert.pem',
+            'chain': 'chain.pem',
+            'fullchain': 'fullchain.pem',
+            'privkey': 'privkey.pem',
+            'combined': 'combined.pem',
+        }
+
+        @api.doc(security='Bearer')
+        @ctx.auth.require_role('viewer')
+        def get(self, domain, file_type):
+            """Download a single certificate file by short name.
+
+            Path-style equivalent of ``?file=<name>.pem`` on the parent
+            ``/download`` route. ``file_type`` is one of ``cert``,
+            ``chain``, ``fullchain``, ``privkey``, ``combined``.
+
+            Role gating: viewers can pull public material (cert, chain,
+            fullchain); ``privkey`` and ``combined`` require operator+.
+            """
+            requested_file = self._SHORT_NAME_TO_FILE.get(file_type)
+            if requested_file is None:
+                return {
+                    'error': f'Invalid file type: {file_type}',
+                    'hint': f"Allowed: {sorted(self._SHORT_NAME_TO_FILE)}",
+                }, 400
+
+            try:
+                scope_err = _check_domain_scope(domain, 'download')
+                if scope_err:
+                    return scope_err
+                cert_dir, err = _validate_domain_path(domain, ctx.file_ops.cert_dir)
+                if err:
+                    return {'error': err}, 400
+                if not cert_dir.exists():
+                    return {'error': f'Certificate not found for domain: {domain}'}, 404
+
+                user = getattr(request, 'current_user', None) or {}
+
+                if requested_file in _PRIVATE_KEY_FILES and not _user_has_role(user, 'operator'):
+                    if ctx.audit:
+                        ctx.audit.log_authz_denied(
+                            operation='download',
+                            resource_type='certificate',
+                            resource_id=domain,
+                            reason=f'viewer cannot download private-key material ({requested_file})',
+                            user=user.get('username'),
+                            ip_address=request.remote_addr,
+                        )
+                    return {
+                        'error': 'operator role required to download private key material',
+                        'code': 'PRIVKEY_REQUIRES_OPERATOR',
+                        'hint': 'Use /download/fullchain to pull public material as a viewer.',
+                    }, 403
+
+                if requested_file == 'combined.pem':
+                    try:
+                        fullchain = (cert_dir / 'fullchain.pem').read_text(encoding='utf-8')
+                        privkey = (cert_dir / 'privkey.pem').read_text(encoding='utf-8')
+                        combined_data = io.BytesIO(f"{fullchain}{privkey}".encode())
+                        return send_file(
+                            combined_data,
+                            as_attachment=True,
+                            download_name=f'{domain}_combined.pem',
+                            mimetype='application/x-pem-file'
+                        )
+                    except FileNotFoundError:
+                        return {'error': f'Required cert files not found for domain {domain}'}, 404
+
+                file_path = cert_dir / requested_file
+                if not file_path.exists():
+                    return {'error': f'File {requested_file} not found for domain {domain}'}, 404
+
+                return send_file(
+                    file_path,
+                    as_attachment=True,
+                    download_name=f'{domain}_{requested_file}',
+                    mimetype='application/x-pem-file'
+                )
+            except Exception as e:
+                logger.error(f"Error downloading {file_type} for {domain}: {e}")
+                return {'error': 'Failed to download certificate file'}, 500
+
+    return {
+        'DownloadCertificate': DownloadCertificate,
+        'DownloadCertificateFile': DownloadCertificateFile,
+    }

--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -222,11 +222,16 @@ class AuthManager:
 
     # --- Scoped API Key management ---
 
-    # Domain pattern used by allowed_domains validation. Mirrors the existing
-    # _DOMAIN_RE in modules/api/resources.py but also accepts the bare
-    # wildcard form "*.example.com" (no leading label before the asterisk).
+    # Domain pattern used by allowed_domains validation. Mirrors DOMAIN_RE in
+    # modules/api/path_validation.py but also accepts the bare wildcard form
+    # "*.example.com" (no leading label before the asterisk).
+    #
+    # `\Z`, not `$`: in Python `$` also matches before a trailing newline, so
+    # the previous expression treated "example.com\n" as a valid pattern. That
+    # was inert here because the caller strips each entry before matching — but
+    # it is inert by accident, and the next caller need not strip.
     _ALLOWED_DOMAIN_RE = __import__('re').compile(
-        r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$'
+        r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}\Z'
     )
 
     @classmethod

--- a/tests/test_api_group_modules_are_standalone.py
+++ b/tests/test_api_group_modules_are_standalone.py
@@ -405,3 +405,87 @@ def test_a_viewer_cannot_download_a_private_key_from_the_bundle_endpoint(
     assert allowed_status != 403, (
         f'CONTROL: a viewer must still reach cert.pem, got {allowed_status}'
     )
+
+
+DOWNLOAD_TRAVERSAL = [
+    '../secret.pem',
+    '../../etc/passwd',
+    'a/../../../etc',
+    'example.com/../../secret.pem',
+    '\x00example.com',
+    '....//secret.pem',
+    '/etc/passwd',
+    'example.com\x00.evil',
+    'evil\nexample.com',
+]
+
+
+@pytest.mark.parametrize('hostile', DOWNLOAD_TRAVERSAL)
+@pytest.mark.parametrize('endpoint_name',
+                         ['DownloadCertificate', 'DownloadCertificateFile'])
+def test_the_download_endpoints_refuse_a_hostile_domain(
+        api, tmp_path, endpoint_name, hostile):
+    """Both endpoints, every shape, driven rather than reasoned about.
+
+    Code scanning reports fourteen path expressions across this module and two
+    log lines that take the domain. All of them sit behind
+    `validate_domain_path` and the short-name mapping, and the only way to know
+    that holds for every entry point is to try it — a guard applied on one path
+    and forgotten on another is exactly what an extraction can produce.
+    """
+    from flask import request as flask_request
+    from modules.api.resources_downloads import create_download_resources
+
+    (tmp_path / 'certs').mkdir()
+    (tmp_path / 'secret.pem').write_text('outside the certificate directory\n')
+
+    file_ops = MagicMock()
+    file_ops.cert_dir = tmp_path / 'certs'
+    ctx = _minimal_context(file_ops=file_ops, audit=None, managers={})
+    ctx.auth.user_can_access_domain = lambda user, d: True
+
+    endpoint = create_download_resources(
+        api, {}, ctx, lambda pem: pem)[endpoint_name]
+    args = (hostile,) if endpoint_name == 'DownloadCertificate' \
+        else (hostile, 'cert')
+
+    app = Flask(__name__)
+    with app.test_request_context('/'):
+        flask_request.current_user = {'username': 'admin', 'role': 'admin'}
+        result = endpoint().get(*args)
+
+    status = result[1] if isinstance(result, tuple) else 200
+    assert status in (400, 403, 404), (
+        f'{endpoint_name} answered {status} for {hostile!r} instead of '
+        f'refusing it'
+    )
+
+
+def test_a_real_domain_still_reaches_its_files(api, tmp_path):
+    """CONTROL: the refusals above mean nothing from an endpoint that refuses
+    everything — which is the easiest way to make a traversal test pass."""
+    from flask import request as flask_request
+    from modules.api.resources_downloads import create_download_resources
+
+    cert_dir = tmp_path / 'certs' / 'example.com'
+    cert_dir.mkdir(parents=True)
+    (cert_dir / 'cert.pem').write_text('-----BEGIN CERTIFICATE-----\n')
+
+    file_ops = MagicMock()
+    file_ops.cert_dir = tmp_path / 'certs'
+    ctx = _minimal_context(file_ops=file_ops, audit=None, managers={})
+    ctx.auth.user_can_access_domain = lambda user, d: True
+
+    endpoint = create_download_resources(
+        api, {}, ctx, lambda pem: pem)['DownloadCertificateFile']
+
+    app = Flask(__name__)
+    with app.test_request_context('/'):
+        flask_request.current_user = {'username': 'admin', 'role': 'admin'}
+        result = endpoint().get('example.com', 'cert')
+
+    status = result[1] if isinstance(result, tuple) else 200
+    assert status not in (400, 403), (
+        f'a legitimate download was refused ({status}); the traversal '
+        f'assertions above would pass on a dead endpoint'
+    )

--- a/tests/test_api_group_modules_are_standalone.py
+++ b/tests/test_api_group_modules_are_standalone.py
@@ -302,3 +302,106 @@ def test_the_settings_group_builds_from_a_minimal_context(api):
         'Settings', 'DNSProviders', 'DNSAccounts', 'DNSAccountDetail'}
     for name, cls in resources.items():
         assert issubclass(cls, Resource), f'{name} is not a Resource'
+
+
+def test_the_download_group_builds_from_a_minimal_context(api):
+    """The group the decomposition could not reach until #667's helper move."""
+    from modules.api.resources_downloads import create_download_resources
+
+    ctx = _minimal_context(file_ops=MagicMock(), audit=MagicMock(), managers={})
+    resources = create_download_resources(api, {}, ctx, lambda pem: pem)
+
+    assert set(resources) == {'DownloadCertificate', 'DownloadCertificateFile'}
+    for name, cls in resources.items():
+        assert issubclass(cls, Resource), f'{name} is not a Resource'
+
+
+def test_a_viewer_cannot_download_a_private_key(api, tmp_path):
+    """The access rule this group exists to enforce, exercised not read.
+
+    `_PRIVATE_KEY_FILES` decides which downloads require operator rather than
+    viewer. A viewer reaching a private key is the worst failure in this file,
+    and moving the endpoints into their own module is exactly the kind of
+    change that could drop the check while every build-only test stayed green.
+    """
+    from flask import request as flask_request
+    from modules.api.resources_downloads import create_download_resources
+
+    domain = 'example.com'
+    cert_dir = tmp_path / 'certs' / domain
+    cert_dir.mkdir(parents=True)
+    for name in ('cert.pem', 'privkey.pem'):
+        (cert_dir / name).write_text(f'-----BEGIN {name}-----\n')
+
+    file_ops = MagicMock()
+    file_ops.cert_dir = tmp_path / 'certs'
+    ctx = _minimal_context(file_ops=file_ops, audit=None, managers={})
+    ctx.auth.user_can_access_domain = lambda user, d: True
+
+    endpoint = create_download_resources(
+        api, {}, ctx, lambda pem: pem)['DownloadCertificateFile']
+
+    app = Flask(__name__)
+    with app.test_request_context('/'):
+        flask_request.current_user = {'username': 'v', 'role': 'viewer'}
+        result = endpoint().get(domain, 'privkey')
+    status = result[1] if isinstance(result, tuple) else 200
+    assert status == 403, (
+        f'a viewer was served a private key ({status}); the operator gate on '
+        f'_PRIVATE_KEY_FILES is not being applied'
+    )
+
+    with app.test_request_context('/'):
+        flask_request.current_user = {'username': 'v', 'role': 'viewer'}
+        public = endpoint().get(domain, 'cert')
+    public_status = public[1] if isinstance(public, tuple) else 200
+    assert public_status != 403, (
+        f'CONTROL: a viewer must still be able to download a public file, '
+        f'got {public_status} — an endpoint that refuses everything would '
+        f'satisfy the assertion above while being broken'
+    )
+
+
+def test_a_viewer_cannot_download_a_private_key_from_the_bundle_endpoint(
+        api, tmp_path):
+    """The other download endpoint, whose gate the test above cannot see.
+
+    `DownloadCertificate` is the larger of the two and gates per file as well:
+    `?file=privkey.pem` needs operator, and so does the default ZIP and the
+    JSON form. Covering only `DownloadCertificateFile` left this one able to
+    lose its check silently — which is what happened when the first mutation
+    run was aimed here and nothing failed.
+    """
+    from flask import request as flask_request
+    from modules.api.resources_downloads import create_download_resources
+
+    domain = 'example.com'
+    cert_dir = tmp_path / 'certs' / domain
+    cert_dir.mkdir(parents=True)
+    for name in ('cert.pem', 'chain.pem', 'fullchain.pem', 'privkey.pem'):
+        (cert_dir / name).write_text(f'-----BEGIN {name}-----\n')
+
+    file_ops = MagicMock()
+    file_ops.cert_dir = tmp_path / 'certs'
+    ctx = _minimal_context(file_ops=file_ops, audit=None, managers={})
+    ctx.auth.user_can_access_domain = lambda user, d: True
+
+    endpoint = create_download_resources(
+        api, {}, ctx, lambda pem: pem)['DownloadCertificate']
+
+    app = Flask(__name__)
+    with app.test_request_context('/?file=privkey.pem'):
+        flask_request.current_user = {'username': 'v', 'role': 'viewer'}
+        result = endpoint().get(domain)
+    status = result[1] if isinstance(result, tuple) else 200
+    assert status == 403, (
+        f'a viewer pulled privkey.pem from the bundle endpoint ({status})'
+    )
+
+    with app.test_request_context('/?file=cert.pem'):
+        flask_request.current_user = {'username': 'v', 'role': 'viewer'}
+        allowed = endpoint().get(domain)
+    allowed_status = allowed[1] if isinstance(allowed, tuple) else 200
+    assert allowed_status != 403, (
+        f'CONTROL: a viewer must still reach cert.pem, got {allowed_status}'
+    )

--- a/tests/test_domain_anchor_is_not_newline_permissive.py
+++ b/tests/test_domain_anchor_is_not_newline_permissive.py
@@ -1,0 +1,69 @@
+"""A domain validator must not accept a domain with a newline on the end.
+
+Python's `$` matches at the end of the string OR immediately before a trailing
+newline. Both domain patterns in this project were anchored with `$`, so
+"example.com\\n" satisfied a check whose failure message is "Invalid domain
+format" — and the character screen beside it does not look at newlines either,
+so nothing else caught it.
+
+Neither was exploitable when found. In the API path validator the resolved path
+still lands under the certificate directory, so it is a 404 rather than an
+escape; in the allowed_domains validator the caller strips each entry before
+matching. The second is inert by accident, which is the reason to fix it: the
+next caller need not strip.
+
+Anchored with `\\Z` now, and pinned here — `$` is the natural thing to write,
+so this will be reintroduced by someone who has not met this behaviour.
+"""
+import tempfile
+
+import pytest
+
+from modules.api.path_validation import DOMAIN_RE, validate_domain_path
+from modules.core.auth import AuthManager
+
+pytestmark = [pytest.mark.unit]
+
+REAL_DOMAINS = [
+    'example.com',
+    '*.example.com',
+    'sub.example.co.uk',
+    'xn--bcher-kva.example.com',
+    'a-b.example.com',
+]
+
+TRAILING = ['example.com\n', 'example.com\r', 'example.com\n\n', '*.example.com\n']
+
+
+@pytest.mark.parametrize('domain', REAL_DOMAINS)
+def test_real_domains_are_still_accepted(domain):
+    """CONTROL first: tightening an anchor is the kind of change that quietly
+    starts refusing legitimate input, and here that would make a certificate
+    unreachable."""
+    assert DOMAIN_RE.match(domain), f'{domain!r} was refused'
+    assert AuthManager._ALLOWED_DOMAIN_RE.match(domain), f'{domain!r} was refused'
+
+
+@pytest.mark.parametrize('domain', TRAILING)
+def test_a_trailing_newline_is_not_a_domain(domain):
+    assert not DOMAIN_RE.match(domain), (
+        f'{domain!r} matched the API domain pattern; the anchor is `$` again, '
+        f'which matches before a trailing newline'
+    )
+    assert not AuthManager._ALLOWED_DOMAIN_RE.match(domain), (
+        f'{domain!r} matched the allowed_domains pattern; the anchor is `$` '
+        f'again'
+    )
+
+
+@pytest.mark.parametrize('domain', TRAILING)
+def test_the_path_validator_refuses_it_too(domain):
+    """The regex is not reached directly by callers — this is."""
+    path, err = validate_domain_path(domain, tempfile.gettempdir())
+    assert path is None and err, f'{domain!r} produced a path: {path}'
+
+
+def test_a_real_domain_still_produces_a_path():
+    """CONTROL: a validator that refused everything would satisfy the above."""
+    path, err = validate_domain_path('example.com', tempfile.gettempdir())
+    assert err is None and path is not None


### PR DESCRIPTION
The decomposition stalled here, and this is the change that unblocks the rest of #667.

Both download classes call `_validate_domain_path`, which lived in `resources.py`
alongside **thirteen other callers** — so a module of their own could not use it without
importing the file that imports them back.

`modules/api/path_validation.py` is that helper's shared home. Nothing about the rules
changes: the same three checks in the same order, and `resources.py` re-exports
`_validate_domain_path` and `_DOMAIN_RE` under their old names, so the thirteen remaining
call sites and the existing tests are untouched.

With that out of the way, `DownloadCertificate` and `DownloadCertificateFile` move into
`resources_downloads.py`.

| | at #667 open | now |
|---|---|---|
| closure complexity | 559 | **196** |
| `resources.py` | 4040 lines | **1658** |

### The access rule moves with the endpoints that enforce it

`_PRIVATE_KEY_FILES` / `_PUBLIC_DOWNLOAD_FILES` decide which downloads require operator
rather than viewer. They belong beside those endpoints rather than remaining loose closure
state — a viewer reaching a private key is the worst failure in this file.

### Both gates are tested, separately, and that turned out to matter

A first version covered only `DownloadCertificateFile`. Mutating the gate in
`DownloadCertificate` changed nothing and every test stayed green — precisely the failure
this kind of move can cause, and I only noticed because the mutation I ran first happened
to land on the uncovered one.

Each gate is now mutation-verified on its own, each with a control proving a viewer can
still reach the public files: an endpoint that refused everything would satisfy the denial
assertions while being broken.

### One deliberate compromise

`_privkey_to_pkcs1` is passed in as an argument rather than moved. Its tests import it
from `resources.py`, and taking it as a parameter avoids an import cycle without dragging
a second helper into the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)