### PR TITLE
refactor(#672): the config edit goes through the service, not around it

### DIFF
--- a/modules/api/resources_certificates.py
+++ b/modules/api/resources_certificates.py
@@ -14,7 +14,6 @@ from ..core.certificates import DomainOperationInProgress
 from ..core.constants import iter_cert_domain_dirs
 from .path_validation import validate_domain_path as _validate_domain_path
 from .resource_context import ApiContext, check_domain_scope
-from .tls_probe import _PROBE_PROTOCOLS
 
 logger = logging.getLogger(__name__)
 
@@ -160,9 +159,6 @@ def create_certificates_resources(api, models, ctx: ApiContext) -> dict:
             new_dns_provider = data.get('dns_provider')
             new_account_id = data.get('account_id')
             new_alias_dns_provider = data.get('alias_dns_provider')
-            new_deploy_port = data.get('deployment_port')
-            new_deploy_protocol = data.get('deployment_protocol')
-            new_deploy_host = data.get('deployment_host')
 
             # Allow requests that only set deployment probe fields
             # (deployment_port / deployment_protocol / deployment_host) without
@@ -213,72 +209,31 @@ def create_certificates_resources(api, models, ctx: ApiContext) -> dict:
                     }, 400
 
             try:
-                # Serialise this metadata read-modify-write against an in-flight
-                # renewal (which carries a pre-renewal metadata snapshot across
-                # its whole certbot run and would otherwise clobber this write).
-                with ctx.certificates.domain_lock(domain):
-                    # 1. Update on-disk metadata.json. Read through the manager
-                    # (which builds the path from the already-validated domain
-                    # and quarantines corrupt JSON instead of silently returning
-                    # {}) rather than opening cert_dir/'metadata.json' directly.
-                    metadata = ctx.certificates._load_metadata(domain)
+                # The read-modify-write, its validation, and the domain
+                # lock that serialises it against an in-flight renewal all
+                # live in the service now (#672). This is the adapter: shape
+                # the request into a change set, map the service's errors onto
+                # status codes.
+                changes = {
+                    'dns_provider': new_dns_provider,
+                    'account_id': new_account_id,
+                    'alias_dns_provider': new_alias_dns_provider,
+                }
+                # Probe keys are forwarded only when the caller SENT them:
+                # absent means "leave it alone", explicit null means "delete
+                # it", and the service depends on telling them apart.
+                for key in ('deployment_port', 'deployment_protocol',
+                            'deployment_host'):
+                    if key in data:
+                        changes[key] = data[key]
 
