### PR TITLE
fix: make SESSION_TIMEOUT_HOURS reach the cookie, and constants tell the truth (#590)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,12 @@ API_BEARER_TOKEN=your_secure_api_token_here
 # Alternatively, set SECRET_KEY_FILE to a path containing the key.
 SECRET_KEY=your_secret_key_here
 
+# Optional: how long a login session lasts, in hours (default 8).
+# Governs both the server-side session record and the browser cookie, so a
+# shorter value really does log people out sooner. Values below 1 are clamped
+# to 1 hour so a typo cannot expire every session the moment it is created.
+# SESSION_TIMEOUT_HOURS=8
+
 # Optional: logging
 # CERTMATE_LOG_LEVEL=INFO          # DEBUG, INFO, WARNING, ERROR
 # CERTMATE_LOG_JSON=true           # structured JSON on stdout

--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -104,11 +104,32 @@ class AuthManager:
         self._last_used_persist_ts = {}
         self._last_used_lock = threading.Lock()
         import os
-        _timeout_hours = int(os.getenv('SESSION_TIMEOUT_HOURS', '8'))
+        from .constants import DEFAULT_SESSION_TIMEOUT_HOURS
+        try:
+            _timeout_hours = int(os.getenv(
+                'SESSION_TIMEOUT_HOURS', str(DEFAULT_SESSION_TIMEOUT_HOURS)))
+        except ValueError:
+            logger.warning(
+                "SESSION_TIMEOUT_HOURS is not an integer; using the default "
+                "of %d hours", DEFAULT_SESSION_TIMEOUT_HOURS)
+            _timeout_hours = DEFAULT_SESSION_TIMEOUT_HOURS
+        # max(1, ...) so a zero or negative value cannot expire every session
+        # at the moment it is created and lock everyone out.
         self._session_timeout = max(1, _timeout_hours) * 60 * 60
         if not BCRYPT_AVAILABLE:
             logger.warning("bcrypt not available; using the scrypt KDF fallback. "
                            "Install bcrypt for the preferred password hashing.")
+
+    @property
+    def session_timeout_seconds(self) -> int:
+        """How long a session lives, in seconds.
+
+        Public because the cookie has to agree with it (#590): both mint sites
+        set ``max_age`` from this rather than repeating a literal, so an
+        operator who changes SESSION_TIMEOUT_HOURS gets a browser cookie that
+        expires with the server-side record instead of eight hours later.
+        """
+        return self._session_timeout
 
     def set_audit_logger(self, audit_logger):
         """Inject the AuditLogger so authorization denials emit a real audit

--- a/modules/core/cache.py
+++ b/modules/core/cache.py
@@ -3,6 +3,7 @@ Cache management module for CertMate
 Handles deployment status caching and cache operations
 """
 
+from .constants import DEFAULT_CACHE_TTL
 import logging
 from .utils import DeploymentStatusCache
 
@@ -21,7 +22,7 @@ class CacheManager:
         """Update cache settings from configuration"""
         try:
             settings = self.settings_manager.load_settings()
-            cache_ttl = settings.get('cache_ttl', 300)
+            cache_ttl = settings.get('cache_ttl', DEFAULT_CACHE_TTL)
             self.deployment_cache.set_ttl(cache_ttl)
             logger.info(f"Updated deployment cache TTL to {cache_ttl} seconds")
         except Exception as e:

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from cryptography import x509
 from .shell import ShellExecutor
 from .dns_strategies import DNSStrategyFactory, HTTP01Strategy, acme_webroot_dir, check_certbot_plugin_installed
-from .constants import CERTIFICATE_FILES
+from .constants import CERTIFICATE_FILES, DEFAULT_RENEWAL_THRESHOLD_DAYS
 from .utils import (
     DeploymentStatusCache, validate_domain, utc_now, utc_now_iso, validate_key_options,
     repair_certbot_lineage_symlinks,
@@ -243,7 +243,9 @@ class CertificateManager:
             return 5.0
 
     @staticmethod
-    def _coerce_renewal_threshold_days(settings: dict | None, default: int = 30) -> int:
+    def _coerce_renewal_threshold_days(
+            settings: dict | None,
+            default: int = DEFAULT_RENEWAL_THRESHOLD_DAYS) -> int:
         """Return a usable renewal threshold in days from settings.
 
         A non-int, zero, or negative ``renewal_threshold_days`` (a typo via

--- a/modules/core/constants.py
+++ b/modules/core/constants.py
@@ -53,18 +53,28 @@ MAX_CERTIFICATE_VALIDITY_DAYS = 3650  # ~10 years
 # Minimum validity period for certificates
 MIN_CERTIFICATE_VALIDITY_DAYS = 1
 
-# Default renewal threshold (days before expiry to trigger renewal)
+# Default renewal threshold (days before expiry to trigger renewal).
+# Read by certificates.py, digest.py and metrics.py as the fallback when
+# settings.json carries no renewal_threshold_days.
 DEFAULT_RENEWAL_THRESHOLD_DAYS = 30
 
-# Rate limiting defaults
-DEFAULT_LOGIN_RATE_LIMIT = 5  # attempts
-DEFAULT_LOGIN_RATE_WINDOW = 60  # seconds
+# Default session lifetime, in hours. Overridden by SESSION_TIMEOUT_HOURS.
+# Read by AuthManager, which is also what both cookie mint sites ask for their
+# max_age — so the server record and the browser cookie cannot drift apart.
+#
+# This said 24 while the code used 8 and nothing read the file (#590). The
+# value here is now the one shipped installs have always run.
+DEFAULT_SESSION_TIMEOUT_HOURS = 8
 
-# Session defaults
-DEFAULT_SESSION_TIMEOUT_HOURS = 24
+# Default deployment-status cache TTL, in seconds. Read by CacheManager as the
+# fallback when settings.json carries no cache_ttl.
+DEFAULT_CACHE_TTL = 300
 
-# API defaults
-DEFAULT_CACHE_TTL = 300  # seconds
+# Login rate-limiting defaults deliberately do NOT live here. There is no
+# single pair any more: routes.py runs two buckets with four values (5 attempts
+# / 60s per IP, 10 / 300s per username), and a lone DEFAULT_LOGIN_RATE_LIMIT
+# could only misdescribe them. They stay next to the algorithm that reads
+# them.
 
 
 def get_domain_name(domain_config):

--- a/modules/core/digest.py
+++ b/modules/core/digest.py
@@ -12,7 +12,7 @@ from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from typing import Dict, Any, List
 
-from .constants import iter_cert_domain_dirs
+from .constants import DEFAULT_RENEWAL_THRESHOLD_DAYS, iter_cert_domain_dirs
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +54,8 @@ class WeeklyDigest:
         expired = 0
         expiring_domains: List[str] = []
 
-        renewal_threshold = settings.get('renewal_threshold_days', 30)
+        renewal_threshold = settings.get(
+            'renewal_threshold_days', DEFAULT_RENEWAL_THRESHOLD_DAYS)
 
         for domain in sorted(all_domains):
             info = self.certificate_manager.get_certificate_info(domain)

--- a/modules/core/metrics.py
+++ b/modules/core/metrics.py
@@ -9,7 +9,7 @@ import time
 from datetime import datetime, timezone
 import logging
 
-from .constants import iter_cert_domain_dirs
+from .constants import DEFAULT_RENEWAL_THRESHOLD_DAYS, iter_cert_domain_dirs
 
 
 def _iso_to_epoch(value):
@@ -310,7 +310,8 @@ class CertMateMetricsCollector:
                 return
                 
             # Get configurable renewal threshold (default 30 days for backward compatibility)
-            renewal_threshold_days = settings.get('renewal_threshold_days', 30)
+            renewal_threshold_days = settings.get(
+                'renewal_threshold_days', DEFAULT_RENEWAL_THRESHOLD_DAYS)
                 
             domains = settings.get('domains', [])
             total_domains.set(len(domains))

--- a/modules/web/auth_routes.py
+++ b/modules/web/auth_routes.py
@@ -70,7 +70,11 @@ def register_auth_routes(app, managers, require_web_auth, auth_manager,
             response.set_cookie(
                 'certmate_session', session_id, httponly=True,
                 secure=request.is_secure, samesite='Strict', path='/',
-                max_age=8 * 60 * 60
+                # Follows SESSION_TIMEOUT_HOURS (#590). Hardcoded at eight
+                # hours, this ignored the setting entirely: the server kept
+                # the session for as long as configured and the browser threw
+                # the cookie away at eight.
+                max_age=auth_manager.session_timeout_seconds
             )
             return response
         except Exception as e:

--- a/modules/web/oidc_routes.py
+++ b/modules/web/oidc_routes.py
@@ -170,13 +170,14 @@ def register_oidc_routes(app, managers, auth_manager, oidc_manager,
 
         next_url = oidc_manager.consume_next_url()
         response = redirect(next_url)
-        # Match local-login cookie attributes verbatim
-        # (auth_routes.py:64-68): HttpOnly, Secure when over HTTPS,
-        # SameSite=Strict, path=/, 8h max_age.
+        # Match local-login cookie attributes: HttpOnly, Secure when over
+        # HTTPS, SameSite=Strict, path=/, and the same lifetime. "Verbatim"
+        # used to mean a copied `8 * 60 * 60`, which is how one hardcoded
+        # duration became two (#590); both now ask the AuthManager.
         response.set_cookie(
             'certmate_session', session_id, httponly=True,
             secure=request.is_secure, samesite='Strict', path='/',
-            max_age=8 * 60 * 60,
+            max_age=auth_manager.session_timeout_seconds,
         )
 
         if audit_logger:

--- a/tests/test_session_timeout_is_one_number.py
+++ b/tests/test_session_timeout_is_one_number.py
@@ -1,0 +1,191 @@
+"""SESSION_TIMEOUT_HOURS must reach the cookie, not just the server (#590).
+
+The session lifetime existed as three different numbers:
+
+    constants.py    DEFAULT_SESSION_TIMEOUT_HOURS = 24   (read by nobody)
+    auth.py:107     os.getenv('SESSION_TIMEOUT_HOURS', '8')
+    auth_routes.py  max_age=8 * 60 * 60                  (hardcoded)
+    oidc_routes.py  max_age=8 * 60 * 60                  (hardcoded)
+
+Only the second was configurable, and it governed only the server-side record.
+The cookie the browser actually holds was pinned at eight hours regardless. So
+an operator who set `SESSION_TIMEOUT_HOURS=24` was still logged out after eight
+— the setting is read, documented, and does not do what it says. Setting it
+*shorter* is the less visible half: the server rejects the session on time, but
+the browser keeps presenting a dead id until its own eight hours are up.
+
+The tests assert the property rather than the constant: whatever the operator
+configures, the server record and the cookie agree.
+"""
+import pytest
+
+from modules.core import constants
+from modules.core.auth import AuthManager
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def settings_manager(tmp_path):
+    from modules.core.file_operations import FileOperations
+    from modules.core.settings import SettingsManager
+
+    dirs = [tmp_path / n for n in ('certificates', 'data', 'backups', 'logs')]
+    for directory in dirs:
+        directory.mkdir()
+    manager = SettingsManager(FileOperations(*dirs), dirs[1] / 'settings.json')
+    manager.load_settings()
+    return manager
+
+
+# ---------------------------------------------------------------------------
+# One number
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('hours', [1, 8, 24])
+def test_the_configured_value_drives_the_session_lifetime(
+        settings_manager, monkeypatch, hours):
+    monkeypatch.setenv('SESSION_TIMEOUT_HOURS', str(hours))
+    auth = AuthManager(settings_manager)
+
+    assert auth.session_timeout_seconds == hours * 60 * 60
+
+
+def test_the_default_comes_from_constants(settings_manager, monkeypatch):
+    """The point of a constants module. Before this, constants.py said 24 while
+    the code used 8 and nothing read the file."""
+    monkeypatch.delenv('SESSION_TIMEOUT_HOURS', raising=False)
+    auth = AuthManager(settings_manager)
+
+    assert auth.session_timeout_seconds == (
+        constants.DEFAULT_SESSION_TIMEOUT_HOURS * 60 * 60)
+
+
+def test_constants_records_the_value_the_code_actually_uses(
+        settings_manager, monkeypatch):
+    """CONTROL. The two assertions above would both pass if constants.py were
+    edited to any value and auth.py followed it — which is right — but the
+    declared default must also be the one shipped installs have been running.
+    That is 8, not the 24 the file claimed.
+    """
+    assert constants.DEFAULT_SESSION_TIMEOUT_HOURS == 8
+
+
+def test_a_nonsense_value_does_not_produce_a_zero_length_session(
+        settings_manager, monkeypatch):
+    """`max(1, ...)` was already there; keep it. A zero or negative timeout
+    would expire every session at creation and lock everyone out."""
+    monkeypatch.setenv('SESSION_TIMEOUT_HOURS', '0')
+    auth = AuthManager(settings_manager)
+
+    assert auth.session_timeout_seconds >= 60 * 60
+
+
+# ---------------------------------------------------------------------------
+# It reaches the cookie
+# ---------------------------------------------------------------------------
+
+def _cookie_max_age(response, name='certmate_session'):
+    for header in response.headers.getlist('Set-Cookie'):
+        if header.startswith(name + '='):
+            for part in header.split(';'):
+                part = part.strip()
+                if part.lower().startswith('max-age='):
+                    return int(part.split('=', 1)[1])
+    return None
+
+
+@pytest.mark.parametrize('hours', [1, 24])
+def test_the_login_cookie_expires_when_the_session_does(
+        tmp_path, monkeypatch, hours):
+    """The reported defect: the cookie ignored the setting entirely."""
+    from pathlib import Path
+
+    monkeypatch.setenv('SESSION_TIMEOUT_HOURS', str(hours))
+    project_root = tmp_path / 'certmate'
+    module_dir = project_root / 'modules' / 'core'
+    module_dir.mkdir(parents=True)
+    (module_dir / 'factory.py').write_text('# test path anchor\n')
+    monkeypatch.setattr('modules.core.factory.__file__',
+                        str(module_dir / 'factory.py'))
+    monkeypatch.setenv('FLASK_ENV', 'testing')
+    monkeypatch.setenv('TESTING', 'true')
+
+    from modules.core.factory import create_app
+    app, container = create_app()
+    assert Path(container.cert_dir).resolve().is_relative_to(tmp_path)
+
+    client = app.test_client()
+    client.post('/api/web/settings/users', json={
+        'username': 'admin', 'password': 'Password123!', 'role': 'admin'})
+    client.post('/api/auth/config', json={'local_auth_enabled': True})
+    resp = client.post('/api/auth/login', json={
+        'username': 'admin', 'password': 'Password123!'})
+
+    assert resp.status_code == 200, resp.get_json()
+    max_age = _cookie_max_age(resp)
+    assert max_age == hours * 60 * 60, (
+        f'SESSION_TIMEOUT_HOURS={hours} but the cookie lives {max_age}s; the '
+        f'setting is read by the server and ignored by the browser'
+    )
+
+
+def test_both_cookie_mint_sites_use_the_configured_lifetime():
+    """OIDC mints the same cookie in a second place, and its comment says it
+    matches the local-login one "verbatim" — which is exactly how a hardcoded
+    duration gets copied. Asserted on the source so a new mint site cannot
+    reintroduce the literal.
+    """
+    import inspect
+    import re
+
+    from modules.web import auth_routes, oidc_routes
+
+    for module in (auth_routes, oidc_routes):
+        src = inspect.getsource(module)
+        assert 'certmate_session' in src, f'{module.__name__} mints no session'
+        literals = re.findall(r'max_age\s*=\s*(\d+\s*\*\s*\d+\s*\*\s*\d+)', src)
+        assert not literals, (
+            f'{module.__name__} hardcodes the session cookie lifetime '
+            f'({literals}); it must follow SESSION_TIMEOUT_HOURS'
+        )
+
+
+# ---------------------------------------------------------------------------
+# The rest of the file
+# ---------------------------------------------------------------------------
+
+def test_every_default_in_constants_has_a_reader():
+    """A constants file that nothing reads is worse than none: it documents
+    values the code does not use. Five of them had zero readers.
+
+    `_FILESYSTEM_ARTIFACT_DIR_NAMES` is deliberately exempt — it is
+    underscore-private and read inside its own module, which is what a private
+    constant looks like rather than a defect.
+    """
+    import re
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent.parent
+    source = constants.__file__
+    declared = [
+        name for name in vars(constants)
+        if name.isupper() and not name.startswith('_')
+    ]
+
+    unread = []
+    for name in declared:
+        found = False
+        for path in root.glob('modules/**/*.py'):
+            if str(path) == source:
+                continue
+            if re.search(rf'\b{name}\b', path.read_text()):
+                found = True
+                break
+        if not found:
+            unread.append(name)
+
+    assert not unread, (
+        f'these constants are declared and read by nothing, so they document '
+        f'values the code does not use: {sorted(unread)}'
+    )


### PR DESCRIPTION
Closes #590.

## The session lifetime was three numbers

```
constants.py    DEFAULT_SESSION_TIMEOUT_HOURS = 24   ← read by nobody
auth.py:107     getenv('SESSION_TIMEOUT_HOURS', '8')
auth_routes.py  max_age = 8 * 60 * 60                ← hardcoded
oidc_routes.py  max_age = 8 * 60 * 60                ← hardcoded (copied, with a
                                                       comment saying "verbatim")
```

Only the second was configurable, and it governed **only the server-side record**. The cookie the browser holds was pinned at eight hours regardless. So `SESSION_TIMEOUT_HOURS=24` still logged you out after eight — a setting that is read, documented, and does not do what it says.

The shorter direction is the quieter half, and it is the one the docs recommend: RELEASE_NOTES suggests `SESSION_TIMEOUT_HOURS=1` *"for high-security deployments"*. Until now that left a cookie alive **seven hours after** the session it named was already dead.

`AuthManager.session_timeout_seconds` is now public and both mint sites ask for it, so the record and the cookie cannot drift. The constant is **8** — what shipped installs have always run, not the 24 the file claimed — and `auth.py` reads it. A non-integer value warns and falls back rather than raising during startup.

## The other four unread names

| constant | outcome |
|---|---|
| `DEFAULT_RENEWAL_THRESHOLD_DAYS` | now read by `certificates.py`, `digest.py`, `metrics.py` — each of which hand-wrote `30` |
| `DEFAULT_CACHE_TTL` | now read by `cache.py` |
| `DEFAULT_LOGIN_RATE_LIMIT` | **deleted** |
| `DEFAULT_LOGIN_RATE_WINDOW` | **deleted** |

The rate-limit pair goes because **there is no single pair any more**: `routes.py` runs two buckets with four values (5 attempts / 60s per IP, 10 / 300s per username). A lone `DEFAULT_LOGIN_RATE_LIMIT = 5` could only misdescribe them — that is the defect this issue is about, not a fix for it. They stay next to the algorithm that reads them.

**`_FILESYSTEM_ARTIFACT_DIR_NAMES` stays.** The issue counted it among the six, but it is underscore-private and read inside its own module by `iter_cert_domain_dirs`. "No reader outside the file" is the definition of a private constant, not a defect.

## Verification

Ten tests, all confirmed failing before the fix — including one that enumerated exactly the five unread names. Five mutations, each confirmed to trip a test:

| mutation | tests tripped |
|---|---|
| the login cookie goes back to a hardcoded 8h | 3 |
| **only the OIDC cookie** goes back to hardcoded | 1 |
| `constants.py` declares 24 again | 1 |
| `max(1, ...)` removed (zero-length sessions) | 1 |
| an unread constant is reintroduced | 1 |

The second row is why the source-level assertion exists: with only the OIDC cookie re-hardcoded, both behavioural cookie tests still pass — they exercise local login. A second mint site with a copied literal is exactly how this defect got duplicated in the first place.

A test now fails the build for any **public** constant nothing reads, so the file cannot drift back into documenting values the code does not use.

`SESSION_TIMEOUT_HOURS` was in no `.env.example` and in no doc except a release note; it is now in the template, which has its own test asserting every variable there is actually read.

Suite 3584 → 3595 (+11), gated flake8 clean, per-module coverage floors met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)