### PR TITLE
refactor(#666): one cleanup record and one deletion loop for create and renew (step 4)

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -108,6 +108,21 @@ _KNOWN_METADATA_KEYS = _REISSUE_OWNED_METADATA_KEYS | frozenset({
 })
 
 
+def _remove_temp_files(artifacts):
+    """Delete every temp file an issuance or renewal created.
+
+    Never raises: a cleanup failure must not turn a successful issuance into a
+    reported error, and must not mask the real exception on the failure path.
+    """
+    for path in artifacts.temp_paths():
+        if not path:
+            continue
+        try:
+            os.unlink(path)
+        except (FileNotFoundError, OSError):
+            pass
+
+
 def _propagation_seconds(settings, dns_provider, strategy):
     """How long to wait for a DNS-01 TXT record to propagate, in seconds.
 
@@ -172,6 +187,24 @@ class _IssuanceArtifacts:
     ca_extra_env: dict = field(default_factory=dict)
     credentials_file: str | None = None
     extra_credential_files: list = field(default_factory=list)
+    alias_hook_config: str | None = None
+
+    def temp_paths(self):
+        """Every path whose file must be removed when the operation ends.
+
+        One list with one owner. Create and renew each had their own deletion
+        loop over their own set of locals, and the sets had already diverged:
+        renew tracked the DNS-alias hook config separately while create folded
+        it into ``credentials_file``, and only renew knew about the CA bundle
+        as a path rather than as an environment value. A file that one path
+        removes and the other forgets is a secret left on disk.
+        """
+        return [
+            self.credentials_file,
+            self.alias_hook_config,
+            *self.extra_credential_files,
+            self.ca_extra_env.get('REQUESTS_CA_BUNDLE'),
+        ]
 
 
 @dataclass(frozen=True)
@@ -1915,11 +1948,12 @@ class CertificateManager:
                 f"DNS alias '{effective_domain_alias}' requested for {domain}; "
                 f"using {alias_hook_provider} manual hook to create TXT records on the alias zone."
             )
-            artifacts.credentials_file = self._create_dns_alias_hook_config(
+            artifacts.alias_hook_config = self._create_dns_alias_hook_config(
                 alias_hook_provider, alias_hook_config, effective_domain_alias,
                 propagation_time or strategy.default_propagation_seconds
             )
-            self._configure_dns_alias_arguments(certbot_cmd, artifacts.credentials_file)
+            self._configure_dns_alias_arguments(certbot_cmd,
+                                                artifacts.alias_hook_config)
         else:
             # Create Config File. Pass the SAN list so the discovery
             # path (Azure today) can resolve every cert FQDN against
@@ -2197,20 +2231,7 @@ class CertificateManager:
             # create_google_config only mops up crashed runs, not live ones.
             # (Google needs no side file since #385: its credentials file IS the
             # service-account JSON, so it is unlinked as the main one.)
-            for cred_path in [artifacts.credentials_file,
-                              *artifacts.extra_credential_files]:
-                if cred_path:
-                    try:
-                        os.unlink(cred_path)
-                    except (FileNotFoundError, OSError):
-                        pass
-            # Clean up CA bundle temp file if created
-            ca_bundle = artifacts.ca_extra_env.get('REQUESTS_CA_BUNDLE')
-            if ca_bundle:
-                try:
-                    os.unlink(ca_bundle)
-                except (FileNotFoundError, OSError):
-                    pass
+            _remove_temp_files(artifacts)
 
     @staticmethod
     def _cert_fingerprint(cert_path):
@@ -2228,12 +2249,11 @@ class CertificateManager:
         domain_lock = self._get_domain_lock(domain)
         if not domain_lock.acquire(timeout=self._domain_lock_timeout()):
             raise DomainOperationInProgress(domain)
-        alias_hook_config = None
-        credentials_file = None
-        ca_bundle_path = None
-        # Secret side files the credentials ini references (Google's SA
-        # JSON); deleted in the finally alongside the ini.
-        extra_credential_files = []
+        # The same record create_certificate uses (#666). Renewal kept its own
+        # four locals and its own deletion loop, and the two sets had already
+        # diverged — a file one path removes and the other forgets is a secret
+        # left on disk.
+        artifacts = _IssuanceArtifacts()
         try:
             # Use the same config/work/log directories as during creation
             cert_dir = self.cert_dir
@@ -2310,6 +2330,7 @@ class CertificateManager:
             ca_bundle_path = self._renewal_ca_bundle(metadata)
             if ca_bundle_path:
                 process_env['REQUESTS_CA_BUNDLE'] = ca_bundle_path
+                artifacts.ca_extra_env['REQUESTS_CA_BUNDLE'] = ca_bundle_path
 
             dns_provider = metadata.get('dns_provider')
             challenge_type = metadata.get('challenge_type', 'dns-01')
@@ -2338,13 +2359,13 @@ class CertificateManager:
                 propagation_time = _propagation_seconds(
                     settings, alias_provider, strategy)
 
-                alias_hook_config = self._create_dns_alias_hook_config(
+                artifacts.alias_hook_config = self._create_dns_alias_hook_config(
                     alias_provider,
                     dns_config,
                     domain_alias,
                     propagation_time,
                 )
-                self._configure_dns_alias_arguments(cmd, alias_hook_config)
+                self._configure_dns_alias_arguments(cmd, artifacts.alias_hook_config)
                 logger.info(
                     f"Renewing {domain} with DNS alias '{domain_alias}' "
                     f"using {alias_provider} manual hook."
@@ -2367,21 +2388,13 @@ class CertificateManager:
                     # without a metadata migration.
                     strategy = DNSStrategyFactory.get_strategy(dns_provider)
                     strategy.prepare_environment(process_env, dns_config)
-                    # BEHAVIOUR CHANGE, deliberate: this copy never clamped.
-                    # A dns_propagation_seconds of 0 asked the hook to validate
-                    # before the TXT record existed; 86400 held the per-domain
-                    # lock for a day. The other three copies bounded it to
-                    # 1..3600 and this one did not — which is what "two copies
-                    # that drift" looks like in practice.
-                    renew_propagation = _propagation_seconds(
-                        settings, dns_provider, strategy)
-                    alias_hook_config = self._create_dns_alias_hook_config(
+                    artifacts.alias_hook_config = self._create_dns_alias_hook_config(
                         dns_provider,
                         dns_config,
                         acme_dns_alias,
-                        max(1, min(3600, renew_propagation)),
+                        _propagation_seconds(settings, dns_provider, strategy),
                     )
-                    self._configure_dns_alias_arguments(cmd, alias_hook_config)
+                    self._configure_dns_alias_arguments(cmd, artifacts.alias_hook_config)
                     # Strip CR/LF so a crafted domain cannot forge log entries
                     # (CodeQL py/log-injection), matching modules/web/cert_routes.py.
                     safe_domain = str(domain).replace('\r', ' ').replace('\n', ' ')
@@ -2398,8 +2411,9 @@ class CertificateManager:
                     strategy_config = self._dns_config_for_strategy(
                         dns_provider, dns_config, domain, san_domains=renew_sans,
                     )
-                    credentials_file = strategy.create_config_file(strategy_config)
-                    extra_credential_files = list(
+                    artifacts.credentials_file = strategy.create_config_file(
+                        strategy_config)
+                    artifacts.extra_credential_files = list(
                         getattr(strategy, 'extra_credential_files', []) or [])
                     # Pass the authenticator + credentials explicitly at renew
                     # (mirrors the create path) so renewal does not depend on the
@@ -2409,8 +2423,9 @@ class CertificateManager:
                     # broke renewal for file-based DNS providers. Env-based
                     # providers (route53) return no credentials file and keep
                     # using the stored authenticator + prepared env vars.
-                    if credentials_file:
-                        strategy.configure_certbot_arguments(cmd, credentials_file)
+                    if artifacts.credentials_file:
+                        strategy.configure_certbot_arguments(
+                            cmd, artifacts.credentials_file)
                     if dns_provider == 'custom-script':
                         # Mirror the create path: expose the propagation
                         # setting to the hooks certbot replays at renewal.
@@ -2602,23 +2617,7 @@ class CertificateManager:
             logger.error(f"Exception during certificate renewal for {domain}: {error_msg}")
             raise RuntimeError(f"Exception: {error_msg}")
         finally:
-            if alias_hook_config:
-                try:
-                    os.unlink(alias_hook_config)
-                except (FileNotFoundError, OSError):
-                    pass
-            # Includes side files the ini references (Google's SA JSON).
-            for cred_path in [credentials_file, *extra_credential_files]:
-                if cred_path:
-                    try:
-                        os.unlink(cred_path)
-                    except (FileNotFoundError, OSError):
-                        pass
-            if ca_bundle_path:
-                try:
-                    os.unlink(ca_bundle_path)
-                except (FileNotFoundError, OSError):
-                    pass
+            _remove_temp_files(artifacts)
             domain_lock.release()
 
     def _renewal_ca_bundle(self, metadata):

--- a/tests/test_issuance_cleans_up_after_a_partial_build.py
+++ b/tests/test_issuance_cleans_up_after_a_partial_build.py
@@ -227,3 +227,113 @@ def test_a_busy_domain_raises_before_any_artifact_exists(tmp_path,
             _issue(manager)
     finally:
         lock.release()
+
+
+# ---------------------------------------------------------------------------
+# Renewal uses the same record, and the same deletion loop
+# ---------------------------------------------------------------------------
+#
+# Renewal kept its own four locals and its own loop, and the two sets had
+# already diverged: renew tracked the DNS-alias hook config separately while
+# create folded it into `credentials_file`, and only renew knew the CA bundle
+# as a path rather than as an environment value. A file one path removes and
+# the other forgets is a secret left on disk — so both now build the list the
+# same way, and these assert it for the renew side, which nothing covered.
+
+def _seed_renewable(cm, domain='example.com', **metadata_over):
+    import json
+
+    metadata = {
+        'domain': domain,
+        'dns_provider': 'cloudflare',
+        'challenge_type': 'dns-01',
+        'ca_provider': 'letsencrypt',
+    }
+    metadata.update(metadata_over)
+    domain_dir = cm.cert_dir / domain
+    domain_dir.mkdir(parents=True, exist_ok=True)
+    (domain_dir / 'cert.pem').write_text('placeholder')
+    (domain_dir / 'metadata.json').write_text(json.dumps(metadata))
+    return domain_dir
+
+
+def test_renewal_removes_its_credentials_file(tmp_path, monkeypatch):
+    written = []
+    from modules.core.dns_strategies import CloudflareStrategy
+
+    original = CloudflareStrategy.create_config_file
+
+    def spy(self, config):
+        path = original(self, config)
+        written.append(path)
+        return path
+
+    monkeypatch.setattr(CloudflareStrategy, 'create_config_file', spy)
+
+    manager = _manager(tmp_path)
+    manager.dns_manager.get_dns_provider_account_config.return_value = (
+        {'api_token': 'cf-token'}, 'default')
+    _seed_renewable(manager)
+
+    try:
+        manager.renew_certificate('example.com', force=True)
+    except Exception:
+        pass          # the shell double reports no renewal; cleanup is the point
+
+    assert written, 'renewal wrote no credentials file, so this proves nothing'
+    for path in written:
+        assert not pathlib.Path(path).exists(), (
+            f'{path} outlived a renewal'
+        )
+
+
+def test_renewal_removes_the_ca_bundle(tmp_path, monkeypatch):
+    """The private-CA trust bundle. Renewal is the path where forgetting it
+    used to mean every renewal against such a CA failed TLS verification
+    silently until the certificate expired — the bundle is now tracked in the
+    same record as everything else."""
+    bundle = tmp_path / 'renewal-ca-bundle.pem'
+    bundle.write_text('-----BEGIN CERTIFICATE-----')
+
+    manager = _manager(tmp_path)
+    monkeypatch.setattr(manager, '_renewal_ca_bundle', lambda metadata: str(bundle))
+    _seed_renewable(manager, ca_provider='private_ca')
+
+    try:
+        manager.renew_certificate('example.com', force=True)
+    except Exception:
+        pass
+
+    assert not bundle.exists(), (
+        'the renewal trust bundle was not cleaned up'
+    )
+
+
+def test_both_paths_build_the_delete_list_the_same_way():
+    """The asymmetry that made this worth doing, asserted directly.
+
+    create and renew each had their own deletion loop over their own locals.
+    Now there is one `temp_paths`, and neither writes its own.
+    """
+    import inspect
+    import re
+
+    from modules.core.certificates import CertificateManager, _IssuanceArtifacts
+
+    record = _IssuanceArtifacts()
+    record.credentials_file = '/tmp/creds.ini'
+    record.alias_hook_config = '/tmp/alias.json'
+    record.extra_credential_files = ['/tmp/sa.json']
+    record.ca_extra_env['REQUESTS_CA_BUNDLE'] = '/tmp/bundle.pem'
+
+    assert set(p for p in record.temp_paths() if p) == {
+        '/tmp/creds.ini', '/tmp/alias.json', '/tmp/sa.json', '/tmp/bundle.pem'}
+
+    unlink = re.compile(r'os\.unlink\(')
+    for method in (CertificateManager.create_certificate,
+                   CertificateManager.renew_certificate):
+        src = inspect.getsource(method)
+        assert not unlink.search(src), (
+            f'{method.__qualname__} deletes temp files itself again; that '
+            f'belongs to _remove_temp_files, or the two lists drift'
+        )

--- a/tests/test_propagation_seconds_has_one_home.py
+++ b/tests/test_propagation_seconds_has_one_home.py
@@ -6,11 +6,12 @@ in `renew_certificate` (the alias branch, the acme-dns alias branch, and
 path": a copy that announces it is a copy is exactly the drift this issue is
 about.
 
-And they had already drifted. Three clamped the result to 1..3600; the
-acme-dns alias branch did not, so a `dns_propagation_seconds` of 0 there asked
-the hook to validate before the TXT record existed, and 86400 held the
-per-domain lock for a day. Unifying them fixes that, which is a behaviour
-change and is called out as one.
+All four clamped to 1..3600, but not in the same place: three clamped where
+the value was computed, the acme-dns alias branch clamped at the call site. I
+first read that as one copy having drifted into not clamping at all, and said
+so in #736 — wrongly. The clamp was there, four lines further down. Unifying
+them changes no behaviour; what it removes is four chances for the next edit
+to move one of those clamps and not the others.
 
 There is one `_propagation_seconds` now. These pin what it must do, because the
 bounds are the interesting part: too small and certbot asks the CA to validate


### PR DESCRIPTION
Step 4 of #666, on top of #736.

| | before this PR | after |
|---|---|---|
| `create_certificate` | D(24) | **C(19)** |
| `renew_certificate` | F(56) | **F(49)** |

*(started at F(115) and F(62))*

## Two lists that had to agree, maintained separately

Renewal kept its own four locals — `alias_hook_config`, `credentials_file`, `extra_credential_files`, `ca_bundle_path` — and its own deletion loop. Create had three and another loop. **The sets had already diverged in shape:**

- renew tracked the DNS-alias hook config **separately**, create folded it into `credentials_file`;
- only renew knew the CA bundle as a *path*; create knew it as an environment value.

A file one path removes and the other forgets is a secret left on disk. Both now use `_IssuanceArtifacts`; `temp_paths()` is the single answer to "what has to go", and `_remove_temp_files` is the single loop.

Create's alias hook config stops masquerading as a credentials file and gets the field it belongs in — which is what made the two lists comparable at all.

## The renew side had no tests

Three now, including the one that matters most: **the trust bundle**. Forgetting it at renewal is the defect the file's own comment memorialises — *"renewal built its own environment and never read ca_provider, so every renewal against such a CA failed TLS verification — silently, until the certificate expired."*

Four mutations, each confirmed to turn them red:

| mutation | killed |
|---|---|
| `temp_paths()` drops the alias hook config | ✅ |
| `temp_paths()` drops the CA bundle | ✅ (3) |
| renew stops recording the bundle on the record | ✅ |
| renew stops recording the credentials file | ✅ |

Plus a source guard: neither `create_certificate` nor `renew_certificate` may call `os.unlink` itself again, or the two lists drift back apart.

## A correction to #736

That PR claimed the acme-dns alias branch never clamped the propagation value, and called unifying it a deliberate behaviour change. **It did clamp** — at the call site, four lines below the assignment:

```python
renew_propagation = int(propagation_map.get(...))     # I read this
...
    max(1, min(3600, renew_propagation)),             # and not this
```

So there was no behaviour change, and the consequences I described (a `0` validating early, an `86400` holding the lock for a day) did not exist. Nothing shipped differently — the claim was wrong, not the code. The misleading comment and the redundant second clamp it left behind are removed here, the test docstring says what actually happened, and #736 carries a correction comment.

Suite 3632 → 3635, gated flake8 clean, **real-cert E2E 13 tests / 231s** against LE staging.

## Still to come

`renew_certificate` is F(49): the DNS credentials setup itself (`prepare_environment` → `create_config_file` → `configure_certbot_arguments`) is still written twice, and the result-handling half of both functions is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)