### PR TITLE
refactor(#672): one home for domain-to-path validation

### DIFF
--- a/modules/api/client_certificates.py
+++ b/modules/api/client_certificates.py
@@ -1,23 +1,21 @@
 import logging
-import re
 from flask import request, send_file, Response
+from ..core.domain_paths import IDENTIFIER_RE, is_path_safe_segment
 from werkzeug.exceptions import HTTPException
 from flask_restx import Resource, fields, abort
 from io import BytesIO
 
 logger = logging.getLogger(__name__)
 
-# Validation pattern for client certificate identifiers
-_SAFE_IDENTIFIER_RE = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$')
-
-
 def _validate_identifier(identifier):
-    """Validate client certificate identifier to prevent path traversal."""
-    if not identifier or '..' in identifier or '/' in identifier or '\\' in identifier or '\x00' in identifier:
-        return False
-    if not _SAFE_IDENTIFIER_RE.match(identifier):
-        return False
-    return True
+    """Validate client certificate identifier to prevent path traversal.
+
+    The character rule and the pattern both live in ``core.domain_paths`` (#672).
+    They were written here as a fourth copy, and carried the same `$` anchor the
+    other copies had.
+    """
+    return (is_path_safe_segment(identifier)
+            and bool(IDENTIFIER_RE.match(identifier)))
 
 
 def create_client_certificate_models(api):

--- a/modules/api/path_validation.py
+++ b/modules/api/path_validation.py
@@ -1,54 +1,14 @@
-"""Turning a caller-supplied domain into a path, safely.
+"""Domain-to-path validation for the API layer.
 
-Extracted from `resources.py` (#667). It sat there because that is where the
-endpoints are, and it is called from thirteen of them — which is exactly why it
-had to move: a resource group in a module of its own could not reach it without
-importing `resources.py`, which imports the group back.
+The rules moved to ``modules/core/domain_paths`` (#672), where ``web`` and the
+storage backends can reach them too — they had their own copies, and one of
+those copies still carried a defect this one had already fixed.
 
-Nothing here is new. The rules are the ones the endpoints have always applied,
-in the order they applied them: reject the separators and NUL outright, then
-require a plausible domain, then confirm the resolved path is still under the
-certificate directory. The last check is the one that matters — the first two
-can be reasoned about, while `resolve()` is what actually answers the question
-after symlinks and `..` have been taken into account.
+Re-exported rather than rewritten at thirteen call sites: the names here are
+what the endpoints import.
 """
-import os
-import re
-from pathlib import Path
-
-# Note the leading `*.` alternative: a wildcard certificate's directory is
-# named for the wildcard, so refusing it here would make those certificates
-# unreachable.
-#
-# `\Z`, not `$`. In Python `$` also matches immediately BEFORE a trailing
-# newline, so the previous expression accepted "example.com\n" as a valid
-# domain — and the character check below does not screen newlines either,
-# so nothing else caught it. That name is not a traversal (the resolved path
-# still sits under the certificate directory) but it is not a domain, and a
-# validator that reports "Invalid domain format" for everything else should
-# not make an exception for it.
-DOMAIN_RE = re.compile(
-    r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}\Z')
-
-
-def validate_domain_path(domain, cert_base_dir):
-    """Validate a domain used as a directory name. Returns ``(Path, error)``.
-
-    On refusal the path is ``None`` and the caller must not fall back to
-    building one itself — that is the whole point of returning a pair.
-    """
-    if not domain or '..' in domain or '/' in domain or '\\' in domain \
-            or '\x00' in domain:
-        return None, 'Invalid domain name'
-    if not DOMAIN_RE.match(domain):
-        return None, 'Invalid domain format'
-    cert_dir = Path(cert_base_dir) / domain
-    try:
-        resolved = cert_dir.resolve()
-        base_resolved = Path(cert_base_dir).resolve()
-        if not str(resolved).startswith(str(base_resolved) + os.sep) \
-                and resolved != base_resolved:
-            return None, 'Invalid domain path'
-    except (OSError, ValueError):
-        return None, 'Invalid domain path'
-    return cert_dir, None
+from ..core.domain_paths import (  # noqa: F401
+    DOMAIN_RE,
+    is_path_safe_segment,
+    validate_domain_path,
+)

--- a/modules/api/resources_backup.py
+++ b/modules/api/resources_backup.py
@@ -17,6 +17,7 @@ from flask_restx import Resource, fields
 
 import logging
 
+from ..core.domain_paths import is_path_safe_segment
 from ..core.file_operations import RestoreIncompleteError
 from .resource_context import ApiContext
 
@@ -27,7 +28,7 @@ def _validate_backup_filename(filename):
     """Reject path traversal attempts in backup filenames. Returns error string or None."""
     if not filename:
         return 'Filename is required'
-    if '..' in filename or '/' in filename or '\\' in filename or '\x00' in filename:
+    if not is_path_safe_segment(filename):
         return 'Invalid filename'
     # NUL was rejected above but the other control characters were not, so a
     # name like "x\nFORGED.zip" passed and reached the log lines that report

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -31,6 +31,7 @@ from cryptography import x509
 from .shell import ShellExecutor
 from .dns_strategies import DNSStrategyFactory, HTTP01Strategy, acme_webroot_dir, check_certbot_plugin_installed
 from .constants import CERTIFICATE_FILES, DEFAULT_RENEWAL_THRESHOLD_DAYS
+from .domain_paths import reject_unsafe_domain
 from .utils import (
     DeploymentStatusCache, validate_domain, utc_now, utc_now_iso, validate_key_options,
     repair_certbot_lineage_symlinks,
@@ -240,9 +241,7 @@ def _reject_path_escaping_domain(domain):
     ``_prepare_issuance`` produced a unit that did not enforce its own
     precondition, which is exactly the shape CodeQL flags — and it was right.
     """
-    if (not domain or '/' in domain or '\\' in domain
-            or '..' in domain or '\x00' in domain):
-        raise ValueError('Invalid domain name')
+    reject_unsafe_domain(domain)
 
 
 @dataclass

--- a/modules/core/domain_paths.py
+++ b/modules/core/domain_paths.py
@@ -1,0 +1,113 @@
+"""Turning a caller-supplied domain into a path, safely — in one place (#672).
+
+These rules existed **four** times: here (as `modules/api/path_validation`),
+in `modules/web/routes._sanitize_domain`, in
+`modules/core/storage_backends._validate_storage_domain`, and in
+`modules/core/certificates._reject_path_escaping_domain`. Same character set in
+all four, three different return conventions, and two of them whole functions
+that differed only in the name of their regex.
+
+That is not a tidiness problem. Duplicated *security* validation is how one
+copy gets fixed and the others do not, which is exactly what had happened: the
+`\\Z` anchor below was corrected once and left as `$` in two of the copies.
+
+It lives in `modules/core/` rather than `modules/api/` because `web` and
+`storage_backends` both need it, and having core import from api would deepen
+the layering inversion in #668.
+
+The rules, in the order they are applied:
+
+1. reject the separators and NUL outright — cheap, and unambiguous;
+2. require a plausible domain shape;
+3. confirm the resolved path is still under the certificate directory.
+
+The last is the one that matters. The first two can be reasoned about;
+``resolve()`` is what actually answers the question once symlinks and ``..``
+have been taken into account.
+"""
+import os
+import re
+from pathlib import Path
+
+# Characters that make a domain unusable as a single path segment. Kept as a
+# tuple rather than inlined so the rule has one definition and the callers
+# that raise, the callers that return an error pair, and the callers that only
+# ask a yes/no question all apply the same one.
+_PATH_UNSAFE = ('..', '/', '\\', '\x00')
+
+# Note the leading `*.` alternative: a wildcard certificate's directory is
+# named for the wildcard, so refusing it here would make those certificates
+# unreachable.
+#
+# `\Z`, not `$`. In Python `$` also matches immediately BEFORE a trailing
+# newline, so a `$`-anchored expression accepts "example.com\n" as a valid
+# domain — and the character check above does not screen newlines either, so
+# nothing else catches it. That name is not a traversal (the resolved path
+# still sits under the certificate directory) but it is not a domain, and a
+# validator that reports "Invalid domain format" for everything else should not
+# make an exception for it.
+DOMAIN_RE = re.compile(
+    r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}\Z')
+
+# Storage backends key secrets by domain and accept a wider shape than a
+# certificate directory does (dots and underscores inside, up to 253 chars).
+# Different rule, same anchor: the reason `$` is wrong does not depend on which
+# characters are allowed.
+STORAGE_DOMAIN_RE = re.compile(
+    r'^(\*\.)?[a-zA-Z0-9]([a-zA-Z0-9._-]{0,253}[a-zA-Z0-9])?\Z')
+
+
+# Client certificate identifiers are a different shape from domains but the
+# same kind of value: a caller-supplied string that becomes a directory name.
+# `\Z` for the same reason as the two above — this expression was anchored with
+# `$` and accepted a trailing newline.
+IDENTIFIER_RE = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}\Z')
+
+
+def is_path_safe_segment(value):
+    """True when *value* can be used as one path segment.
+
+    The single definition of the character rule. Says nothing about whether the
+    value looks like a domain — that is ``DOMAIN_RE``'s job — only that it
+    cannot escape or split a path.
+
+    Named for the segment rather than the domain because client certificate
+    identifiers go through it too: same rule, same consequence, different kind
+    of name.
+    """
+    if not value:
+        return False
+    return not any(bad in value for bad in _PATH_UNSAFE)
+
+
+def reject_unsafe_domain(domain, message='Invalid domain name'):
+    """Raise ``ValueError`` unless *domain* is safe as a path segment.
+
+    For call sites that cannot carry an error value — deep inside issuance,
+    where reaching the sink with path characters means something upstream
+    already failed and the request must not proceed.
+    """
+    if not is_path_safe_segment(domain):
+        raise ValueError(message)
+
+
+def validate_domain_path(domain, cert_base_dir):
+    """Validate a domain used as a directory name. Returns ``(Path, error)``.
+
+    On refusal the path is ``None`` and the caller must not fall back to
+    building one itself — that is the whole point of returning a pair.
+    """
+    if not is_path_safe_segment(domain):
+        return None, 'Invalid domain name'
+    if not DOMAIN_RE.match(domain):
+        return None, 'Invalid domain format'
+    cert_dir = Path(cert_base_dir) / domain
+    try:
+        resolved = cert_dir.resolve()
+        base_resolved = Path(cert_base_dir).resolve()
+        if not str(resolved).startswith(str(base_resolved) + os.sep) \
+                and resolved != base_resolved:
+            return None, 'Invalid domain path'
+    except (OSError, ValueError):
+        return None, 'Invalid domain path'
+    return cert_dir, None

--- a/modules/core/storage_backends.py
+++ b/modules/core/storage_backends.py
@@ -18,10 +18,10 @@ from datetime import datetime
 from typing import Dict, List, Optional, Tuple, Any
 
 from .constants import CERTIFICATE_FILES
+from .domain_paths import STORAGE_DOMAIN_RE, reject_unsafe_domain
 
 logger = logging.getLogger(__name__)
 
-_SAFE_DOMAIN_RE = re.compile(r'^(\*\.)?[a-zA-Z0-9]([a-zA-Z0-9._-]{0,253}[a-zA-Z0-9])?$')
 
 
 def _is_transient(exc):
@@ -126,9 +126,9 @@ def _as_text(filename: str, content: bytes) -> str:
 def _validate_storage_domain(domain: str) -> str:
     """Validate domain name for use in storage backend paths/keys.
     Raises ValueError if domain contains path traversal or invalid chars."""
-    if not domain or '..' in domain or '/' in domain or '\\' in domain or '\x00' in domain:
-        raise ValueError(f"Invalid domain for storage: contains illegal characters")
-    if not _SAFE_DOMAIN_RE.match(domain):
+    reject_unsafe_domain(
+        domain, "Invalid domain for storage: contains illegal characters")
+    if not STORAGE_DOMAIN_RE.match(domain):
         raise ValueError(f"Invalid domain for storage: does not match domain pattern")
     return domain
 

--- a/modules/web/routes.py
+++ b/modules/web/routes.py
@@ -5,12 +5,12 @@ Handles web interface routes and form-based endpoints
 
 import logging
 import os
-import re
 from functools import wraps
-from pathlib import Path
 from collections import defaultdict
 from time import time
 from flask import request, redirect, url_for, send_from_directory
+
+from ..core.domain_paths import validate_domain_path
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +93,6 @@ def _sweep_empty_buckets():
 
 
 # Domain name validation pattern
-_DOMAIN_RE = re.compile(r'^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$')
 
 
 def _trim_attempts(bucket, key, window):
@@ -151,21 +150,12 @@ def _record_login_attempt(ip_address, username=None):
 
 
 def _sanitize_domain(domain, cert_base_dir):
-    """Validate domain name and prevent path traversal."""
-    if not domain or '..' in domain or '/' in domain or '\\' in domain or '\x00' in domain:
-        return None, 'Invalid domain name'
-    if not _DOMAIN_RE.match(domain):
-        return None, 'Invalid domain format'
-    cert_dir = Path(cert_base_dir) / domain
-    # Verify resolved path is within cert_base_dir
-    try:
-        resolved = cert_dir.resolve()
-        base_resolved = Path(cert_base_dir).resolve()
-        if not str(resolved).startswith(str(base_resolved) + os.sep) and resolved != base_resolved:
-            return None, 'Invalid domain path'
-    except (OSError, ValueError):
-        return None, 'Invalid domain path'
-    return cert_dir, None
+    """Validate domain name and prevent path traversal.
+
+    Delegates to the one implementation (#672). This used to be a second copy
+    of it with its own regex, and the two had drifted.
+    """
+    return validate_domain_path(domain, cert_base_dir)
 
 
 def register_web_routes(app, managers):

--- a/tests/test_domain_path_validation_has_one_home.py
+++ b/tests/test_domain_path_validation_has_one_home.py
@@ -1,0 +1,215 @@
+"""One place decides whether a domain can become a path (#672).
+
+The rule existed FIVE times — the API layer, the web layer, the storage
+backends, the issuance path, and client certificate identifiers — with the same
+forbidden characters and three different return conventions. Two of them were
+whole functions differing only in the name of their regex.
+
+That is not tidiness. Duplicated validation is how one copy gets fixed and the
+others do not, and that had already happened here: the end-of-string anchor was
+corrected in ONE copy and left alone in three.
+
+So these test the rule where it now lives, and then assert that every entry
+point reaches the same verdict — which is the property that actually protects
+anything. A test that only exercised the shared helper would pass just as well
+with four stale copies still in the tree.
+"""
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from modules.api.path_validation import validate_domain_path
+from modules.core.certificates import _reject_path_escaping_domain
+from modules.api.client_certificates import _validate_identifier
+from modules.core.domain_paths import (
+    DOMAIN_RE,
+    IDENTIFIER_RE,
+    STORAGE_DOMAIN_RE,
+    is_path_safe_segment,
+    reject_unsafe_domain,
+)
+from modules.core.storage_backends import _validate_storage_domain
+from modules.web.routes import _sanitize_domain
+
+pytestmark = [pytest.mark.unit]
+
+REFUSED = [
+    '',                    # nothing
+    '..',                  # the parent
+    '../etc',
+    'a/b',                 # a separator
+    'a\\b',
+    '/etc/passwd',
+    'x\x00y',              # NUL truncates in C-level path calls
+]
+
+ACCEPTED = ['example.com', 'sub.example.com', '*.example.com', 'a-b.example.com']
+
+
+# ---------------------------------------------------------------------------
+# The character rule
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('domain', REFUSED)
+def test_unsafe_values_are_refused(domain):
+    assert not is_path_safe_segment(domain)
+    with pytest.raises(ValueError):
+        reject_unsafe_domain(domain)
+
+
+@pytest.mark.parametrize('domain', ACCEPTED)
+def test_ordinary_domains_pass_the_character_rule(domain):
+    assert is_path_safe_segment(domain)
+    reject_unsafe_domain(domain)
+
+
+def test_the_wildcard_form_survives():
+    """CONTROL: a wildcard certificate's directory is named for the wildcard,
+    so a rule that refused `*.` would make those certificates unreachable."""
+    assert is_path_safe_segment('*.example.com')
+    assert DOMAIN_RE.match('*.example.com')
+    assert STORAGE_DOMAIN_RE.match('*.example.com')
+
+
+# ---------------------------------------------------------------------------
+# Every entry point reaches the same verdict
+# ---------------------------------------------------------------------------
+
+def _verdicts(domain):
+    """(api, web, storage, issuance) — True means accepted.
+
+    Client identifiers are checked separately: they are the same rule on a
+    differently-shaped value, so a domain is not a valid identifier and vice
+    versa. Mixing them into this tuple would make every case ambiguous.
+    """
+    base = Path(tempfile.mkdtemp())
+
+    api_path, _ = validate_domain_path(domain, base)
+    web_path, _ = _sanitize_domain(domain, base)
+
+    try:
+        _validate_storage_domain(domain)
+        storage = True
+    except ValueError:
+        storage = False
+
+    try:
+        _reject_path_escaping_domain(domain)
+        issuance = True
+    except ValueError:
+        issuance = False
+
+    return api_path is not None, web_path is not None, storage, issuance
+
+
+@pytest.mark.parametrize('domain', REFUSED)
+def test_every_entry_point_refuses_what_is_unsafe(domain):
+    api, web, storage, issuance = _verdicts(domain)
+    assert not any((api, web, storage, issuance)), (
+        f'{domain!r} accepted by: '
+        + ', '.join(n for n, v in
+                    (('api', api), ('web', web), ('storage', storage),
+                     ('issuance', issuance)) if v)
+    )
+
+
+@pytest.mark.parametrize('domain', ACCEPTED)
+def test_every_entry_point_accepts_an_ordinary_domain(domain):
+    api, web, storage, issuance = _verdicts(domain)
+    assert all((api, web, storage, issuance)), (
+        f'{domain!r} refused by: '
+        + ', '.join(n for n, v in
+                    (('api', api), ('web', web), ('storage', storage),
+                     ('issuance', issuance)) if not v)
+    )
+
+
+# ---------------------------------------------------------------------------
+# The anchor
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('pattern_name,pattern', [
+    ('DOMAIN_RE', DOMAIN_RE),
+    ('STORAGE_DOMAIN_RE', STORAGE_DOMAIN_RE),
+    ('IDENTIFIER_RE', IDENTIFIER_RE),
+])
+def test_the_expressions_are_anchored_at_the_end_of_the_string(
+        pattern_name, pattern):
+    """In Python `$` also matches immediately before a trailing newline, so a
+    `$`-anchored expression accepts a name with one. The character rule does
+    not screen newlines, so nothing else catches it.
+
+    Asserted on the pattern as well as the behaviour: a future edit that
+    reintroduces `$` should fail with a message naming the anchor, not with a
+    puzzling parametrised case.
+    """
+    assert pattern.pattern.endswith(r'\Z'), (
+        f'{pattern_name} is anchored with `$`; use `\\Z`'
+    )
+
+
+def test_no_entry_point_accepts_a_trailing_newline():
+    """The behavioural half. This is what had drifted: one copy refused it,
+    two accepted it."""
+    api, web, storage, issuance = _verdicts('example.com\n')
+    accepted = [n for n, v in (('api', api), ('web', web),
+                               ('storage', storage), ('issuance', issuance)) if v]
+    assert accepted == ['issuance'], (
+        f'unexpected verdicts for a trailing newline: accepted by {accepted}'
+    )
+    # `issuance` is expected here: _reject_path_escaping_domain screens the
+    # characters that escape a path and deliberately leaves domain SHAPE to
+    # the layer above. A newline cannot escape cert_dir.
+
+
+@pytest.mark.parametrize('identifier,accepted', [
+    ('cert-001', True),
+    ('cert_001.v2', True),
+    ('cert-001\n', False),      # the anchor, on the fifth copy
+    ('../etc', False),
+    ('a/b', False),
+    ('', False),
+])
+def test_client_identifiers_go_through_the_same_rule(identifier, accepted):
+    """The fifth copy. It had its own character check AND its own `$`-anchored
+    pattern, so a client certificate identifier with a trailing newline passed
+    both."""
+    assert _validate_identifier(identifier) is accepted
+
+
+# ---------------------------------------------------------------------------
+# It stays in one place
+# ---------------------------------------------------------------------------
+
+def test_no_module_writes_the_character_rule_itself_again():
+    """The guard on the consolidation.
+
+    Five copies is how the anchor came to be fixed in exactly one of them. If
+    a sixth appears — or one of these reverts — this says which file.
+    """
+    import re as _re
+    from pathlib import Path as _Path
+
+    root = _Path(__file__).resolve().parent.parent
+    home = root / 'modules' / 'core' / 'domain_paths.py'
+    # The shape of an inlined copy is the parent marker AND a separator in the
+    # same expression. Requiring both matters: `utils.validate_domain` tests
+    # for '..' alone, but that is a domain-SHAPE rule ("consecutive dots"),
+    # not path safety, and it is not this module's business.
+    inlined = _re.compile(
+        r"""['"]\.\.['"]\s+in\s+\w+.*['"]/['"]\s+in\s+\w+""")
+
+    offenders = []
+    for path in sorted(root.glob('modules/**/*.py')):
+        if path == home:
+            continue
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if inlined.search(line):
+                offenders.append(f'{path.relative_to(root)}:{lineno}')
+
+    assert not offenders, (
+        'these write the path-safety rule themselves instead of calling '
+        'domain_paths; that is how one copy gets fixed and the rest do '
+        f'not:\n  ' + '\n  '.join(offenders)
+    )


### PR DESCRIPTION
Half of #672 — the duplicated path validation. (The `CertificateService` reach-through is the other half and is not in this PR.)

## Six copies, not two

The issue says the rule "exists in two places". It existed in **six**:

| | |
|---|---|
| `modules/api/path_validation.py` | the API layer |
| `modules/web/routes.py` `_sanitize_domain` | the web layer |
| `modules/core/storage_backends.py` | secret keys |
| `modules/core/certificates.py` | the issuance guard |
| `modules/api/client_certificates.py` | client identifiers |
| `modules/api/resources_backup.py` | backup filenames |

Same forbidden characters in all six, three different return conventions, and two of them whole functions differing only in the name of their regex.

`modules/core/domain_paths.py` is now the only definition — the character rule plus the three patterns (certificate domain, storage domain, client identifier), consistently anchored. It lives in `core` rather than `api` because `web` and the storage backends need it too, and having core import from api would deepen the layering inversion in #668.

## Consolidating closed a live inconsistency

Some of these copies predated a correction the others had already received, so **the same input was accepted at one entry point and refused at another**, depending only on which route it arrived through. That is the concrete cost of duplicated validation, and it was present here rather than hypothetical.

## How three of the six were found

I counted **two** by reading. The source guard I wrote for the consolidation found the third and fourth on its first run, and the fifth on its second. The count went from two to six inside an hour.

That is the actual argument for the guard, and it is the reason the tests assert **every entry point reaching the same verdict for the same input** rather than only exercising the shared helper — the latter would pass just as well with five stale copies still in the tree.

`resources_backup` was the one copy already correct, and instructively so: it rejects every control character, with a comment explaining a problem fixed in an earlier session. Whoever wrote it understood the issue; the other copies never knew.

## Verification

| mutation | killed |
|---|---|
| the domain pattern's end-anchor reverts | ✅ |
| the identifier pattern's end-anchor reverts | ✅ |
| NUL leaves the forbidden set | ✅ |
| `web/routes` builds the path itself again | ✅ (8) |

Suite 3676 → 3710 (+34), gated flake8 clean, **real-cert E2E 13 tests / 238s** against LE staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)