### PR TITLE
refactor(#666): pin the certbot command, then extract _prepare_issuance (step 1)

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -108,6 +108,30 @@ _KNOWN_METADATA_KEYS = _REISSUE_OWNED_METADATA_KEYS | frozenset({
 })
 
 
+def _reject_path_escaping_domain(domain):
+    """Refuse a domain that could escape ``cert_dir`` when used as a path.
+
+    ``domain`` becomes a directory name under the certificate root, the certbot
+    ``--config-dir``, and the key of the per-domain lock. A URL-form value whose
+    netloc passed ``validate_domain`` but was kept raw ("https://x/../y") would
+    escape ``cert_dir`` and drop the ACME account private key under the public
+    ``/.well-known/acme-challenge`` webroot.
+
+    Reject rather than normalise: normalisation is the source's job, and
+    reaching this sink with path characters means something upstream failed, so
+    the request must not proceed.
+
+    Module-level and called from every entry point rather than written inline
+    once (#666). While it lived at the top of ``create_certificate`` it
+    protected the code below it by position; extracting that code into
+    ``_prepare_issuance`` produced a unit that did not enforce its own
+    precondition, which is exactly the shape CodeQL flags — and it was right.
+    """
+    if (not domain or '/' in domain or '\\' in domain
+            or '..' in domain or '\x00' in domain):
+        raise ValueError('Invalid domain name')
+
+
 @dataclass(frozen=True)
 class _PreparedIssuance:
     """Everything ``create_certificate`` resolves before it builds a command.
@@ -1468,6 +1492,11 @@ class CertificateManager:
         Raises the same exceptions the inline code did — FileExistsError,
         ValueError, RuntimeError — so the caller's handlers are unchanged.
         """
+        # create_certificate rejects these before taking the per-domain lock,
+        # and this repeats it rather than trusting the caller: `domain` is used
+        # here to build cert_dir paths, and a unit that assumes its caller
+        # validated is only safe by position.
+        _reject_path_escaping_domain(domain)
         settings = None
         # Settings are loaded lazily and at most once: several branches
         # below need settings (CA default, challenge type, DNS provider,
@@ -1723,9 +1752,7 @@ class CertificateManager:
         # escape. Reject rather than normalise: normalisation is the source's
         # job; reaching the sink with path characters means something upstream
         # failed and the request must not proceed.
-        if (not domain or '/' in domain or '\\' in domain
-                or '..' in domain or '\x00' in domain):
-            raise ValueError('Invalid domain name')
+        _reject_path_escaping_domain(domain)
 
         # Acquire per-domain lock to prevent concurrent create/renew operations
         domain_lock = self._get_domain_lock(domain)

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -16,6 +16,7 @@ import time
 import logging
 import shutil
 from contextlib import contextmanager
+from dataclasses import dataclass
 
 try:  # POSIX only; the lock degrades to a no-op without it
     import fcntl
@@ -105,6 +106,31 @@ _KNOWN_METADATA_KEYS = _REISSUE_OWNED_METADATA_KEYS | frozenset({
     'renewed_at', 'deployment_host', 'deployment_port', 'deployment_protocol',
     'deployment_status', 'key_type', 'key_size', 'elliptic_curve',
 })
+
+
+@dataclass(frozen=True)
+class _PreparedIssuance:
+    """Everything ``create_certificate`` resolves before it builds a command.
+
+    A frozen record rather than fourteen locals threaded through a 517-line
+    function: the point of splitting the phases is that what crosses between
+    them is visible and cannot be reassigned halfway down.
+    """
+    settings: dict | None
+    ca_provider: str
+    staging: bool
+    ca_account_config: dict | None
+    used_ca_account_id: str | None
+    challenge_type: str
+    dns_provider: str | None
+    dns_config: dict | None
+    strategy: object
+    all_domains: list
+    cert_dir: Path
+    cert_output_dir: Path
+    key_type: str | None
+    key_size: int | None
+    elliptic_curve: str | None
 
 
 class CertificateManager:
@@ -1419,6 +1445,233 @@ class CertificateManager:
             f"{quarantine.name}; reissue will rebuild it from scratch"
         )
 
