### PR TITLE
fix: a certificate with no usable private key is not healthy (#608)

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -161,6 +161,24 @@ def create_api_models(api):
         'days_left': fields.Integer(description='Days until expiry'),
         'days_until_expiry': fields.Integer(description='Days until expiry (alias for days_left)'),
         'needs_renewal': fields.Boolean(description='Whether certificate needs renewal'),
+        'usable': fields.Boolean(
+            description=(
+                'Whether this certificate can actually serve TLS: it exists AND '
+                'a matching private key is beside it. Null on the '
+                'storage-backend listing path, which fetches the certificate '
+                'without the key on purpose and therefore cannot say. A false '
+                'here also forces needs_renewal, because a keyless certificate '
+                'has nothing to wait for.'
+            )),
+        'private_key_present': fields.Boolean(
+            description=(
+                'Whether a private key was found beside the certificate. Null '
+                'when it was not looked for. Restoring a share-safe backup '
+                'produces certificates with no key, which is why this is '
+                'reported rather than assumed.'
+            )),
+        'private_key_state': fields.String(
+            description="One of 'present', 'missing', 'mismatched' or 'unknown'."),
         'auto_renew': fields.Boolean(description='Whether automatic renewal is enabled for this certificate'),
         'dns_provider': fields.String(description='DNS provider used for the certificate'),
         'domain_alias': fields.String(description='DNS alias target used for DNS-01 validation'),

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -1141,7 +1141,17 @@ class CertificateManager:
                 if storage_result:
                     cert_files, metadata = storage_result
                     if 'cert.pem' in cert_files:
-                        info = self._parse_certificate_info(domain, cert_files['cert.pem'], metadata, settings=cache_settings)
+                        # 'unknown', NOT 'missing'. retrieve_certificate_info
+                        # deliberately returns cert.pem alone — its whole point
+                        # is to avoid pulling private keys out of a secrets
+                        # backend for a listing view. Reading the absent key as
+                        # a missing key would mark every storage-backed
+                        # certificate as needing renewal (#608).
+                        info = self._parse_certificate_info(
+                            domain, cert_files['cert.pem'], metadata,
+                            settings=cache_settings,
+                            key_state=('present' if cert_files.get('privkey.pem')
+                                       else 'unknown'))
                         if cache_enabled:
                             self._set_cached_certificate_info(domain, info, cache_settings)
                         return info
@@ -1181,12 +1191,66 @@ class CertificateManager:
         try:
             with open(cert_file, 'rb') as f:
                 cert_content = f.read()
-            return self._parse_certificate_info(domain, cert_content, metadata, settings=settings)
+            return self._parse_certificate_info(
+                domain, cert_content, metadata, settings=settings,
+                key_state=self.private_key_state(domain, cert_content))
         except Exception as e:
             logger.error(f"Failed to read certificate file for {domain}: {e}")
             return self._create_empty_cert_info(domain)
     
-    def _parse_certificate_info(self, domain, cert_content, metadata=None, settings=None):
+    def private_key_state(self, domain, cert_content=None):
+        """Is there a usable private key beside this certificate? (#608)
+
+        Returns one of ``'present'``, ``'missing'`` or ``'mismatched'``.
+
+        `get_certificate_info` decided a certificate existed by looking at
+        cert.pem alone, so a directory holding a certificate and no key was
+        reported healthy with `needs_renewal: false` — and the scheduler then
+        left it alone until an expiry that does not matter, because the
+        instance cannot serve TLS for that name at all.
+
+        That state is not hypothetical: it is exactly what restoring a
+        share-safe backup produces, since those deliberately carry no key
+        material. An operator verifying a recovery the obvious way — the API
+        lists my certificates with sane expiries — is told the node is fine.
+
+        The mismatch case is checked too, and is the cheaper half of the same
+        question: cert.pem from one issuance beside privkey.pem from another
+        cannot complete a handshake either, and comparing public numbers
+        catches it for RSA and EC alike without needing to know the key type.
+        """
+        key_file = self.cert_dir / domain / 'privkey.pem'
+        if not key_file.exists():
+            return 'missing'
+        if cert_content is None:
+            return 'present'
+
+        try:
+            from cryptography.hazmat.primitives import serialization
+            from cryptography import x509
+
+            private_key = serialization.load_pem_private_key(
+                key_file.read_bytes(), password=None)
+            certificate = x509.load_pem_x509_certificate(cert_content)
+        except Exception as e:
+            # An unreadable or encrypted key is not a usable one. Say so
+            # rather than reporting the certificate as fine.
+            logger.warning(
+                "Could not verify the private key for %s: %s",
+                str(domain).replace(chr(10), ' ').replace(chr(13), ' '), e)
+            return 'mismatched'
+
+        try:
+            matches = (private_key.public_key().public_numbers()
+                       == certificate.public_key().public_numbers())
+        except Exception:
+            # Different key types have incomparable public_numbers; that is
+            # itself a mismatch.
+            matches = False
+        return 'present' if matches else 'mismatched'
+
+    def _parse_certificate_info(self, domain, cert_content, metadata=None,
+                                settings=None, key_state='present'):
         """Parse certificate information from certificate content.
 
         ``settings`` mirrors the get_certificate_info parameter: callers
@@ -1242,7 +1306,21 @@ class CertificateManager:
                 # Inclusive boundary: a cert with exactly renewal_threshold_days
                 # left must renew. Using `<` skipped the boundary, delaying
                 # renewal by a day; digest.py and metrics.py already use `<=`.
-                'needs_renewal': days_left <= renewal_threshold_days,
+                # A certificate with no usable private key cannot serve TLS,
+                # so it needs attention now rather than at its expiry — which
+                # is what let a restored keyless certificate sit untouched
+                # while reporting itself healthy (#608).
+                # 'unknown' is not evidence of a problem: the storage-backed
+                # listing path never fetches the key, so only a key we looked
+                # for and did not find (or one that does not match) forces
+                # attention here.
+                'needs_renewal': (days_left <= renewal_threshold_days
+                                  or key_state in ('missing', 'mismatched')),
+                'private_key_present': (None if key_state == 'unknown'
+                                        else key_state != 'missing'),
+                'private_key_state': key_state,
+                'usable': (None if key_state == 'unknown'
+                           else key_state == 'present'),
                 'dns_provider': dns_provider,
                 'domain_alias': domain_alias,
                 'alias_dns_provider': alias_dns_provider,
@@ -1272,6 +1350,10 @@ class CertificateManager:
             'days_left': None,
             'days_until_expiry': None,
             'needs_renewal': True,
+            'private_key_present': (None if key_state == 'unknown'
+                                    else key_state != 'missing'),
+            'private_key_state': key_state,
+            'usable': False,
             'dns_provider': dns_provider,
             'domain_alias': domain_alias,
             'alias_dns_provider': alias_dns_provider,

--- a/tests/test_cert_info_inproc_parse.py
+++ b/tests/test_cert_info_inproc_parse.py
@@ -26,8 +26,15 @@ from modules.core.settings import SettingsManager
 pytestmark = [pytest.mark.unit]
 
 
-def _make_cert_pem(not_after: datetime) -> bytes:
-    """Build a throwaway self-signed cert with a known notAfter."""
+def _make_cert_pem(not_after: datetime, with_key: bool = False):
+    """Build a throwaway self-signed cert with a known notAfter.
+
+    With ``with_key`` it returns ``(cert_pem, key_pem)``. These tests are about
+    expiry arithmetic, so they need a COMPLETE certificate on disk: since #608 a
+    certificate with no private key is reported as needing attention regardless
+    of its expiry, which would otherwise make a threshold assertion pass or fail
+    for a reason it is not testing.
+    """
     key = ec.generate_private_key(ec.SECP256R1())
     name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "example.com")])
     cert = (
@@ -40,7 +47,15 @@ def _make_cert_pem(not_after: datetime) -> bytes:
         .not_valid_after(not_after)
         .sign(key, hashes.SHA256())
     )
-    return cert.public_bytes(serialization.Encoding.PEM)
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    if not with_key:
+        return cert_pem
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return cert_pem, key_pem
 
 
 @pytest.fixture
@@ -76,15 +91,17 @@ def cert_manager(tmp_path):
     )
 
 
-def _write_cert(cert_manager, domain, pem):
+def _write_cert(cert_manager, domain, pem, key_pem=None):
     cert_path = cert_manager.cert_dir / domain
     cert_path.mkdir(parents=True, exist_ok=True)
     (cert_path / "cert.pem").write_bytes(pem)
+    if key_pem is not None:
+        (cert_path / "privkey.pem").write_bytes(key_pem)
 
 
 def test_expiry_parsed_in_process_without_openssl(cert_manager):
     not_after = datetime.now(timezone.utc) + timedelta(days=42)
-    _write_cert(cert_manager, "example.com", _make_cert_pem(not_after))
+    _write_cert(cert_manager, "example.com", *_make_cert_pem(not_after, with_key=True))
 
     info = cert_manager.get_certificate_info("example.com")
 
@@ -99,7 +116,7 @@ def test_expiry_parsed_in_process_without_openssl(cert_manager):
 
 def test_near_expiry_flags_needs_renewal(cert_manager):
     not_after = datetime.now(timezone.utc) + timedelta(days=5)
-    _write_cert(cert_manager, "soon.example.com", _make_cert_pem(not_after))
+    _write_cert(cert_manager, "soon.example.com", *_make_cert_pem(not_after, with_key=True))
 
     info = cert_manager.get_certificate_info("soon.example.com")
 
@@ -119,7 +136,7 @@ def test_renewal_boundary_is_inclusive(cert_manager):
     truncating `.days` land on exactly 30 regardless of sub-second skew.
     """
     not_after = datetime.now(timezone.utc) + timedelta(days=30, hours=12)
-    _write_cert(cert_manager, "boundary.example.com", _make_cert_pem(not_after))
+    _write_cert(cert_manager, "boundary.example.com", *_make_cert_pem(not_after, with_key=True))
 
     info = cert_manager.get_certificate_info("boundary.example.com")
 
@@ -131,7 +148,7 @@ def test_just_above_threshold_does_not_renew(cert_manager):
     """One day past the threshold must NOT renew — guards against the fix
     over-correcting into premature renewal."""
     not_after = datetime.now(timezone.utc) + timedelta(days=31, hours=12)
-    _write_cert(cert_manager, "above.example.com", _make_cert_pem(not_after))
+    _write_cert(cert_manager, "above.example.com", *_make_cert_pem(not_after, with_key=True))
 
     info = cert_manager.get_certificate_info("above.example.com")
 

--- a/tests/test_keyless_certificate_is_not_healthy.py
+++ b/tests/test_keyless_certificate_is_not_healthy.py
@@ -1,0 +1,211 @@
+"""A certificate with no usable private key must not report as healthy (#608).
+
+`get_certificate_info` decided a certificate existed from `cert.pem` alone. A
+directory holding a valid certificate and no key therefore came back as
+
+    exists True   days_left 74   needs_renewal False
+
+and the renewal sweep left it alone for another six weeks — for an instance
+that cannot complete a TLS handshake for that name at all.
+
+The state is not hypothetical. It is exactly what restoring a **share-safe**
+backup produces, because those deliberately carry no key material: the restore
+writes back cert.pem, chain.pem and fullchain.pem and nothing else. An operator
+verifying a recovery the obvious way — the API lists my certificates with sane
+expiries — is told the node is fine.
+
+The mismatch case is the same question asked once more: cert.pem from one
+issuance beside privkey.pem from another cannot handshake either.
+
+One thing this must NOT do, and the reason half this file exists: the
+storage-backed listing path fetches `cert.pem` alone **on purpose**, to avoid
+pulling private keys out of a secrets backend for a dashboard. Reading that
+absence as a missing key would mark every storage-backed certificate as needing
+renewal. Absent-because-nobody-looked is reported as `unknown`, not `missing`.
+"""
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from modules.core.certificates import CertificateManager
+from modules.core.file_operations import FileOperations
+from modules.core.settings import SettingsManager
+
+pytestmark = [pytest.mark.unit]
+
+
+def _self_signed(days_left=74):
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'example.com')])
+    cert = (x509.CertificateBuilder()
+            .subject_name(name).issuer_name(name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=days_left))
+            .sign(key, hashes.SHA256()))
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption())
+    return cert.public_bytes(serialization.Encoding.PEM), key_pem
+
+
+@pytest.fixture
+def manager(tmp_path):
+    dirs = [tmp_path / n for n in ('certificates', 'data', 'backups', 'logs')]
+    for directory in dirs:
+        directory.mkdir()
+    file_ops = FileOperations(*dirs)
+    settings = SettingsManager(file_ops, dirs[1] / 'settings.json')
+    return CertificateManager(
+        cert_dir=dirs[0], settings_manager=settings, dns_manager=MagicMock(),
+        shell_executor=MagicMock())
+
+
+def _plant(manager, domain, cert_pem, key_pem=None):
+    directory = manager.cert_dir / domain
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / 'cert.pem').write_bytes(cert_pem)
+    if key_pem is not None:
+        (directory / 'privkey.pem').write_bytes(key_pem)
+    return directory
+
+
+# ---------------------------------------------------------------------------
+# The state a restored share-safe backup leaves behind
+# ---------------------------------------------------------------------------
+
+def test_a_certificate_with_no_key_is_not_reported_healthy(manager):
+    cert_pem, _key = _self_signed(days_left=74)
+    _plant(manager, 'example.com', cert_pem)
+
+    info = manager.get_certificate_info('example.com')
+
+    assert info['private_key_present'] is False
+    assert info['usable'] is False
+    assert info['needs_renewal'] is True, (
+        'a certificate that cannot serve TLS was left for the scheduler to '
+        'ignore until an expiry that does not matter'
+    )
+    assert info['days_left'] > 30, (
+        'this test is only meaningful while the expiry is far away — '
+        'otherwise needs_renewal would be True for the ordinary reason'
+    )
+
+
+def test_a_complete_certificate_is_still_healthy(manager):
+    """CONTROL: the point is not to mark everything as broken."""
+    cert_pem, key_pem = _self_signed(days_left=74)
+    _plant(manager, 'good.example.com', cert_pem, key_pem)
+
+    info = manager.get_certificate_info('good.example.com')
+
+    assert info['private_key_present'] is True
+    assert info['usable'] is True
+    assert info['needs_renewal'] is False
+
+
+def test_a_key_from_a_different_issuance_is_not_usable(manager):
+    """cert.pem from one issuance beside privkey.pem from another cannot
+    complete a handshake — the split-bundle state a partial publish leaves."""
+    cert_pem, _own_key = _self_signed()
+    _other_cert, foreign_key = _self_signed()
+    _plant(manager, 'split.example.com', cert_pem, foreign_key)
+
+    info = manager.get_certificate_info('split.example.com')
+
+    assert info['private_key_state'] == 'mismatched'
+    assert info['usable'] is False
+    assert info['needs_renewal'] is True
+
+
+def test_an_unreadable_key_is_not_treated_as_a_good_one(manager):
+    cert_pem, _key = _self_signed()
+    _plant(manager, 'broken.example.com', cert_pem, b'not a private key')
+
+    info = manager.get_certificate_info('broken.example.com')
+
+    assert info['usable'] is False
+    assert info['needs_renewal'] is True
+
+
+# ---------------------------------------------------------------------------
+# The false positive this must not create
+# ---------------------------------------------------------------------------
+
+def test_the_storage_listing_path_does_not_invent_a_missing_key(tmp_path):
+    """`retrieve_certificate_info` returns cert.pem alone BY DESIGN — its whole
+    purpose is to avoid fetching private keys out of a secrets backend for a
+    listing view. Treating that as a missing key would mark every
+    storage-backed certificate as needing renewal.
+    """
+    dirs = [tmp_path / n for n in ('certificates', 'data', 'backups', 'logs')]
+    for directory in dirs:
+        directory.mkdir()
+    file_ops = FileOperations(*dirs)
+    settings = SettingsManager(file_ops, dirs[1] / 'settings.json')
+
+    cert_pem, _key = _self_signed(days_left=60)
+    storage = MagicMock()
+    storage.retrieve_certificate_info.return_value = (
+        {'cert.pem': cert_pem}, {'domain': 'example.com', 'dns_provider': 'azure'})
+
+    manager = CertificateManager(
+        cert_dir=dirs[0], settings_manager=settings, dns_manager=MagicMock(),
+        storage_manager=storage, shell_executor=MagicMock())
+
+    info = manager.get_certificate_info('example.com')
+
+    assert info['private_key_state'] == 'unknown'
+    assert info['private_key_present'] is None, (
+        'the listing path reported a definite answer about a key it never '
+        'asked for'
+    )
+    assert info['needs_renewal'] is False, (
+        'every storage-backed certificate was marked for renewal because the '
+        'lightweight listing bundle does not carry a private key'
+    )
+
+
+def test_a_storage_bundle_that_does_carry_a_key_says_so(tmp_path):
+    """CONTROL: when the key IS in the bundle, the answer is definite."""
+    dirs = [tmp_path / n for n in ('certificates', 'data', 'backups', 'logs')]
+    for directory in dirs:
+        directory.mkdir()
+    file_ops = FileOperations(*dirs)
+    settings = SettingsManager(file_ops, dirs[1] / 'settings.json')
+
+    cert_pem, key_pem = _self_signed(days_left=60)
+    storage = MagicMock()
+    storage.retrieve_certificate_info.return_value = (
+        {'cert.pem': cert_pem, 'privkey.pem': key_pem}, {'domain': 'example.com'})
+
+    manager = CertificateManager(
+        cert_dir=dirs[0], settings_manager=settings, dns_manager=MagicMock(),
+        storage_manager=storage, shell_executor=MagicMock())
+
+    info = manager.get_certificate_info('example.com')
+
+    assert info['private_key_state'] == 'present'
+    assert info['private_key_present'] is True
+
+
+# ---------------------------------------------------------------------------
+# The helper on its own
+# ---------------------------------------------------------------------------
+
+def test_the_key_state_helper_answers_without_a_certificate(manager):
+    """Callers that only want to know whether a key file is there should not
+    have to load and parse the certificate."""
+    cert_pem, key_pem = _self_signed()
+    _plant(manager, 'a.example.com', cert_pem, key_pem)
+    _plant(manager, 'b.example.com', cert_pem)
+
+    assert manager.private_key_state('a.example.com') == 'present'
+    assert manager.private_key_state('b.example.com') == 'missing'


