### PR TITLE
fix: let an operator forget an inventory record (#634)

### DIFF
--- a/docs/discovery-inventory.md
+++ b/docs/discovery-inventory.md
@@ -213,6 +213,20 @@ subject/SAN falls within their `allowed_domains`.
 | GET | `/api/inventory/crypto-report` | viewer | Readiness report (`?format=csv`) |
 | GET | `/api/inventory/<fingerprint>/adopt` | viewer | Adoption plan (feasibility + pre-fill) |
 | POST | `/api/inventory/<fingerprint>/adopt` | operator | Adopt & manage the certificate |
+| DELETE | `/api/inventory/<fingerprint>` | operator | Forget a record (the certificate itself is untouched) |
+
+### Forgetting a record
+
+`DELETE /api/inventory/<fingerprint>` removes a certificate and every endpoint
+observed for it. The certificate itself is not touched — CertMate only forgets
+that it saw it — so this is how you clean up after a mistaken scan, a
+decommissioned host, or a name that was never yours. The **Forget** button on
+each inventory row does the same thing.
+
+It forgets an observation; it is not a blocklist. If the domain is still in the
+discovery configuration the certificate will be recorded again on the next
+sweep, so remove it from **Discovery configuration** first when the intent is
+"stop looking at this".
 
 ---
 

--- a/modules/api/resources_inventory.py
+++ b/modules/api/resources_inventory.py
@@ -64,6 +64,42 @@ def create_inventory_resources(api, models, ctx: ApiContext) -> dict:
                 logger.error(f"Error listing inventory: {e}")
                 return {'error': 'Failed to list inventory'}, 500
 
+    class InventoryRecord(Resource):
+        @api.doc(security='Bearer')
+        @ctx.auth.require_role('operator')
+        def delete(self, fingerprint):
+            """Forget a discovered certificate (#634).
+
+            The inventory was append-only: taking a domain out of the discovery
+            configuration stopped future scans from finding it, but every row
+            already recorded stayed, with no way to remove it.
+
+            This forgets an observation rather than suppressing one. A
+            certificate whose domain is still configured for discovery will be
+            recorded again on the next scan, so the response says so instead of
+            leaving the operator to discover it by repeating the deletion.
+            """
+            inventory = ctx.managers.get('cert_inventory')
+            if inventory is None:
+                return {'error': 'Certificate inventory not available'}, 503
+
+            record = inventory.get(fingerprint)
+            # Scope first: an out-of-scope record must be indistinguishable
+            # from one that does not exist, exactly as the read paths treat it.
+            if record is None or not _record_in_scope(record):
+                return {'error': 'Certificate not found in inventory'}, 404
+
+            if not inventory.delete(fingerprint):
+                return {'error': 'Certificate not found in inventory'}, 404
+
+            return {
+                'status': 'deleted',
+                'fingerprint': fingerprint,
+                'note': ('Removed from the inventory. It will be recorded '
+                         'again on the next scan if its domain is still in '
+                         'the discovery configuration.'),
+            }, 200
+
     class InventoryConfig(Resource):
         @api.doc(security='Bearer')
         @ctx.auth.require_role('viewer')
@@ -224,6 +260,7 @@ def create_inventory_resources(api, models, ctx: ApiContext) -> dict:
 
     return {
         'InventoryList': InventoryList,
+        'InventoryRecord': InventoryRecord,
         'InventoryConfig': InventoryConfig,
         'InventoryScan': InventoryScan,
         'InventoryCryptoReport': InventoryCryptoReport,

--- a/modules/core/cert_inventory.py
+++ b/modules/core/cert_inventory.py
@@ -389,6 +389,26 @@ class CertInventory:
             )
             return cur.rowcount > 0
 
+    def delete(self, fingerprint):
+        """Forget a certificate and every endpoint observed for it (#634).
+
+        Returns True if a record existed and was removed, so the caller can
+        answer 404 rather than reporting a deletion that did not happen.
+
+        The endpoint rows go with it via ``ON DELETE CASCADE``, which SQLite
+        applies only because ``_connect`` enables ``PRAGMA foreign_keys``.
+
+        This forgets an observation; it is not a blocklist. A certificate whose
+        domain is still in the discovery configuration will be recorded again
+        on the next scan, which is why the configuration is the thing to edit
+        when the intent is "stop looking at this".
+        """
+        with self._write_conn() as conn:
+            cur = conn.execute(
+                "DELETE FROM certificates WHERE fingerprint = ?", (fingerprint,)
+            )
+            return cur.rowcount > 0
+
     def count(self):
         """Return the number of distinct certificates in the inventory."""
         with self._read_conn() as conn:

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -1065,6 +1065,11 @@ def setup_api(container: AppContainer, app):
     ns_inventory.add_resource(api_resources['InventoryScan'], '/scan')
     ns_inventory.add_resource(api_resources['InventoryCryptoReport'], '/crypto-report')
     ns_inventory.add_resource(api_resources['InventoryAdopt'], '/<string:fingerprint>/adopt')
+    # '/<string:fingerprint>' sits at the same depth as '/config', '/scan' and
+    # '/crypto-report'. Werkzeug weights static segments above converters, so
+    # those keep winning regardless of registration order — verified, not
+    # assumed, and pinned by test_inventory_records_can_be_removed (#634).
+    ns_inventory.add_resource(api_resources['InventoryRecord'], '/<string:fingerprint>')
 
     container.api = api
 

--- a/static/js/inventory.js
+++ b/static/js/inventory.js
@@ -69,16 +69,30 @@
     }
 
     function actionsCell(r) {
-        // Only unmanaged (discovered) certificates can be adopted, and only by
-        // an operator+. Managed certs and viewers get no button.
-        if (r.managed || !roleAtLeast('operator')) { return ''; }
-        // Pass the fingerprint via a data attribute (read in adoptFromEl) rather
-        // than interpolating it into an inline onclick JS-string.
-        return '<button type="button" data-fp="' + escapeHtml(r.fingerprint) + '" '
-            + 'onclick="InventoryPage.adoptFromEl(this)" '
-            + 'class="px-2 py-1 text-xs bg-surface-2 text-primary rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition" '
-            + 'title="Take over issuance/renewal of this certificate">'
-            + '<i class="fas fa-hand-holding-medical mr-1"></i>Adopt</button>';
+        // Viewers get no buttons at all.
+        if (!roleAtLeast('operator')) { return ''; }
+        // Pass the fingerprint via a data attribute (read in adoptFromEl /
+        // forgetFromEl) rather than interpolating it into an inline onclick
+        // JS-string.
+        var fp = escapeHtml(r.fingerprint);
+        var html = '';
+        // Only unmanaged (discovered) certificates can be adopted.
+        if (!r.managed) {
+            html += '<button type="button" data-fp="' + fp + '" '
+                + 'onclick="InventoryPage.adoptFromEl(this)" '
+                + 'class="px-2 py-1 text-xs bg-surface-2 text-primary rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition" '
+                + 'title="Take over issuance/renewal of this certificate">'
+                + '<i class="fas fa-hand-holding-medical mr-1"></i>Adopt</button>';
+        }
+        // Forget removes the inventory row (#634). Offered for managed records
+        // too: the certificate itself is untouched, so the only consequence is
+        // that CertMate stops listing this observation.
+        html += '<button type="button" data-fp="' + fp + '" '
+            + 'onclick="InventoryPage.forgetFromEl(this)" '
+            + 'class="ml-1 px-2 py-1 text-xs bg-surface-2 text-muted rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition" '
+            + 'title="Remove this certificate from the inventory">'
+            + '<i class="fas fa-eraser mr-1"></i>Forget</button>';
+        return html;
     }
 
     function passesFilters(r) {
@@ -151,6 +165,29 @@
                     });
             })
             .catch(function (err) { window.alert('Could not load adoption plan (' + err + ').'); });
