### PR TITLE
fix(#671): no broad handler catches everything and then says nothing

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,6 +89,10 @@ if __name__ == '__main__':
             try:
                 container.scheduler.shutdown()
                 print("📅 Background scheduler stopped")
-            except Exception:
-                pass
+            except Exception as e:
+                # Ctrl-C is already on its way out; a scheduler that will not
+                # stop cleanly must not turn that into a traceback. But it is
+                # worth one line, because "stopped" printing and "stopped"
+                # happening were previously indistinguishable (#671).
+                print(f"⚠️  Background scheduler did not stop cleanly: {e}")
         sys.exit(0)

--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -647,8 +647,14 @@ class AuthManager:
                                 s['api_keys'] = keys
                         try:
                             self.settings_manager.update(_touch, None)
-                        except Exception:
-                            pass  # Non-critical, don't fail auth on last_used update
+                        except Exception as e:
+                            # Non-critical: never fail auth over a last_used
+                            # write. But never silent either — this swallow
+                            # already hid one defect (see the comment above:
+                            # json.dump refused a datetime and the column
+                            # stayed empty for every key, forever).
+                            logger.debug(
+                                "Could not persist last_used_at for an API key: %s", e)
                     return {
                         'username': 'api_key:' + key_data.get('name', key_id),
                         'role': self._normalize_role(key_data.get('role', 'viewer')),

--- a/modules/core/digest.py
+++ b/modules/core/digest.py
@@ -260,8 +260,11 @@ Generated {digest['generated_at']} by CertMate
             finally:
                 try:
                     server.quit()
-                except Exception:
-                    pass
+                except (smtplib.SMTPException, OSError) as e:
+                    # The mail is already sent; a failure closing the session
+                    # changes nothing for the caller. Narrow, and logged, so
+                    # it is not indistinguishable from a send that failed.
+                    logger.debug("SMTP quit failed after sending digest: %s", e)
 
         except Exception as e:
             logger.error(f"Weekly digest email failed: {e}")

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -326,8 +326,16 @@ def setup_directories(container: AppContainer, test_config=None):
                         logger.debug(f"Cleaned up orphan temp file: {_tmp}")
                     except OSError:
                         pass
-        except Exception:
-            pass
+        except OSError as e:
+            # The inner handler covers a single unlink; this one covers the
+            # scan itself (an unreadable directory). Cleaning orphan temp
+            # files is best-effort, but "best-effort" and "invisible" are
+            # different things.
+            # f-string, not %-args: this module's logger is a StructuredLogger
+            # whose level methods are (msg, **kwargs), so the stdlib idiom
+            # raises TypeError exactly when the code wanted to report a
+            # problem — the same failure shape #671 is about.
+            logger.debug(f"Could not sweep orphan temp files: {e}")
 
     # Docker volume persistence check (#130). Warn loudly if /app/data
     # appears to be ephemeral container storage rather than a persistent

--- a/modules/core/notifier.py
+++ b/modules/core/notifier.py
@@ -446,8 +446,8 @@ class Notifier:
             finally:
                 try:
                     server.quit()
-                except Exception:
-                    pass
+                except (smtplib.SMTPException, OSError) as e:
+                    logger.debug("SMTP quit failed after sending notification: %s", e)
 
         except Exception as e:
             logger.error(f"Email notification failed: {e}")

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -1194,8 +1194,11 @@ class SettingsManager:
                             # produced seconds ago by this boot and don't help
                             # the operator recover from pre-existing data loss.
                             backups = [b for b in backups if '_migration' not in b]
-                    except Exception:
-                        pass
+                    except OSError as e:
+                        # A failure here makes the message say "no backups
+                        # found", which is what an operator reads as "there is
+                        # nothing to restore from".
+                        logger.warning("Could not list unified backups: %s", e)
                     if backups:
                         logger.error(
                             "CRITICAL: settings.json has no users. If this is "
@@ -1215,8 +1218,11 @@ class SettingsManager:
                     if cert_dir and cert_dir.exists():
                         try:
                             cert_domains = [d.name for d in iter_cert_domain_dirs(cert_dir)]
-                        except Exception:
-                            pass
+                        except OSError as e:
+                            # Same shape: silence here turns "I could not look"
+                            # into "there is nothing there".
+                            logger.warning(
+                                "Could not enumerate certificate directories: %s", e)
                     if cert_domains:
                         logger.warning(
                             "settings.json has no domains but certificates exist "

--- a/modules/core/storage_backends.py
+++ b/modules/core/storage_backends.py
@@ -1081,8 +1081,14 @@ class AzureKeyVaultBackend(CertificateStorageBackend):
                 secret_name = self._sanitize_secret_name(f"cert-{domain}-cert-pem")
                 client.get_secret(secret_name)
                 return True
-            except Exception:
-                pass
+            except Exception as e:
+                # A transient auth or network failure here is reported to the
+                # caller as "the certificate does not exist", which is how a
+                # present certificate gets re-issued. Cannot be narrowed
+                # without importing the Azure SDK exceptions, so at least say
+                # so out loud.
+                logger.debug(
+                    "Azure Key Vault secret lookup failed for %s: %s", domain, e)
         if self.writes_certificate:
             try:
                 return self._get_cert_importer().exists(domain)

--- a/tests/test_no_silent_swallows.py
+++ b/tests/test_no_silent_swallows.py
@@ -1,0 +1,106 @@
+"""No handler may catch broadly and then say nothing (#671).
+
+`except Exception: pass` on a certificate manager is how a genuine failure
+becomes a wrong value with no error attached. That is not a hypothetical here:
+
+* `auth.py` swallowed the write of `last_used_at`, and the comment above it
+  records what that cost — `json.dump` refused a datetime and the column
+  stayed empty for every API key, forever, with nothing logged;
+* during the #666 decomposition a `NameError` introduced in the propagation
+  lookup was swallowed by its surrounding `except Exception` and turned into
+  the strategy default: 60 seconds instead of the configured 30, silently.
+
+So this file draws the line at the shape that cannot be defended — a *broad*
+catch whose entire body is `pass` — rather than at the 397 broad handlers,
+most of which do log or return something. Narrow silent handlers stay
+allowed: `except OSError: pass` around an `unlink` in a cleanup path says
+exactly what it means.
+
+The bare-except half of the issue is already enforced: `E722` is in the gated
+flake8 selection in both `.github/workflows/ci.yml` and `scripts/release.sh`,
+and there are none left. `test_bare_excepts_stay_gated` pins that so removing
+the flag from the gate fails here instead of quietly reopening the door.
+"""
+import ast
+import pathlib
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+BROAD = {'Exception', 'BaseException'}
+
+
+def _silent_handlers(tree):
+    """Yield (lineno, caught) for handlers whose whole body is `pass`."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ExceptHandler):
+            continue
+        if len(node.body) != 1 or not isinstance(node.body[0], ast.Pass):
+            continue
+        yield node.lineno, (ast.unparse(node.type) if node.type else '<bare>')
+
+
+def _python_sources():
+    return sorted(ROOT.glob('modules/**/*.py')) + [ROOT / 'app.py']
+
+
+def test_no_broad_handler_swallows_in_silence():
+    offenders = []
+    for path in _python_sources():
+        tree = ast.parse(path.read_text())
+        for lineno, caught in _silent_handlers(tree):
+            if caught == '<bare>' or caught in BROAD:
+                offenders.append(f'{path.relative_to(ROOT)}:{lineno} '
+                                 f'except {caught}: pass')
+
+    assert not offenders, (
+        'these catch everything and then say nothing, so a real failure '
+        'becomes a wrong value with no error attached:\n  '
+        + '\n  '.join(offenders)
+    )
+
+
+def test_narrow_silent_handlers_are_still_allowed():
+    """CONTROL: the rule above must not be read as "no silent handler ever".
+
+    `except OSError: pass` around an unlink in a cleanup path is precise about
+    what it ignores and why. If this ever reaches zero, someone has widened
+    the rule into a style edict and the codebase will grow log noise instead
+    of clarity.
+    """
+    narrow = 0
+    for path in _python_sources():
+        tree = ast.parse(path.read_text())
+        for _lineno, caught in _silent_handlers(tree):
+            if caught != '<bare>' and caught not in BROAD:
+                narrow += 1
+
+    assert narrow > 0, (
+        'no narrow silent handlers remain, which suggests this rule was '
+        'applied as a blanket ban rather than to broad catches'
+    )
+
+
+def test_bare_excepts_stay_gated():
+    """E722 in the gated flake8 selection is what keeps `except:` out.
+
+    The issue reported it as missing; it is present in both gates. Asserted
+    here so removing it fails visibly rather than reopening the door quietly.
+    """
+    for gate in ('.github/workflows/ci.yml', 'scripts/release.sh'):
+        text = (ROOT / gate).read_text()
+        assert 'E722' in text, f'{gate} no longer gates on E722'
+
+
+def test_there_are_no_bare_excepts_left():
+    """The other half: the gate only helps if the count is already zero."""
+    offenders = []
+    for path in _python_sources():
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ExceptHandler) and node.type is None:
+                offenders.append(f'{path.relative_to(ROOT)}:{node.lineno}')
+
+    assert not offenders, f'bare `except:` remains at {offenders}'


### PR DESCRIPTION
First slice of #671. **Eight `except Exception: pass`, now zero**, plus the gate that keeps them there.

The issue counted seven. The eighth was in `app.py` — which my own scan missed because it only walked `modules/`. **The gate found it on its first run**, which is roughly the point of writing the gate before declaring the count.

## What each one was hiding

| | |
|---|---|
| `auth.py` | the `last_used_at` write. The comment **directly above it** already records what this swallow cost once: `json.dump` refused a datetime and the column stayed empty for every API key, forever, with nothing logged |
| `storage_backends.py` | Azure Key Vault `certificate_exists`. A transient auth or network failure was reported to the caller as **"the certificate does not exist"** — which is how a certificate that is present gets re-issued |
| `settings.py` ×2 | listing backups, and enumerating certificate directories. Silence turned *"I could not look"* into *"there is nothing there"*, in the two messages an operator reads while recovering |
| `digest.py`, `notifier.py` | SMTP `quit()` after a successful send. Narrowed to `(SMTPException, OSError)` and logged at debug |
| `factory.py` | the orphan temp-file sweep |
| `app.py` | scheduler shutdown on Ctrl-C — `"stopped"` printing and `"stopped"` happening were indistinguishable |

## The other half was already done, and reported as missing

The issue says `E722` is not in the gated flake8 selection. **It is** — in both `.github/workflows/ci.yml` and `scripts/release.sh` — and there are **zero** bare excepts left. Verified rather than assumed, and now pinned by a test so removing the flag from either gate fails visibly instead of quietly reopening the door.

## The rule is broad-and-silent, not silent

`except OSError: pass` around an `unlink` in a cleanup path is precise about what it ignores and why. A **control test fails if those reach zero**, because that would mean the rule had been applied as a style edict and the codebase was growing log noise instead of clarity.

That leaves the 397 broad handlers themselves for a later slice: most of them do log or return something, and sorting the ones that matter from the ones that are fine is a different job from this one.

## One thing the suite caught that would have shipped

`factory.py` uses a `StructuredLogger` whose level methods are `(msg, **kwargs)`. My first version used the stdlib `logger.debug("x %s", e)` idiom, which raises `TypeError` there — **exactly when the code wanted to report a problem.** The same failure shape this issue is about, caught by `test_structured_logger_call_shape` on the first full run.

## Verification

Confirmed the gate bites: reintroducing `except Exception: pass` in `digest.py` turns it red.

Suite 3655 → 3659, gated flake8 clean, per-module coverage floors met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)