### PR TITLE
feat: the backup list says which archives carry private keys (#595)

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -375,6 +375,16 @@ def create_api_models(api):
                 'credential. Decided with the same predicate the restore path '
                 'applies, and false whenever the archive cannot be inspected.'
             )),
+        'contains_key_material': fields.Boolean(
+            description=(
+                'Whether this archive carries private keys, read from the '
+                'archive itself rather than from its manifest. Every backup '
+                'made before v2.26.0 says secrets_masked: true and carries '
+                'them anyway. Null when the archive could not be inspected — '
+                'which is not the same as carrying none.'
+            )),
+        'key_file_count': fields.Integer(
+            description='How many key files were found; null when uninspectable.'),
         'restore_blocked_reason': fields.String(
             description='Why it cannot restore; null when it can.'),
         'metadata': fields.Raw(description='Backup metadata')

--- a/modules/core/file_operations.py
+++ b/modules/core/file_operations.py
@@ -733,6 +733,52 @@ class FileOperations:
         logger.info(f"Backup ingested from upload: {filename} ({len(raw)} bytes)")
         return filename, None
 
+    def _archive_key_files(self, backup_file):
+        """Key files inside *backup_file*, or None if it cannot be inspected.
+
+        None is not an answer of "none": an encrypted archive this instance has
+        no passphrase for genuinely cannot be read, and reporting that as clean
+        would be the same mistake the old manifests made.
+        """
+        try:
+            if backup_file.name.endswith(_BACKUP_ENC_SUFFIX):
+                passphrase = _backup_passphrase()
+                if not passphrase:
+                    return None
+                source = io.BytesIO(_decrypt_backup_payload(
+                    backup_file.read_bytes(), passphrase))
+            else:
+                source = backup_file
+            with zipfile.ZipFile(source, 'r') as zipf:
+                return self._archive_key_material(zipf.namelist())
+        except Exception as e:
+            logger.debug(f"Could not inspect {backup_file.name} for keys: {e}")
+            return None
+
+    @staticmethod
+    def _archive_key_material(names):
+        """The key files an archive carries, from its NAME LIST alone.
+
+        Every backup made before v2.26.0 with the default settings contains the
+        private key of every certificate, while its manifest says
+        `secrets_masked: true` and the interface called it share-safe (#595).
+        Archives from v2.22.0 also carry the private CA key and every
+        client-certificate key.
+
+        An operator who shared one believing it harmless has no way to tell
+        from the listing, and the advice — unzip and grep — assumes they know
+        to look. So the listing looks for them.
+
+        Reads the name list only: no entry is decompressed, so this stays cheap
+        enough to run while rendering a page.
+        """
+        from pathlib import PurePosixPath
+
+        return sorted({
+            name for name in names
+            if not name.endswith('/') and _is_key_material(PurePosixPath(name))
+        })
+
     def _backup_restorability(self, backup_file):
         """Can this archive actually bring the instance back? ``(bool, reason)``.
 
@@ -815,8 +861,19 @@ class FileOperations:
                             logger.debug(f"Could not read ZIP metadata from {backup_file}: {e}")
 
                         can_restore, reason = self._backup_restorability(backup_file)
+                        key_files = self._archive_key_files(backup_file)
                         backups["unified"].append({
                             "filename": backup_file.name,
+                            # Whether this archive carries private keys, read
+                            # from the archive itself rather than from its
+                            # manifest — every backup made before v2.26.0 says
+                            # secrets_masked: true and carries them anyway
+                            # (#595). None when the archive cannot be opened
+                            # here, which is not the same as "no keys".
+                            "contains_key_material": (
+                                None if key_files is None else bool(key_files)),
+                            "key_file_count": (
+                                None if key_files is None else len(key_files)),
                             # Stated per entry rather than left to be inferred
                             # from `metadata.secrets_masked`: that field names
                             # the mechanism, and the operator needs the

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1734,6 +1734,17 @@
                 var canRestore = backup.can_restore === true;
                 var blockedReason = escapeHtml(backup.restore_blocked_reason ||
                     'this archive cannot restore the instance');
+                // Archives written before v2.26.0 carry every private key while
+                // their manifest claims to be share-safe, so this is read from
+                // the archive rather than from that claim (#595). Only a
+                // definite true warns: null means it could not be inspected,
+                // and crying wolf on those would train people to ignore it.
+                var carriesKeys = backup.contains_key_material === true;
+                var keyCount = backup.key_file_count;
+                var keyBadge = !carriesKeys ? '' :
+                    '<span aria-hidden="true">·</span>' +
+                    '<span class="px-1.5 py-0.5 rounded bg-danger-surface border border-danger-line text-danger-strong text-[11px]" ' +
+                    'title="This archive contains ' + (keyCount || 'private') + ' private key file(s). If it was ever shared or copied off this host, treat those keys as exposed and reissue.">contains private keys</span>';
                 var restoreBadge = canRestore ? '' :
                     '<span aria-hidden="true">·</span>' +
                     '<span class="px-1.5 py-0.5 rounded bg-warning-surface border border-warning-line text-warning-strong text-[11px]" title="' + blockedReason + '">cannot restore</span>';
@@ -1750,6 +1761,7 @@
                             '<span aria-hidden="true">·</span>' +
                             '<span class="px-1.5 py-0.5 rounded bg-surface-2 text-[11px]">' + safeReason + '</span>' +
                             restoreBadge +
+                            keyBadge +
                         '</div>' +
                     '</div>' +
                     '<div class="flex items-center gap-0.5 shrink-0">' +

--- a/tests/test_backup_listing_flags_key_material.py
+++ b/tests/test_backup_listing_flags_key_material.py
@@ -1,0 +1,171 @@
+"""The backup list says which archives carry private keys (#595).
+
+Every backup CertMate made before v2.26.0 with the default settings contains
+the private key of every certificate, while its manifest says
+`secrets_masked: true` and the interface called it *share-safe*. Archives from
+v2.22.0 also carry the private CA key and every client-certificate key.
+
+That is a published advisory, and an advisory is something an operator has to
+go and read. The archives are still on their disk, still described by a
+manifest that says the wrong thing, and the advice — unzip and grep — assumes
+they already know to look.
+
+So the listing looks. It reads the archive's NAME LIST rather than its
+manifest, because the manifest is precisely the thing that was wrong.
+
+The important negative: an archive that cannot be inspected reports `None`, not
+`False`. "I could not look" and "there is nothing there" are different answers,
+and conflating them is the same mistake the old manifests made.
+"""
+import io
+import json
+import zipfile
+
+import pytest
+
+from modules.core.file_operations import FileOperations
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def file_ops(tmp_path):
+    dirs = [tmp_path / n for n in ('certificates', 'data', 'backups', 'logs')]
+    for directory in dirs:
+        directory.mkdir()
+    (dirs[2] / 'unified').mkdir()
+    return FileOperations(*dirs)
+
+
+def _archive(file_ops, name, entries, masked=True):
+    """An archive with an arbitrary entry list and a v2.25-style manifest."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, 'w') as zipf:
+        zipf.writestr('settings.json', json.dumps({'settings': {'email': 'a@b.c'}}))
+        zipf.writestr('backup_metadata.json',
+                      json.dumps({'type': 'unified', 'secrets_masked': masked}))
+        for entry in entries:
+            zipf.writestr(entry, 'x')
+    path = file_ops.backup_dir / 'unified' / name
+    path.write_bytes(buffer.getvalue())
+    return path
+
+
+def _entry(file_ops, filename):
+    return next(e for e in file_ops.list_backups()['unified']
+                if e['filename'] == filename)
+
+
+# ---------------------------------------------------------------------------
+# The archives the advisory is about
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('key_entry', [
+    'certificates/example.com/privkey.pem',
+    'certificates/example.com/privkey1.pem',
+    'data/certs/ca/ca.key',
+    'data/certs/clients/alice.pfx',
+    'data/acme/private_key.json',
+    'certificates/example.com/0000_key-certbot.pem',
+])
+def test_an_archive_that_carries_a_key_is_flagged(file_ops, key_entry):
+    """These are the shapes `_is_key_material` knows, seen through the listing.
+
+    The manifest on these says `secrets_masked: true` — which is exactly the
+    claim that was wrong, so the flag must not be derived from it.
+    """
+    _archive(file_ops, 'backup_20250101_000000.zip',
+             ['certificates/example.com/cert.pem', key_entry], masked=True)
+
+    entry = _entry(file_ops, 'backup_20250101_000000.zip')
+
+    assert entry['contains_key_material'] is True, (
+        f'{key_entry} was not recognised as key material'
+    )
+    assert entry['key_file_count'] == 1
+
+
+def test_a_modern_share_safe_archive_is_not_flagged(file_ops):
+    """CONTROL: flagging everything would make the flag useless, and would tell
+    operators to reissue certificates that were never exposed."""
+    _archive(file_ops, 'backup_20260101_000000.zip', [
+        'certificates/example.com/cert.pem',
+        'certificates/example.com/chain.pem',
+        'certificates/example.com/fullchain.pem',
+    ])
+
+    entry = _entry(file_ops, 'backup_20260101_000000.zip')
+
+    assert entry['contains_key_material'] is False
+    assert entry['key_file_count'] == 0
+
+
+def test_every_key_in_an_archive_is_counted(file_ops):
+    """The count is what tells an operator how much to reissue."""
+    _archive(file_ops, 'backup_20250102_000000.zip', [
+        'certificates/a.example.com/privkey.pem',
+        'certificates/b.example.com/privkey.pem',
+        'data/certs/ca/ca.key',
+    ])
+
+    assert _entry(file_ops, 'backup_20250102_000000.zip')['key_file_count'] == 3
+
+
+# ---------------------------------------------------------------------------
+# "I could not look" is not "there is nothing there"
+# ---------------------------------------------------------------------------
+
+def test_an_archive_that_cannot_be_read_reports_unknown(file_ops):
+    path = file_ops.backup_dir / 'unified' / 'backup_20250103_000000.zip'
+    path.write_bytes(b'not a zip at all')
+
+    entry = _entry(file_ops, 'backup_20250103_000000.zip')
+
+    assert entry['contains_key_material'] is None, (
+        'an unreadable archive was reported as carrying no keys, which is the '
+        'same false reassurance the old manifests gave'
+    )
+    assert entry['key_file_count'] is None
+
+
+def test_an_encrypted_archive_without_the_passphrase_reports_unknown(
+        file_ops, monkeypatch):
+    monkeypatch.delenv('CERTMATE_BACKUP_PASSPHRASE', raising=False)
+    path = file_ops.backup_dir / 'unified' / 'backup_20250104_000000.zip.enc'
+    path.write_bytes(b'\x00encrypted-and-unopenable-here')
+
+    entry = _entry(file_ops, 'backup_20250104_000000.zip.enc')
+    assert entry['contains_key_material'] is None
+
+
+def test_an_encrypted_archive_is_inspected_when_it_can_be_opened(
+        file_ops, monkeypatch):
+    """CONTROL for the case above: with the passphrase, the answer is definite —
+    otherwise `None` would just mean "encrypted" and say nothing useful."""
+    monkeypatch.setenv('CERTMATE_BACKUP_PASSPHRASE', 'operator-chosen')
+    name = file_ops.create_unified_backup(
+        {'email': 'ops@example.com'}, 'probe', include_secrets=True)
+
+    entry = _entry(file_ops, name)
+    assert entry['contains_key_material'] is not None, (
+        'an archive this instance can open was still reported as uninspectable'
+    )
+
+
+# ---------------------------------------------------------------------------
+# The predicate itself
+# ---------------------------------------------------------------------------
+
+def test_the_scanner_reads_names_only(file_ops):
+    """It must not need to decompress anything: the listing runs while a page
+    is rendering, and an archive can be hundreds of megabytes."""
+    names = ['certificates/x/cert.pem', 'certificates/x/privkey.pem',
+             'certificates/x/', 'data/certs/ca/ca.key']
+
+    found = FileOperations._archive_key_material(names)
+
+    assert found == ['certificates/x/privkey.pem', 'data/certs/ca/ca.key']
+
+
+def test_a_directory_entry_is_not_mistaken_for_a_key(file_ops):
+    assert FileOperations._archive_key_material(['data/certs/ca.key/']) == []


### PR DESCRIPTION
Addresses #595 by turning the advisory into something the product tells you.

Every backup made before v2.26.0 with the default settings contains the private key of
every certificate, while its manifest says `secrets_masked: true` and the interface
called it *share-safe*. Archives from v2.22.0 also carry the private CA key and every
client-certificate key.

That is published, pinned, and still an **advisory** — something an operator has to go
and read. The archives are on their disk right now, described by a manifest that says the
wrong thing, and the published advice (unzip and grep) assumes they already know to look.

### So the listing looks

`contains_key_material` / `key_file_count` on every listed backup, and a badge on those
rows in Settings.

Read from the archive's **name list**, never from its manifest — the manifest is
precisely the thing that was wrong. Names only: nothing is decompressed, so it stays
cheap enough to run while a page renders.

### The important negative

An archive that cannot be inspected reports **null, not false**. *"I could not look"* and
*"there is nothing there"* are different answers, and conflating them would be the same
false reassurance the old manifests gave. An encrypted archive this instance holds the
passphrase for **is** opened and answered definitely, so null means uninspectable rather
than merely encrypted.

Only a definite `true` warns in the UI. Crying wolf on the unknowns would train people to
ignore the badge, which costs more than it saves.

Mutation-verified both ways: deriving the flag from anything but the archive fails nine
cases, and reporting an uninspectable archive as clean fails the case written for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)