+    }
+
+    function forget(fingerprint, label) {
+        // Removing an inventory row is not the same as stopping discovery, and
+        // the difference is the whole of #634: say it in the confirmation so an
+        // operator does not delete the same row after every scan.
+        var name = label || fingerprint;
+        if (!window.confirm(
+            'Remove "' + name + '" from the inventory?\n\n'
+            + 'The certificate itself is not touched — CertMate only forgets '
+            + 'that it observed it.\n\n'
+            + 'If this domain is still in the discovery configuration it will '
+            + 'be recorded again on the next scan. Remove it there first to '
+            + 'stop looking at it.')) { return; }
+
+        fetch('/api/inventory/' + encodeURIComponent(fingerprint),
+            { method: 'DELETE', headers: API_HEADERS, credentials: 'same-origin' })
+            .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+            .then(function (res) {
+                if (res.ok) { load(); }
+                else { window.alert('Could not remove it: ' + (res.j.error || 'unknown error')); }
+            })
+            .catch(function (err) { window.alert('Could not remove it (' + err + ').'); });
     }
 
     function setSummary(s) {
@@ -274,9 +311,22 @@
         if (fp) { adopt(fp); }
     }
 
+    function forgetFromEl(elm) {
+        var fp = elm && elm.getAttribute('data-fp');
+        if (!fp) { return; }
+        // Name the certificate in the prompt by its subject, not its
+        // fingerprint: the operator recognises the hostname.
+        var match = null;
+        for (var i = 0; i < records.length; i++) {
+            if (records[i].fingerprint === fp) { match = records[i]; break; }
+        }
+        forget(fp, match && match.subject_cn);
+    }
+
     window.InventoryPage = {
         load: load, render: render, saveConfig: saveConfig,
-        runScan: runScan, adopt: adopt, adoptFromEl: adoptFromEl
+        runScan: runScan, adopt: adopt, adoptFromEl: adoptFromEl,
+        forget: forget, forgetFromEl: forgetFromEl
     };
 
     document.addEventListener('DOMContentLoaded', function () {

--- a/tests/test_api_group_modules_are_standalone.py
+++ b/tests/test_api_group_modules_are_standalone.py
@@ -229,7 +229,7 @@ def test_the_inventory_group_builds_from_a_minimal_context(api):
     resources = create_inventory_resources(api, {}, ctx)
 
     assert set(resources) == {
-        'InventoryList', 'InventoryConfig', 'InventoryScan',
+        'InventoryList', 'InventoryRecord', 'InventoryConfig', 'InventoryScan',
         'InventoryCryptoReport', 'InventoryAdopt'}
     for name, cls in resources.items():
         assert issubclass(cls, Resource), f'{name} is not a Resource'

--- a/tests/test_api_resource_contract.py
+++ b/tests/test_api_resource_contract.py
@@ -35,7 +35,7 @@ EXPECTED_RESOURCES = {
     'RenewCertificate', 'CertificateReissue',
     'CertificateJob', 'CertificateJobs', 'CertificateAutoRenew',
     'CertificateRunDeploy', 'CheckDNSAlias', 'CertificateDNSAliasCheck',
-    'InventoryList', 'InventoryConfig', 'InventoryScan',
+    'InventoryList', 'InventoryRecord', 'InventoryConfig', 'InventoryScan',
     'InventoryCryptoReport', 'InventoryAdopt', 'ZombieScan',
     'BackupList', 'BackupCreate', 'BackupDownload', 'BackupRestore',
     'BackupDelete',

--- a/tests/test_inventory_records_can_be_removed.py
+++ b/tests/test_inventory_records_can_be_removed.py
@@ -1,0 +1,219 @@
+"""A discovered certificate must be removable from the inventory (#634).
+
+Reported by a user: add a domain to the discovery configuration, scan, then
+remove the domain again — "xxx.yy is still in list down below and cant be
+removed".
+
+That is not a filtering bug. `CertInventory` had no delete of any kind
+and the API exposed no DELETE route, so the inventory was append-only: taking a
+domain out of the discovery configuration stops future scans from finding it,
+but every row already recorded stays forever. An operator cleaning up after a
+mistaken scan, a decommissioned host, or a domain that was never theirs had no
+way to do it short of deleting inventory.db.
+
+Two properties are worth pinning beyond "the row goes away":
+
+* the `endpoints` rows must go with it. The schema declares `ON DELETE CASCADE`,
+  which SQLite ignores unless `PRAGMA foreign_keys` is ON per connection — it is
+  (`_connect`), and `test_deleting_a_record_takes_its_endpoints_with_it` fails
+  loudly if that ever regresses, since orphan endpoint rows would silently
+  accumulate against a fingerprint that no longer exists.
+* deleting one record must not disturb its neighbours, which is the assertion
+  that a `DELETE` missing its WHERE clause would trip.
+"""
+from pathlib import Path
+
+import pytest
+
+from modules.core.cert_inventory import CertInventory
+from modules.core.factory import create_app
+
+pytestmark = [pytest.mark.unit]
+
+
+CERT_A = {
+    'fingerprint_sha256': 'aaa', 'subject_cn': 'gone.example.com',
+    'san_dns': ['gone.example.com'], 'key': {'type': 'RSA', 'size': 2048},
+    'not_after': '2099-01-01T00:00:00Z',
+}
+CERT_B = {
+    'fingerprint_sha256': 'bbb', 'subject_cn': 'kept.example.com',
+    'san_dns': ['kept.example.com'], 'key': {'type': 'RSA', 'size': 2048},
+    'not_after': '2099-01-01T00:00:00Z',
+}
+
+
+@pytest.fixture
+def inventory(tmp_path):
+    inv = CertInventory(str(tmp_path))
+    inv.record_certificate(CERT_A, source='ct-log')
+    inv.record_certificate(CERT_B, source='ct-log')
+    return inv
+
+
+# ---------------------------------------------------------------------------
+# The manager
+# ---------------------------------------------------------------------------
+
+def test_a_discovered_record_can_be_deleted(inventory):
+    """The reported case."""
+    assert inventory.get('aaa') is not None, 'nothing to delete'
+
+    assert inventory.delete('aaa') is True
+    assert inventory.get('aaa') is None, (
+        'the record survived deletion and stays in the inventory list'
+    )
+
+
+def test_deleting_one_record_leaves_the_others_alone(inventory):
+    """A DELETE that lost its WHERE clause would empty the inventory."""
+    inventory.delete('aaa')
+
+    assert inventory.get('bbb') is not None, 'deleting one record removed another'
+    assert inventory.count() == 1
+
+
+def test_deleting_a_record_takes_its_endpoints_with_it(tmp_path):
+    """ON DELETE CASCADE is declared, but SQLite honours it only when
+    PRAGMA foreign_keys is ON for the connection. If that regresses, endpoint
+    rows outlive their certificate and accumulate invisibly."""
+    inv = CertInventory(str(tmp_path))
+    inv.record_certificate(CERT_A, source='probed')
+    inv.record_observation(fingerprint='aaa', host='host.example.com', port=443)
+
+    record = inv.get('aaa')
+    assert record['endpoints'], 'this test needs an endpoint to orphan'
+
+    inv.delete('aaa')
+
+    with inv._read_conn() as conn:
+        orphans = conn.execute(
+            "SELECT COUNT(*) FROM endpoints WHERE fingerprint = ?", ('aaa',)
+        ).fetchone()[0]
+    assert orphans == 0, (
+        f'{orphans} endpoint rows outlived their certificate — '
+        'PRAGMA foreign_keys is not enabled on this connection'
+    )
+
+
+def test_deleting_an_unknown_fingerprint_reports_false(inventory):
+    """So the route can answer 404 instead of pretending it removed something."""
+    assert inventory.delete('does-not-exist') is False
+    assert inventory.count() == 2
+
+
+def test_a_deleted_record_can_be_rediscovered(inventory):
+    """Deletion forgets an observation; it is not a blocklist. A domain still
+    in the discovery configuration will legitimately come back on the next
+    scan, and the operator needs that to be true rather than surprising."""
+    inventory.delete('aaa')
+    inventory.record_certificate(CERT_A, source='ct-log')
+
+    assert inventory.get('aaa') is not None
+
+
+# ---------------------------------------------------------------------------
+# The route
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def app_container(tmp_path, monkeypatch):
+    project_root = tmp_path / "certmate"
+    module_dir = project_root / "modules" / "core"
+    module_dir.mkdir(parents=True)
+    (module_dir / "factory.py").write_text("# test path anchor\n")
+    monkeypatch.setattr("modules.core.factory.__file__", str(module_dir / "factory.py"))
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.setenv("TESTING", "true")
+    application, container = create_app()
+    assert Path(container.cert_dir).resolve().is_relative_to(tmp_path)
+    return application, container
+
+
+@pytest.fixture
+def client(app_container):
+    return app_container[0].test_client()
+
+
+@pytest.fixture
+def container(app_container):
+    return app_container[1]
+
+
+def test_delete_route_removes_the_record(client, container):
+    inv = container.managers['cert_inventory']
+    inv.record_certificate(CERT_A, source='ct-log')
+
+    resp = client.delete('/api/inventory/aaa')
+
+    assert resp.status_code == 200, resp.get_json()
+    assert inv.get('aaa') is None
+
+
+def test_delete_route_404s_for_an_unknown_fingerprint(client, container):
+    resp = client.delete('/api/inventory/nope')
+    assert resp.status_code == 404
+
+
+def test_delete_route_is_registered_with_the_delete_verb(app_container):
+    """url_map is the source of truth; a resource added under the wrong path
+    would leave the UI button calling nothing."""
+    app, _ = app_container
+    rules = {
+        str(r): sorted(r.methods - {'HEAD', 'OPTIONS'})
+        for r in app.url_map.iter_rules()
+        if str(r) == '/api/inventory/<string:fingerprint>'
+    }
+    assert rules, 'no /api/inventory/<fingerprint> rule is registered'
+    assert 'DELETE' in rules['/api/inventory/<string:fingerprint>']
+
+
+def test_every_inline_handler_the_table_emits_is_actually_exported():
+    """The Forget button reaches the DOM as
+    `onclick="InventoryPage.forgetFromEl(this)"`. If the function is not on the
+    exported object the button is inert and clicking it raises in the console —
+    a failure no server-side test can see, and the reason the reported bug
+    would look unfixed.
+    """
+    import re
+
+    js = Path('static/js/inventory.js').read_text()
+
+    called = set(re.findall(r'InventoryPage\.([A-Za-z_]\w*)\s*\(', js))
+    assert 'forgetFromEl' in called, (
+        'the Forget button is not wired to a handler at all'
+    )
+
+    exported_block = js[js.index('window.InventoryPage'):]
+    exported_block = exported_block[:exported_block.index('};')]
+    exported = set(re.findall(r'(\w+)\s*:', exported_block))
+
+    missing = called - exported
+    assert not missing, (
+        f'inventory.js calls InventoryPage.{sorted(missing)} from generated '
+        f'markup but does not export it — those buttons do nothing'
+    )
+
+
+def test_the_new_route_does_not_swallow_its_sibling_paths(app_container):
+    """`/<string:fingerprint>` sits at the same depth as `/config`, `/scan` and
+    `/crypto-report`. Werkzeug weights static segments above converters so
+    those still win, but the cost of being wrong is that the whole inventory
+    settings page starts answering "certificate not found" — so it is matched,
+    not reasoned about.
+    """
+    app, _ = app_container
+    adapter = app.url_map.bind('localhost')
+
+    expected = {
+        ('/api/inventory/config', 'GET'): 'inventory_inventory_config',
+        ('/api/inventory/scan', 'POST'): 'inventory_inventory_scan',
+        ('/api/inventory/crypto-report', 'GET'): 'inventory_inventory_crypto_report',
+        ('/api/inventory/abc123', 'DELETE'): 'inventory_inventory_record',
+        ('/api/inventory/abc123/adopt', 'POST'): 'inventory_inventory_adopt',
+    }
+    for (path, method), endpoint in expected.items():
+        matched, _args = adapter.match(path, method=method)
+        assert matched == endpoint, (
+            f'{method} {path} resolved to {matched}, not {endpoint}'
+        )


### PR DESCRIPTION
Closes #634.

## The defect

> go to inventory tab → added `xxx.yy` to discovery configuration → scan now → removed `xxx.yy` from discovery configuration (not wanted anymore) → refresh/scan now → `xxx.yy` is still in list down below and **cant be removed**.
>
> — @SpeeDFireCZE

This is not a filtering bug. `CertInventory` had **no delete of any kind**, and the API exposed **no DELETE route** — the inventory was append-only. Removing a domain from the discovery configuration stops future scans finding it, but every row already recorded stays forever. The only way out was deleting `inventory.db`.

## The fix

| | |
|---|---|
| `CertInventory.delete(fingerprint)` | forgets the certificate and every endpoint observed for it |
| `DELETE /api/inventory/<fingerprint>` | operator role, scope-checked like the read paths |
| **Forget** button | on every inventory row |

**Cascade is real, not just declared.** The `endpoints` rows go with the certificate through `ON DELETE CASCADE` — which SQLite applies only because `_connect` enables `PRAGMA foreign_keys`. A test asserts no endpoint row outlives its certificate, so that cannot quietly regress into orphan rows accumulating against a fingerprint that no longer exists.

**It forgets an observation; it is not a blocklist.** A domain still in the discovery configuration *will* be recorded again on the next sweep. Both the API response and the confirmation dialog say so — otherwise an operator deletes the same row after every scan and concludes the button is broken. The docs now spell out that the configuration is the thing to edit when the intent is "stop looking at this".

**Managed records can be forgotten too.** The certificate on disk is untouched; the only consequence is that CertMate stops listing that observation.

**Routing.** `/<string:fingerprint>` sits at the same depth as `/config`, `/scan` and `/crypto-report`. Werkzeug weights static segments above converters so those keep winning — verified by matching all five paths rather than reasoned about, and pinned by a test, because the cost of being wrong is the whole inventory settings page answering "certificate not found".

## Verification

Ten tests in `tests/test_inventory_records_can_be_removed.py`, all confirmed failing before the fix. Five mutations, each confirmed to trip them:

| mutation | tests tripped |
|---|---|
| `DELETE` loses its `WHERE` clause (empties the inventory) | 6 |
| `PRAGMA foreign_keys` off (orphan endpoint rows) | 1 |
| `delete()` always reports success (404 becomes impossible) | 1 |
| route not registered | 3 |
| click handler left off the exported object | 1 |

That last one is a **dead button** — the markup emits `onclick="InventoryPage.forgetFromEl(this)"`, and if the function is not exported the click raises in the console and nothing happens. No server-side test can see it, so it is asserted against the JS source.

The two `#667` contract guards (`test_api_resource_contract`, `test_api_group_modules_are_standalone`) correctly refused the new resource until it was added deliberately; both updated.

Suite 3549 → 3559 (+10, arithmetic checked), gated flake8 clean, per-module coverage floors met, `theme_codemod --check` clean, `css:build` produces no drift (every class used is already in the bundle, and `fa-eraser` is in the vendored Font Awesome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)