### PR TITLE
feat: settings.json declares its schema, and a file from the future is refused (#669)

### DIFF
--- a/modules/core/constants.py
+++ b/modules/core/constants.py
@@ -66,6 +66,13 @@ DEFAULT_RENEWAL_THRESHOLD_DAYS = 30
 # value here is now the one shipped installs have always run.
 DEFAULT_SESSION_TIMEOUT_HOURS = 8
 
+# Shape of settings.json, bumped ONLY when that shape changes — unlike
+# `certmate_version`, which is the product version and moves on every release
+# (#669). A file whose schema is NEWER than this is refused rather than read:
+# an older process writing to a shape it does not understand is the failure
+# rollback actually produces, and it is silent.
+SETTINGS_SCHEMA_VERSION = 1
+
 # Protocols the deployment probe can speak. A domain fact, not an API one: the
 # service validates against it and modules/api/tls_probe drives it (#672 — it
 # lived in the API layer, which core could not reach without importing api and

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -11,7 +11,7 @@ from collections import deque
 from pathlib import Path
 
 from modules import __version__ as _CERTMATE_VERSION
-from .constants import iter_cert_domain_dirs
+from .constants import SETTINGS_SCHEMA_VERSION, iter_cert_domain_dirs
 from .file_operations import FileOperations, _backup_passphrase
 from .utils import (
     generate_secure_token, validate_email, validate_api_token, validate_domain,
@@ -132,6 +132,21 @@ _NON_SECRET_KEY_NAMES = frozenset({
     'default_key_size',
     'default_elliptic_curve',
 })
+
+
+class SettingsSchemaTooNewError(SettingsUnreadableError):
+    """settings.json declares a schema this build does not understand (#669).
+
+    Subclasses SettingsUnreadableError so app.py stops the process rather than
+    starting an instance that will write a shape it cannot read back. The
+    alternative — logging and continuing — is what the product-version check
+    did, and it leaves an older process free to overwrite fields it does not
+    know about.
+
+    Escapable on purpose: ``CERTMATE_ALLOW_SCHEMA_DOWNGRADE=1`` proceeds
+    anyway, for an operator who has read the release notes and accepts the
+    consequence. Safe by default, deliberate to override.
+    """
 
 
 class BearerTokenUnusableError(SettingsUnreadableError):
@@ -876,6 +891,10 @@ class SettingsManager:
 
         with self._lock:
             default_settings = {
+                # The shape a fresh install writes (#669). Present here as well
+                # as in the stamping below because a fresh install never
+                # reaches that path — it has no file to migrate.
+                'settings_schema_version': SETTINGS_SCHEMA_VERSION,
                 'cloudflare_token': '',
                 'domains': [],
                 'email': '',
@@ -968,6 +987,9 @@ class SettingsManager:
 
             # Only create full template for first-time setup
             first_time_template = {
+                # Same reason as default_settings: a first boot writes
+                # this dict and never reaches the stamping path (#669).
+                'settings_schema_version': SETTINGS_SCHEMA_VERSION,
                 'cloudflare_token': '',
                 'domains': [],
                 'email': '',
@@ -1081,6 +1103,36 @@ class SettingsManager:
                             disk_version, _CERTMATE_VERSION
                         )
 
+                # Schema gate (#669). `certmate_version` above is the PRODUCT
+                # version: it moves on every release, so it cannot say whether
+                # the shape changed. This one moves only when it does.
+                #
+                # A file from the future is refused rather than read. The
+                # shape-sniffing migrations below still run at every version —
+                # they are not only migrations, they are also the defence
+                # against a stale settings tab POSTing an old payload shape and
+                # reintroducing a retired field.
+                disk_schema = settings.get('settings_schema_version')
+                if isinstance(disk_schema, int) and disk_schema > SETTINGS_SCHEMA_VERSION:
+                    if os.getenv('CERTMATE_ALLOW_SCHEMA_DOWNGRADE') == '1':
+                        logger.error(
+                            "settings.json declares schema v%s and this build "
+                            "understands v%s. Continuing because "
+                            "CERTMATE_ALLOW_SCHEMA_DOWNGRADE=1 — this process "
+                            "may overwrite fields it does not know about.",
+                            disk_schema, SETTINGS_SCHEMA_VERSION)
+                    else:
+                        raise SettingsSchemaTooNewError(
+                            f"settings.json declares schema v{disk_schema} but "
+                            f"this build understands v{SETTINGS_SCHEMA_VERSION}. "
+                            f"Refusing to start: an older process writing this "
+                            f"file can drop fields it cannot read. Run the "
+                            f"newer version, restore a matching backup from "
+                            f"{self.file_ops.backup_dir / 'unified'}, or set "
+                            f"CERTMATE_ALLOW_SCHEMA_DOWNGRADE=1 to proceed "
+                            f"anyway."
+                        )
+
                 # Apply migrations for backward compatibility
                 settings, was_migrated = self._migrate_settings_format(settings)
 
@@ -1157,6 +1209,12 @@ class SettingsManager:
                 # a write when the version actually changed.
                 if settings.get('certmate_version') != _CERTMATE_VERSION:
                     settings['certmate_version'] = _CERTMATE_VERSION
+                    was_migrated = True
+                # Stamp the schema too. A file that predates versioning has
+                # just been through the shape migrations above, so it is now v1
+                # whatever it was before.
+                if settings.get('settings_schema_version') != SETTINGS_SCHEMA_VERSION:
+                    settings['settings_schema_version'] = SETTINGS_SCHEMA_VERSION
                     was_migrated = True
 
                 # If the save fails (disk full, permission denied, validation
@@ -1334,6 +1392,17 @@ class SettingsManager:
                 if not isinstance(settings, dict):
                     logger.error("Settings must be a dictionary")
                     return False
+
+                # Every write declares the schema it wrote (#669).
+                #
+                # Stamping only on load is not enough: a caller that hands over
+                # a payload without the key — which POST /api/settings does,
+                # and which any future route may do — drops it from the file,
+                # and a file with no declared schema is one an older build
+                # reads happily. The gate in load_settings can only refuse what
+                # is written down, so it is written here, where every write
+                # passes.
+                settings['settings_schema_version'] = SETTINGS_SCHEMA_VERSION
 
                 # Validate critical settings before saving
                 if 'email' in settings and settings['email']:

--- a/tests/test_settings_schema_version.py
+++ b/tests/test_settings_schema_version.py
@@ -1,0 +1,180 @@
+"""settings.json declares its schema, and a file from the future is refused (#669).
+
+There was already a `certmate_version` on disk and a downgrade *warning*. That
+field is the PRODUCT version: it moves on every release, including the many
+with no shape change, and it compares only major.minor — so it cannot answer
+"is this file a shape I understand", which is the question that matters when
+someone rolls back.
+
+`settings_schema_version` moves only when the shape does. A file declaring a
+newer one is refused rather than read, because the failure a rollback actually
+produces is silent: an older process reading a file it half-understands and
+writing it back without the fields it never knew about.
+
+The refusal is escapable — `CERTMATE_ALLOW_SCHEMA_DOWNGRADE=1` — because an
+operator who has read the release notes may have good reason. Safe by default,
+deliberate to override.
+
+What did NOT change: the shape-sniffing migrations still run at every version.
+They are not only migrations. Migration 4's own comment says it must stay
+"idempotent and permanent" because a stale settings tab can POST an old payload
+shape at any time, so gating them behind a version bump would remove a
+defence, not a redundancy.
+"""
+import json
+
+import pytest
+
+from modules.core.constants import SETTINGS_SCHEMA_VERSION
+from modules.core.file_operations import FileOperations
+from modules.core.settings import SettingsManager, SettingsSchemaTooNewError
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def manager(tmp_path):
+    dirs = [tmp_path / n for n in ('certificates', 'data', 'backups', 'logs')]
+    for d in dirs:
+        d.mkdir()
+    return SettingsManager(FileOperations(*dirs), dirs[1] / 'settings.json')
+
+
+def _write(manager, payload):
+    manager.settings_file.write_text(json.dumps(payload))
+
+
+# ---------------------------------------------------------------------------
+# Stamping
+# ---------------------------------------------------------------------------
+
+def test_a_fresh_install_declares_the_current_schema(manager):
+    settings = manager.load_settings(use_cache=False)
+    assert settings['settings_schema_version'] == SETTINGS_SCHEMA_VERSION
+
+
+def test_a_file_that_predates_versioning_is_stamped(manager):
+    """Every existing install. It has just been through the shape migrations,
+    so it IS the current schema whatever it was before."""
+    _write(manager, {'domains': ['example.com'], 'email': 'a@b.com'})
+
+    settings = manager.load_settings(use_cache=False)
+
+    assert settings['settings_schema_version'] == SETTINGS_SCHEMA_VERSION
+    assert json.loads(manager.settings_file.read_text())[
+        'settings_schema_version'] == SETTINGS_SCHEMA_VERSION, 'not persisted'
+
+
+def test_the_current_schema_is_read_without_complaint(manager):
+    _write(manager, {'settings_schema_version': SETTINGS_SCHEMA_VERSION,
+                     'domains': [], 'email': 'a@b.com'})
+    assert manager.load_settings(use_cache=False)['email'] == 'a@b.com'
+
+
+def test_a_write_that_omits_the_key_still_declares_the_schema(manager):
+    """The one that makes the gate worth having.
+
+    Stamping on load alone leaves a hole the app walks through daily: a caller
+    that hands over a payload without the key — POST /api/settings does — wrote
+    a file with NO declared schema, and a file with no declared schema is one an
+    older build reads happily. The gate can only refuse what is written down.
+    """
+    manager.load_settings(use_cache=False)
+
+    manager.save_settings({'email': 'b@example.com', 'domains': [],
+                           'dns_provider': 'cloudflare'})
+
+    on_disk = json.loads(manager.settings_file.read_text())
+    assert on_disk.get('settings_schema_version') == SETTINGS_SCHEMA_VERSION, (
+        'a save that omitted the key erased the schema declaration'
+    )
+
+
+# ---------------------------------------------------------------------------
+# A file from the future
+# ---------------------------------------------------------------------------
+
+def test_a_newer_schema_is_refused(manager):
+    _write(manager, {'settings_schema_version': SETTINGS_SCHEMA_VERSION + 1,
+                     'domains': []})
+
+    with pytest.raises(SettingsSchemaTooNewError) as excinfo:
+        manager.load_settings(use_cache=False)
+
+    message = str(excinfo.value)
+    assert str(SETTINGS_SCHEMA_VERSION + 1) in message, (
+        'the message does not say which schema the file declares'
+    )
+    assert 'CERTMATE_ALLOW_SCHEMA_DOWNGRADE' in message, (
+        'the message does not tell the operator how to proceed anyway'
+    )
+
+
+def test_the_refusal_stops_the_process_rather_than_degrading(manager):
+    """It subclasses SettingsUnreadableError on purpose: app.py exits rather
+    than starting an instance that will write a shape it cannot read back."""
+    from modules.core.settings import SettingsUnreadableError
+
+    assert issubclass(SettingsSchemaTooNewError, SettingsUnreadableError)
+
+
+def test_the_escape_hatch_proceeds(manager, monkeypatch):
+    monkeypatch.setenv('CERTMATE_ALLOW_SCHEMA_DOWNGRADE', '1')
+    _write(manager, {'settings_schema_version': SETTINGS_SCHEMA_VERSION + 5,
+                     'domains': [], 'email': 'a@b.com'})
+
+    assert manager.load_settings(use_cache=False)['email'] == 'a@b.com'
+
+
+@pytest.mark.parametrize('value', ['2', 'v2', None, [], {}, 1.5])
+def test_a_non_integer_schema_does_not_trip_the_gate(manager, value):
+    """A hand-edited or corrupt field must not brick the instance. It is
+    re-stamped instead — the shape migrations have run either way."""
+    _write(manager, {'settings_schema_version': value, 'domains': [],
+                     'email': 'a@b.com'})
+
+    settings = manager.load_settings(use_cache=False)
+    assert settings['settings_schema_version'] == SETTINGS_SCHEMA_VERSION
+
+
+def test_an_older_schema_is_read_and_restamped(manager):
+    """CONTROL: the gate must refuse only what is NEWER. Refusing an older
+    file would make every upgrade fail."""
+    _write(manager, {'settings_schema_version': 0, 'domains': [],
+                     'email': 'a@b.com'})
+
+    settings = manager.load_settings(use_cache=False)
+    assert settings['email'] == 'a@b.com'
+    assert settings['settings_schema_version'] == SETTINGS_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# What the version is NOT
+# ---------------------------------------------------------------------------
+
+def test_the_schema_version_is_not_the_product_version(manager):
+    """They answer different questions and must not be conflated: the product
+    version moves on every release, this one only when the shape changes."""
+    settings = manager.load_settings(use_cache=False)
+
+    assert settings['settings_schema_version'] != settings.get('certmate_version')
+    assert isinstance(settings['settings_schema_version'], int)
+
+
+def test_the_shape_migrations_still_run_at_the_current_version(manager):
+    """The thing that must NOT have changed. Migration 4 drops a retired
+    letsencrypt field, and its comment says it stays permanent because a stale
+    settings tab can POST the old shape at any time. Gating it behind a version
+    bump would remove a defence, not a redundancy.
+    """
+    _write(manager, {
+        'settings_schema_version': SETTINGS_SCHEMA_VERSION,
+        'ca_providers': {'letsencrypt': {'environment': 'staging'}},
+        'domains': [], 'email': 'a@b.com',
+    })
+
+    settings = manager.load_settings(use_cache=False)
+
+    assert 'environment' not in settings['ca_providers']['letsencrypt'], (
+        'the retired field survived a load at the current schema version'
+    )


### PR DESCRIPTION
Closes #669.

### The issue was half-stale, and the half that was true is the one that bites

`settings.json` already carried a `certmate_version`, and `load_settings`
already logged an error when the file came from a newer build. So the issue read
as "already done". It is not the same mechanism:

* `certmate_version` is the **product** version. It moves on every release,
  including the many with no shape change, and it compares only `major.minor`.
  It cannot answer *is this file a shape I understand* — which is the only
  question that matters on a rollback.
* it **logged and continued**. The older process then went on to read a file it
  half-understood and write it back without the fields it never knew about.
  That is the failure a rollback actually produces, and it is silent.

### What this adds

`SETTINGS_SCHEMA_VERSION` in `modules/core/constants.py`, bumped only when the
shape of `settings.json` changes.

A file declaring a **newer** schema raises `SettingsSchemaTooNewError` — a
subclass of `SettingsUnreadableError`, so `app.py` stops the process rather than
starting an instance that will drop fields. The message names both versions and
points at the backup directory.

`CERTMATE_ALLOW_SCHEMA_DOWNGRADE=1` proceeds anyway, for an operator who has
read the release notes and accepts the consequence. Safe by default, deliberate
to override.

An **older** schema is read and re-stamped — refusing those would make every
upgrade fail. A non-integer value (hand-edited, truncated) does not brick the
instance either; it is re-stamped, since the shape migrations have run regardless.

### Written on every save, not only on load

Stamping on load alone leaves a hole the app walks through daily: a caller that
hands over a payload without the key — `POST /api/settings` does — writes a file
with **no** declared schema, and a file with no declared schema is one an older
build reads happily. The gate can only refuse what is written down, so the stamp
goes in `save_settings`, where every write passes. Also present in
`default_settings` and `first_time_template`, because a fresh install never
reaches the migration path.

### What deliberately did not change

The shape-sniffing migrations still run at every version. They are not only
migrations — Migration 4's own comment says it must stay "idempotent and
permanent" because a stale settings tab can POST an old payload shape at any
time. Gating them behind a version bump would remove a defence, not a redundancy.

### Checks

16 tests in `tests/test_settings_schema_version.py`. Each load-bearing line was
mutated to confirm a test fails: removing the gate, inverting it to `!=` (so
every upgrade would fail), and dropping either stamping site. Full unit suite
3772 passed / 31 skipped, gated flake8 clean, per-module coverage floors met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)