-                    old_provider = metadata.get('dns_provider')
-                    if new_dns_provider:
-                        metadata['dns_provider'] = new_dns_provider
-                    if new_account_id:
-                        metadata['account_id'] = new_account_id
-                    if new_alias_dns_provider:
-                        metadata['alias_dns_provider'] = new_alias_dns_provider
-
-                    # --- deployment probe config ---
-                    # Only touch probe config when the caller actually sends the
-                    # key: an ABSENT key leaves existing config intact, an explicit
-                    # null deletes it. Keying off `is not None` instead would let a
-                    # DNS-only PATCH silently wipe a cert's probe config.
-                    if 'deployment_port' in data:
-                        if new_deploy_port is not None:
-                            try:
-                                port = int(new_deploy_port)
-                                if port < 1 or port > 65535:
-                                    return {'error': 'deployment_port must be 1-65535'}, 400
-                                metadata['deployment_port'] = port
-                            except (TypeError, ValueError):
-                                return {'error': 'deployment_port must be an integer'}, 400
-                        else:
-                            metadata.pop('deployment_port', None)
-
-                    if 'deployment_protocol' in data:
-                        if new_deploy_protocol is not None:
-                            if new_deploy_protocol not in _PROBE_PROTOCOLS:
-                                return {
-                                    'error': f"deployment_protocol must be one of {_PROBE_PROTOCOLS!r}"
-                                }, 400
-                            metadata['deployment_protocol'] = new_deploy_protocol
-                        else:
-                            metadata.pop('deployment_protocol', None)
-
-                    if 'deployment_host' in data:
-                        if new_deploy_host is not None:
-                            if not isinstance(new_deploy_host, str):
-                                return {'error': 'deployment_host must be a string'}, 400
-                            host = new_deploy_host.strip()
-                            # A probe target is a bare hostname: no scheme, no path,
-                            # no whitespace, and no wildcard label (you deploy a
-                            # cert on a concrete name, not on "*.").
-                            if (not host or len(host) > 253 or host.startswith('*.')
-                                    or any(c in host for c in ' \t/\\')
-                                    or '://' in host):
-                                return {
-                                    'error': 'deployment_host must be a bare hostname '
-                                             '(no scheme, path, whitespace, or wildcard)'
-                                }, 400
-                            metadata['deployment_host'] = host
-                        else:
-                            metadata.pop('deployment_host', None)
-
-                    if not ctx.certificates._save_metadata(domain, metadata):
-                        return {'error': f'Failed to update metadata for domain: {domain}'}, 500
+                try:
+                    metadata, old_provider = ctx.cert_service.update_config(
+                        domain, changes)
+                except ValueError as e:
+                    return {'error': str(e)}, 400
+                except RuntimeError as e:
+                    return {'error': str(e)}, 500
                 logger.info(
                     f"Updated DNS provider for {domain}: "
                     f"{old_provider} → {new_dns_provider or old_provider}"

--- a/modules/api/resources_deployment.py
+++ b/modules/api/resources_deployment.py
@@ -82,7 +82,8 @@ def create_deployment_resources(api, models, ctx: ApiContext) -> dict:
             # defaults. Stored via PATCH /api/certificates/<domain> as
             # ``deployment_port``, ``deployment_protocol`` and (optional)
             # ``deployment_host``.
-            metadata = ctx.certificates._load_metadata(domain) if hasattr(ctx.certificates, '_load_metadata') else {}
+            # Through the service, not the manager's private method (#672).
+            metadata = ctx.cert_service.read_metadata(domain)
             raw_port = metadata.get('deployment_port')
             deploy_port = raw_port if raw_port is not None else 0
             deploy_protocol = metadata.get('deployment_protocol') or 'https-tls'

--- a/modules/api/tls_probe.py
+++ b/modules/api/tls_probe.py
@@ -14,6 +14,7 @@ Patching a name re-exported somewhere else rebinds that copy and leaves the
 call site untouched — a test that still runs and no longer tests anything.
 """
 import base64
+from ..core.constants import PROBE_PROTOCOLS
 import http.client
 import logging
 import os
@@ -104,7 +105,9 @@ def _tls_probe_timeout_seconds():
         return 3.0
     return max(1.0, min(value, 30.0))
 
-_PROBE_PROTOCOLS = ('https-tls', 'tls', 'smtp-starttls')
+# Moved to core.constants (#672); re-exported so the existing
+# imports of `_PROBE_PROTOCOLS` from here keep working.
+_PROBE_PROTOCOLS = PROBE_PROTOCOLS
 
 def _https_proxy_for(host):
     """Return (proxy_host, proxy_port, auth_headers) for tunneling to *host*.

--- a/modules/core/cert_service.py
+++ b/modules/core/cert_service.py
@@ -18,6 +18,7 @@ adapters map to HTTP 403.
 import logging
 
 from .structured_logging import scrub_log_value
+from .constants import PROBE_PROTOCOLS
 from .utils import validate_domain, validate_key_options
 
 logger = logging.getLogger(__name__)
@@ -261,6 +262,98 @@ class CertificateService:
             'san_count': len(prepared.get('san_domains') or []),
         })
         return result
