### PR TITLE
docs: state the single-instance model where it is read (#673)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ CertMate solves the complexity of SSL certificate management in modern distribut
 - **Unified Backup System** - Atomic backups of settings and certificates ensuring data consistency
 - **Real-Time Dashboard** - SSE-powered live updates, command palette, keyboard shortcuts, dark mode
 
+> **CertMate runs as a single instance.** Its renewal scheduler runs inside the
+> web process, so a second replica is a second scheduler issuing against the
+> same certificate store — duplicate ACME orders, and the CA's
+> duplicate-certificate rate limit. The Helm chart refuses to render more than
+> one replica rather than let that happen quietly.
+>
+> This is a deliberate design choice, not a missing feature: one writer is what
+> makes certificate state safe without a distributed lock service. It scales
+> *up* (a single instance manages thousands of certificates across many
+> datacenters), not *out*. For availability, run active/standby with the data
+> volume on shared storage and fail over — see
+> [Availability and failover](docs/architecture.md#availability-and-failover).
+
 ## Key Features
 
 ### **Certificate Management**
@@ -405,7 +418,9 @@ curl -X POST "http://localhost:8000/api/certificates/create" \
 Choose the installation method that best fits your environment:
 
 ### Docker (Recommended)
-Perfect for production deployments with isolation and easy scaling. **Supports multiple architectures**: AMD64 (Intel/AMD), ARM64 (Apple Silicon, ARM servers), and ARM v7 (Raspberry Pi).
+Isolated, reproducible, and the way CertMate is tested and released. Run **one**
+container (see the single-instance note above); give it more CPU and memory
+rather than more replicas. **Supports multiple architectures**: AMD64 (Intel/AMD), ARM64 (Apple Silicon, ARM servers), and ARM v7 (Raspberry Pi).
 
 ```bash
 # Quick start with Docker Compose
@@ -453,7 +468,9 @@ python app.py
 ```
 
 ### Kubernetes
-For container orchestration and high availability deployments.
+For container orchestration and managed rollouts. **`replicas: 1` is not an
+example value** — it is the supported configuration, and the Helm chart fails at
+template time if you change it.
 
 ```yaml
 # Example Kubernetes deployment

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -798,20 +798,41 @@ Each certificate has a `metadata.json` file containing:
 
 ### Production Recommendations
 
-- Use storage backend (Azure, AWS, Vault) for HA
+- Use a storage backend (Azure, AWS, Vault) so certificate material survives the node
 - Enable audit logging for compliance
 - Configure rate limiting based on load
 - Regular CRL updates (daily or on revocation)
 - Back up CA keys and metadata with a disaster-recovery archive (`include_secrets=true` + `CERTMATE_BACKUP_PASSPHRASE`); the default share-safe backup deliberately leaves the CA key out
 - Monitor audit logs for suspicious activity
 
-### High Availability
+### Availability and failover
 
-For multi-instance deployments:
-1. Use shared storage backend for certificates
-2. Synchronize audit logs to central location
-3. Use load balancer with sticky sessions
-4. Monitor rate limit counters across instances
+**CertMate does not run multiple instances.** The renewal scheduler
+(APScheduler) runs inside the web process and gunicorn runs a single worker on
+purpose, so a second replica is a second scheduler issuing and renewing against
+the same certificate store: duplicate ACME orders, and the CA's
+duplicate-certificate rate limit. The Helm chart fails at template time if
+`replicaCount` is anything but `1`.
+
+
+What availability looks like instead — **active/standby**:
+
+1. Put `DATA_DIR` on storage that can be reattached (a network volume, or a
+   replicated filesystem). This is the state that matters: settings, the audit
+   chain, the private CA, and the certificates themselves.
+2. Configure a [storage backend](#storage-backends) (Azure Key Vault, AWS
+   Secrets Manager, Vault, Infisical) so certificate material also lives
+   somewhere independent of the node.
+3. Run **one** instance. On failure, start a replacement against the same data
+   and point the ingress at it. A missed renewal window is not urgent — renewal
+   begins 30 days before expiry, so a failover has weeks of slack.
+4. Keep [disaster-recovery backups](./guide.md) with
+   `CERTMATE_BACKUP_PASSPHRASE` set, so a rebuild from scratch is possible when
+   the volume itself is lost.
+
+The consumers of certificates are what should be highly available. CertMate
+issues and distributes; it is not in the request path of the services it issues
+for, and it being down for an hour does not take anything else down with it.
 
 ---
 

--- a/docs/de/architecture.md
+++ b/docs/de/architecture.md
@@ -775,20 +775,42 @@ Jedes Zertifikat besitzt eine `metadata.json`-Datei mit folgenden Inhalten:
 
 ### Empfehlungen für den Produktionsbetrieb
 
-- Storage-Backend (Azure, AWS, Vault) für Hochverfügbarkeit verwenden
+- Storage-Backend (Azure, AWS, Vault) verwenden, damit Zertifikatsmaterial den Knoten überlebt
 - Audit-Protokollierung zur Compliance aktivieren
 - Rate Limiting entsprechend der Last konfigurieren
 - Regelmäßige CRL-Aktualisierungen (täglich oder bei Sperrungen)
 - CA-Schlüssel und Metadaten sichern
 - Audit-Protokolle auf verdächtige Aktivitäten überwachen
 
-### Hochverfügbarkeit
+### Verfügbarkeit und Failover
 
-Für Multi-Instanz-Deployments:
-1. Gemeinsames Storage-Backend für Zertifikate verwenden
-2. Audit-Protokolle an einen zentralen Speicherort synchronisieren
-3. Load Balancer mit Sticky Sessions einsetzen
-4. Rate-Limiting-Zähler instanzübergreifend überwachen
+**CertMate läuft nicht in mehreren Instanzen.** Der Erneuerungs-Scheduler
+(APScheduler) läuft im Web-Prozess, und gunicorn verwendet absichtlich einen
+einzigen Worker: eine zweite Replik ist ein zweiter Scheduler, der gegen
+denselben Zertifikatsspeicher ausstellt und erneuert — doppelte ACME-Bestellungen
+und das Duplicate-Certificate-Rate-Limit der CA. Das Helm-Chart schlägt zur
+Template-Zeit fehl, wenn `replicaCount` nicht `1` ist.
+
+
+So sieht Verfügbarkeit stattdessen aus — **aktiv/standby**:
+
+1. `DATA_DIR` auf wieder anhängbaren Speicher legen (ein Netzwerk-Volume oder
+   ein repliziertes Dateisystem). Das ist der Zustand, auf den es ankommt:
+   Einstellungen, Audit-Kette, private CA und die Zertifikate selbst.
+2. Ein [Storage-Backend](#storage-backends) (Azure Key Vault, AWS Secrets
+   Manager, Vault, Infisical) konfigurieren, damit auch Zertifikatsmaterial
+   unabhängig vom Knoten liegt.
+3. **Eine** Instanz betreiben. Bei einem Ausfall einen Ersatz gegen dieselben
+   Daten starten und den Ingress darauf zeigen lassen. Ein verpasstes
+   Erneuerungsfenster ist nicht dringend: die Erneuerung beginnt 30 Tage vor
+   Ablauf, ein Failover hat also Wochen Spielraum.
+4. [Disaster-Recovery-Backups](./guide.md) mit gesetztem
+   `CERTMATE_BACKUP_PASSPHRASE` pflegen, damit ein Neuaufbau von Grund auf
+   möglich bleibt, wenn das Volume selbst verloren geht.
+
+Hochverfügbar sein sollten die Verbraucher der Zertifikate. CertMate stellt aus
+und verteilt; es liegt nicht im Anfragepfad der Dienste, für die es ausstellt,
+und wenn es eine Stunde ausfällt, reißt es nichts anderes mit.
 
 ---
 

--- a/docs/es/architecture.md
+++ b/docs/es/architecture.md
@@ -775,20 +775,43 @@ Cada certificado tiene un archivo `metadata.json` que contiene:
 
 ### Recomendaciones para producción
 
-- Usar un backend de almacenamiento (Azure, AWS, Vault) para alta disponibilidad
+- Usar un backend de almacenamiento (Azure, AWS, Vault) para que el material de los certificados sobreviva al nodo
 - Habilitar el registro de auditoría para cumplimiento normativo
 - Configurar la limitación de tasa en función de la carga
 - Actualizaciones regulares de la CRL (diarias o en cada revocación)
 - Hacer copia de seguridad de las claves CA y los metadatos
 - Monitorizar los registros de auditoría en busca de actividad sospechosa
 
-### Alta disponibilidad
+### Disponibilidad y conmutación por error
 
-Para despliegues multi-instancia:
-1. Usar un backend de almacenamiento compartido para los certificados
-2. Sincronizar los registros de auditoría en una ubicación central
-3. Usar un balanceador de carga con sesiones persistentes
-4. Monitorizar los contadores de limitación de tasa entre instancias
+**CertMate no se ejecuta en varias instancias.** Su planificador de renovaciones
+(APScheduler) corre dentro del proceso web y gunicorn usa un único worker a
+propósito: una segunda réplica es un segundo planificador emitiendo y renovando
+contra el mismo almacén de certificados — pedidos ACME duplicados y el límite de
+tasa de la AC por certificados duplicados. El chart de Helm falla en tiempo de
+plantilla si `replicaCount` no es `1`.
+
+
+Cómo se consigue la disponibilidad aquí — **activo/en espera**:
+
+1. Situar `DATA_DIR` en almacenamiento reconectable (un volumen de red o un
+   sistema de archivos replicado). Ese es el estado que importa: ajustes,
+   cadena de auditoría, AC privada y los certificados en sí.
+2. Configurar un [backend de almacenamiento](#backends-de-almacenamiento)
+   (Azure Key Vault, AWS Secrets Manager, Vault, Infisical) para que el
+   material de los certificados también viva con independencia del nodo.
+3. Ejecutar **una** instancia. Ante un fallo, arrancar un reemplazo contra los
+   mismos datos y apuntar el ingress hacia él. Perder una ventana de renovación
+   no es urgente: la renovación empieza 30 días antes del vencimiento, así que
+   una conmutación tiene semanas de margen.
+4. Mantener [copias de recuperación ante desastres](./guide.md) con
+   `CERTMATE_BACKUP_PASSPHRASE` establecida, para que una reconstrucción desde
+   cero siga siendo posible aunque se pierda el volumen.
+
+Quienes deben tener alta disponibilidad son los consumidores de los
+certificados. CertMate emite y distribuye; no está en la ruta de las peticiones
+de los servicios para los que emite, y que esté caído una hora no arrastra nada
+más consigo.
 
 ---
 

--- a/docs/fr/architecture.md
+++ b/docs/fr/architecture.md
@@ -776,20 +776,44 @@ Chaque certificat a un fichier `metadata.json` contenant :
 
 ### Recommandations pour la production
 
-- Utiliser un backend de stockage (Azure, AWS, Vault) pour la haute disponibilité
+- Utiliser un backend de stockage (Azure, AWS, Vault) pour que le matériel des certificats survive au nœud
 - Activer la journalisation d'audit pour la conformité
 - Configurer la limitation de débit en fonction de la charge
 - Mises à jour régulières de la CRL (quotidiennes ou lors des révocations)
 - Sauvegarder les clés CA et les métadonnées
 - Surveiller les journaux d'audit pour les activités suspectes
 
-### Haute disponibilité
+### Disponibilité et bascule
 
-Pour les déploiements multi-instances :
-1. Utiliser un backend de stockage partagé pour les certificats
-2. Synchroniser les journaux d'audit vers un emplacement central
-3. Utiliser un équilibreur de charge avec sessions persistantes
-4. Surveiller les compteurs de limitation de débit entre les instances
+**CertMate ne fonctionne pas en plusieurs instances.** Son ordonnanceur de
+renouvellement (APScheduler) s'exécute dans le processus web et gunicorn n'a
+qu'un seul worker à dessein : une deuxième réplique est un deuxième
+ordonnanceur qui émet et renouvelle sur le même magasin de certificats — d'où
+des commandes ACME dupliquées et la limite de débit de l'AC sur les certificats
+dupliqués. Le chart Helm échoue au moment du template si `replicaCount` vaut
+autre chose que `1`.
+
+
+À quoi ressemble la disponibilité ici — **actif/veille** :
+
+1. Placer `DATA_DIR` sur un stockage réattachable (un volume réseau ou un
+   système de fichiers répliqué). C'est l'état qui compte : réglages, chaîne
+   d'audit, AC privée et les certificats eux-mêmes.
+2. Configurer un [backend de stockage](#backends-de-stockage) (Azure Key Vault,
+   AWS Secrets Manager, Vault, Infisical) pour que le matériel des certificats
+   vive lui aussi indépendamment du nœud.
+3. Exécuter **une seule** instance. En cas de panne, démarrer un remplaçant sur
+   les mêmes données et y pointer l'ingress. Une fenêtre de renouvellement
+   manquée n'est pas urgente : le renouvellement commence 30 jours avant
+   l'expiration, une bascule dispose donc de semaines de marge.
+4. Conserver des [sauvegardes de reprise après sinistre](./guide.md) avec
+   `CERTMATE_BACKUP_PASSPHRASE` définie, pour qu'une reconstruction complète
+   reste possible même si le volume est perdu.
+
+Ce sont les consommateurs des certificats qui doivent être hautement
+disponibles. CertMate émet et distribue ; il n'est pas dans le chemin des
+requêtes des services pour lesquels il émet, et son indisponibilité pendant une
+heure n'entraîne rien d'autre avec elle.
 
 ---
 

--- a/docs/it/architecture.md
+++ b/docs/it/architecture.md
@@ -776,20 +776,42 @@ Ogni certificato ha un file `metadata.json` contenente:
 
 ### Raccomandazioni per la produzione
 
-- Utilizzare un backend di archiviazione (Azure, AWS, Vault) per l'alta disponibilità
+- Utilizzare un backend di archiviazione (Azure, AWS, Vault) perché il materiale dei certificati sopravviva al nodo
 - Abilitare la registrazione di audit per la conformità
 - Configurare il rate limiting in base al carico
 - Aggiornamenti regolari della CRL (giornalieri o alla revoca)
 - Effettuare il backup delle chiavi CA e dei metadati
 - Monitorare i registri di audit per attività sospette
 
-### Alta disponibilità
+### Disponibilità e failover
 
-Per i deployment multi-istanza:
-1. Utilizzare un backend di archiviazione condiviso per i certificati
-2. Sincronizzare i registri di audit in una posizione centrale
-3. Utilizzare un load balancer con sessioni persistenti
-4. Monitorare i contatori di rate limiting tra le istanze
+**CertMate non gira in più istanze.** Lo scheduler dei rinnovi (APScheduler)
+gira dentro il processo web e gunicorn usa un solo worker di proposito: una
+seconda replica è un secondo scheduler che emette e rinnova sullo stesso
+archivio di certificati, quindi ordini ACME duplicati e il rate limit della CA
+sui certificati duplicati. Il chart Helm fallisce in fase di template se
+`replicaCount` è diverso da `1`.
+
+
+Come si ottiene invece la disponibilità — **attivo/standby**:
+
+1. Mettere `DATA_DIR` su storage riagganciabile (un volume di rete o un
+   filesystem replicato). È questo lo stato che conta: impostazioni, catena di
+   audit, CA privata e i certificati stessi.
+2. Configurare un [backend di archiviazione](#backend-di-archiviazione) (Azure Key
+   Vault, AWS Secrets Manager, Vault, Infisical) perché anche il materiale dei
+   certificati viva indipendentemente dal nodo.
+3. Far girare **una** istanza. In caso di guasto, avviarne una di ricambio
+   sugli stessi dati e puntarci l'ingress. Una finestra di rinnovo mancata non
+   è urgente: il rinnovo parte 30 giorni prima della scadenza, quindi un
+   failover ha settimane di margine.
+4. Mantenere [backup di disaster recovery](./guide.md) con
+   `CERTMATE_BACKUP_PASSPHRASE` impostata, così una ricostruzione da zero resta
+   possibile anche perdendo il volume.
+
+Ad essere altamente disponibili devono essere i consumatori dei certificati.
+CertMate emette e distribuisce; non sta nel percorso delle richieste dei
+servizi per cui emette, e se resta giù un'ora non trascina giù nient'altro.
 
 ---
 

--- a/tests/test_docs_do_not_promise_multi_instance.py
+++ b/tests/test_docs_do_not_promise_multi_instance.py
@@ -1,0 +1,152 @@
+"""The docs must not promise a topology the product refuses to run (#673).
+
+CertMate is single-instance by design: APScheduler runs inside the web process
+and gunicorn runs one worker, so a second replica is a second scheduler issuing
+against the same certificate store. The Helm chart enforces this — it calls
+`fail` at template time when `replicaCount != 1`.
+
+The documentation said otherwise in two places, and the second was worse than
+the issue reported. The README led with "easy scaling" and "high availability
+deployments" while the constraint sat in a docker-compose YAML comment ~73% of
+the way down a 2,700-line file. And `docs/architecture.md` carried a **High
+Availability** section giving operational steps for multi-instance deployments —
+shared storage, a load balancer with sticky sessions, rate-limit counters across
+instances — replicated verbatim into all four translations. Following it
+produces duplicate ACME orders and the CA's duplicate-certificate rate limit,
+not availability.
+
+Prose drifts back, so this pins the outcome rather than the wording: the
+constraint is stated where a reader forms a first impression, and no document in
+any language instructs anyone to run more than one.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+ROOT = Path(__file__).resolve().parent.parent
+ARCHITECTURE_DOCS = [
+    ROOT / 'docs' / 'architecture.md',
+    ROOT / 'docs' / 'it' / 'architecture.md',
+    ROOT / 'docs' / 'de' / 'architecture.md',
+    ROOT / 'docs' / 'fr' / 'architecture.md',
+    ROOT / 'docs' / 'es' / 'architecture.md',
+]
+
+# How far into the README still counts as "where a reader forms their first
+# impression". The constraint used to be at line ~1997 of ~2700.
+FIRST_IMPRESSION_LINES = 150
+
+
+def test_every_architecture_translation_is_present():
+    """The translations are this project's recurring blind spot: a fix lands in
+    the English file and four copies keep the old claim. Fail loudly if one is
+    renamed or added, rather than silently checking four files out of five.
+    """
+    missing = [str(p.relative_to(ROOT)) for p in ARCHITECTURE_DOCS if not p.exists()]
+    assert not missing, f'architecture docs missing: {missing}'
+
+    found = sorted(p.name for p in (ROOT / 'docs').glob('*/architecture.md'))
+    expected = sorted(p.name for p in ARCHITECTURE_DOCS[1:])
+    assert found == expected, (
+        f'a translated architecture doc appeared or vanished: {found} != '
+        f'{expected}; add it to ARCHITECTURE_DOCS so it is checked too'
+    )
+
+
+def test_the_single_instance_constraint_is_stated_up_front():
+    """Not buried at 73% of the way down, under headline claims that
+    contradict it."""
+    head = '\n'.join(
+        (ROOT / 'README.md').read_text().splitlines()[:FIRST_IMPRESSION_LINES]
+    ).lower()
+
+    assert 'single instance' in head or 'single-instance' in head, (
+        f'the README does not say CertMate is single-instance within its '
+        f'first {FIRST_IMPRESSION_LINES} lines'
+    )
+    assert 'replica' in head, (
+        'the first impression does not mention replicas, so a reader planning '
+        'a Kubernetes deployment has no reason to look further'
+    )
+
+
+@pytest.mark.parametrize('claim', [
+    'easy scaling',
+    'high availability deployments',
+])
+def test_the_contradicting_readme_claims_are_gone(claim):
+    """Named individually so a reintroduction says which sentence came back."""
+    text = re.sub(r'\s+', ' ', (ROOT / 'README.md').read_text().lower())
+    assert claim not in text, (
+        f'README claims "{claim}", which the Helm chart refuses to render'
+    )
+
+
+@pytest.mark.parametrize('doc', ARCHITECTURE_DOCS, ids=lambda p: p.parent.name)
+def test_no_architecture_doc_instructs_a_multi_instance_deployment(doc):
+    """The operational recipe, in every language it was copied into.
+
+    Matching on "sticky sessions" and its translations rather than on the words
+    "high availability": a document may legitimately explain how to *achieve*
+    availability, and the replacement text does. What must not come back is
+    telling someone to put a load balancer in front of several CertMates.
+    """
+    # Whitespace-normalised, because these files are hard-wrapped at ~80
+    # columns and a two-word phrase lands across a line break about half the
+    # time. Measured: the English file contained "sticky\nsessions" and a plain
+    # substring check passed on it while the French file, wrapped differently,
+    # failed. A guard that depends on where the wrapping fell is not a guard.
+    text = re.sub(r'\s+', ' ', doc.read_text().lower())
+    forbidden = [
+        'sticky sessions',        # en
+        'sessioni persistenti',   # it
+        'sticky session',         # de (uses the English term)
+        'sessions persistantes',  # fr
+        'sesiones persistentes',  # es
+    ]
+    hit = [phrase for phrase in forbidden if phrase in text]
+    assert not hit, (
+        f'{doc.relative_to(ROOT)} still describes load balancing across '
+        f'instances ({hit}); the chart fails at template time for '
+        f'replicaCount != 1'
+    )
+
+
+@pytest.mark.parametrize('doc', ARCHITECTURE_DOCS, ids=lambda p: p.parent.name)
+def test_each_architecture_doc_states_the_constraint(doc):
+    """CONTROL for the test above: deleting the section would satisfy a
+    forbidden-phrase check while leaving readers with nothing.
+    """
+    text = doc.read_text().lower()
+    assert 'replicacount' in text, (
+        f'{doc.relative_to(ROOT)} no longer names the replicaCount guard, so '
+        f'a reader has no way to learn the constraint from this document'
+    )
+
+
+def _slugify(heading):
+    """GitHub's anchor rules, near enough for our headings: lowercase, drop
+    punctuation, spaces to hyphens."""
+    slug = heading.strip().lower()
+    slug = re.sub(r'[^\w\s-]', '', slug, flags=re.UNICODE)
+    return re.sub(r'\s+', '-', slug)
+
+
+@pytest.mark.parametrize('doc', ARCHITECTURE_DOCS, ids=lambda p: p.parent.name)
+def test_the_in_document_anchors_resolve(doc):
+    """The availability section links to the storage-backend section, and the
+    heading is translated in every file — so the anchor is too. A dead anchor
+    scrolls nowhere and is invisible in review.
+    """
+    text = doc.read_text()
+    anchors = {_slugify(m) for m in re.findall(r'^#{1,6}\s+(.*)$', text, re.M)}
+    used = set(re.findall(r'\]\(#([^)]+)\)', text))
+
+    dead = sorted(a for a in used if a not in anchors)
+    assert not dead, (
+        f'{doc.relative_to(ROOT)} links to anchors that no heading produces: '
+        f'{dead}'
+    )


### PR DESCRIPTION
Closes #673.

## The claim, and the enforcement

CertMate is single-instance by design: APScheduler runs inside the web process and gunicorn runs one worker, so a second replica is a second scheduler issuing against the same certificate store. The Helm chart already **enforces** this — `fail` at template time when `replicaCount != 1`.

The README said otherwise. It led with *"easy scaling"* and *"high availability deployments"*, while the constraint sat in a docker-compose YAML comment roughly 73% of the way down a 2,700-line file.

## The bigger find, which the issue did not name

`docs/architecture.md` carried a **High Availability** section with operational steps for multi-instance deployments:

> 1. Use shared storage backend for certificates
> 2. Synchronize audit logs to central location
> 3. **Use load balancer with sticky sessions**
> 4. Monitor rate limit counters across instances

Following that produces duplicate ACME orders and the CA's duplicate-certificate rate limit — not availability. And it was replicated verbatim into **all four translations**, so the wrong instructions existed five times.

Checking the translations first is a habit this repo earned: they have been the blind spot in four consecutive audits.

All five now describe **active/standby**, which is what actually works: `DATA_DIR` on reattachable storage, a storage backend so certificate material outlives the node, one instance with a replacement started against the same data on failure, and DR backups for the case where the volume itself is lost. Renewal begins 30 days before expiry, so a failover has weeks of slack — that is the part that makes single-instance acceptable, and it is now said out loud.

## Changes

- **README** — a note in "Why CertMate?" stating the model as the deliberate design choice it is (one writer is what makes certificate state safe without a distributed lock service, and it scales *up*, not *out*). The Docker section no longer says "easy scaling"; the Kubernetes section says `replicas: 1` is the supported configuration, not an example value.
- **docs/architecture.md + it/de/fr/es** — "High Availability" → "Availability and failover", rewritten.
- **tests/test_docs_do_not_promise_multi_instance.py** — 19 tests.

## The guard, and why it normalises whitespace

Not cosmetic. These files are hard-wrapped at ~80 columns, the English file contained `sticky\nsessions`, and a plain substring check **passed on it** while the French file — wrapped differently — failed. A check whose result depends on where the line wrapping fell is not a check.

It also asserts that every in-document anchor resolves, because the storage-backend heading is translated in each file and the link to it has to be too. And it fails if a translated `architecture.md` appears or vanishes without being added to the list, so a sixth language cannot be silently unchecked.

Five mutations, each confirmed to trip a test:

| mutation | tests tripped |
|---|---|
| the whole single-instance note removed from the README | 1 |
| `easy scaling` returns | 1 |
| `sticky sessions` returns, **split across two lines** | 1 |
| the load-balancer recipe returns in Spanish only | 1 |
| the French anchor points at an English heading | 1 |

A sixth mutation — replacing only the note's bold lead — did **not** trip anything, and correctly so: the constraint and its mechanism were still stated in the sentences below it. The mutation was badly chosen, not the test blind; removing the whole note does fail.

Unit suite 3565 → 3584 (+19), gated flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)