### PR DESCRIPTION
Closes #608.

`get_certificate_info` decided a certificate existed from `cert.pem` **alone**, so a
directory holding a valid certificate and no key came back as

```
exists True   days_left 74   needs_renewal False
```

and the renewal sweep left it for another six weeks — for an instance that cannot
complete a handshake for that name.

**Not hypothetical.** Restoring a share-safe backup produces exactly this, because those
deliberately carry no key material. An operator verifying a recovery the obvious way —
*the API lists my certificates with sane expiries* — is told the node is fine.

### What it now reports

`private_key_state()` answers the real question, and the cheaper half of it too: a key
that does not *match* the certificate cannot handshake either, and comparing public
numbers catches that for RSA and EC alike without knowing the key type. An unreadable or
encrypted key counts as unusable rather than fine.

`private_key_present` / `private_key_state` / `usable` are surfaced on the info dict and
the API model, and a missing or mismatched key forces `needs_renewal` so the scheduler
acts instead of waiting for an expiry that is irrelevant.

### The part worth reviewing: what this does NOT do

The storage-backend listing path calls `retrieve_certificate_info`, which returns
`cert.pem` alone **by design** — its entire purpose is to avoid pulling private keys out
of a secrets backend for a dashboard. Reading that absence as a *missing* key would have
marked **every storage-backed certificate as needing renewal**.

It reports `'unknown'`, with `private_key_present` and `usable` as null, and does not
touch `needs_renewal`.

I want to be plain about how that was found: **the first version of this change had the
false positive in it.** A test failed, and reading what `retrieve_certificate_info`
actually promises — rather than assuming the bundle shape — is what caught it. Both
directions are mutation-verified: ignoring the key state fails three cases, and treating
`unknown` as `missing` fails the storage case.

### Existing tests

Four cases in two files asserted threshold arithmetic against fixtures that wrote
`cert.pem` without a key, so they were tripping on the new rule rather than on what they
test. Their helpers now write a matching key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)