### PR TITLE
fix: OIDC config changes take effect, and an algorithm rejection is not permanent (#647)

### DIFF
--- a/modules/core/oidc.py
+++ b/modules/core/oidc.py
@@ -122,6 +122,7 @@ class OIDCManager:
         self._audit_logger = audit_logger
         self._oauth = None  # cached OAuth registry (Authlib)
         self._cached_issuer = None  # invalidate cache if issuer changes
+        self._cached_client_key = None
 
     # ----------------------------------------------------------------- config
 
@@ -187,11 +188,11 @@ class OIDCManager:
 
         normalized = _normalize_oidc_config(merged)
 
-        # Drop the cached OAuth client — if issuer/client_id changed, the
-        # next login must rediscover.
-        if normalized.get('issuer_url') != self._cached_issuer:
-            self._oauth = None
-            self._cached_issuer = None
+        # Drop the cached OAuth client whenever anything that shapes it
+        # changes — issuer, client id, secret or scopes. Keyed on the issuer
+        # alone, a rotated secret was silently ignored until a restart (#647).
+        if self._client_fingerprint(normalized) != self._cached_client_key:
+            self._invalidate_client()
 
         def _mutate(settings):
             settings['oidc'] = normalized
@@ -242,6 +243,48 @@ class OIDCManager:
 
     # ----------------------------------------------------------- Authlib glue
 
+    def _advertised_signing_algorithms(self):
+        """What the cached discovery document says the IdP signs with.
+
+        Read for the error message only: it is the single fact that turns
+        "Algorithm of 'RS256' is not allowed" from a dead end into something
+        an operator can act on.
+        """
+        try:
+            client = self._oauth.create_client('certmate_oidc') if self._oauth else None
+            metadata = getattr(client, 'server_metadata', None) or {}
+            return metadata.get('id_token_signing_alg_values_supported')
+        except Exception:
+            return None
+
+    def _invalidate_client(self):
+        """Forget the cached Authlib client and its discovery document."""
+        self._oauth = None
+        self._cached_issuer = None
+        self._cached_client_key = None
+
+    @staticmethod
+    def _client_fingerprint(cfg):
+        """Everything about the config that changes the Authlib client.
+
+        The cache used to be keyed on issuer_url alone, so rotating the client
+        secret or changing the scopes had no effect until the process
+        restarted — the stale client, and the discovery document cached inside
+        it, were handed back unchanged (#647).
+
+        The secret is hashed rather than kept: this value lives on the manager
+        and ends up in comparisons and, one day, in somebody's debug print.
+        """
+        import hashlib
+
+        secret = cfg.get('client_secret') or ''
+        return (
+            cfg.get('issuer_url'),
+            cfg.get('client_id'),
+            hashlib.sha256(secret.encode()).hexdigest(),
+            tuple(cfg.get('scopes') or ()),
+        )
+
     def _build_oauth_client(self, app):
         """Return a cached Authlib client bound to ``app``.
 
@@ -253,7 +296,8 @@ class OIDCManager:
         if not (cfg['enabled'] and cfg['issuer_url'] and cfg['client_id']):
             raise RuntimeError('OIDC is not enabled or fully configured')
 
-        if self._oauth is not None and self._cached_issuer == cfg['issuer_url']:
+        fingerprint = self._client_fingerprint(cfg)
+        if self._oauth is not None and self._cached_client_key == fingerprint:
             return self._oauth
 
         # Lazy import so units tests that don't exercise the flow don't
@@ -278,6 +322,7 @@ class OIDCManager:
         )
         self._oauth = oauth
         self._cached_issuer = cfg['issuer_url']
+        self._cached_client_key = fingerprint
         return oauth
 
     def _client(self, app):
@@ -321,6 +366,31 @@ class OIDCManager:
             client = self._client(current_app)
             token = client.authorize_access_token()
         except Exception as exc:
+            # An algorithm rejection is almost never a code problem: Authlib
+            # restricts the accepted signing algorithms to whatever the
+            # discovery document advertised, and that document is fetched once
+            # and cached for the life of the process. Change the signing
+            # algorithm on the IdP and CertMate keeps enforcing the old list,
+            # rejecting every login with "Algorithm of 'RS256' is not allowed"
+            # and giving the operator nothing to act on (#647).
+            #
+            # So say what the mismatch actually is, and drop the cached client
+            # so the next attempt refetches. One retry costs a discovery
+            # request; not retrying costs an SSO that never works again until
+            # somebody restarts the container.
+            if 'algorithm' in str(exc).lower() or 'alg' in str(exc).lower():
+                advertised = self._advertised_signing_algorithms()
+                logger.warning(
+                    "OIDC token exchange failed on the id_token signing "
+                    "algorithm: %s. The IdP's discovery document advertises "
+                    "%s. If the IdP was reconfigured, this cached document is "
+                    "stale — it has been dropped and the next login will "
+                    "refetch it. If the list is genuinely wrong, fix "
+                    "id_token_signing_alg_values_supported at the IdP.",
+                    str(exc).replace(chr(10), ' ').replace(chr(13), ' '),
+                    advertised or 'nothing')
+                self._invalidate_client()
+                return None, 'token_exchange_algorithm'
             logger.warning(f"OIDC token exchange failed: {exc}")
             return None, 'token_exchange'
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -259,6 +259,20 @@
             try {
                 var err = new URLSearchParams(window.location.search).get('error');
                 if (!err) return;
+                // One code gets a real sentence, because the generic
+                // rendering ("token exchange algorithm") tells an operator
+                // nothing and this failure is almost always a stale discovery
+                // document rather than a broken login (#647).
+                if (err === 'oidc_token_exchange_algorithm') {
+                    showError('Single sign-on failed: the identity provider ' +
+                        'signed the token with an algorithm its discovery ' +
+                        'document does not advertise. CertMate has dropped ' +
+                        'the cached document — try again. If it keeps ' +
+                        'failing, check id_token_signing_alg_values_supported ' +
+                        'at the identity provider. The server log names both ' +
+                        'the algorithm and the advertised list.');
+                    return;
+                }
                 var label = err.replace(/^oidc_/, '').replace(/_/g, ' ');
                 showError('Single sign-on failed: ' + label);
             } catch (e) { /* no-op */ }

--- a/tests/test_oidc_client_cache_is_not_stale.py
+++ b/tests/test_oidc_client_cache_is_not_stale.py
@@ -1,0 +1,191 @@
+"""OIDC config changes must take effect, and an algorithm rejection must not
+be permanent (#647).
+
+Reported by a user connecting Authentik: every login failed on the id_token
+signing algorithm, and every algorithm they tried failed in turn —
+
+    unsupported_algorithm: Algorithm of 'RS256' is not allowed
+    invalid_key_type: Algorithm 'HS256' requires 'oct' key
+
+The 'not allowed' wording is the clue. Authlib restricts accepted signing
+algorithms to whatever the discovery document advertised
+(`id_token_signing_alg_values_supported`), and that document is fetched once,
+when the Authlib client is first built, then cached.
+
+The client was cached on `issuer_url` alone. So nothing the operator changed —
+not the client secret, not the scopes, and nothing at all on the IdP side —
+ever reached CertMate again until the process restarted. The instance went on
+enforcing an algorithm list from the first login attempt of that container's
+life.
+
+Two properties here. The cache must follow the configuration, and a failure on
+the algorithm must drop the cached document so the next attempt refetches:
+otherwise a reconfigured IdP means an SSO that can never work again without a
+restart, which is what the report describes.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modules.core.oidc import OIDCManager
+
+pytestmark = [pytest.mark.unit]
+
+BASE_CONFIG = {
+    'enabled': True,
+    'issuer_url': 'https://idp.example.com',
+    'client_id': 'certmate',
+    'client_secret': 'original-secret',
+    'scopes': ['openid', 'profile'],
+    'username_claim': 'preferred_username',
+}
+
+
+@pytest.fixture
+def manager():
+    settings = MagicMock()
+    settings.load_settings.return_value = {'oidc': dict(BASE_CONFIG)}
+    instance = OIDCManager.__new__(OIDCManager)
+    instance.settings_manager = settings
+    instance._oauth = None
+    instance._cached_issuer = None
+    instance._cached_client_key = None
+    return instance
+
+
+def _reconfigure(manager, **changes):
+    manager.settings_manager.load_settings.return_value = {
+        'oidc': {**BASE_CONFIG, **changes}}
+
+
+# ---------------------------------------------------------------------------
+# The cache has to follow the configuration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('change', [
+    {'client_secret': 'rotated-secret'},
+    {'client_id': 'a-different-client'},
+    {'scopes': ['openid', 'profile', 'email']},
+    {'issuer_url': 'https://other-idp.example.com'},
+])
+def test_a_config_change_rebuilds_the_client(manager, change):
+    """Each of these changes what Authlib is registered with. Keyed on the
+    issuer alone, three of the four were silently ignored until a restart —
+    including a rotated client secret, which is a credential an operator
+    reasonably expects to take effect when they save it.
+    """
+    pytest.importorskip('authlib', reason='OIDC is an optional dependency')
+    import authlib.integrations.flask_client  # noqa: F401
+    from flask import Flask
+
+    app = Flask(__name__)
+    app.secret_key = 'test'
+
+    with patch('authlib.integrations.flask_client.OAuth') as OAuthClass:
+        manager._build_oauth_client(app)
+        before = OAuthClass.return_value.register.call_count
+
+        _reconfigure(manager, **change)
+        manager._build_oauth_client(app)
+        after = OAuthClass.return_value.register.call_count
+
+    assert after > before, (
+        f'changing {list(change)} did not rebuild the client, so it never '
+        f'reached Authlib — and neither did the discovery document, which is '
+        f'what decides the accepted signing algorithms'
+    )
+
+
+def test_an_unchanged_config_reuses_the_client(manager):
+    """CONTROL: rebuilding on every call would refetch the discovery document
+    on every login, which is why it is cached in the first place."""
+    pytest.importorskip('authlib', reason='OIDC is an optional dependency')
+    import authlib.integrations.flask_client  # noqa: F401
+    from flask import Flask
+
+    app = Flask(__name__)
+    app.secret_key = 'test'
+
+    with patch('authlib.integrations.flask_client.OAuth') as OAuthClass:
+        first = manager._build_oauth_client(app)
+        second = manager._build_oauth_client(app)
+        assert OAuthClass.return_value.register.call_count == 1
+    assert first is second
+
+
+def test_the_fingerprint_does_not_keep_the_secret_in_the_clear():
+    """It lives on the manager and ends up in comparisons — and one day in
+    somebody's debug print."""
+    fingerprint = OIDCManager._client_fingerprint(BASE_CONFIG)
+    assert BASE_CONFIG['client_secret'] not in fingerprint
+
+
+def test_the_fingerprint_still_distinguishes_two_secrets():
+    """CONTROL: hashing must not collapse different secrets into one key, or
+    a rotation would go unnoticed again."""
+    other = dict(BASE_CONFIG, client_secret='a-different-secret')
+    assert (OIDCManager._client_fingerprint(BASE_CONFIG)
+            != OIDCManager._client_fingerprint(other))
+
+
+# ---------------------------------------------------------------------------
+# An algorithm rejection must not be permanent
+# ---------------------------------------------------------------------------
+
+class _AlgorithmRejected(Exception):
+    def __str__(self):
+        return "unsupported_algorithm: Algorithm of 'RS256' is not allowed"
+
+
+def test_an_algorithm_failure_drops_the_cached_discovery_document(manager):
+    """The reported loop: without this, every subsequent login re-applies the
+    same stale algorithm list and fails identically, forever."""
+    manager._oauth = MagicMock()
+    manager._cached_issuer = BASE_CONFIG['issuer_url']
+    manager._cached_client_key = OIDCManager._client_fingerprint(BASE_CONFIG)
+
+    with patch.object(OIDCManager, '_client',
+                      side_effect=_AlgorithmRejected()):
+        claims, error = manager.handle_callback(MagicMock())
+
+    assert claims is None
+    assert error == 'token_exchange_algorithm', (
+        'the algorithm case must be distinguishable from a generic exchange '
+        'failure, or the login page cannot say anything useful about it'
+    )
+    assert manager._oauth is None, (
+        'the cached client survived, so the next attempt would re-apply the '
+        'same stale algorithm list'
+    )
+
+
+def test_an_ordinary_failure_keeps_the_cache(manager):
+    """CONTROL: dropping the client on every failure would refetch discovery
+    on each bad login, which is a request to the IdP per failed attempt."""
+    manager._oauth = MagicMock()
+    manager._cached_client_key = OIDCManager._client_fingerprint(BASE_CONFIG)
+
+    with patch.object(OIDCManager, '_client',
+                      side_effect=RuntimeError('connection reset')):
+        claims, error = manager.handle_callback(MagicMock())
+
+    assert claims is None
+    assert error == 'token_exchange'
+    assert manager._oauth is not None, (
+        'an unrelated failure invalidated the client'
+    )
+
+
+def test_the_login_page_explains_the_algorithm_case():
+    """The generic rendering turns the code into 'token exchange algorithm',
+    which tells an operator nothing about where to look."""
+    from pathlib import Path
+
+    login = (Path(__file__).resolve().parent.parent
+             / 'templates' / 'login.html').read_text(encoding='utf-8')
+
+    assert 'oidc_token_exchange_algorithm' in login
+    assert 'id_token_signing_alg_values_supported' in login, (
+        'the message must name the IdP setting to check, or it is just a '
+        'longer way of saying it did not work'
+    )