+
+
+    # ------------------------------------------------------------------
+    # Configuration, as opposed to issuance
+    # ------------------------------------------------------------------
+
+    def read_metadata(self, domain):
+        """The certificate's stored metadata, or ``{}``.
+
+        A public read (#672). Route handlers were calling
+        ``certificate_manager._load_metadata`` — a private method — which meant
+        the manager could not change how it stores metadata without breaking
+        them. Reading through the manager still matters, though, and this keeps
+        that: it builds the path from the validated domain and quarantines
+        corrupt JSON rather than silently returning ``{}``.
+        """
+        return self._certs._load_metadata(domain) or {}
+
+    def update_config(self, domain, changes):
+        """Apply a configuration change to a certificate's metadata.
+
+        Takes the raw change set — not keyword arguments — because the
+        semantics depend on a key being ABSENT versus present-and-null: an
+        absent key leaves existing config alone, an explicit ``None`` deletes
+        it. Keyword defaults cannot express that, and getting it wrong lets a
+        DNS-only edit silently wipe a certificate's probe configuration.
+
+        Validation lives here rather than in the route so both HTTP layers get
+        the same answer, and raises :class:`ValueError` with the message the
+        caller should surface.
+
+        Returns ``(metadata, old_dns_provider)``.
+        """
+        # The whole read-modify-write happens under the domain lock, so an
+        # in-flight renewal — which carries a pre-renewal metadata snapshot
+        # across its entire certbot run — cannot clobber this write.
+        with self._certs.domain_lock(domain):
+            metadata = self.read_metadata(domain)
+            old_dns_provider = metadata.get('dns_provider')
+
+            for key in ('dns_provider', 'account_id', 'alias_dns_provider'):
+                value = changes.get(key)
+                if value:
+                    metadata[key] = value
+
+            if 'deployment_port' in changes:
+                port = changes['deployment_port']
+                if port is None:
+                    metadata.pop('deployment_port', None)
+                else:
+                    try:
+                        port = int(port)
+                    except (TypeError, ValueError):
+                        raise ValueError('deployment_port must be an integer')
+                    if port < 1 or port > 65535:
+                        raise ValueError('deployment_port must be 1-65535')
+                    metadata['deployment_port'] = port
+
+            if 'deployment_protocol' in changes:
+                protocol = changes['deployment_protocol']
+                if protocol is None:
+                    metadata.pop('deployment_protocol', None)
+                elif protocol not in PROBE_PROTOCOLS:
+                    raise ValueError(
+                        f"deployment_protocol must be one of {PROBE_PROTOCOLS!r}")
+                else:
+                    metadata['deployment_protocol'] = protocol
+
+            if 'deployment_host' in changes:
+                host = changes['deployment_host']
+                if host is None:
+                    metadata.pop('deployment_host', None)
+                else:
+                    if not isinstance(host, str):
+                        raise ValueError('deployment_host must be a string')
+                    host = host.strip()
+                    # A probe target is a bare hostname: no scheme, no path, no
+                    # whitespace, and no wildcard label — you deploy a
+                    # certificate on a concrete name, not on "*.".
+                    if (not host or len(host) > 253 or host.startswith('*.')
+                            or any(c in host for c in ' \t/\\')
+                            or '://' in host):
+                        raise ValueError(
+                            'deployment_host must be a bare hostname '
+                            '(no scheme, path, whitespace, or wildcard)')
+                    metadata['deployment_host'] = host
+
+            if not self._certs._save_metadata(domain, metadata):
+                raise RuntimeError(
+                    f'Failed to update metadata for domain: {domain}')
+
+        return metadata, old_dns_provider
 
     def prepare_reissue(self, *, domain, san_domains=None, dns_provider=None,
                         account_id=None, ca_provider=None, challenge_type=None,

--- a/modules/core/constants.py
+++ b/modules/core/constants.py
@@ -66,6 +66,12 @@ DEFAULT_RENEWAL_THRESHOLD_DAYS = 30
 # value here is now the one shipped installs have always run.
 DEFAULT_SESSION_TIMEOUT_HOURS = 8
 
+# Protocols the deployment probe can speak. A domain fact, not an API one: the
+# service validates against it and modules/api/tls_probe drives it (#672 — it
+# lived in the API layer, which core could not reach without importing api and
+# deepening #668).
+PROBE_PROTOCOLS = ('https-tls', 'tls', 'smtp-starttls')
+
 # Default deployment-status cache TTL, in seconds. Read by CacheManager as the
 # fallback when settings.json carries no cache_ttl.
 DEFAULT_CACHE_TTL = 300

--- a/tests/test_http_layers_do_not_reach_through.py
+++ b/tests/test_http_layers_do_not_reach_through.py
@@ -1,0 +1,161 @@
+"""HTTP layers go through the service, not around it (#672).
+
+`CertificateService` was created to be the one place issuance and configuration
+happen. It was half-adopted: create, renew and reissue went through it, while
+the config-edit and probe-read handlers called
+`certificate_manager._load_metadata` and `_save_metadata` — private methods —
+and did the read-modify-write inline.
+
+Two costs, and the second is the one that bit:
+
+* the manager could not change how it stores metadata without breaking route
+  handlers that were never supposed to know;
+* validation and locking lived in the route, so a second HTTP surface could
+  reach the same data with different rules. `test_patch_metadata_takes_domain_lock`
+  documents what that already cost once — a PATCH landing inside a renewal
+  window was silently reverted, and every later renewal used the decommissioned
+  credential.
+
+The read-modify-write, its validation and its lock now live in
+`CertificateService.update_config`; reads go through `read_metadata`. These
+assert both that nothing reaches around it again, and that the semantics the
+route used to own survived the move — particularly absent-versus-null, which is
+what stops a DNS-only edit from wiping a certificate's probe configuration.
+"""
+import re
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.certificates import CertificateManager
+from modules.core.cert_service import CertificateService
+
+pytestmark = [pytest.mark.unit]
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _service(stored=None, sink=None):
+    manager = CertificateManager.__new__(CertificateManager)
+    manager._domain_locks = {}
+    manager._domain_locks_mutex = threading.Lock()
+    manager._domain_lock_timeout = lambda: 0.2
+    manager._load_metadata = lambda domain: dict(stored or {})
+    manager._save_metadata = (
+        lambda domain, metadata: (sink.update(metadata) if sink is not None else None) or True)
+    return CertificateService(manager, MagicMock(), MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Nothing reaches around the service
+# ---------------------------------------------------------------------------
+
+def test_no_http_layer_calls_the_managers_private_metadata_methods():
+    offenders = []
+    for path in sorted(list(ROOT.glob('modules/api/**/*.py'))
+                       + list(ROOT.glob('modules/web/**/*.py'))):
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if re.search(r'\._(load|save)_metadata\s*\(', line):
+                offenders.append(f'{path.relative_to(ROOT)}:{lineno}')
+
+    assert not offenders, (
+        'these reach past CertificateService into the manager\'s private '
+        'methods, so the manager cannot change how it stores metadata:\n  '
+        + '\n  '.join(offenders)
+    )
+
+
+def test_the_service_still_reads_through_the_manager():
+    """CONTROL: the fix is a boundary, not a bypass.
+
+    Opening `cert_dir/metadata.json` directly from the service would satisfy
+    the scan above while losing what reading through the manager gives —
+    the path built from the validated domain, and corrupt JSON quarantined
+    rather than silently returning {}.
+    """
+    import inspect
+
+    src = inspect.getsource(CertificateService.read_metadata)
+    assert '_load_metadata' in src, (
+        'the service no longer reads through the manager'
+    )
+
+
+# ---------------------------------------------------------------------------
+# The semantics the route used to own
+# ---------------------------------------------------------------------------
+
+def test_an_absent_key_leaves_existing_probe_config_alone():
+    """The one that matters. Keying off `is not None` instead of `in changes`
+    would let a DNS-only edit silently wipe a certificate's probe config."""
+    sink = {}
+    service = _service(stored={'deployment_port': 8443,
+                               'deployment_protocol': 'tls',
+                               'deployment_host': 'www.example.com'},
+                       sink=sink)
+
+    metadata, _old = service.update_config('example.com',
+                                           {'dns_provider': 'route53'})
+
+    assert metadata['deployment_port'] == 8443
+    assert metadata['deployment_protocol'] == 'tls'
+    assert metadata['deployment_host'] == 'www.example.com'
+
+
+@pytest.mark.parametrize('key,stored', [
+    ('deployment_port', 8443),
+    ('deployment_protocol', 'tls'),
+    ('deployment_host', 'www.example.com'),
+])
+def test_an_explicit_null_deletes(key, stored):
+    service = _service(stored={key: stored})
+    metadata, _old = service.update_config('example.com', {key: None})
+    assert key not in metadata
+
+
+@pytest.mark.parametrize('changes,message', [
+    ({'deployment_port': 'abc'}, 'must be an integer'),
+    ({'deployment_port': 0}, 'must be 1-65535'),
+    ({'deployment_port': 70000}, 'must be 1-65535'),
+    ({'deployment_protocol': 'gopher'}, 'must be one of'),
+    ({'deployment_host': 12}, 'must be a string'),
+    ({'deployment_host': '*.example.com'}, 'bare hostname'),
+    ({'deployment_host': 'https://example.com'}, 'bare hostname'),
+    ({'deployment_host': 'a b'}, 'bare hostname'),
+    ({'deployment_host': 'a/b'}, 'bare hostname'),
+])
+def test_invalid_values_are_refused_by_the_service(changes, message):
+    """Validation moved with the write, so both HTTP surfaces get the same
+    answer instead of whichever one the route implemented."""
+    with pytest.raises(ValueError, match=message):
+        _service().update_config('example.com', changes)
+
+
+def test_a_valid_probe_config_is_stored():
+    sink = {}
+    service = _service(sink=sink)
+    metadata, _old = service.update_config('example.com', {
+        'deployment_port': '587',
+        'deployment_protocol': 'smtp-starttls',
+        'deployment_host': '  mail.example.com  ',
+    })
+
+    assert metadata['deployment_port'] == 587, 'a numeric string must coerce'
+    assert metadata['deployment_protocol'] == 'smtp-starttls'
+    assert metadata['deployment_host'] == 'mail.example.com', 'not trimmed'
+    assert sink['deployment_host'] == 'mail.example.com', 'not persisted'
+
+
+def test_a_failed_save_is_an_error_not_a_silent_success():
+    manager = CertificateManager.__new__(CertificateManager)
+    manager._domain_locks = {}
+    manager._domain_locks_mutex = threading.Lock()
+    manager._domain_lock_timeout = lambda: 0.2
+    manager._load_metadata = lambda domain: {}
+    manager._save_metadata = lambda domain, metadata: False
+
+    service = CertificateService(manager, MagicMock(), MagicMock())
+    with pytest.raises(RuntimeError, match='Failed to update metadata'):
+        service.update_config('example.com', {'dns_provider': 'route53'})

--- a/tests/test_patch_metadata_takes_domain_lock.py
+++ b/tests/test_patch_metadata_takes_domain_lock.py
@@ -81,23 +81,65 @@ def test_renew_uses_the_same_lock_object(cm):
     assert a is b
 
 
-def test_patch_handler_wraps_the_metadata_write_in_the_lock():
-    """The handler moved out of the create_api_resources closure (#667).
+def test_update_config_takes_the_lock_and_reports_contention(tmp_path):
+    """Where the lock lives now, asserted by BEHAVIOUR rather than by source.
 
-    It now lives in resources_certificates, and the manager it reaches through
-    is named `ctx.certificates` rather than the closure's `certificate_manager`
-    — so both the module this reads and the expression it looks for changed
-    with the move. The property is the same one: the metadata write happens
-    inside the per-domain lock, and a concurrent operation surfaces as
-    DomainOperationInProgress rather than a lost update.
+    The handler moved out of the closure in #667, and the read-modify-write
+    moved again in #672 — from the route into CertificateService.update_config.
+    Each move broke a source-scanning version of this test, which is the
+    argument for not writing another one: hold the lock, call the service, and
+    require it to refuse.
+    """
+    from unittest.mock import MagicMock
+
+    from modules.core.cert_service import CertificateService
+
+    manager = CertificateManager.__new__(CertificateManager)
+    manager._domain_locks = {}
+    manager._domain_locks_mutex = threading.Lock()
+    manager._domain_lock_timeout = lambda: 0.2
+    manager._load_metadata = lambda domain: {}
+    manager._save_metadata = lambda domain, metadata: True
+
+    service = CertificateService(manager, MagicMock(), MagicMock())
+
+    with manager.domain_lock('example.com'):
+        with pytest.raises(DomainOperationInProgress):
+            service.update_config('example.com', {'dns_provider': 'route53'})
+
+
+def test_update_config_writes_when_nothing_holds_the_lock(tmp_path):
+    """CONTROL: a test that only proves refusal would pass on a service that
+    always refuses."""
+    from unittest.mock import MagicMock
+
+    from modules.core.cert_service import CertificateService
+
+    written = {}
+    manager = CertificateManager.__new__(CertificateManager)
+    manager._domain_locks = {}
+    manager._domain_locks_mutex = threading.Lock()
+    manager._domain_lock_timeout = lambda: 0.2
+    manager._load_metadata = lambda domain: {'dns_provider': 'cloudflare'}
+    manager._save_metadata = lambda domain, metadata: written.update(metadata) or True
+
+    service = CertificateService(manager, MagicMock(), MagicMock())
+    metadata, old = service.update_config('example.com',
+                                          {'dns_provider': 'route53'})
+
+    assert old == 'cloudflare'
+    assert metadata['dns_provider'] == 'route53'
+    assert written['dns_provider'] == 'route53'
+
+
+def test_the_route_still_turns_contention_into_409():
+    """The half that stays at the HTTP layer: the service raises, the adapter
+    maps it. Source-level, because the mapping IS the route's only job here.
     """
     import inspect
     from modules.api import resources_certificates
 
     src = inspect.getsource(resources_certificates.create_certificates_resources)
-    assert 'ctx.certificates.domain_lock(domain)' in src, (
-        'the PATCH handler no longer takes the per-domain lock'
-    )
     assert 'except DomainOperationInProgress' in src, (
-        'the handler no longer reports a concurrent operation'
+        'the handler no longer reports a concurrent operation as 409'
     )

--- a/tests/test_patch_probe_config.py
+++ b/tests/test_patch_probe_config.py
@@ -191,3 +191,79 @@ def test_patch_null_deletes_deployment_host(tmp_path):
     )
     assert resp.status_code == 200
     assert 'deployment_host' not in saved
+
+
+# ---------------------------------------------------------------------------
+# The adapter's only job (#672)
+# ---------------------------------------------------------------------------
+#
+# The read-modify-write, its validation and its lock moved into
+# CertificateService. What is left in the route is turning the request into a
+# change set and turning the service's errors into status codes — so that is
+# what these test, at the HTTP boundary where the mapping actually happens.
+
+def test_an_invalid_value_becomes_a_400(tmp_path):
+    saved = {}
+    app = _build_app(_managers(tmp_path, saved))
+    resp = app.test_client().patch('/api/certificates/example.com',
+                                   json={'deployment_port': 70000})
+
+    assert resp.status_code == 400, resp.get_json()
+    assert 'deployment_port' in resp.get_json()['error']
+    assert not saved, 'a refused change was persisted anyway'
+
+
+def test_an_unknown_protocol_becomes_a_400(tmp_path):
+    app = _build_app(_managers(tmp_path, {}))
+    resp = app.test_client().patch('/api/certificates/example.com',
+                                   json={'deployment_protocol': 'gopher'})
+    assert resp.status_code == 400
+    assert 'deployment_protocol' in resp.get_json()['error']
+
+
+def test_a_hostname_with_a_scheme_becomes_a_400(tmp_path):
+    app = _build_app(_managers(tmp_path, {}))
+    resp = app.test_client().patch('/api/certificates/example.com',
+                                   json={'deployment_host': 'https://example.com'})
+    assert resp.status_code == 400
+    assert 'bare hostname' in resp.get_json()['error']
+
+
+def test_a_failed_write_becomes_a_500_not_a_200(tmp_path):
+    """The mapping that had no test. A save that returns False must not be
+    reported to the caller as a successful configuration change — they would
+    walk away believing the certificate now renews with the new provider.
+    """
+    managers = _managers(tmp_path, {})
+    managers['certificates']._save_metadata = MagicMock(return_value=False)
+    app = _build_app(managers)
+
+    resp = app.test_client().patch('/api/certificates/example.com',
+                                   json={'dns_provider': 'route53'})
+
+    assert resp.status_code == 500, resp.get_json()
+    assert 'Failed to update metadata' in resp.get_json()['error']
+
+
+def test_a_successful_change_updates_the_settings_entry_too(tmp_path):
+    """metadata.json is what renewal reads; settings.json is what the UI lists.
+    A change that lands in one and not the other is the shape of the bug this
+    handler's lock exists for.
+    """
+    managers = _managers(tmp_path, {})
+    app = _build_app(managers)
+
+    resp = app.test_client().patch('/api/certificates/example.com',
+                                   json={'dns_provider': 'route53'})
+
+    assert resp.status_code == 200, resp.get_json()
+    managers['settings'].update.assert_called_once()
+    mutate, reason = managers['settings'].update.call_args[0]
+    assert reason == 'dns_provider_change'
+
+    # Apply the mutation the route handed to the settings manager and check it
+    # actually rewrites the entry — asserting only that update() was called
+    # would pass for a closure that does nothing.
+    state = {'domains': [{'domain': 'example.com', 'dns_provider': 'cloudflare'}]}
+    mutate(state)
+    assert state['domains'][0]['dns_provider'] == 'route53'


### PR DESCRIPTION
The other half of #672. Closes it together with #742.

## The reach-through

Three route handlers called `certificate_manager._load_metadata` / `_save_metadata` — **private methods** — and did the read-modify-write inline, with the validation and the per-domain lock living in the route.

`CertificateService` now owns it: `read_metadata` for the read, `update_config` for the write. The routes shape the request and map errors onto status codes, which is all an adapter should do.

**`update_config` takes the raw change set, not keyword arguments.** The semantics depend on a key being *absent* versus *present-and-null*: absent leaves existing config alone, explicit `null` deletes it. Keyword defaults cannot express that, and getting it wrong is what once let a DNS-only edit silently wipe a certificate's probe configuration.

`PROBE_PROTOCOLS` moved from `modules/api/tls_probe` to `core.constants` — the service validates against it, and core cannot import from api without deepening #668. `tls_probe` re-exports the old name.

## A test that moved instead of being deleted

`test_patch_metadata_takes_domain_lock` documents a real past bug: a PATCH landing inside a renewal window was silently reverted, and every later renewal used the decommissioned credential.

One of its tests asserted the lock appears **in the route's source**. That assertion moved with the lock — and was rewritten to be **behavioural**: hold the lock, call the service, require `DomainOperationInProgress`. Its two previous versions each broke when the code moved (#667, then this), which is the argument against writing a third source-scanning one.

## The floor gate caught a real gap, and the gap was mine

The route lost forty covered lines to the service and fell to **48.6%**, under its floor of 50. The gate says exactly the right thing:

> Add tests, or say explicitly why the floor should move — lowering it to go green records the regression instead of fixing it.

Moving the floor was defensible on the arithmetic — a smaller module, the same absolute coverage. **But the missing coverage turned out to be real:** the `RuntimeError → 500` mapping I had just introduced had **no test at all**.

Five adapter tests at the HTTP boundary now, including the one that matters: a save returning `False` must be a **500**, not a 200. A caller told their change succeeded would walk away believing the certificate now renews with the new provider.

One of them also applies the settings mutation the route hands over rather than only asserting `update()` was called — the latter passes for a closure that does nothing.

## Verification

| mutation | killed |
|---|---|
| absent and null collapse (probe config wiped by a DNS-only edit) | ✅ |
| `update_config` loses the per-domain lock | ✅ |
| a failed save passes as success | ✅ (3) |
| `deployment_host` no longer has to be a string | ✅ |

Suite 3712 → 3734, gated flake8 clean, coverage floors met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)