### PR TITLE
chore: rebuild on the current base image digest (#403)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # moving target on Docker Hub, the digest is content-addressed and
 # guarantees byte-identical bytes. Bump deliberately when there's a
 # CVE fix or feature reason — not implicitly on every rebuild.
-FROM python:3.12-slim-trixie@sha256:2c941e860699f878900b0edc2403613c234d4b32eda3cc9fa7036991a2a63c4a AS builder
+FROM python:3.12-slim-trixie@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea AS builder
 
 # Set working directory for build stage
 WORKDIR /build
@@ -66,7 +66,7 @@ RUN pip install "pip==${PIP_VERSION}" -U setuptools wheel && \
     fi
 
 # Production stage — same digest pin as the builder stage above.
-FROM python:3.12-slim-trixie@sha256:2c941e860699f878900b0edc2403613c234d4b32eda3cc9fa7036991a2a63c4a
+FROM python:3.12-slim-trixie@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea
 
 # Set working directory
 WORKDIR /app
@@ -105,6 +105,16 @@ WORKDIR /app
 # copy is what the Trivy scan keeps reporting (CVE-2026-8643, CVE-2026-6357,
 # CVE-2026-3219 against pip 25.0.1); the app itself runs from /opt/venv and
 # never uses it. See issue #403.
+#
+# NOT bumped past 26.1.2 on purpose. 26.2.1 fixes CVE-2026-13346 in pip
+# itself, but vendors msgpack 1.1.2 and setuptools 70.3.0, which a scan then
+# reports as three findings of its own. Measured on this image, same scanner,
+# same day: base-image bump alone 216 -> 150 with nothing new; base bump plus
+# pip 26.2.1 -> 151, the difference being those three vendored packages.
+# All four live in pip, which this image never uses at runtime — the app runs
+# from /opt/venv and installs nothing. Trading one unreachable finding for
+# three is chasing the number rather than the risk (#403). Revisit when pip's
+# vendor tree catches up.
 #
 # Pinned, for the same reason the base image is pinned by digest a few lines
 # up: an unpinned `--upgrade pip` would make the runtime stage's contents


### PR DESCRIPTION
Addresses the first and third buckets of #403. Supersedes #638, which proposed the same
digest — this adds the measurement and a decision on the pip bucket.

### Measured, both builds local so the comparison is like for like

| | CRITICAL | HIGH | MEDIUM | total |
|---|---|---|---|---|
| before | 3 | 93 | 120 | **216** |
| after | 3 | 63 | 84 | **150** |

**66 cleared, 0 introduced.**

The three CRITICALs are `perl-base` (CVE-2026-13221, CVE-2026-42496, CVE-2026-8376) and
Debian has **no fix** for any of them, so nothing here moves them. They stay tracked
rather than dismissed.

### The pip bucket: deliberately not done

The issue lists upgrading the system pip as optional. It is already done — both pips in
the image report 26.1.2, verified inside it.

Going *further*, to 26.2.1, fixes CVE-2026-13346 in pip itself and **vendors msgpack
1.1.2 and setuptools 70.3.0**, which the scanner then reports as three findings of its
own: **216 → 151 with both bumps, against 216 → 150 with the base bump alone.**

All four live in pip, which this image never uses at runtime — the app runs from
`/opt/venv` and installs nothing. Trading one unreachable finding for three is chasing
the number rather than the risk. The reasoning is recorded beside the pin so the next
person does not have to rediscover it.

### Verification

`certbot --version` answers in the rebuilt image and `acme.crypto_util` imports — the
check this repo does not ship an image without, since the cryptography/pyOpenSSL pin has
broken exactly that before.

One note on method: my first comparison scanned the *published* image remotely against a
*local* build, which is not the same measurement — it reported three phantom new findings.
Rebuilt both locally before trusting any of these numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)