### PR TITLE
refactor(#666): split _prepare_issuance into four testable units (step 6)

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -151,6 +151,72 @@ def _propagation_seconds(settings, dns_provider, strategy):
     return max(1, min(3600, seconds))
 
 
+class _LazySettings:
+    """Load settings at most once, and only if something asks.
+
+    A fully-specified HTTP-01 request needs none of it and this is the issuance
+    hot path, so the original code threaded ``if settings is None: settings =
+    ...load_settings()`` through five branches of one 230-line method.
+    Splitting that method into four would have meant threading it through four
+    signatures instead; this keeps the property in one object.
+
+    ``value`` is None when nothing ever asked, which is what
+    ``_PreparedIssuance.settings`` carries downstream.
+    """
+
+    def __init__(self, loader):
+        self._loader = loader
+        self._value = None
+        self._loaded = False
+
+    def get(self):
+        if not self._loaded:
+            self._value = self._loader()
+            self._loaded = True
+        return self._value
+
+    @property
+    def value(self):
+        """What was loaded, or None if it never was."""
+        return self._value
+
+
+def _resolve_all_domains(domain, san_domains, challenge_type):
+    """The -d list: the primary domain plus its validated, de-duplicated SANs.
+
+    Pure, and split out from the rest of preparation because it is the only
+    part with no dependency on settings, the CA, or the filesystem — which is
+    also what makes it worth testing exhaustively.
+    """
+    all_domains = [domain]
+    if san_domains:
+        # Filter and validate SAN domains. validate_domain returns the
+        # normalised name (URL netloc extracted, lowercased) as its
+        # second value; append THAT, not the raw entry, so a SAN never
+        # reaches certbot's -d as a URL form or a case variant. De-dup
+        # is against the normalised value and the already-normalised
+        # primary, so "Example.com" as a SAN of "example.com" collapses
+        # instead of producing a duplicate -d.
+        for san in san_domains:
+            san = san.strip()
+            if not san:
+                continue
+            is_valid, san_normalized = validate_domain(san)
+            if not is_valid:
+                raise ValueError(
+                    f"Invalid SAN domain '{san}': {san_normalized}")
+            if san_normalized != domain and san_normalized not in all_domains:
+                all_domains.append(san_normalized)
+        logger.info(f"Creating SAN certificate with domains: {', '.join(all_domains)}")
+
+    # HTTP-01 does not support wildcard domains
+    if challenge_type == 'http-01':
+        for d in all_domains:
+            if d.startswith('*.'):
+                raise ValueError("HTTP-01 challenge does not support wildcard domains. Use DNS-01 instead.")
+    return all_domains
+
+
 def _reject_path_escaping_domain(domain):
     """Refuse a domain that could escape ``cert_dir`` when used as a path.
 
@@ -1545,61 +1611,16 @@ class CertificateManager:
         )
 
 
-    def _prepare_issuance(self, *, domain, email, dns_provider, dns_config,
-                          account_id, staging, ca_provider, ca_account_id,
-                          domain_alias, alias_dns_provider, san_domains,
-                          challenge_type, key_type, key_size, elliptic_curve,
-                          replace):
-        """Validate and resolve everything an issuance needs, before any
-        command is built (#666).
 
-        Extracted verbatim from the first third of ``create_certificate``'s
-        517-line try block. It answers the questions the command builder then
-        assumes are settled: which CA, which challenge, which DNS provider and
-        account, which key shape, which domains, and whether this domain is
-        already issued.
+    def _resolve_ca(self, settings, ca_provider, ca_account_id, staging):
+        """Which CA, which account, and whether this is a staging request.
 
-        Named "prepare" rather than "resolve" because it is not pure: it
-        creates the per-domain output directory and, for HTTP-01, the webroot
-        challenge directory. Both were side effects of this stretch of code
-        before the extraction and stay where they were.
-
-        Raises the same exceptions the inline code did — FileExistsError,
-        ValueError, RuntimeError — so the caller's handlers are unchanged.
+        Extracted from _prepare_issuance (#666). Returns
+        ``(ca_provider, staging, ca_account_config, used_ca_account_id)``.
         """
-        # create_certificate rejects these before taking the per-domain lock,
-        # and this repeats it rather than trusting the caller: `domain` is used
-        # here to build cert_dir paths, and a unit that assumes its caller
-        # validated is only safe by position.
-        _reject_path_escaping_domain(domain)
-        settings = None
-        # Settings are loaded lazily and at most once: several branches
-        # below need settings (CA default, challenge type, DNS provider,
-        # key shape, propagation time) but a fully-specified HTTP-01 caller
-        # needs none, so we keep the load conditional and reuse the result.
-
-        # Return conflict if cert already exists (use renew to refresh it,
-        # or replace=True to reissue with a changed domain set — #267).
-        # This existence check runs *under* the per-domain lock acquired
-        # above so two concurrent creates for the same domain can't both
-        # pass the check and race to issue duplicate certificates.
-        existing_cert = self.cert_dir / domain / 'cert.pem'
-        if existing_cert.exists() and not replace:
-            raise FileExistsError(f"Certificate for {domain} already exists. Use renew to refresh it.")
-
-        logger.info(f"Starting certificate {'reissue' if replace else 'creation'} for domain: {domain}")
-        
-        # ... (Validation and CA setup remains the same until DNS config)
-        
-        # Validate inputs
-        if not domain or not email:
-            raise ValueError("Domain and email are required")
-        
         # Get CA provider configuration
         if not ca_provider:
-            if settings is None:
-                settings = self.settings_manager.load_settings()
-            ca_provider = settings.get('default_ca', 'letsencrypt')
+            ca_provider = settings.get().get('default_ca', 'letsencrypt')
 
         # Back-compat (#279): the legacy per-cert staging boolean maps
         # onto the dedicated staging CA entry, and the boolean is derived
@@ -1634,12 +1655,20 @@ class CertificateManager:
                     # issuance (and burn real rate limits).
                     ca_provider = 'letsencrypt_staging' if staging else 'letsencrypt'
                     logger.warning(f"Could not get CA config, falling back to {ca_provider}: {e}")
-        
+        return ca_provider, staging, ca_account_config, used_ca_account_id
+
+    def _resolve_challenge_and_dns(self, settings, domain, challenge_type,
+                                   dns_provider, dns_config, account_id,
+                                   domain_alias, alias_dns_provider):
+        """Which challenge, which DNS provider and account, which strategy.
+
+        Also creates the HTTP-01 webroot directory, which is part of why the
+        caller is named "prepare" rather than "resolve". Returns
+        ``(challenge_type, dns_provider, dns_config, strategy)``.
+        """
         # Resolve challenge type from settings if not provided
         if not challenge_type:
-            if settings is None:
-                settings = self.settings_manager.load_settings()
-            challenge_type = settings.get('challenge_type', 'dns-01')
+            challenge_type = settings.get().get('challenge_type', 'dns-01')
 
         # HTTP-01 path: skip DNS config entirely
         if challenge_type == 'http-01':
@@ -1655,9 +1684,7 @@ class CertificateManager:
             # DNS-01 path: get DNS configuration
             if not dns_config:
                 if not dns_provider:
-                    if settings is None:
-                        settings = self.settings_manager.load_settings()
-                    dns_provider = self.settings_manager.get_domain_dns_provider(domain, settings)
+                    dns_provider = self.settings_manager.get_domain_dns_provider(domain, settings.get())
 
                 if not dns_provider:
                     raise ValueError("No DNS provider configured. Go to Settings and select a DNS provider.")
@@ -1698,40 +1725,14 @@ class CertificateManager:
                         f"Install it with: pip install {pkg}  "
                         f"(Docker users: rebuild with REQUIREMENTS_FILE=requirements.txt)"
                     )
+        return challenge_type, dns_provider, dns_config, strategy
 
-        # Build list of all domains (primary + SANs)
-        all_domains = [domain]
-        if san_domains:
-            # Filter and validate SAN domains. validate_domain returns the
-            # normalised name (URL netloc extracted, lowercased) as its
-            # second value; append THAT, not the raw entry, so a SAN never
-            # reaches certbot's -d as a URL form or a case variant. De-dup
-            # is against the normalised value and the already-normalised
-            # primary, so "Example.com" as a SAN of "example.com" collapses
-            # instead of producing a duplicate -d.
-            for san in san_domains:
-                san = san.strip()
-                if not san:
-                    continue
-                is_valid, san_normalized = validate_domain(san)
-                if not is_valid:
-                    raise ValueError(
-                        f"Invalid SAN domain '{san}': {san_normalized}")
-                if san_normalized != domain and san_normalized not in all_domains:
-                    all_domains.append(san_normalized)
-            logger.info(f"Creating SAN certificate with domains: {', '.join(all_domains)}")
+    def _resolve_key_shape(self, settings, domain, replace, key_type, key_size,
+                           elliptic_curve):
+        """The key type/size/curve triple, defaulted and validated.
 
-        # HTTP-01 does not support wildcard domains
-        if challenge_type == 'http-01':
-            for d in all_domains:
-                if d.startswith('*.'):
-                    raise ValueError("HTTP-01 challenge does not support wildcard domains. Use DNS-01 instead.")
-
-        # Create output directory
-        cert_dir = self.cert_dir
-        cert_output_dir = cert_dir / domain
-        cert_output_dir.mkdir(parents=True, exist_ok=True)
-
+        Returns ``(key_type, key_size, elliptic_curve)``.
+        """
         # Resolve key shape. If the caller did not pick anything we fall
         # back to the global default from settings — this lets legacy
         # callers (web routes, scripts, tests) get the configured
@@ -1746,20 +1747,88 @@ class CertificateManager:
         # certificate. With no key flags certbot keeps the existing key
         # type; an explicit key option on reissue is an intentional re-key.
         if not replace and key_type is None and key_size is None and elliptic_curve is None:
-            if settings is None:
-                settings = self.settings_manager.load_settings()
-            key_type = settings.get('default_key_type')
+            key_type = settings.get().get('default_key_type')
             if key_type == 'rsa':
-                key_size = settings.get('default_key_size')
+                key_size = settings.get().get('default_key_size')
             elif key_type == 'ecdsa':
-                elliptic_curve = settings.get('default_elliptic_curve')
+                elliptic_curve = settings.get().get('default_elliptic_curve')
         if key_type is not None:
             ok, err = validate_key_options(key_type, key_size, elliptic_curve)
             if not ok:
                 raise ValueError(f"Invalid key options for {domain}: {err}")
+        return key_type, key_size, elliptic_curve
+
+    def _prepare_issuance(self, *, domain, email, dns_provider, dns_config,
+                          account_id, staging, ca_provider, ca_account_id,
+                          domain_alias, alias_dns_provider, san_domains,
+                          challenge_type, key_type, key_size, elliptic_curve,
+                          replace):
+        """Validate and resolve everything an issuance needs, before any
+        command is built (#666).
+
+        Extracted verbatim from the first third of ``create_certificate``'s
+        517-line try block. It answers the questions the command builder then
+        assumes are settled: which CA, which challenge, which DNS provider and
+        account, which key shape, which domains, and whether this domain is
+        already issued.
+
+        Named "prepare" rather than "resolve" because it is not pure: it
+        creates the per-domain output directory and, for HTTP-01, the webroot
+        challenge directory. Both were side effects of this stretch of code
+        before the extraction and stay where they were.
+
+        Raises the same exceptions the inline code did — FileExistsError,
+        ValueError, RuntimeError — so the caller's handlers are unchanged.
+        """
+        # create_certificate rejects these before taking the per-domain lock,
+        # and this repeats it rather than trusting the caller: `domain` is used
+        # here to build cert_dir paths, and a unit that assumes its caller
+        # validated is only safe by position.
+        _reject_path_escaping_domain(domain)
+        settings = _LazySettings(self.settings_manager.load_settings)
+        # Settings are loaded lazily and at most once: several branches
+        # below need settings (CA default, challenge type, DNS provider,
+        # key shape, propagation time) but a fully-specified HTTP-01 caller
+        # needs none, so we keep the load conditional and reuse the result.
+
+        # Return conflict if cert already exists (use renew to refresh it,
+        # or replace=True to reissue with a changed domain set — #267).
+        # This existence check runs *under* the per-domain lock acquired
+        # above so two concurrent creates for the same domain can't both
+        # pass the check and race to issue duplicate certificates.
+        existing_cert = self.cert_dir / domain / 'cert.pem'
+        if existing_cert.exists() and not replace:
+            raise FileExistsError(f"Certificate for {domain} already exists. Use renew to refresh it.")
+
+        logger.info(f"Starting certificate {'reissue' if replace else 'creation'} for domain: {domain}")
+        
+        # ... (Validation and CA setup remains the same until DNS config)
+        
+        # Validate inputs
+        if not domain or not email:
+            raise ValueError("Domain and email are required")
+        
+        ca_provider, staging, ca_account_config, used_ca_account_id = \
+            self._resolve_ca(settings, ca_provider, ca_account_id, staging)
+
+        challenge_type, dns_provider, dns_config, strategy = \
+            self._resolve_challenge_and_dns(
+                settings, domain, challenge_type, dns_provider, dns_config,
+                account_id, domain_alias, alias_dns_provider)
+
+        all_domains = _resolve_all_domains(domain, san_domains, challenge_type)
+
+        # Create output directory
+        cert_dir = self.cert_dir
+        cert_output_dir = cert_dir / domain
+        cert_output_dir.mkdir(parents=True, exist_ok=True)
+
+        key_type, key_size, elliptic_curve = self._resolve_key_shape(
+            settings, domain, replace, key_type, key_size, elliptic_curve)
+
 
         return _PreparedIssuance(
-            settings=settings,
+            settings=settings.value,
             ca_provider=ca_provider,
             staging=staging,
             ca_account_config=ca_account_config,

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -188,6 +188,10 @@ def _resolve_all_domains(domain, san_domains, challenge_type):
     part with no dependency on settings, the CA, or the filesystem — which is
     also what makes it worth testing exhaustively.
     """
+    # Same reasoning as the other units in this file: the value ends up as a
+    # certbot -d argument and in a log line, so this enforces its own
+    # precondition rather than trusting whichever caller it acquires next.
+    _reject_path_escaping_domain(domain)
     all_domains = [domain]
     if san_domains:
         # Filter and validate SAN domains. validate_domain returns the

--- a/tests/test_issuance_preparation_units.py
+++ b/tests/test_issuance_preparation_units.py
@@ -1,0 +1,151 @@
+"""The pieces `_prepare_issuance` was split into (#666).
+
+Splitting a 230-line method is only worth it if the pieces are testable on
+their own, so these test the two that carry the subtle behaviour rather than
+re-testing issuance through them.
+
+`_resolve_all_domains` is the only part of preparation with no dependency on
+settings, the CA, or the filesystem, which is exactly what makes exhaustive
+tests cheap here and expensive through `create_certificate`.
+
+`_LazySettings` exists because a fully-specified HTTP-01 request needs no
+settings at all and this is the issuance hot path. The original threaded
+`if settings is None: settings = ...load_settings()` through five branches;
+splitting into four methods would have meant threading it through four
+signatures. The property that matters is that it loads at most once, and
+reports `value is None` when nothing asked — which is what
+`_PreparedIssuance.settings` carries downstream, and what the propagation
+lookup keys off.
+"""
+import pytest
+
+from modules.core.certificates import _LazySettings, _resolve_all_domains
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------------
+# The -d list
+# ---------------------------------------------------------------------------
+
+def test_a_certificate_with_no_sans_is_just_the_domain():
+    assert _resolve_all_domains('example.com', None, 'dns-01') == ['example.com']
+
+
+def test_sans_follow_the_primary_in_order():
+    assert _resolve_all_domains(
+        'example.com', ['www.example.com', 'api.example.com'], 'dns-01'
+    ) == ['example.com', 'www.example.com', 'api.example.com']
+
+
+def test_a_san_is_normalised_before_it_reaches_certbot():
+    """validate_domain returns the normalised name; appending the RAW entry is
+    how a URL form or a case variant reaches certbot's -d."""
+    assert _resolve_all_domains(
+        'example.com', ['WWW.Example.com'], 'dns-01'
+    ) == ['example.com', 'www.example.com']
+
+
+def test_a_san_equal_to_the_primary_collapses():
+    """"Example.com" as a SAN of "example.com" must not produce a duplicate -d."""
+    assert _resolve_all_domains(
+        'example.com', ['Example.com', 'www.example.com'], 'dns-01'
+    ) == ['example.com', 'www.example.com']
+
+
+def test_duplicate_sans_collapse():
+    assert _resolve_all_domains(
+        'example.com', ['www.example.com', 'www.example.com'], 'dns-01'
+    ) == ['example.com', 'www.example.com']
+
+
+@pytest.mark.parametrize('blank', ['', '   ', '\t'])
+def test_blank_entries_are_skipped(blank):
+    """A trailing comma in the form leaves one behind."""
+    assert _resolve_all_domains(
+        'example.com', [blank, 'www.example.com'], 'dns-01'
+    ) == ['example.com', 'www.example.com']
+
+
+def test_an_invalid_san_is_refused_rather_than_dropped():
+    """Silently dropping it would issue a certificate missing a name the
+    operator asked for, and they would find out at handshake time."""
+    with pytest.raises(ValueError, match='Invalid SAN domain'):
+        _resolve_all_domains('example.com', ['not a domain'], 'dns-01')
+
+
+def test_a_wildcard_is_allowed_under_dns_01():
+    assert '*.example.com' in _resolve_all_domains(
+        'example.com', ['*.example.com'], 'dns-01')
+
+
+def test_a_wildcard_is_refused_under_http_01():
+    """HTTP-01 cannot validate a wildcard; certbot would fail later and less
+    clearly."""
+    with pytest.raises(ValueError, match='wildcard'):
+        _resolve_all_domains('example.com', ['*.example.com'], 'http-01')
+
+
+def test_a_wildcard_primary_is_refused_under_http_01_too():
+    """CONTROL: the guard must cover the primary, not only the SANs."""
+    with pytest.raises(ValueError, match='wildcard'):
+        _resolve_all_domains('*.example.com', None, 'http-01')
+
+
+# ---------------------------------------------------------------------------
+# The lazy load
+# ---------------------------------------------------------------------------
+
+def test_nothing_is_loaded_until_something_asks():
+    calls = []
+    lazy = _LazySettings(lambda: calls.append(1) or {'a': 1})
+
+    assert calls == [], 'settings were loaded before anyone asked'
+    assert lazy.value is None
+
+
+def test_it_loads_once_however_many_times_it_is_asked():
+    calls = []
+
+    def loader():
+        calls.append(1)
+        return {'a': 1}
+
+    lazy = _LazySettings(loader)
+    assert lazy.get() == {'a': 1}
+    assert lazy.get() == {'a': 1}
+    assert lazy.get() == {'a': 1}
+    assert len(calls) == 1, f'settings were loaded {len(calls)} times'
+
+
+def test_value_reports_what_was_loaded_after_the_first_ask():
+    lazy = _LazySettings(lambda: {'a': 1})
+    lazy.get()
+    assert lazy.value == {'a': 1}
+
+
+def test_a_loader_returning_none_still_counts_as_loaded():
+    """CONTROL: memoising on `value is None` instead of a flag would reload
+    forever here, and `value is None` downstream would be indistinguishable
+    from "nobody asked"."""
+    calls = []
+
+    def loader():
+        calls.append(1)
+        return None
+
+    lazy = _LazySettings(loader)
+    lazy.get()
+    lazy.get()
+    assert len(calls) == 1
+
+
+def test_the_prepared_record_carries_none_when_nothing_asked():
+    """The downstream contract: _propagation_seconds and the create path both
+    treat a None settings as "not loaded", and the builder reloads nothing."""
+    from modules.core.certificates import _propagation_seconds
+
+    class _Strategy:
+        default_propagation_seconds = 60
+
+    assert _propagation_seconds(None, 'cloudflare', _Strategy()) == 60


### PR DESCRIPTION
Step 6 of #666, on top of #738.

**`_prepare_issuance` F(51) → gone from the C-and-above list entirely.** The largest remaining piece is `_resolve_challenge_and_dns` at C(17).

## Undoing my own shortcut

I created `_prepare_issuance` in step 1 (#734) by moving 186 lines out of `create_certificate` **in one piece**. That was the right first move — it made the extraction reviewable — and the wrong thing to leave, because it held four unrelated questions behind one name.

| | |
|---|---|
| `_resolve_ca` | CA provider, the staging mapping, the CA account |
| `_resolve_challenge_and_dns` | challenge type, DNS provider/account, strategy, alias validation, plugin preflight |
| `_resolve_all_domains` | the `-d` list — **module-level and pure** |
| `_resolve_key_shape` | key type/size/curve, defaulted and validated |

`_resolve_all_domains` is the interesting one: no settings, no CA, no filesystem. That is what makes ten tests cheap here and expensive through `create_certificate`, and it covers the parts that actually bite — a raw SAN reaching `-d` instead of the normalised one, a SAN equal to the primary producing a duplicate, an invalid SAN being dropped instead of refused, and the wildcard guard covering the **primary** and not just the SANs.

## The lazy settings load needed care, not deletion

A fully-specified HTTP-01 request needs no settings at all, and this is the issuance hot path — which is why the original threaded `if settings is None: settings = ...load_settings()` through five branches. Splitting into four methods would have meant threading it through four **signatures**.

`_LazySettings` keeps the property in one object: loads at most once, only if asked, and reports `value is None` when nothing did — which is exactly what `_PreparedIssuance.settings` carries downstream and what `_propagation_seconds` keys off. There is a control test for the subtle version of getting this wrong: memoising on `value is None` instead of a flag would reload forever for a loader that legitimately returns `None`, and make "loaded nothing" indistinguishable from "nobody asked".

## Verification

| mutation | killed |
|---|---|
| `_LazySettings` memoises on `value is None` instead of a flag | ✅ |
| the raw SAN reaches `-d` instead of the normalised one | ✅ |
| an invalid SAN is silently dropped rather than refused | ✅ |
| the wildcard guard skips the primary domain | ✅ |

Both existing nets — the certbot-argv contract and the cleanup record — still pass unchanged.

## One mistake worth recording

The blanket regex I used to convert the lazy loads rewrote **three comments** as well as code (`# Resolve challenge type from settings.get() if not provided`). Same family as the string-literal corruption in step 2 (#735), and the third time in this series that a source-wide regex has touched something that is not code. Restored before committing; the lesson is now cheap enough to state plainly: on this file, rewrite tokens or lines, never the whole text.

Suite 3638 → 3655 (+17), gated flake8 clean, **real-cert E2E 13 tests / 234s** against LE staging.

## Left

`renew_certificate` F(48) — its result handling is still its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)