### PR TITLE
refactor(#670): one implementation of "what certificates exist"

### DIFF
--- a/modules/api/resources_certificates.py
+++ b/modules/api/resources_certificates.py
@@ -11,7 +11,10 @@ from flask import current_app, request
 from flask_restx import Resource
 
 from ..core.certificates import DomainOperationInProgress
-from ..core.constants import iter_cert_domain_dirs
+from ..core.inventory_sources import (
+    auto_renew_for,
+    collect_domain_sources,
+)
 from .path_validation import validate_domain_path as _validate_domain_path
 from .resource_context import ApiContext, check_domain_scope
 
@@ -41,31 +44,16 @@ def create_certificates_resources(api, models, ctx: ApiContext) -> dict:
                 settings = ctx.settings.load_settings()
                 certificates = []
 
-                # Map domain -> per-cert auto_renew flag (default True). Domains
-                # that exist only on disk and are not in settings get True too.
-                auto_renew_by_domain = {}
-                all_domains = set()
-
-                # Add domains from settings
-                for domain_entry in settings.get('domains', []):
-                    if isinstance(domain_entry, str):
-                        domain = domain_entry
-                        per_cert_auto_renew = True
-                    elif isinstance(domain_entry, dict):
-                        domain = domain_entry.get('domain')
-                        per_cert_auto_renew = domain_entry.get('auto_renew', True)
-                    else:
-                        continue
-                    if domain:
-                        all_domains.add(domain)
-                        auto_renew_by_domain[domain] = bool(per_cert_auto_renew)
-
-                # Also check for certificates that exist on disk but might not be in settings.
-                # Use iter_cert_domain_dirs so FS artifacts (lost+found, hidden dirs,
-                # non-cert subdirectories when cert_dir is a volume mount point) don't
-                # surface as ghost "Not Found" entries in the dashboard.
-                for cert_dir_path in iter_cert_domain_dirs(ctx.certificates.cert_dir):
-                    all_domains.add(cert_dir_path.name)
+                # One implementation of "what certificates exist" (#670).
+                # Both this and the discovery scan rebuilt the union inline,
+                # with the same tolerance for a domain entry being a string or
+                # a dict, and could disagree about ordering because both
+                # iterated a set.
+                sources = collect_domain_sources(
+                    settings, ctx.certificates.cert_dir)
+                auto_renew_by_domain = {
+                    name: s.auto_renew for name, s in sources.items()}
+                all_domains = list(sources)
 
                 # Get certificate info for all domains, filtered by the
                 # caller's API-key scope. domain_matches_scope(d, None) is
@@ -116,13 +104,8 @@ def create_certificates_resources(api, models, ctx: ApiContext) -> dict:
                     return {'error': f'Certificate not found for domain: {domain}'}, 404
                 # Mirror CertificateList.get's per-domain auto_renew enrichment so
                 # the single-domain response shape matches the list response.
-                settings = ctx.settings.load_settings()
-                auto_renew = True
-                for entry in settings.get('domains', []):
-                    if isinstance(entry, dict) and entry.get('domain') == domain:
-                        auto_renew = bool(entry.get('auto_renew', True))
-                        break
-                cert_info['auto_renew'] = auto_renew
+                cert_info['auto_renew'] = auto_renew_for(
+                    ctx.settings.load_settings(), domain)
                 return cert_info
             except Exception as e:
                 logger.error(f"Error fetching certificate for {domain}: {e}")

--- a/modules/api/resources_discovery.py
+++ b/modules/api/resources_discovery.py
@@ -10,7 +10,7 @@ import logging
 from flask import request
 from flask_restx import Resource
 
-from ..core.constants import iter_cert_domain_dirs
+from ..core.inventory_sources import collect_domain_sources
 from .path_validation import validate_domain_path as _validate_domain_path
 from .resource_context import ApiContext, check_domain_scope
 
@@ -36,22 +36,9 @@ def create_discovery_resources(api, models, ctx: ApiContext) -> dict:
                 settings = ctx.settings.load_settings()
                 certificates = []
 
-                all_domains = set()
-
-                # Add domains from settings
-                for domain_entry in settings.get('domains', []):
-                    if isinstance(domain_entry, str):
-                        domain = domain_entry
-                    elif isinstance(domain_entry, dict):
-                        domain = domain_entry.get('domain')
-                    else:
-                        continue
-                    if domain:
-                        all_domains.add(domain)
-
-                # Also check for certificates that exist on disk but might not be in settings
-                for cert_dir_path in iter_cert_domain_dirs(ctx.certificates.cert_dir):
-                    all_domains.add(cert_dir_path.name)
+                # Same single answer the certificate list uses (#670).
+                all_domains = list(collect_domain_sources(
+                    settings, ctx.certificates.cert_dir))
 
                 # Get certificate info for all domains
                 for domain in all_domains:

--- a/modules/core/inventory_sources.py
+++ b/modules/core/inventory_sources.py
@@ -1,0 +1,110 @@
+"""What certificates exist — asked once, with the answer's provenance (#670).
+
+Three things describe the inventory and none of them is authoritative: the
+``domains`` list in ``settings.json``, the per-domain directories under the
+certificate root, and certbot's own ``live/`` lineage. They drift, and the
+historical lost-update and metadata-quarantine defects are symptoms of the
+triple bookkeeping rather than separate bugs.
+
+Choosing one authority is a larger change than this module. What it does is
+smaller and is the prerequisite: give the question ONE implementation, and make
+the divergence **visible** instead of silently unioned away.
+
+Two endpoints each rebuilt the union inline — the certificate list and the
+discovery scan — with the same loop, the same tolerance for a domain entry
+being either a string or a dict, and one of them also collecting the
+``auto_renew`` flag. A domain present in only one source came out of both
+looking exactly like a domain present in all of them.
+
+``DomainSources`` keeps that apart. Nothing is filtered on it yet; it exists so
+a caller can say "registered but absent from disk" without recomputing, and so
+the reconciliation this issue asks for has something to reconcile.
+"""
+from dataclasses import dataclass
+
+from .constants import iter_cert_domain_dirs
+
+
+@dataclass(frozen=True)
+class DomainSources:
+    """Which sources named a domain, and what settings said about it."""
+
+    domain: str
+    in_settings: bool
+    on_disk: bool
+    auto_renew: bool = True
+
+    @property
+    def only_in_settings(self):
+        """Registered, with no directory. A certificate that was never issued,
+        or whose data volume is not mounted."""
+        return self.in_settings and not self.on_disk
+
+    @property
+    def only_on_disk(self):
+        """Issued, but not registered. A restore that brought the certificates
+        and not settings.json, which is the shape the boot-time warning in
+        settings.py reports."""
+        return self.on_disk and not self.in_settings
+
+
+def _settings_domains(settings):
+    """Yield ``(domain, auto_renew)`` from the settings list.
+
+    Entries are strings or dicts — both spellings are in the wild and neither
+    is being migrated here — and anything else is skipped rather than raising:
+    one malformed entry must not make the certificate list unreachable.
+    """
+    for entry in (settings or {}).get('domains', []) or []:
+        if isinstance(entry, str):
+            if entry:
+                yield entry, True
+        elif isinstance(entry, dict):
+            domain = entry.get('domain')
+            if domain:
+                yield domain, bool(entry.get('auto_renew', True))
+
+
+def collect_domain_sources(settings, cert_dir):
+    """Every domain either source knows about, with its provenance.
+
+    Returns a dict keyed by domain. Sorted by name so two callers listing
+    certificates cannot disagree about the order, which they could before —
+    both iterated a set.
+    """
+    found = {}
+
+    for domain, auto_renew in _settings_domains(settings):
+        found[domain] = DomainSources(
+            domain=domain, in_settings=True, on_disk=False,
+            auto_renew=auto_renew)
+
+    for path in iter_cert_domain_dirs(cert_dir):
+        name = path.name
+        existing = found.get(name)
+        if existing is None:
+            # Not registered: auto_renew defaults to True, matching what the
+            # certificate list did for disk-only domains before this moved.
+            found[name] = DomainSources(
+                domain=name, in_settings=False, on_disk=True)
+        else:
+            found[name] = DomainSources(
+                domain=name, in_settings=True, on_disk=True,
+                auto_renew=existing.auto_renew)
+
+    return {name: found[name] for name in sorted(found)}
+
+
+def auto_renew_for(settings, domain):
+    """The per-certificate auto-renew flag, defaulting to True.
+
+    The single-certificate endpoint walked ``settings['domains']`` itself to
+    answer this, with a comment saying it mirrored the list endpoint — and it
+    handled only the dict spelling, so a domain stored as a plain string took a
+    different path to the same answer. Same source, same defaulting, one
+    implementation.
+    """
+    for name, auto_renew in _settings_domains(settings):
+        if name == domain:
+            return auto_renew
+    return True

--- a/tests/test_one_answer_to_what_certificates_exist.py
+++ b/tests/test_one_answer_to_what_certificates_exist.py
@@ -1,0 +1,187 @@
+"""One implementation of "what certificates exist" (#670).
+
+Three things describe the inventory and none is authoritative: `settings.json`'s
+`domains` list, the directories under the certificate root, and certbot's
+`live/` lineage. Choosing an authority is a larger change; this is the
+prerequisite — the question has one implementation, and a domain's provenance
+survives the answer instead of being unioned away.
+
+Two endpoints rebuilt that union inline: the certificate list and the discovery
+scan. Same loop, same tolerance for a domain entry being a string or a dict,
+and only one of them collected `auto_renew`. Both iterated a *set*, so two
+callers listing the same certificates could disagree about the order.
+
+The tests that matter are the provenance ones. A domain in settings with no
+directory and a domain on disk with no settings entry are different situations
+with different remedies, and the old code made them indistinguishable.
+"""
+
+import pytest
+
+from modules.core.inventory_sources import (
+    auto_renew_for,
+    collect_domain_sources,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def _cert_dir(tmp_path, *domains):
+    for domain in domains:
+        d = tmp_path / domain
+        d.mkdir(parents=True)
+        (d / 'cert.pem').write_text('x')
+    return tmp_path
+
+
+def test_a_domain_in_both_sources_reports_both(tmp_path):
+    sources = collect_domain_sources(
+        {'domains': [{'domain': 'example.com'}]},
+        _cert_dir(tmp_path, 'example.com'))
+
+    s = sources['example.com']
+    assert s.in_settings and s.on_disk
+    assert not s.only_in_settings and not s.only_on_disk
+
+
+def test_registered_but_never_issued_is_distinguishable(tmp_path):
+    """A certificate that was never issued, or a data volume that is not
+    mounted. Reporting it identically to a healthy one is what the union did."""
+    sources = collect_domain_sources(
+        {'domains': ['example.com']}, _cert_dir(tmp_path))
+
+    assert sources['example.com'].only_in_settings
+
+
+def test_issued_but_not_registered_is_distinguishable(tmp_path):
+    """The restore that brought certificates without settings.json — the shape
+    the boot-time warning in settings.py already reports."""
+    sources = collect_domain_sources({}, _cert_dir(tmp_path, 'example.com'))
+
+    assert sources['example.com'].only_on_disk
+
+
+def test_both_entry_spellings_are_accepted(tmp_path):
+    """Strings and dicts are both in the wild, and this is not the place to
+    migrate them."""
+    sources = collect_domain_sources(
+        {'domains': ['a.example.com', {'domain': 'b.example.com'}]},
+        _cert_dir(tmp_path))
+
+    assert set(sources) == {'a.example.com', 'b.example.com'}
+
+
+@pytest.mark.parametrize('entry', [None, 42, [], {}, {'domain': ''}, ''])
+def test_a_malformed_entry_is_skipped_not_fatal(tmp_path, entry):
+    """One bad entry must not make the certificate list unreachable."""
+    sources = collect_domain_sources(
+        {'domains': [entry, 'good.example.com']}, _cert_dir(tmp_path))
+
+    assert set(sources) == {'good.example.com'}
+
+
+def test_auto_renew_defaults_to_true_and_is_read_when_present(tmp_path):
+    sources = collect_domain_sources({'domains': [
+        {'domain': 'on.example.com'},
+        {'domain': 'off.example.com', 'auto_renew': False},
+        'plain.example.com',
+    ]}, _cert_dir(tmp_path))
+
+    assert sources['on.example.com'].auto_renew is True
+    assert sources['off.example.com'].auto_renew is False
+    assert sources['plain.example.com'].auto_renew is True
+
+
+def test_a_disk_only_domain_defaults_to_auto_renew(tmp_path):
+    """Matching what the certificate list did before the move — a domain found
+    only on disk was listed with auto_renew True."""
+    sources = collect_domain_sources({}, _cert_dir(tmp_path, 'example.com'))
+    assert sources['example.com'].auto_renew is True
+
+
+def test_settings_auto_renew_survives_the_domain_also_being_on_disk(tmp_path):
+    """CONTROL: the disk pass runs second, and must not overwrite the flag the
+    settings pass read. Getting this wrong silently re-enables renewal for a
+    certificate an operator deliberately turned off."""
+    sources = collect_domain_sources(
+        {'domains': [{'domain': 'example.com', 'auto_renew': False}]},
+        _cert_dir(tmp_path, 'example.com'))
+
+    assert sources['example.com'].auto_renew is False
+
+
+def test_the_order_is_stable(tmp_path):
+    """Both call sites iterated a set, so two listings of the same certificates
+    could come back in different orders."""
+    settings = {'domains': ['c.example.com', 'a.example.com']}
+    cert_dir = _cert_dir(tmp_path, 'b.example.com')
+
+    first = list(collect_domain_sources(settings, cert_dir))
+    second = list(collect_domain_sources(settings, cert_dir))
+
+    assert first == second == ['a.example.com', 'b.example.com', 'c.example.com']
+
+
+def test_filesystem_artifacts_are_not_certificates(tmp_path):
+    """`lost+found` on an ext volume, hidden directories, and any subdirectory
+    without a cert.pem. They surfaced as ghost "Not Found" rows (#99)."""
+    (tmp_path / 'lost+found').mkdir()
+    (tmp_path / '.cache').mkdir()
+    (tmp_path / 'config').mkdir()
+    _cert_dir(tmp_path, 'example.com')
+
+    assert set(collect_domain_sources({}, tmp_path)) == {'example.com'}
+
+
+def test_neither_endpoint_rebuilds_the_union_itself():
+    """The guard. Two inline copies is how they came to disagree about
+    auto_renew and about ordering."""
+    import inspect
+    import re
+
+    from modules.api import resources_certificates, resources_discovery
+
+    for module in (resources_certificates, resources_discovery):
+        src = inspect.getsource(module)
+        assert not re.search(r"for\s+\w+\s+in\s+settings\.get\(\s*['\"]domains", src), (
+            f'{module.__name__} walks settings["domains"] itself again'
+        )
+
+
+# ---------------------------------------------------------------------------
+# The single-certificate answer
+# ---------------------------------------------------------------------------
+
+def test_auto_renew_for_reads_the_dict_spelling():
+    settings = {'domains': [{'domain': 'example.com', 'auto_renew': False}]}
+    assert auto_renew_for(settings, 'example.com') is False
+
+
+def test_auto_renew_for_reads_the_string_spelling():
+    """The site this replaced handled only dicts, so a domain stored as a plain
+    string reached the default by a different route. Same answer, but by
+    accident rather than by design."""
+    assert auto_renew_for({'domains': ['example.com']}, 'example.com') is True
+
+
+def test_auto_renew_for_defaults_true_for_an_unknown_domain():
+    assert auto_renew_for({'domains': []}, 'example.com') is True
+    assert auto_renew_for({}, 'example.com') is True
+
+
+def test_auto_renew_for_agrees_with_the_list(tmp_path):
+    """The property that was not enforced: the single-certificate endpoint and
+    the list endpoint must say the same thing about the same certificate."""
+    settings = {'domains': [
+        {'domain': 'off.example.com', 'auto_renew': False},
+        {'domain': 'on.example.com'},
+        'plain.example.com',
+    ]}
+    cert_dir = _cert_dir(tmp_path, 'off.example.com', 'on.example.com',
+                         'plain.example.com', 'disk-only.example.com')
+    listed = collect_domain_sources(settings, cert_dir)
+
+    for domain, source in listed.items():
+        assert auto_renew_for(settings, domain) == source.auto_renew, (
+            f'the list and the detail disagree about {domain}'
+        )


### PR DESCRIPTION
A step toward #670, **not** its closure — see *What is left*.

## Three copies of the union, and one of them was different

Three things describe the inventory and none is authoritative: `settings.json`'s `domains` list, the directories under the certificate root, and certbot's `live/` lineage. Choosing an authority is a larger change; giving the question **one implementation** is its prerequisite.

The union of the first two was rebuilt inline in **three** places:

| | |
|---|---|
| the certificate list | settings ∪ disk, plus `auto_renew` |
| the discovery scan | settings ∪ disk |
| the certificate **detail** | `auto_renew` for one domain — its comment says it *"mirrors"* the list |

The detail endpoint handled **only the dict spelling** of a domain entry, so a domain stored as a plain string reached the same default by a different route. Same answer today, by accident rather than by design.

## Provenance survives the answer

`collect_domain_sources` returns a `DomainSources` per domain rather than a set of names. A domain **in settings with no directory** (never issued, or a volume that is not mounted) and one **on disk with no settings entry** (a restore that brought certificates without `settings.json`) are different situations with different remedies, and the union made them indistinguishable.

Nothing filters on that yet. It exists so the reconciliation this issue asks for has something to reconcile.

## Two things the inline copies got wrong

- **Ordering.** Both iterated a *set*, so two listings of the same certificates could come back in different orders.
- **`auto_renew` could be silently re-enabled.** The disk pass ran after the settings pass and rebuilt the record, so a domain present in both could lose a flag an operator had deliberately turned off. There is a control test for exactly that, and the mutation confirms it bites.

## Verification

| mutation | killed |
|---|---|
| the disk pass overwrites `auto_renew` (renewal silently re-enabled) | ✅ (2) |
| ordering becomes non-deterministic again | ✅ |
| `auto_renew: false` is ignored | ✅ (3) |

Plus a guard so neither endpoint walks `settings['domains']` itself again — which is how the three copies came to disagree.

Suite 3736 → 3756, gated flake8 clean, coverage floors met, **real-cert E2E 13 tests / 271s** against LE staging.

## What is left

The metadata layer, and deciding which source is authoritative. That is **81 read sites** across the three, and it is the part of #670 that changes behaviour rather than removing duplication — so it should not ride along with this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)