### PR DESCRIPTION
Closes #647.

A user connecting Authentik reported that every login failed on the id_token signing
algorithm, and every algorithm they tried failed in turn:

```
unsupported_algorithm: Algorithm of 'RS256' is not allowed
invalid_key_type:      Algorithm 'HS256' requires 'oct' key
```

**The wording is the clue.** Authlib restricts accepted signing algorithms to whatever
the discovery document advertised in `id_token_signing_alg_values_supported`, and that
document is fetched once — when the Authlib client is first built — then cached.

### Cause, reproduced against the real library

The client was cached on **`issuer_url` alone**. Rotating `client_secret` or changing
`scopes` returns the same cached client and Authlib is never re-registered:

```
registrations: after first=1, after config change=1
same cached client returned: True
```

So nothing the operator changed — on either side — reached CertMate again until the
process restarted. The instance went on enforcing an algorithm list from the first login
attempt of that container's life.

### Two changes

**The cache follows the configuration.** Keyed on issuer, client id, secret and scopes,
so saving a rotated secret does what an operator expects. The secret is *hashed* into
that key rather than kept in the clear — it lives on the manager and ends up in
comparisons and, one day, in somebody's debug print.

**An algorithm failure drops the cached client** and returns a distinct
`token_exchange_algorithm`, so the next attempt refetches discovery. Without that, a
reconfigured IdP means an SSO that can never work again until someone restarts the
container — which is exactly the report. An ordinary failure still keeps the cache;
refetching discovery on every bad login would be a request to the IdP per failed attempt.

**And it says what is wrong.** The log names the algorithm *and* what discovery
advertises; the login page names the IdP setting to check. `Algorithm of 'RS256' is not
allowed` is a dead end — the mismatch between those two lists is the whole answer.

### One note on verification

Authlib is declared in `requirements.txt` but was not installed in my local venv, so
five of these tests **skipped**. Installed it and re-ran: 10/10. Mutation-verified —
keying the cache on the issuer alone fails 3, removing the invalidation fails 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)