### PR TITLE
refactor(#666): one propagation formula instead of four, and one had drifted (step 3)

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -108,6 +108,34 @@ _KNOWN_METADATA_KEYS = _REISSUE_OWNED_METADATA_KEYS | frozenset({
 })
 
 
+def _propagation_seconds(settings, dns_provider, strategy):
+    """How long to wait for a DNS-01 TXT record to propagate, in seconds.
+
+    One formula with one home (#666). It existed twice — once in
+    ``create_certificate`` for every provider, once in ``renew_certificate``
+    narrowed to ``custom-script`` — with identical arithmetic and a comment on
+    the second saying "Mirror the create path". Two copies that must agree, one
+    of which announces that it is a copy, is the shape this issue is about.
+
+    Falls back to the strategy default when the settings map has no entry, when
+    the entry will not parse, or when settings cannot be read at all, and
+    clamps to 1 second .. 1 hour so a typo cannot make an issuance hang or
+    return before the record is visible.
+    """
+    try:
+        propagation_map = (settings or {}).get('dns_propagation_seconds', {}) or {}
+    except Exception as e:
+        logger.debug("Failed to read dns_propagation_seconds: %s", e)
+        propagation_map = {}
+
+    default_seconds = strategy.default_propagation_seconds
+    try:
+        seconds = int(propagation_map.get(dns_provider, default_seconds))
+    except (ValueError, TypeError):
+        seconds = default_seconds
+    return max(1, min(3600, seconds))
+
+
 def _reject_path_escaping_domain(domain):
     """Refuse a domain that could escape ``cert_dir`` when used as a path.
 
@@ -1844,22 +1872,13 @@ class CertificateManager:
         # Set propagation time (DNS-01 only; HTTP-01 has no propagation)
         propagation_time = None
         if challenge_type != 'http-01':
-            try:
-                if settings is None:
+            if settings is None:
+                try:
                     settings = self.settings_manager.load_settings()
-                propagation_map = settings.get('dns_propagation_seconds', {}) or {}
-            except Exception as e:
-                logger.debug("Failed to load settings in issue_certificate for propagation time: %s", e)
-                propagation_map = {}
-
-            # Default to strategy default if not in settings map
-            default_seconds = strategy.default_propagation_seconds
-            try:
-                propagation_time = int(propagation_map.get(dns_provider, default_seconds))
-            except (ValueError, TypeError):
-                propagation_time = default_seconds
-            # Ensure propagation time is within reasonable bounds (1 second to 1 hour)
-            propagation_time = max(1, min(3600, propagation_time))
+                except Exception as e:
+                    logger.debug("Failed to load settings for propagation time: %s", e)
+                    settings = {}
+            propagation_time = _propagation_seconds(settings, dns_provider, strategy)
 
             # --manual has no propagation flag: surface the configured
             # per-provider value to custom-script hooks via env instead.
@@ -2316,12 +2335,8 @@ class CertificateManager:
                 # Inject provider env vars (e.g. AWS credentials) for alias renewals too
                 strategy.prepare_environment(process_env, dns_config)
 
-                propagation_map = settings.get('dns_propagation_seconds', {}) or {}
-                try:
-                    propagation_time = int(propagation_map.get(alias_provider, strategy.default_propagation_seconds))
-                except (ValueError, TypeError):
-                    propagation_time = strategy.default_propagation_seconds
-                propagation_time = max(1, min(3600, propagation_time))
+                propagation_time = _propagation_seconds(
+                    settings, alias_provider, strategy)
 
                 alias_hook_config = self._create_dns_alias_hook_config(
                     alias_provider,
@@ -2352,12 +2367,14 @@ class CertificateManager:
                     # without a metadata migration.
                     strategy = DNSStrategyFactory.get_strategy(dns_provider)
                     strategy.prepare_environment(process_env, dns_config)
-                    propagation_map = settings.get('dns_propagation_seconds', {}) or {}
-                    try:
-                        renew_propagation = int(propagation_map.get(
-                            dns_provider, strategy.default_propagation_seconds))
-                    except (ValueError, TypeError):
-                        renew_propagation = strategy.default_propagation_seconds
+                    # BEHAVIOUR CHANGE, deliberate: this copy never clamped.
+                    # A dns_propagation_seconds of 0 asked the hook to validate
+                    # before the TXT record existed; 86400 held the per-domain
+                    # lock for a day. The other three copies bounded it to
+                    # 1..3600 and this one did not — which is what "two copies
+                    # that drift" looks like in practice.
+                    renew_propagation = _propagation_seconds(
+                        settings, dns_provider, strategy)
                     alias_hook_config = self._create_dns_alias_hook_config(
                         dns_provider,
                         dns_config,
@@ -2397,14 +2414,10 @@ class CertificateManager:
                     if dns_provider == 'custom-script':
                         # Mirror the create path: expose the propagation
                         # setting to the hooks certbot replays at renewal.
-                        propagation_map = settings.get('dns_propagation_seconds', {}) or {}
-                        try:
-                            renew_propagation = int(propagation_map.get(dns_provider, strategy.default_propagation_seconds))
-                        except (ValueError, TypeError):
-                            renew_propagation = strategy.default_propagation_seconds
                         process_env.setdefault(
                             'CERTMATE_DNS_PROPAGATION_SECONDS',
-                            str(max(1, min(3600, renew_propagation))))
+                            str(_propagation_seconds(settings, dns_provider,
+                                                     strategy)))
                     logger.info(f"Prepared DNS environment for renewal of {domain} with {dns_provider}")
                 else:
                     # The DNS account this cert was issued with is gone from

--- a/tests/test_propagation_seconds_has_one_home.py
+++ b/tests/test_propagation_seconds_has_one_home.py
@@ -1,0 +1,108 @@
+"""Create and renew must agree on the DNS propagation wait (#666).
+
+The formula existed **four** times — once in `create_certificate`, three times
+in `renew_certificate` (the alias branch, the acme-dns alias branch, and
+`custom-script`). One of them carried a comment reading "Mirror the create
+path": a copy that announces it is a copy is exactly the drift this issue is
+about.
+
+And they had already drifted. Three clamped the result to 1..3600; the
+acme-dns alias branch did not, so a `dns_propagation_seconds` of 0 there asked
+the hook to validate before the TXT record existed, and 86400 held the
+per-domain lock for a day. Unifying them fixes that, which is a behaviour
+change and is called out as one.
+
+There is one `_propagation_seconds` now. These pin what it must do, because the
+bounds are the interesting part: too small and certbot asks the CA to validate
+before the TXT record is visible, too large and a wedged issuance holds a
+per-domain lock for hours.
+
+A note on what did NOT change. `certbot renew` replays the flags stored in
+`renewal/<domain>.conf`, so the renew path deliberately does not re-emit
+`--{plugin}-propagation-seconds` the way create does; it only exports the value
+to the hooks for `custom-script`. That asymmetry is real — an operator who
+raises the setting after issuance keeps the old value until the next create or
+reissue — but it is behaviour, not duplication, and changing it is not a
+refactor. Recorded here so the next reader does not "fix" it by accident.
+"""
+import pytest
+
+from modules.core.certificates import _propagation_seconds
+
+pytestmark = [pytest.mark.unit]
+
+
+class _Strategy:
+    def __init__(self, default=60):
+        self.default_propagation_seconds = default
+
+
+def test_a_configured_value_is_used():
+    settings = {'dns_propagation_seconds': {'cloudflare': 30}}
+    assert _propagation_seconds(settings, 'cloudflare', _Strategy()) == 30
+
+
+def test_an_unconfigured_provider_falls_back_to_the_strategy_default():
+    settings = {'dns_propagation_seconds': {'cloudflare': 30}}
+    assert _propagation_seconds(settings, 'route53', _Strategy(45)) == 45
+
+
+@pytest.mark.parametrize('settings', [
+    {},
+    {'dns_propagation_seconds': None},
+    {'dns_propagation_seconds': {}},
+    None,
+])
+def test_a_missing_map_falls_back_rather_than_raising(settings):
+    """`None` covers the create path's lazy load returning nothing."""
+    assert _propagation_seconds(settings, 'cloudflare', _Strategy(60)) == 60
+
+
+@pytest.mark.parametrize('value', ['abc', None, [], {'a': 1}])
+def test_an_unparseable_value_falls_back(value):
+    """A typo in settings.json must not take issuance down."""
+    settings = {'dns_propagation_seconds': {'cloudflare': value}}
+    assert _propagation_seconds(settings, 'cloudflare', _Strategy(60)) == 60
+
+
+@pytest.mark.parametrize('configured,expected', [
+    (0, 1),          # zero would ask the CA to validate immediately
+    (-5, 1),
+    (3600, 3600),
+    (86400, 3600),   # a day would hold the per-domain lock all day
+    (1, 1),
+])
+def test_the_value_is_clamped_to_one_second_and_one_hour(configured, expected):
+    settings = {'dns_propagation_seconds': {'cloudflare': configured}}
+    assert _propagation_seconds(settings, 'cloudflare', _Strategy()) == expected
+
+
+def test_a_string_that_is_a_number_is_accepted():
+    """settings.json is hand-edited often enough that "30" happens."""
+    settings = {'dns_propagation_seconds': {'cloudflare': '30'}}
+    assert _propagation_seconds(settings, 'cloudflare', _Strategy()) == 30
+
+
+def test_neither_path_computes_it_inline_any_more():
+    """The point of the extraction, asserted on the source.
+
+    Both call sites reading the same settings key with their own arithmetic is
+    exactly how they drifted; if a third appears, or one reverts, this says so.
+    """
+    import inspect
+    import re
+
+    from modules.core.certificates import CertificateManager
+
+    # Matches the READ, not the word: the first version of this asserted the
+    # bare name was absent and tripped on a comment that merely mentions it.
+    pattern = re.compile(r"""\.get\(\s*['"]dns_propagation_seconds['"]""")
+
+    for method in (CertificateManager.create_certificate,
+                   CertificateManager.renew_certificate,
+                   CertificateManager._build_issuance_command):
+        src = inspect.getsource(method)
+        assert not pattern.search(src), (
+            f'{method.__qualname__} reads the propagation setting directly '
+            f'again; it belongs to _propagation_seconds'
+        )


### PR DESCRIPTION
Step 3 of #666, on top of #735. **`renew_certificate` F(62) → F(56)** — and this is the first step that touches the half the issue actually cares about: *"create/renew stop being two copies that drift."*

## Four copies, not two

The DNS-01 propagation wait was computed in **four** places:

| where | clamped to 1..3600? |
|---|---|
| `create_certificate`, every provider | yes |
| `renew_certificate`, alias branch | yes |
| `renew_certificate`, `custom-script` | yes |
| `renew_certificate`, **acme-dns alias branch** | **no** |

Same settings key, same arithmetic, hand-written each time. One of them carries a comment reading *"Mirror the create path"* — a copy that announces it is a copy.

## They had already drifted

That is the point of the issue rather than a hypothetical risk. Three copies bounded the value to 1 second .. 1 hour. The acme-dns alias branch did not, so:

- `dns_propagation_seconds: 0` asked the hook to validate **before the TXT record existed**;
- `dns_propagation_seconds: 86400` held the per-domain lock for a **day**, which under `check_renewals` (serial, `max_instances=1`) stalls every subsequent renewal behind it.

**Behaviour change, deliberate:** that branch now clamps like the other three. Called out here rather than folded into "refactor", because it is the one thing in this PR that changes what the program does.

## How the other two were found

I found two of the four by reading. The other two were found by the test, which asserts on the source that no call site reads `dns_propagation_seconds` with its own arithmetic again — it failed immediately, twice, on copies I had missed.

That guard needed correcting too: its first version asserted the bare *name* was absent and tripped on a comment that merely mentions it. It matches the **read** now (`.get('dns_propagation_seconds'`), not the word. Confirmed it bites by reintroducing a copy in `renew_certificate`.

## What deliberately did not change

`certbot renew` replays the flags stored in `renewal/<domain>.conf`, so the renew path does not re-emit `--{plugin}-propagation-seconds` the way create does. That asymmetry is real — an operator who raises the setting after issuance keeps the old value until the next create or reissue — but it is **behaviour, not duplication**, and changing it is not a refactor. It is recorded in the test module docstring so the next reader does not "fix" it by accident.

## Verification

17 tests on the helper (bounds, unparseable values, a missing map, `None` settings from the lazy load) plus the source guard. Suite 3615 → 3632 (+17), gated flake8 clean, **real-cert E2E 13 tests / 238s** against LE staging.

## Still to come

`renew_certificate` is still F(56): the DNS credentials setup (`create_config_file` → `extra_credential_files` → `configure_certbot_arguments`) is duplicated between create and renew as well, and renew keeps its own cleanup trio rather than the `_IssuanceArtifacts` record from #735.

🤖 Generated with [Claude Code](https://claude.com/claude-code)