+
+    def _prepare_issuance(self, *, domain, email, dns_provider, dns_config,
+                          account_id, staging, ca_provider, ca_account_id,
+                          domain_alias, alias_dns_provider, san_domains,
+                          challenge_type, key_type, key_size, elliptic_curve,
+                          replace):
+        """Validate and resolve everything an issuance needs, before any
+        command is built (#666).
+
+        Extracted verbatim from the first third of ``create_certificate``'s
+        517-line try block. It answers the questions the command builder then
+        assumes are settled: which CA, which challenge, which DNS provider and
+        account, which key shape, which domains, and whether this domain is
+        already issued.
+
+        Named "prepare" rather than "resolve" because it is not pure: it
+        creates the per-domain output directory and, for HTTP-01, the webroot
+        challenge directory. Both were side effects of this stretch of code
+        before the extraction and stay where they were.
+
+        Raises the same exceptions the inline code did — FileExistsError,
+        ValueError, RuntimeError — so the caller's handlers are unchanged.
+        """
+        settings = None
+        # Settings are loaded lazily and at most once: several branches
+        # below need settings (CA default, challenge type, DNS provider,
+        # key shape, propagation time) but a fully-specified HTTP-01 caller
+        # needs none, so we keep the load conditional and reuse the result.
+
+        # Return conflict if cert already exists (use renew to refresh it,
+        # or replace=True to reissue with a changed domain set — #267).
+        # This existence check runs *under* the per-domain lock acquired
+        # above so two concurrent creates for the same domain can't both
+        # pass the check and race to issue duplicate certificates.
+        existing_cert = self.cert_dir / domain / 'cert.pem'
+        if existing_cert.exists() and not replace:
+            raise FileExistsError(f"Certificate for {domain} already exists. Use renew to refresh it.")
+
+        logger.info(f"Starting certificate {'reissue' if replace else 'creation'} for domain: {domain}")
+        
+        # ... (Validation and CA setup remains the same until DNS config)
+        
+        # Validate inputs
+        if not domain or not email:
+            raise ValueError("Domain and email are required")
+        
+        # Get CA provider configuration
+        if not ca_provider:
+            if settings is None:
+                settings = self.settings_manager.load_settings()
+            ca_provider = settings.get('default_ca', 'letsencrypt')
+
+        # Back-compat (#279): the legacy per-cert staging boolean maps
+        # onto the dedicated staging CA entry, and the boolean is derived
+        # from the entry from here on. Keeping both views coherent means
+        # the no-ca_manager fallback below (which only knows --staging)
+        # and metadata stay correct whichever way the caller asked.
+        if staging and ca_provider == 'letsencrypt':
+            ca_provider = 'letsencrypt_staging'
+        staging = staging or ca_provider == 'letsencrypt_staging'
+
+        logger.info(f"Using CA provider: {ca_provider}")
+
+        # Get CA account configuration if CA manager is available
+        ca_account_config = None
+        used_ca_account_id = None
+        if self.ca_manager:
+            try:
+                ca_account_config, used_ca_account_id = self.ca_manager.get_ca_config(ca_provider, ca_account_id)
+                logger.info(f"Using CA account: {used_ca_account_id}")
+            except Exception as e:
+                if ca_provider in ('letsencrypt', 'letsencrypt_staging'):
+                    # Let's Encrypt needs no per-account credentials; with
+                    # no saved CA config the plain-certbot branch below
+                    # handles it (staging via --staging). Do NOT reset the
+                    # provider — that would silently flip a staging
+                    # request to production issuance.
+                    logger.info(f"No saved CA config for {ca_provider}; using certbot defaults: {e}")
+                else:
+                    # Preserve the caller's staging intent across the
+                    # fallback: resetting to production letsencrypt here
+                    # would turn a test request into trusted production
+                    # issuance (and burn real rate limits).
+                    ca_provider = 'letsencrypt_staging' if staging else 'letsencrypt'
+                    logger.warning(f"Could not get CA config, falling back to {ca_provider}: {e}")
+        
+        # Resolve challenge type from settings if not provided
+        if not challenge_type:
+            if settings is None:
+                settings = self.settings_manager.load_settings()
+            challenge_type = settings.get('challenge_type', 'dns-01')
+
+        # HTTP-01 path: skip DNS config entirely
+        if challenge_type == 'http-01':
+            strategy = HTTP01Strategy()
+            dns_config = dns_config or {}
+            dns_provider = dns_provider or 'http-01'
+            # Ensure webroot directory exists (same path the serving route
+            # reads — see acme_webroot_dir).
+            challenge_dir = acme_webroot_dir() / '.well-known' / 'acme-challenge'
+            challenge_dir.mkdir(parents=True, exist_ok=True)
+            logger.info("Using HTTP-01 challenge (webroot)")
+        else:
+            # DNS-01 path: get DNS configuration
+            if not dns_config:
+                if not dns_provider:
+                    if settings is None:
+                        settings = self.settings_manager.load_settings()
+                    dns_provider = self.settings_manager.get_domain_dns_provider(domain, settings)
+
+                if not dns_provider:
+                    raise ValueError("No DNS provider configured. Go to Settings and select a DNS provider.")
+
+                dns_config, used_account_id = self._get_dns_config(
+                    dns_provider, account_id
+                )
+
+                if not dns_config:
+                    raise ValueError(f"DNS provider '{dns_provider}' account '{account_id or 'default'}' not configured")
+
+                logger.info(f"Using DNS provider: {dns_provider} with account: {used_account_id}")
+
+            # Get Strategy
+            strategy = DNSStrategyFactory.get_strategy(dns_provider)
+
+            if domain_alias and (alias_dns_provider or dns_provider) not in DNS_ALIAS_SUPPORTED_PROVIDERS:
+                raise RuntimeError(
+                    "DNS alias mode does not support this DNS provider yet. "
+                    "Use a supported account that controls the alias zone, "
+                    "or omit domain_alias for the provider's normal DNS-01 flow."
+                )
+
+            # Alias mode uses CertMate's manual DNS hook instead of the
+            # provider certbot authenticator, so the plugin is only needed
+            # for the normal non-alias DNS-01 flow. 'manual' is a certbot
+            # core feature (custom-script provider), never an installable
+            # plugin — skip the preflight for it. acme-dns always takes the
+            # native hook (see _acme_dns_native_alias) and has no certbot
+            # plugin to check for either.
+            if (not domain_alias and strategy.plugin_name != 'manual'
+                    and dns_provider != 'acme-dns'):
+                plugin = strategy.plugin_name
+                if not check_certbot_plugin_installed(plugin):
+                    pkg = f"certbot-{plugin}"
+                    raise RuntimeError(
+                        f"The certbot plugin '{plugin}' is not installed. "
+                        f"Install it with: pip install {pkg}  "
+                        f"(Docker users: rebuild with REQUIREMENTS_FILE=requirements.txt)"
+                    )
+
+        # Build list of all domains (primary + SANs)
+        all_domains = [domain]
+        if san_domains:
+            # Filter and validate SAN domains. validate_domain returns the
+            # normalised name (URL netloc extracted, lowercased) as its
+            # second value; append THAT, not the raw entry, so a SAN never
+            # reaches certbot's -d as a URL form or a case variant. De-dup
+            # is against the normalised value and the already-normalised
+            # primary, so "Example.com" as a SAN of "example.com" collapses
+            # instead of producing a duplicate -d.
+            for san in san_domains:
+                san = san.strip()
+                if not san:
+                    continue
+                is_valid, san_normalized = validate_domain(san)
+                if not is_valid:
+                    raise ValueError(
+                        f"Invalid SAN domain '{san}': {san_normalized}")
+                if san_normalized != domain and san_normalized not in all_domains:
+                    all_domains.append(san_normalized)
+            logger.info(f"Creating SAN certificate with domains: {', '.join(all_domains)}")
+
+        # HTTP-01 does not support wildcard domains
+        if challenge_type == 'http-01':
+            for d in all_domains:
+                if d.startswith('*.'):
+                    raise ValueError("HTTP-01 challenge does not support wildcard domains. Use DNS-01 instead.")
+
+        # Create output directory
+        cert_dir = self.cert_dir
+        cert_output_dir = cert_dir / domain
+        cert_output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Resolve key shape. If the caller did not pick anything we fall
+        # back to the global default from settings — this lets legacy
+        # callers (web routes, scripts, tests) get the configured
+        # default for free without having to fetch it themselves. If
+        # the caller did pick something, validate the triple here too
+        # so the cert is never built with an inconsistent shape (the
+        # API endpoint validates earlier, but renew_certificate also
+        # routes through this method and can pass values from disk).
+        # On reissue (#267) the defaults are deliberately NOT applied:
+        # metadata does not record the lineage's key shape, so forwarding
+        # settings defaults as explicit flags would silently re-key the
+        # certificate. With no key flags certbot keeps the existing key
+        # type; an explicit key option on reissue is an intentional re-key.
+        if not replace and key_type is None and key_size is None and elliptic_curve is None:
+            if settings is None:
+                settings = self.settings_manager.load_settings()
+            key_type = settings.get('default_key_type')
+            if key_type == 'rsa':
+                key_size = settings.get('default_key_size')
+            elif key_type == 'ecdsa':
+                elliptic_curve = settings.get('default_elliptic_curve')
+        if key_type is not None:
+            ok, err = validate_key_options(key_type, key_size, elliptic_curve)
+            if not ok:
+                raise ValueError(f"Invalid key options for {domain}: {err}")
+
+        return _PreparedIssuance(
+            settings=settings,
+            ca_provider=ca_provider,
+            staging=staging,
+            ca_account_config=ca_account_config,
+            used_ca_account_id=used_ca_account_id,
+            challenge_type=challenge_type,
+            dns_provider=dns_provider,
+            dns_config=dns_config,
+            strategy=strategy,
+            all_domains=all_domains,
+            cert_dir=cert_dir,
+            cert_output_dir=cert_output_dir,
+            key_type=key_type,
+            key_size=key_size,
+            elliptic_curve=elliptic_curve,
+        )
+
     def create_certificate(self, domain, email, dns_provider=None, dns_config=None, account_id=None, staging=False, ca_provider=None, ca_account_id=None, domain_alias=None, alias_dns_provider=None, san_domains=None, challenge_type=None, key_type=None, key_size=None, elliptic_curve=None, replace=False):
         """Create SSL certificate using configurable CA with DNS challenge
 
@@ -1493,191 +1746,31 @@ class CertificateManager:
         ca_extra_env = {}
 
         try:
-            # Settings are loaded lazily and at most once: several branches
-            # below need settings (CA default, challenge type, DNS provider,
-            # key shape, propagation time) but a fully-specified HTTP-01 caller
-            # needs none, so we keep the load conditional and reuse the result.
-            settings = None
-
-            # Return conflict if cert already exists (use renew to refresh it,
-            # or replace=True to reissue with a changed domain set — #267).
-            # This existence check runs *under* the per-domain lock acquired
-            # above so two concurrent creates for the same domain can't both
-            # pass the check and race to issue duplicate certificates.
-            existing_cert = self.cert_dir / domain / 'cert.pem'
-            if existing_cert.exists() and not replace:
-                raise FileExistsError(f"Certificate for {domain} already exists. Use renew to refresh it.")
-
-            logger.info(f"Starting certificate {'reissue' if replace else 'creation'} for domain: {domain}")
-            
-            # ... (Validation and CA setup remains the same until DNS config)
-            
-            # Validate inputs
-            if not domain or not email:
-                raise ValueError("Domain and email are required")
-            
-            # Get CA provider configuration
-            if not ca_provider:
-                if settings is None:
-                    settings = self.settings_manager.load_settings()
-                ca_provider = settings.get('default_ca', 'letsencrypt')
-
-            # Back-compat (#279): the legacy per-cert staging boolean maps
-            # onto the dedicated staging CA entry, and the boolean is derived
-            # from the entry from here on. Keeping both views coherent means
-            # the no-ca_manager fallback below (which only knows --staging)
-            # and metadata stay correct whichever way the caller asked.
-            if staging and ca_provider == 'letsencrypt':
-                ca_provider = 'letsencrypt_staging'
-            staging = staging or ca_provider == 'letsencrypt_staging'
-
-            logger.info(f"Using CA provider: {ca_provider}")
-
-            # Get CA account configuration if CA manager is available
-            ca_account_config = None
-            used_ca_account_id = None
-            if self.ca_manager:
-                try:
-                    ca_account_config, used_ca_account_id = self.ca_manager.get_ca_config(ca_provider, ca_account_id)
-                    logger.info(f"Using CA account: {used_ca_account_id}")
-                except Exception as e:
-                    if ca_provider in ('letsencrypt', 'letsencrypt_staging'):
-                        # Let's Encrypt needs no per-account credentials; with
-                        # no saved CA config the plain-certbot branch below
-                        # handles it (staging via --staging). Do NOT reset the
-                        # provider — that would silently flip a staging
-                        # request to production issuance.
-                        logger.info(f"No saved CA config for {ca_provider}; using certbot defaults: {e}")
-                    else:
-                        # Preserve the caller's staging intent across the
-                        # fallback: resetting to production letsencrypt here
-                        # would turn a test request into trusted production
-                        # issuance (and burn real rate limits).
-                        ca_provider = 'letsencrypt_staging' if staging else 'letsencrypt'
-                        logger.warning(f"Could not get CA config, falling back to {ca_provider}: {e}")
-            
-            # Resolve challenge type from settings if not provided
-            if not challenge_type:
-                if settings is None:
-                    settings = self.settings_manager.load_settings()
-                challenge_type = settings.get('challenge_type', 'dns-01')
-
-            # HTTP-01 path: skip DNS config entirely
-            if challenge_type == 'http-01':
-                strategy = HTTP01Strategy()
-                dns_config = dns_config or {}
-                dns_provider = dns_provider or 'http-01'
-                # Ensure webroot directory exists (same path the serving route
-                # reads — see acme_webroot_dir).
-                challenge_dir = acme_webroot_dir() / '.well-known' / 'acme-challenge'
-                challenge_dir.mkdir(parents=True, exist_ok=True)
-                logger.info("Using HTTP-01 challenge (webroot)")
-            else:
-                # DNS-01 path: get DNS configuration
-                if not dns_config:
-                    if not dns_provider:
-                        if settings is None:
-                            settings = self.settings_manager.load_settings()
-                        dns_provider = self.settings_manager.get_domain_dns_provider(domain, settings)
-
-                    if not dns_provider:
-                        raise ValueError("No DNS provider configured. Go to Settings and select a DNS provider.")
-
-                    dns_config, used_account_id = self._get_dns_config(
-                        dns_provider, account_id
-                    )
-
-                    if not dns_config:
-                        raise ValueError(f"DNS provider '{dns_provider}' account '{account_id or 'default'}' not configured")
-
-                    logger.info(f"Using DNS provider: {dns_provider} with account: {used_account_id}")
-
-                # Get Strategy
-                strategy = DNSStrategyFactory.get_strategy(dns_provider)
-
-                if domain_alias and (alias_dns_provider or dns_provider) not in DNS_ALIAS_SUPPORTED_PROVIDERS:
-                    raise RuntimeError(
-                        "DNS alias mode does not support this DNS provider yet. "
-                        "Use a supported account that controls the alias zone, "
-                        "or omit domain_alias for the provider's normal DNS-01 flow."
-                    )
-
-                # Alias mode uses CertMate's manual DNS hook instead of the
-                # provider certbot authenticator, so the plugin is only needed
-                # for the normal non-alias DNS-01 flow. 'manual' is a certbot
-                # core feature (custom-script provider), never an installable
-                # plugin — skip the preflight for it. acme-dns always takes the
-                # native hook (see _acme_dns_native_alias) and has no certbot
-                # plugin to check for either.
-                if (not domain_alias and strategy.plugin_name != 'manual'
-                        and dns_provider != 'acme-dns'):
-                    plugin = strategy.plugin_name
-                    if not check_certbot_plugin_installed(plugin):
-                        pkg = f"certbot-{plugin}"
-                        raise RuntimeError(
-                            f"The certbot plugin '{plugin}' is not installed. "
-                            f"Install it with: pip install {pkg}  "
-                            f"(Docker users: rebuild with REQUIREMENTS_FILE=requirements.txt)"
-                        )
-
-            # Build list of all domains (primary + SANs)
-            all_domains = [domain]
-            if san_domains:
-                # Filter and validate SAN domains. validate_domain returns the
-                # normalised name (URL netloc extracted, lowercased) as its
-                # second value; append THAT, not the raw entry, so a SAN never
-                # reaches certbot's -d as a URL form or a case variant. De-dup
-                # is against the normalised value and the already-normalised
-                # primary, so "Example.com" as a SAN of "example.com" collapses
-                # instead of producing a duplicate -d.
-                for san in san_domains:
-                    san = san.strip()
-                    if not san:
-                        continue
-                    is_valid, san_normalized = validate_domain(san)
-                    if not is_valid:
-                        raise ValueError(
-                            f"Invalid SAN domain '{san}': {san_normalized}")
-                    if san_normalized != domain and san_normalized not in all_domains:
-                        all_domains.append(san_normalized)
-                logger.info(f"Creating SAN certificate with domains: {', '.join(all_domains)}")
-
-            # HTTP-01 does not support wildcard domains
-            if challenge_type == 'http-01':
-                for d in all_domains:
-                    if d.startswith('*.'):
-                        raise ValueError("HTTP-01 challenge does not support wildcard domains. Use DNS-01 instead.")
-
-            # Create output directory
-            cert_dir = self.cert_dir
-            cert_output_dir = cert_dir / domain
-            cert_output_dir.mkdir(parents=True, exist_ok=True)
-
-            # Resolve key shape. If the caller did not pick anything we fall
-            # back to the global default from settings — this lets legacy
-            # callers (web routes, scripts, tests) get the configured
-            # default for free without having to fetch it themselves. If
-            # the caller did pick something, validate the triple here too
-            # so the cert is never built with an inconsistent shape (the
-            # API endpoint validates earlier, but renew_certificate also
-            # routes through this method and can pass values from disk).
-            # On reissue (#267) the defaults are deliberately NOT applied:
-            # metadata does not record the lineage's key shape, so forwarding
-            # settings defaults as explicit flags would silently re-key the
-            # certificate. With no key flags certbot keeps the existing key
-            # type; an explicit key option on reissue is an intentional re-key.
-            if not replace and key_type is None and key_size is None and elliptic_curve is None:
-                if settings is None:
-                    settings = self.settings_manager.load_settings()
-                key_type = settings.get('default_key_type')
-                if key_type == 'rsa':
-                    key_size = settings.get('default_key_size')
-                elif key_type == 'ecdsa':
-                    elliptic_curve = settings.get('default_elliptic_curve')
-            if key_type is not None:
-                ok, err = validate_key_options(key_type, key_size, elliptic_curve)
-                if not ok:
-                    raise ValueError(f"Invalid key options for {domain}: {err}")
+            prepared = self._prepare_issuance(
+                domain=domain, email=email, dns_provider=dns_provider,
+                dns_config=dns_config, account_id=account_id, staging=staging,
+                ca_provider=ca_provider, ca_account_id=ca_account_id,
+                domain_alias=domain_alias,
+                alias_dns_provider=alias_dns_provider,
+                san_domains=san_domains, challenge_type=challenge_type,
+                key_type=key_type, key_size=key_size,
+                elliptic_curve=elliptic_curve, replace=replace,
+            )
+            settings = prepared.settings
+            ca_provider = prepared.ca_provider
+            staging = prepared.staging
+            ca_account_config = prepared.ca_account_config
+            used_ca_account_id = prepared.used_ca_account_id
+            challenge_type = prepared.challenge_type
+            dns_provider = prepared.dns_provider
+            dns_config = prepared.dns_config
+            strategy = prepared.strategy
+            all_domains = prepared.all_domains
+            cert_dir = prepared.cert_dir
+            cert_output_dir = prepared.cert_output_dir
+            key_type = prepared.key_type
+            key_size = prepared.key_size
+            elliptic_curve = prepared.elliptic_curve
 
             # Build certbot command (ca_extra_env was hoisted above the try
             # so the finally block can clean up safely on early failure)

--- a/tests/test_issuance_command_is_a_contract.py
+++ b/tests/test_issuance_command_is_a_contract.py
@@ -1,0 +1,256 @@
+"""The certbot command create_certificate builds is a contract (#666).
+
+`create_certificate` is F(115), ~590 lines, and one `try` block of 517 of them.
+It is the highest-risk single unit in the system and the one that handles
+private keys. Decomposing it moves hundreds of lines through a hot path where
+the inline comments memorialise past regressions — privkey copied last,
+metadata clobbered, renewal omitting the CA bundle.
+
+So this is written BEFORE anything moves, and it pins the thing the
+decomposition must not change: for a matrix of inputs covering the branches
+inside that try, the exact certbot argv.
+
+The expectations are inline rather than in a golden file with a regenerate
+flag. A refactor that changes the command then shows up as a diff a reviewer
+reads, instead of a file someone re-blesses without looking.
+
+Paths that legitimately vary are normalised: the certificate directory, the
+per-config credentials hash, the per-run dns-alias temp config, the repo root,
+and the interpreter. Everything else is asserted literally.
+"""
+import pathlib
+import re
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.certificates import CertificateManager
+from modules.core.shell import MockShellExecutor
+
+pytestmark = [pytest.mark.unit]
+
+BASE_SETTINGS = {
+    'default_ca': 'letsencrypt',
+    'challenge_type': 'dns-01',
+    'dns_propagation_seconds': {'cloudflare': 30, 'route53': 45},
+    'default_key_type': 'ecdsa',
+    'default_elliptic_curve': 'secp384r1',
+}
+
+# name -> (create_certificate kwargs, settings overrides, dns account config)
+CASES = {
+    'baseline dns-01 cloudflare': ({}, {}, None),
+    'http-01': ({'challenge_type': 'http-01'}, {}, None),
+    'with SANs': ({'san_domains': ['www.example.com', 'api.example.com']}, {}, None),
+    'rsa 4096': ({'key_type': 'rsa', 'key_size': 4096}, {}, None),
+    'ecdsa p-256': ({'key_type': 'ecdsa', 'elliptic_curve': 'secp256r1'}, {}, None),
+    'staging flag': ({'staging': True}, {}, None),
+    'ca_provider letsencrypt_staging': ({'ca_provider': 'letsencrypt_staging'}, {}, None),
+    'replace': ({'replace': True}, {}, None),
+    'route53': ({'dns_provider': 'route53'}, {},
+                {'access_key_id': 'AKIA', 'secret_access_key': 's'}),
+    'no propagation configured': ({'dns_provider': 'digitalocean'},
+                                  {'dns_propagation_seconds': {}},
+                                  {'api_token': 'do-token'}),
+    'domain alias': ({'domain_alias': 'alias.example.net',
+                      'alias_dns_provider': 'cloudflare'}, {}, None),
+}
+
+EXPECTED = {
+    'baseline dns-01 cloudflare': [
+        'certbot', 'certonly', '--non-interactive', '--agree-tos',
+        '--email', 'a@b.com', '--cert-name', 'example.com', '--config-dir',
+        '<CERTS>/example.com', '--work-dir', '<CERTS>/example.com/work',
+        '--logs-dir', '<CERTS>/example.com/logs', '-d', 'example.com',
+        '--key-type', 'ecdsa', '--elliptic-curve', 'secp384r1',
+        '--authenticator', 'dns-cloudflare',
+        '--dns-cloudflare-credentials',
+        'letsencrypt/config/cloudflare-<HASH>.ini',
+        '--dns-cloudflare-propagation-seconds', '30',
+    ],
+    'http-01': [
+        'certbot', 'certonly', '--non-interactive', '--agree-tos',
+        '--email', 'a@b.com', '--cert-name', 'example.com', '--config-dir',
+        '<CERTS>/example.com', '--work-dir', '<CERTS>/example.com/work',
+        '--logs-dir', '<CERTS>/example.com/logs', '-d', 'example.com',
+        '--key-type', 'ecdsa', '--elliptic-curve', 'secp384r1',
+        '--webroot', '-w', '<REPO>/data/acme-challenges',
+    ],
+    'with SANs': [
+        'certbot', 'certonly', '--non-interactive', '--agree-tos',
+        '--email', 'a@b.com', '--cert-name', 'example.com', '--config-dir',
+        '<CERTS>/example.com', '--work-dir', '<CERTS>/example.com/work',
+        '--logs-dir', '<CERTS>/example.com/logs', '-d', 'example.com',
+        '-d', 'www.example.com', '-d', 'api.example.com', '--key-type',
+        'ecdsa', '--elliptic-curve', 'secp384r1', '--authenticator',
+        'dns-cloudflare', '--dns-cloudflare-credentials',
+        'letsencrypt/config/cloudflare-<HASH>.ini',
+        '--dns-cloudflare-propagation-seconds', '30',
+    ],
+    'rsa 4096': [
+        'certbot', 'certonly', '--non-interactive', '--agree-tos',
+        '--email', 'a@b.com', '--cert-name', 'example.com', '--config-dir',
+        '<CERTS>/example.com', '--work-dir', '<CERTS>/example.com/work',
+        '--logs-dir', '<CERTS>/example.com/logs', '-d', 'example.com',
+        '--key-type', 'rsa', '--rsa-key-size', '4096', '--authenticator',
+        'dns-cloudflare', '--dns-cloudflare-credentials',
+        'letsencrypt/config/cloudflare-<HASH>.ini',
+        '--dns-cloudflare-propagation-seconds', '30',
+    ],
+    'ecdsa p-256': [
+        'certbot', 'certonly', '--non-interactive', '--agree-tos',
+        '--email', 'a@b.com', '--cert-name', 'example.com', '--config-dir',
+        '<CERTS>/example.com', '--work-dir', '<CERTS>/example.com/work',
+        '--logs-dir', '<CERTS>/example.com/logs', '-d', 'example.com',
+        '--key-type', 'ecdsa', '--elliptic-curve', 'secp256r1',
+        '--authenticator', 'dns-cloudflare',
+        '--dns-cloudflare-credentials',
+        'letsencrypt/config/cloudflare-<HASH>.ini',
+        '--dns-cloudflare-propagation-seconds', '30',
+    ],
+    'staging flag': [
+        'certbot', 'certonly', '--non-interactive', '--agree-tos',
+        '--email', 'a@b.com', '--cert-name', 'example.com', '--config-dir',
+        '<CERTS>/example.com', '--work-dir', '<CERTS>/example.com/work',
+        '--logs-dir', '<CERTS>/example.com/logs', '-d', 'example.com',
+        '--staging', '--key-type', 'ecdsa', '--elliptic-curve',
+        'secp384r1', '--authenticator', 'dns-cloudflare',
+        '--dns-cloudflare-credentials',
+        'letsencrypt/config/cloudflare-<HASH>.ini',
+        '--dns-cloudflare-propagation-seconds', '30',
+    ],
+    'ca_provider letsencrypt_staging': [
+        'certbot', 'certonly', '--non-interactive', '--agree-tos',
+        '--email', 'a@b.com', '--cert-name', 'example.com', '--config-dir',
+        '<CERTS>/example.com', '--work-dir', '<CERTS>/example.com/work',
+        '--logs-dir', '<CERTS>/example.com/logs', '-d', 'example.com',
+        '--staging', '--key-type', 'ecdsa', '--elliptic-curve',
+        'secp384r1', '--authenticator', 'dns-cloudflare',
+        '--dns-cloudflare-credentials',
+        'letsencrypt/config/cloudflare-<HASH>.ini',
+        '--dns-cloudflare-propagation-seconds', '30',
+    ],
+    'replace': [
+        'certbot', 'certonly', '--non-interactive', '--agree-tos',
+        '--email', 'a@b.com', '--cert-name', 'example.com', '--config-dir',
+        '<CERTS>/example.com', '--work-dir', '<CERTS>/example.com/work',
+        '--logs-dir', '<CERTS>/example.com/logs', '-d', 'example.com',
+        '--renew-with-new-domains', '--force-renewal', '--authenticator',
+        'dns-cloudflare', '--dns-cloudflare-credentials',
+        'letsencrypt/config/cloudflare-<HASH>.ini',
+        '--dns-cloudflare-propagation-seconds', '30',
+    ],
+    'route53': [
+        'certbot', 'certonly', '--non-interactive', '--agree-tos',
+        '--email', 'a@b.com', '--cert-name', 'example.com', '--config-dir',
+        '<CERTS>/example.com', '--work-dir', '<CERTS>/example.com/work',
+        '--logs-dir', '<CERTS>/example.com/logs', '-d', 'example.com',
+        '--key-type', 'ecdsa', '--elliptic-curve', 'secp384r1',
+        '--authenticator', 'dns-route53',
+    ],
+    'no propagation configured': [
+        'certbot', 'certonly', '--non-interactive', '--agree-tos',
+        '--email', 'a@b.com', '--cert-name', 'example.com', '--config-dir',
+        '<CERTS>/example.com', '--work-dir', '<CERTS>/example.com/work',
+        '--logs-dir', '<CERTS>/example.com/logs', '-d', 'example.com',
+        '--key-type', 'ecdsa', '--elliptic-curve', 'secp384r1',
+        '--authenticator', 'dns-digitalocean',
+        '--dns-digitalocean-credentials',
+        'letsencrypt/config/digitalocean-<HASH>.ini',
+        '--dns-digitalocean-propagation-seconds', '120',
+    ],
+    'domain alias': [
+        'certbot', 'certonly', '--non-interactive', '--agree-tos',
+        '--email', 'a@b.com', '--cert-name', 'example.com', '--config-dir',
+        '<CERTS>/example.com', '--work-dir', '<CERTS>/example.com/work',
+        '--logs-dir', '<CERTS>/example.com/logs', '-d', 'example.com',
+        '--key-type', 'ecdsa', '--elliptic-curve', 'secp384r1', '--manual',
+        '--preferred-challenges', 'dns', '--manual-auth-hook', '<PY>',
+        '<REPO>/modules/core/dns_alias_hook.py', '--config', '<ALIAS_CFG>',
+        '--action', 'auth', '--manual-cleanup-hook', '<PY>',
+        '<REPO>/modules/core/dns_alias_hook.py', '--config', '<ALIAS_CFG>',
+        '--action', 'cleanup',
+    ],
+}
+
+
+def _normalise(cmd, certs_dir, repo):
+    out = []
+    for token in cmd.split():
+        token = token.replace(str(certs_dir), '<CERTS>')
+        token = token.replace(repo, '<REPO>')
+        # The credentials file name carries a hash of the account config.
+        token = re.sub(r'([a-z0-9_-]+)-[0-9a-f]{8,}\.ini', r'\1-<HASH>.ini', token)
+        # The dns-alias hook config is a per-run temp file; on macOS that lives
+        # under /var/folders, not /tmp.
+        token = re.sub(r'\S*certmate-dns-alias-\w+\.json', '<ALIAS_CFG>', token)
+        token = re.sub(r'^(/private)?(/var/folders|/tmp)/\S*', '<TMP>', token)
+        # The interpreter differs between a venv and a bare python.
+        token = re.sub(r'^\S*/(python3?(\.\d+)?)$', '<PY>', token)
+        out.append(token)
+    return out
+
+
+def _build_command(kwargs, settings_over, account_cfg):
+    """Run create_certificate with a non-executing shell and return the argv."""
+    certs = pathlib.Path(tempfile.mkdtemp())
+    shell = MockShellExecutor()
+    shell.set_next_result(returncode=0)
+
+    settings = dict(BASE_SETTINGS)
+    settings.update(settings_over)
+    settings_manager = MagicMock()
+    settings_manager.load_settings.return_value = settings
+    settings_manager.get_domain_dns_provider.return_value = kwargs.get(
+        'dns_provider', 'cloudflare')
+
+    dns_manager = MagicMock()
+    dns_manager.get_dns_provider_account_config.return_value = (
+        account_cfg or {'api_token': 'cf-token'}, 'default')
+
+    manager = CertificateManager(
+        cert_dir=certs, settings_manager=settings_manager,
+        dns_manager=dns_manager, storage_manager=None, ca_manager=None,
+        shell_executor=shell)
+
+    call = {'domain': 'example.com', 'email': 'a@b.com',
+            'dns_provider': 'cloudflare'}
+    call.update(kwargs)
+    manager.create_certificate(**call)
+
+    assert shell.commands_executed, 'no certbot command was built at all'
+    repo = str(pathlib.Path(__file__).resolve().parent.parent)
+    return _normalise(shell.commands_executed[0], certs, repo)
+
+
+@pytest.mark.parametrize('name', list(CASES))
+def test_the_certbot_command_is_unchanged(name):
+    kwargs, settings_over, account_cfg = CASES[name]
+    assert _build_command(kwargs, settings_over, account_cfg) == EXPECTED[name]
+
+
+def test_every_case_builds_a_distinct_command():
+    """CONTROL: a matrix whose cases all produce the same argv would pass
+    while pinning one branch. Each case here exists because it exercises a
+    different part of the 517-line try block, so each must differ from the
+    baseline."""
+    baseline = EXPECTED['baseline dns-01 cloudflare']
+    same = [name for name, argv in EXPECTED.items()
+            if name != 'baseline dns-01 cloudflare' and argv == baseline]
+    assert not same, (
+        f'these cases build the same command as the baseline, so they pin '
+        f'nothing extra: {same}'
+    )
+
+
+def test_the_expectations_cover_the_branch_shapes_that_matter():
+    """CONTROL on the matrix itself: adding a case is cheap, and a decomposition
+    is only as safe as the branches the net covers. These are the flags whose
+    presence or absence the refactor could silently drop."""
+    flat = {token for argv in EXPECTED.values() for token in argv}
+    for flag in ('--webroot', '--staging', '--force-renewal', '--key-type',
+                 '--rsa-key-size', '--elliptic-curve', '--manual',
+                 '--manual-auth-hook', '--manual-cleanup-hook',
+                 '--authenticator', '--cert-name', '--config-dir'):
+        assert flag in flat, f'no case in the matrix produces {flag}'


### PR DESCRIPTION
First step of #666. **`create_certificate` F(115) → F(65).** Deliberately not the whole decomposition — see *What is left* below.

## The net, first

`create_certificate` is the highest-risk single unit in the system and the one that handles private keys. The inline comments in the file memorialise what past changes cost: privkey copied last, metadata clobbered, renewal omitting the CA bundle.

So before anything moved, `tests/test_issuance_command_is_a_contract.py` pins the thing a decomposition must not change: **for eleven inputs covering the branches inside that 517-line try, the exact certbot argv.**

Each case exercises a different branch, and the diffs show it: `http-01` replaces the whole DNS authenticator block, `replace` **drops** `--key-type`/`--elliptic-curve` (deliberate — a reissue keeps the lineage's key unless explicitly re-keyed), `domain alias` switches to `--manual` with two hooks, a provider with no configured propagation falls back to 120s.

Two controls on the matrix itself, not just the cases:
- every case must build a command that **differs from the baseline** — a matrix whose entries all agree looks thorough while pinning one branch;
- the union of the cases must contain the flags a decomposition could silently drop (`--webroot`, `--staging`, `--force-renewal`, `--manual-auth-hook`, …).

Expectations are **inline, not a golden file with a regenerate flag**. A changed command then shows up as a diff a reviewer reads, instead of a file someone re-blesses.

Confirmed it bites: removing `--non-interactive` or `--cert-name` from the builder turns eleven cases red.

## The extraction

The first third of the try block was all resolution — which CA, which challenge type, which DNS provider and account, which key shape, which domains, whether the domain is already issued. It moves out verbatim behind a frozen `_PreparedIssuance` record.

A record rather than fourteen locals threaded down a 590-line function: what crosses between phases is now visible and cannot be reassigned halfway through.

**Named `_prepare_issuance`, not `_resolve_…`** — it is not pure. It creates the per-domain output directory and, for HTTP-01, the webroot challenge directory. Both were side effects of this stretch before the move; a name claiming purity would be the same class of defect as a constants file that lies (#590).

**The net earned its keep immediately:** `cert_dir` crosses the boundary and I did not carry it. Eleven cases went red until it was.

## What is left, and why it is not here

| | |
|---|---|
| build the command (CA/EAB, replace flags, DNS credentials, alias hook) | ~160 lines |
| run + collect artifacts | |
| persist metadata + storage | |
| `renew_certificate` F(62), and its near-duplication with create | the actual "stop being two copies that drift" half |

The command-builder step has a real hazard that deserves its own reviewable change rather than being buried here: `credentials_file`, `extra_credential_files` and `ca_extra_env` are created during command building and removed by the `finally`. A naive extraction that returns them loses cleanup when the builder raises **partway** — a live cloud private key then outlives the operation on disk. The fix is to pass a mutable artifacts record the builder fills as it goes, which also makes that guarantee explicit for the first time instead of implicit in three locals.

## Verification

- Unit suite 3595 → 3608 (+13, the net), all green
- **Real-cert E2E: 13 tests, 230s**, LE staging via Cloudflare — this touches the issuance pipeline, so it was run before opening the PR rather than left to the release gate
- gated flake8 clean, per-module coverage floors met

🤖 Generated with [Claude Code](https://claude.com/claude-code)