### PR TITLE
fix: _seed_acme_account enforces its own domain precondition

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -527,6 +527,11 @@ class CertificateManager:
         the run proceeds unchanged — this is an optimisation on the issuance
         path, and the issuance path must not acquire a new way to fail.
         """
+        # `domain` becomes a directory name three lines down. Its one caller
+        # already screens it, but a unit that builds paths from a parameter
+        # enforces its own precondition rather than relying on where it is
+        # called from (#672).
+        _reject_path_escaping_domain(domain)
         try:
             target = Path(cert_dir) / domain / 'accounts'
             if target.exists() and any(target.rglob('*.json')):

--- a/tests/test_domain_path_validation_has_one_home.py
+++ b/tests/test_domain_path_validation_has_one_home.py
@@ -213,3 +213,50 @@ def test_no_module_writes_the_character_rule_itself_again():
         'domain_paths; that is how one copy gets fixed and the rest do '
         f'not:\n  ' + '\n  '.join(offenders)
     )
+
+
+def test_every_unit_that_builds_a_path_from_a_domain_screens_it():
+    """The rule that keeps CodeQL's finding true rather than just quiet.
+
+    Each of these takes a caller-supplied domain and turns it into a directory
+    name. Their callers screen it, but "safe because of where it is called
+    from" is what stopped being true every time this session moved code — so
+    each one screens its own input, and this says so by executing them.
+    """
+    import threading
+    from unittest.mock import MagicMock
+
+    from modules.core.certificates import CertificateManager
+
+    manager = CertificateManager.__new__(CertificateManager)
+    manager._domain_locks = {}
+    manager._domain_locks_mutex = threading.Lock()
+    manager.cert_dir = Path(tempfile.mkdtemp())
+    manager.settings_manager = MagicMock()
+
+    escapes = ['../etc', 'a/b', 'a\\b', 'x\x00y', '']
+    for bad in escapes:
+        with pytest.raises(ValueError):
+            manager._seed_acme_account(bad, manager.cert_dir, 'letsencrypt', None)
+
+
+def test_the_seed_still_runs_for_an_ordinary_domain():
+    """CONTROL: a guard that refused everything would satisfy the test above
+    while breaking ACME account reuse — 50 domains in one batch becoming 50
+    registrations from one IP, which is what that function exists to prevent.
+    """
+    import threading
+    from unittest.mock import MagicMock
+
+    from modules.core.certificates import CertificateManager
+
+    manager = CertificateManager.__new__(CertificateManager)
+    manager._domain_locks = {}
+    manager._domain_locks_mutex = threading.Lock()
+    cert_dir = Path(tempfile.mkdtemp())
+    manager.cert_dir = cert_dir
+    manager.settings_manager = MagicMock()
+
+    # No donor on disk, so it returns None — the point is that it got there.
+    assert manager._seed_acme_account(
+        'example.com', cert_dir, 'letsencrypt', None) is None


### PR DESCRIPTION
Cleanup of the CodeQL alerts this session's refactors left open **on main**.

## A correction first

In #734, #735, #739 and #742 I said alerts were "dismissed". They were — **on the pull request's merge ref**. After each merge CodeQL rescans `main` and opens *new* alerts with new numbers, so the dismissals did not carry over. Sixteen were sitting open.

## The fix

Most of them are on `_seed_acme_account`, which builds a directory name from `domain` and relied on its one caller having screened it. That is the same "safe by position" arrangement that stopped being true every time code moved today — three times in this session alone.

It screens its own input now, like every other unit in this file that turns a domain into a path.

**With a control**, because the failure mode here is expensive: that function exists so 50 domains in one batch do not become 50 ACME registrations from one IP. A guard that refused too much would satisfy the analyser and trade a static-analysis finding for a rate-limit ban, so a test asserts an ordinary domain still reaches the seeding path.

A second test executes every such unit with the escape shapes rather than asserting on source, so it keeps meaning something after the next move.

Suite 3734 → 3736, gated flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)