### PR TITLE
fix: make the env bearer token authoritative at startup (#401)

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -102,7 +102,7 @@ docker run -d --name certmate \
 |----------|----------|-------------|
 | `SECRET_KEY` | No | Flask secret key for sessions (auto-generated if unset) |
 | `SECRET_KEY_FILE` | No | Path to a file containing the Flask secret key (takes precedence over `SECRET_KEY`) |
-| `API_BEARER_TOKEN` | No (auto-generated) | API auth token. Auto-generated if unset, but set it before exposing a not-yet-onboarded instance to a network; when set, paste it once on the first-run screen to create the admin |
+| `API_BEARER_TOKEN` | No (auto-generated) | API auth token. Auto-generated if unset, but set it before exposing a not-yet-onboarded instance to a network; when set, paste it once on the first-run screen to create the admin. **This value is authoritative:** if it differs from the token already stored, the stored one is replaced at startup and stops working. That is what makes adding or rotating the variable on an existing install take effect — previously enforcement used this value while authentication still checked the old one, and the first-run screen asked for a token it then rejected |
 | `API_BEARER_TOKEN_FILE` | No | Path to a file containing the API bearer token (takes precedence over `API_BEARER_TOKEN`) |
 | `LOG_LEVEL` | No | `INFO` (default), `DEBUG`, `WARNING`, `ERROR` |
 | `CERTMATE_BACKUP_PASSPHRASE` | **Set it if you want automatic backups you can restore from** | Encrypts unified backups at rest (`.zip.enc`, PBKDF2-SHA256 + Fernet), and is what makes automatic backups *complete* — with it they can restore this instance, without it they keep their credentials masked and cannot. The same passphrase is required to restore them, and CertMate never stores it for you. Keep it somewhere other than the machine holding the backups |

--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -1017,6 +1017,90 @@ class AuthManager:
             self._operator_bearer_token = cached
         return cached
 
+    def _operator_supplied_token(self):
+        """The token from API_BEARER_TOKEN(_FILE), or '' if none was given."""
+        token_file = os.getenv('API_BEARER_TOKEN_FILE')
+        if token_file:
+            try:
+                from pathlib import Path
+                return Path(token_file).read_text().strip()
+            except Exception:
+                return ''
+        return (os.getenv('API_BEARER_TOKEN') or '').strip()
+
+    def reconcile_bearer_token_from_env(self):
+        """Make the env/file bearer token authoritative at startup (#401).
+
+        Two different pieces of code decided two different things about the
+        same token. `is_setup_mode()` asked whether the OPERATOR supplied one
+        via API_BEARER_TOKEN(_FILE); `authenticate_api_token()` checked the
+        presented token against the STORED hash. On a fresh install those agree,
+        because the stored value is seeded from the env one.
+
+        They diverge for an operator who ran once without a token — a value was
+        generated and stored — and then added or rotated API_BEARER_TOKEN and
+        restarted. The essential-keys merge never overwrites a token that is
+        already there, so enforcement saw the new token while authentication
+        still checked the old one: the first-run screen asked the operator to
+        paste the token they had just configured, and answered 401. The
+        documented way out was a reset script.
+
+        This closes it by making the supplied token authoritative, which is how
+        `has_operator_bearer_token()` already treats it for enforcement.
+
+        Deliberately narrow. It acts only when a token was supplied, that token
+        is well-formed, and it does NOT already authenticate — so an instance
+        where the two agree is never rewritten, and a malformed token is left to
+        the fail-closed bearer path rather than being stored.
+
+        It cannot open an instance: the token still has to be presented. What it
+        changes is WHICH token opens it, and that is the operator's own.
+        """
+        try:
+            env_token = self._operator_supplied_token()
+            if not env_token:
+                return False
+
+            from .utils import validate_api_token
+            is_valid, cleaned = validate_api_token(env_token)
+            if not is_valid:
+                # Not ours to store. The bearer path already fails closed on a
+                # malformed token, and writing one here would turn a
+                # configuration mistake into a persisted one.
+                return False
+
+            settings = self.settings_manager.load_settings()
+            stored_hash = settings.get('api_bearer_token_hash')
+            stored_plain = settings.get('api_bearer_token')
+
+            if stored_hash and self._verify_api_token(cleaned, stored_hash):
+                return False   # already the same token
+            if not stored_hash and stored_plain == cleaned:
+                return False   # legacy plaintext, already the same
+
+            if not stored_hash and not stored_plain:
+                return False   # nothing stored yet; the normal seeding covers it
+
+            source = ('API_BEARER_TOKEN_FILE'
+                      if os.getenv('API_BEARER_TOKEN_FILE')
+                      else 'API_BEARER_TOKEN')
+            self.settings_manager.atomic_update({'api_bearer_token': cleaned})
+            logger.warning(
+                "Reconciled the stored API bearer token from %s: the value "
+                "supplied there did not match what was stored, so enforcement "
+                "and authentication disagreed and every request with the "
+                "supplied token answered 401. The supplied token is now the "
+                "one that authenticates; any previously stored token no longer "
+                "does. If you did not expect this, the usual causes are a "
+                "token added or rotated after first run, or a settings backup "
+                "restored onto a host with a different SECRET_KEY — in that "
+                "second case other SECRET_KEY-bound values may also need "
+                "attention.", source)
+            return True
+        except Exception as e:
+            logger.debug(f"Bearer token reconciliation skipped: {e}")
+            return False
+
     def warn_if_bearer_token_hash_is_stale(self):
         """At startup, diagnose the one failure that otherwise looks like a
         wrong token: an api_bearer_token_hash that no longer matches SECRET_KEY.

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -519,6 +519,10 @@ def initialize_managers(container: AppContainer, app):
     # Let SettingsManager hash the legacy api_bearer_token on save using the
     # same HMAC scheme as scoped API keys.
     settings_manager.set_token_hasher(auth_manager.hash_api_token)
+    # AFTER the hasher is installed, and only then: reconciliation writes the
+    # token through a normal save, and that save is what hashes it. Called
+    # earlier it would persist the plaintext (#401).
+    auth_manager.reconcile_bearer_token_from_env()
     cache_manager = CacheManager(settings_manager)
     storage_manager = StorageManager(settings_manager)
     ca_manager = CAManager(settings_manager)

--- a/tests/test_bearer_token_env_reconciliation.py
+++ b/tests/test_bearer_token_env_reconciliation.py
@@ -1,0 +1,229 @@
+"""The env bearer token and the stored one must not disagree (#401).
+
+Two pieces of code decided two different things about the same token.
+`is_setup_mode()` asked whether the OPERATOR supplied one via
+API_BEARER_TOKEN(_FILE); `authenticate_api_token()` checked the presented token
+against the STORED hash. On a fresh install those agree, because the stored
+value is seeded from the env one.
+
+They diverge for an operator who ran once without a token — one was generated
+and stored — then added or rotated API_BEARER_TOKEN and restarted. The
+essential-keys merge never overwrites a token that is already there, so
+enforcement saw the new token while authentication still checked the old one:
+the first-run screen asked the operator to paste the token they had just
+configured, and answered 401. The documented way out was a reset script.
+
+Reconciliation makes the supplied token authoritative, which is how enforcement
+already treats it. The tests that matter most here are the ones about what it
+must NOT do: it must not act when the two already agree, must not store a
+malformed token, and must not touch an instance where the operator supplied
+nothing at all.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.auth import AuthManager
+from modules.core.file_operations import FileOperations
+from modules.core.settings import SettingsManager
+
+pytestmark = [pytest.mark.unit]
+
+SECRET = 'a-secret-key-for-hmac'
+ENV_TOKEN = 'EXfHVajpXVkJBoXA5vu6_5DmuPnvhJqtcmoc4iF3j4J7Q9zm'
+OTHER_TOKEN = 'Zq7WmTt2rXbN8sVcLpKdHgFjYuIoEaSxCvBnMlQwRtYu'
+
+
+@pytest.fixture
+def instance(tmp_path, monkeypatch):
+    """A configured instance with a token already stored, and no env token."""
+    monkeypatch.delenv('API_BEARER_TOKEN', raising=False)
+    monkeypatch.delenv('API_BEARER_TOKEN_FILE', raising=False)
+
+    dirs = [tmp_path / n for n in ('certificates', 'data', 'backups', 'logs')]
+    for directory in dirs:
+        directory.mkdir()
+    settings = SettingsManager(FileOperations(*dirs), dirs[1] / 'settings.json')
+    settings.load_settings()
+
+    auth = AuthManager(settings)
+    auth.set_hmac_key(SECRET)
+    settings.set_token_hasher(auth.hash_api_token)
+    # Whatever first boot generated and stored.
+    settings.atomic_update({'api_bearer_token': OTHER_TOKEN})
+    return auth, settings
+
+
+def _authenticates(auth, settings, token):
+    stored = settings.load_settings(use_cache=False).get('api_bearer_token_hash')
+    return bool(stored) and auth._verify_api_token(token, stored)
+
+
+# ---------------------------------------------------------------------------
+# The lockout
+# ---------------------------------------------------------------------------
+
+def test_a_token_added_after_first_run_becomes_the_working_one(
+        instance, monkeypatch):
+    """The reported case: enforcement saw the new token, authentication did not."""
+    auth, settings = instance
+    monkeypatch.setenv('API_BEARER_TOKEN', ENV_TOKEN)
+
+    assert not _authenticates(auth, settings, ENV_TOKEN), (
+        'this test is only meaningful while the two disagree'
+    )
+
+    assert auth.reconcile_bearer_token_from_env() is True
+    assert _authenticates(auth, settings, ENV_TOKEN), (
+        'the operator would still be told to paste a token that 401s'
+    )
+
+
+def test_the_reconciled_token_is_stored_hashed_not_in_the_clear(
+        instance, monkeypatch):
+    """Reconciliation writes through a normal save, and that save is what
+    hashes. Called before the hasher is installed it would persist plaintext,
+    so this pins the outcome rather than the ordering."""
+    auth, settings = instance
+    monkeypatch.setenv('API_BEARER_TOKEN', ENV_TOKEN)
+
+    auth.reconcile_bearer_token_from_env()
+    stored = settings.load_settings(use_cache=False)
+
+    assert 'api_bearer_token' not in stored, (
+        'the bearer token was left on disk in plaintext'
+    )
+    assert stored.get('api_bearer_token_hash', '').startswith('hmac-sha256:')
+
+
+def test_a_token_supplied_by_file_works_the_same(instance, monkeypatch, tmp_path):
+    auth, settings = instance
+    token_file = tmp_path / 'token'
+    token_file.write_text(ENV_TOKEN + '\n')
+    monkeypatch.setenv('API_BEARER_TOKEN_FILE', str(token_file))
+
+    assert auth.reconcile_bearer_token_from_env() is True
+    assert _authenticates(auth, settings, ENV_TOKEN)
+
+
+def test_a_rotated_env_token_replaces_the_previous_one(instance, monkeypatch):
+    """Rotation is the same path as addition, and the OLD token must stop
+    working — otherwise a rotation leaves a credential live."""
+    auth, settings = instance
+    monkeypatch.setenv('API_BEARER_TOKEN', ENV_TOKEN)
+    auth.reconcile_bearer_token_from_env()
+
+    assert not _authenticates(auth, settings, OTHER_TOKEN), (
+        'the previously stored token still authenticates after a rotation'
+    )
+
+
+# ---------------------------------------------------------------------------
+# What it must NOT do
+# ---------------------------------------------------------------------------
+
+def test_nothing_happens_when_no_token_was_supplied(instance, monkeypatch):
+    """An instance the operator never gave a token to must be left alone."""
+    auth, settings = instance
+    before = settings.load_settings(use_cache=False).get('api_bearer_token_hash')
+
+    assert auth.reconcile_bearer_token_from_env() is False
+    assert settings.load_settings(use_cache=False).get(
+        'api_bearer_token_hash') == before
+
+
+def test_nothing_happens_when_the_two_already_agree(instance, monkeypatch):
+    """The common case — a fresh install — must not be rewritten on every boot."""
+    auth, settings = instance
+    monkeypatch.setenv('API_BEARER_TOKEN', OTHER_TOKEN)
+    before = settings.load_settings(use_cache=False).get('api_bearer_token_hash')
+
+    assert auth.reconcile_bearer_token_from_env() is False
+    assert settings.load_settings(use_cache=False).get(
+        'api_bearer_token_hash') == before
+
+
+@pytest.mark.parametrize('bad', [
+    'short',
+    'x' * 600,
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',   # long enough, no variety
+])
+def test_a_malformed_token_makes_the_instance_refuse_to_serve(
+        instance, monkeypatch, bad):
+    """Stronger than "reconciliation skips it", which is what I first wrote.
+
+    load_settings itself raises BearerTokenUnusableError when API_BEARER_TOKEN
+    is set but unusable — ignoring it would leave the instance with no
+    authentication at all. So a malformed token never reaches reconciliation:
+    the boot fails first, loudly, and that is the better guarantee. Recorded
+    here so a future change that softened it into a warning would have to
+    change this test deliberately.
+    """
+    from modules.core.settings import BearerTokenUnusableError
+
+    auth, settings = instance
+    monkeypatch.setenv('API_BEARER_TOKEN', bad)
+
+    with pytest.raises(BearerTokenUnusableError):
+        settings.load_settings(use_cache=False)
+
+    # And reconciliation, which loads settings, reports no change rather than
+    # taking the process down from inside create_app.
+    assert auth.reconcile_bearer_token_from_env() is False
+
+
+def test_an_empty_env_token_is_not_a_configuration(instance, monkeypatch):
+    """An empty string is "no token supplied", not "a bad token"."""
+    auth, settings = instance
+    monkeypatch.setenv('API_BEARER_TOKEN', '')
+    before = settings.load_settings(use_cache=False).get('api_bearer_token_hash')
+
+    assert auth.reconcile_bearer_token_from_env() is False
+    assert settings.load_settings(use_cache=False).get(
+        'api_bearer_token_hash') == before
+
+
+def test_an_instance_with_nothing_stored_is_left_to_normal_seeding(
+        tmp_path, monkeypatch):
+    """A first boot seeds the token through the ordinary path; reconciliation
+    must not race it or duplicate it."""
+    monkeypatch.setenv('API_BEARER_TOKEN', ENV_TOKEN)
+    dirs = [tmp_path / n for n in ('certificates', 'data', 'backups', 'logs')]
+    for directory in dirs:
+        directory.mkdir()
+    settings = SettingsManager(FileOperations(*dirs), dirs[1] / 'settings.json')
+    auth = AuthManager(settings)
+    auth.set_hmac_key(SECRET)
+    settings.set_token_hasher(auth.hash_api_token)
+
+    stored = settings.load_settings(use_cache=False)
+    if not stored.get('api_bearer_token') and not stored.get('api_bearer_token_hash'):
+        assert auth.reconcile_bearer_token_from_env() is False
+
+
+def test_reconciliation_never_raises_into_startup(instance, monkeypatch):
+    """It runs during create_app. A failure here must not take the process with
+    it — an instance that will not boot is worse than one with a token
+    mismatch, which at least has a documented recovery."""
+    auth, _settings = instance
+    monkeypatch.setenv('API_BEARER_TOKEN', ENV_TOKEN)
+    auth.settings_manager = MagicMock()
+    auth.settings_manager.load_settings.side_effect = OSError('disk gone')
+
+    assert auth.reconcile_bearer_token_from_env() is False
+
+
+def test_it_is_called_at_startup_after_the_hasher_is_installed():
+    """Ordering is the difference between a hashed token and a plaintext one,
+    and it is invisible at the call site — so it is asserted on the source."""
+    import inspect
+
+    from modules.core import factory
+
+    src = inspect.getsource(factory.initialize_managers)
+    hasher_at = src.index('set_token_hasher')
+    reconcile_at = src.index('reconcile_bearer_token_from_env')
+    assert reconcile_at > hasher_at, (
+        'reconciliation runs before the token hasher is installed, so the '
+        'token would be written to settings.json in plaintext'
+    )


### PR DESCRIPTION
Closes #401.

`is_setup_mode()` asked whether the **operator** supplied a token via
`API_BEARER_TOKEN(_FILE)`; `authenticate_api_token()` checked the presented token against
the **stored** hash. On a fresh install those agree, because the stored value is seeded
from the env one.

They diverge for an operator who ran once without a token — one was generated and stored
— then added or rotated `API_BEARER_TOKEN` and restarted. Reproduced:

```
has_operator_bearer_token (enforcement sees X): True
X authenticates against the STORED hash:       False
```

The first-run screen asked the operator to paste the token they had just configured, and
answered 401. The documented way out was a reset script.

### The change

Startup reconciles: a supplied token that does not already authenticate is written
through the normal save path, which hashes it. The supplied value wins — which is how
enforcement already treated it.

**Called out in `docs/docker.md`**, per the issue's own consideration: an operator who
rotated via the UI while leaving a stale variable set will now find the variable winning.

Deliberately narrow. It acts only when a token was supplied, is well-formed, and does not
already authenticate; an instance where the two agree is never rewritten. **It cannot open
an instance** — the token still has to be presented. What changes is *which* token opens
it, and that is the operator's own.

### Ordering, which is invisible at the call site

It runs **after** `set_token_hasher`, because the save is what hashes. Called earlier it
would persist the plaintext. A test asserts the order in the source as well as the hashed
outcome, since only one of those two failures is visible.

### One test rewritten, because the code was stricter than I assumed

I first asserted that a malformed `API_BEARER_TOKEN` is "skipped". It is not: `load_settings`
raises `BearerTokenUnusableError` and the instance **refuses to serve**, because ignoring
it would leave no authentication at all. That stronger guarantee is now what the test
records — so softening it later would have to be deliberate.

Matrix per the issue: added-later, rotated, token-file variant, already-agreeing,
nothing-supplied, malformed, nothing-stored-yet, and never-raises-into-startup.
Mutation-verified both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)