### PR TITLE
fix: constrain the extras install layer, and record the hash-pinning decision (#686)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,12 +252,21 @@ jobs:
       if: matrix.python-version == '3.12'
       run: |
         set -euo pipefail
+        # Kept in step with what the Dockerfile, docker-compose.yml and the
+        # README actually advertise —
+        # tests/test_requirements_are_consistent.py fails if one of them names
+        # a combination this list does not resolve. The storage entries below
+        # arrived that way: the comment above claimed "every combination the
+        # Dockerfile advertises", and two of the three it advertises were not
+        # here (#686).
         combos=(
           "requirements-minimal.txt requirements-extended.txt"
           "requirements.txt requirements-aws.txt"
           "requirements.txt requirements-gcp.txt"
           "requirements.txt requirements-azure.txt"
           "requirements.txt requirements-aws.txt requirements-gcp.txt"
+          "requirements.txt requirements-storage-all.txt"
+          "requirements.txt requirements-azure.txt requirements-storage-all.txt"
         )
         pinned=$(grep -oE '^certbot==[0-9.]+' requirements.txt | cut -d= -f3)
         echo "certbot is pinned at $pinned"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,45 @@ jobs:
           echo "::endgroup::"
         done
 
+    # The images are published for amd64 AND arm64, and every check above runs
+    # on exactly one of them. That is how `infisical-python>=2.3.6` sat in two
+    # advertised requirements files: 2.3.6 ships an aarch64 wheel, macOS wheels
+    # and Windows wheels, but no manylinux x86_64 wheel and no sdist. It
+    # installs on the arm64 image and cannot be installed on the amd64 one at
+    # all. A resolver running on either architecture alone sees nothing wrong.
+    #
+    # pip can resolve FOR another platform without emulating it. The check is
+    # not "does it resolve" — with --only-binary a source-only distribution
+    # fails everywhere, and most certbot plugins are source-only — but "do the
+    # two architectures AGREE". A file that fails on both is inconclusive, not
+    # broken, and is reported as such rather than counted as covered.
+    - name: Resolve the optional requirements for both published architectures
+      if: matrix.python-version == '3.12'
+      run: |
+        set -euo pipefail
+        skew=0
+        for req in requirements*.txt; do
+          case "$req" in requirements-test.txt) continue;; esac
+          verdicts=""
+          for plat in manylinux_2_28_x86_64 manylinux_2_28_aarch64; do
+            if python -m pip install --dry-run --quiet --no-cache-dir \
+                 --ignore-installed --only-binary=:all: \
+                 --platform "$plat" --python-version 3.12 \
+                 --target "$(mktemp -d)" -r "$req" >/dev/null 2>&1; then
+              verdicts="$verdicts $plat=ok"
+            else
+              verdicts="$verdicts $plat=no"
+            fi
+          done
+          case "$verdicts" in
+            *x86_64=ok*aarch64=ok*) echo "$req: both architectures resolve";;
+            *x86_64=no*aarch64=no*) echo "$req: inconclusive (source-only distributions; not covered by this check)";;
+            *) echo "::error::$req resolves on one published architecture and not the other:$verdicts. An image built for the other architecture cannot install it."
+               skew=1;;
+          esac
+        done
+        [ "$skew" -eq 0 ]
+
   # Every CA in the registry, asked whether its ACME directory still exists.
   #
   # `digicert` pointed at acme.digicert.com for months after DigiCert retired

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,12 +56,27 @@ ARG PIP_VERSION=26.1.2
 # already there — verified, including downgrading 26.2.1 to 26.1.2 — so the
 # flag only muddies the intent (Copilot, #553). setuptools and wheel keep
 # theirs; they are build-time only and never reach the runtime stage.
+#
+# `-c ${REQUIREMENTS_FILE}` on the extras layer is load-bearing, not tidiness
+# (#686). Each extras install is a separate pip resolution that knows nothing
+# about what the first one pinned, so it is free to move those pins — measured,
+# not theorised: with the base stack installed, `pip install "cryptography<46"`
+# as a second layer silently downgrades 46.0.7 to 45.0.7, below the floor
+# pyopenssl==26.0.0 needs, and the image ships an interpreter where
+# `certbot --version` no longer answers. The extras files reach that same edge
+# by a longer route: they carry unbounded `>=` requirements (azure-identity,
+# boto3, azure-keyvault-*), and a future release of any of them that wants a
+# newer `cryptography` gets it.
+#
+# With the constraint, pip refuses at build time and names the conflict. That
+# is the trade: a variant build that would have shipped a broken stack now
+# fails loudly instead. All documented combinations above resolve under it.
 RUN pip install "pip==${PIP_VERSION}" -U setuptools wheel && \
     pip install --no-cache-dir -r ${REQUIREMENTS_FILE} && \
     if [ -n "${EXTRA_REQUIREMENTS}" ]; then \
         for req in ${EXTRA_REQUIREMENTS}; do \
             echo "==> Installing extras from ${req}"; \
-            pip install --no-cache-dir -r "${req}"; \
+            pip install --no-cache-dir -c "${REQUIREMENTS_FILE}" -r "${req}"; \
         done; \
     fi
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -235,6 +235,54 @@ can be closed. Until then they remain open by choice, not by oversight, and
 this section is the record of that choice: an advisory against `cryptography`
 that is not listed here has not been assessed, and should be treated as new.
 
+## Supply-chain posture for Python dependencies
+
+This section exists so the absence of hash pinning is a **decision on record**
+rather than an oversight (issue #686). What CertMate does and does not claim
+about the packages in its images:
+
+**What is guaranteed.** Every direct dependency in `requirements.txt` and
+`requirements-minimal.txt` is pinned to an exact version, and CI fails if a
+package is pinned to two different versions across files, if a certbot plugin
+is pinned above the certbot pin, or if any advertised
+`EXTRA_REQUIREMENTS` combination stops resolving. The base image is pinned by
+digest. Published images carry an SPDX SBOM and SLSA provenance, so what
+shipped is auditable after the fact. Extras layers install under
+`-c ${REQUIREMENTS_FILE}`, so an optional backend cannot move a pin the base
+layer holds deliberately.
+
+**What is not guaranteed.** There is no `--require-hashes`, no lockfile
+carrying hashes, and nothing that verifies the wheels installed are the wheels
+that were reviewed. A version pin does not defend against a **re-published or
+compromised artifact at that same version**. PyPI does not allow re-uploading a
+filename, so this requires a compromise of the index or of the maintainer's
+account — but it is a real class of attack and this project does not currently
+detect it.
+
+**Why not, specifically.** `--require-hashes` is all-or-nothing per install:
+every requirement, including every transitive one, must carry a hash or pip
+refuses the file. That collides with how these images are built — 12
+requirements files, a layered `EXTRA_REQUIREMENTS` model whose documented
+combinations would multiply rather than compose, two architectures resolving
+different binary wheels, and a resolved set of 121 packages for
+`requirements.txt` plus `requirements-storage-all.txt` alone — every one of
+which would need a hash, per variant, per platform.
+Doing it partially is worse than not doing it: a half-hashed set fails installs
+with errors that name the wrong cause, and the reliable response is to route
+around the mechanism with `--no-deps` or a second unhashed install. The project
+would then carry the maintenance cost of lockfiles *and* the false confidence
+of a guard people bypass.
+
+**What would change the decision.** A generated-lockfile design: pip-tools or
+uv producing hash-locked files per variant per platform in CI rather than by
+hand, a refresh cadence so the lockfiles do not become a reason not to patch,
+and a drift guard tying each lockfile to its requirements file. That is a
+project, not a cleanup, and it is tracked rather than half-started.
+
+**If you are threat-modelling against this**, the honest summary is:
+auditability, not integrity. The SBOM tells you what you got; it does not prove
+it is what was intended.
+
 ## Coordinated disclosure
 
 We coordinate disclosure with the reporter. For high or critical severity:

--- a/requirements-infisical-storage.txt
+++ b/requirements-infisical-storage.txt
@@ -1,2 +1,8 @@
 # Optional dependencies for Infisical storage backend
-infisical-python>=2.3.6
+# Pinned, and not to the latest. infisical-python 2.3.6 ships no
+# manylinux x86_64 wheel and no sdist — only aarch64, macOS and Windows —
+# so `>=2.3.6` cannot be installed on the amd64 image at all, while the
+# arm64 image installs it fine. 2.3.5 is the last release with complete
+# platform coverage. This is the only compiled dependency in the storage
+# extras; the rest ship pure-Python wheels and are architecture-neutral.
+infisical-python==2.3.5

--- a/requirements-storage-all.txt
+++ b/requirements-storage-all.txt
@@ -27,4 +27,10 @@ boto3>=1.43.87
 hvac>=2.4.0
 
 # Infisical
-infisical-python>=2.3.6
+# Pinned, and not to the latest. infisical-python 2.3.6 ships no
+# manylinux x86_64 wheel and no sdist — only aarch64, macOS and Windows —
+# so `>=2.3.6` cannot be installed on the amd64 image at all, while the
+# arm64 image installs it fine. 2.3.5 is the last release with complete
+# platform coverage. This is the only compiled dependency in the storage
+# extras; the rest ship pure-Python wheels and are architecture-neutral.
+infisical-python==2.3.5

--- a/tests/test_requirements_are_consistent.py
+++ b/tests/test_requirements_are_consistent.py
@@ -249,3 +249,39 @@ def test_every_advertised_combination_is_resolved_in_ci():
         "resolved by the CI step, so nothing proves they can be installed:\n  "
         + "\n  ".join(missing)
     )
+
+
+def test_the_architecture_check_covers_every_published_architecture():
+    """The other half of the same drift.
+
+    `infisical-python>=2.3.6` sat in two advertised files because 2.3.6 ships
+    an aarch64 wheel and no manylinux x86_64 wheel: it installs on the arm64
+    image and cannot be installed on the amd64 one, and a resolver running on
+    either architecture alone sees nothing wrong. CI now resolves the optional
+    files for both — which only stays true while "both" means the same two
+    architectures the release publishes.
+    """
+    published = re.search(
+        r"default:\s*'([^']*linux/[^']*)'",
+        (REPO_ROOT / ".github" / "workflows"
+         / "docker-multiplatform.yml").read_text(encoding="utf-8"))
+    assert published, (
+        "could not find the published platform list in "
+        "docker-multiplatform.yml — this test is checking nothing"
+    )
+    architectures = {p.strip().split("/")[-1]
+                     for p in published.group(1).split(",")}
+
+    ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8")
+    # manylinux_2_28_x86_64 -> amd64, manylinux_2_28_aarch64 -> arm64.
+    tag_for = {"amd64": "x86_64", "arm64": "aarch64"}
+    uncovered = [
+        arch for arch in sorted(architectures)
+        if f"manylinux_2_28_{tag_for.get(arch, arch)}" not in ci
+    ]
+    assert not uncovered, (
+        f"the release publishes images for {sorted(architectures)} but CI "
+        f"only resolves the requirements for some of them; {uncovered} could "
+        f"carry a dependency that does not exist for that platform"
+    )

--- a/tests/test_requirements_are_consistent.py
+++ b/tests/test_requirements_are_consistent.py
@@ -153,3 +153,99 @@ def test_powerdns_is_not_bundled_with_lexicon_hungry_plugins(filename):
         f"file will not install at all, in any environment. Install powerdns "
         f"separately, as requirements.txt already says."
     )
+
+
+# ---------------------------------------------------------------------------
+# The extras layer cannot move the base layer's pins (#686)
+# ---------------------------------------------------------------------------
+
+def test_the_extras_install_is_constrained_by_the_base_requirements():
+    """Each extras install is a separate pip resolution.
+
+    It knows nothing about what the first one pinned, so it is free to move
+    those pins. Measured: with the base stack installed, a second
+    `pip install "cryptography<46"` silently takes 46.0.7 down to 45.0.7 —
+    below the floor `pyopenssl==26.0.0` needs, producing an image where
+    `certbot --version` no longer answers. The same edge is reachable the long
+    way round, because the storage extras carry unbounded `>=` requirements.
+
+    `-c ${REQUIREMENTS_FILE}` makes pip refuse at build time instead. This is
+    not a hypothetical failure mode here: it already happened once, with
+    `requirements-aws.txt` dragging certbot from 2.10.0 to 3.3.0 in a build
+    that reported success. That was fixed by correcting the pin; the mechanism
+    that allowed it stayed open until now.
+    """
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    extras_install = [
+        line.strip() for line in dockerfile.splitlines()
+        if "pip install" in line and '-r "${req}"' in line
+    ]
+    assert extras_install, (
+        "the extras install line is no longer recognisable, so this test is "
+        "checking nothing — find how the Dockerfile layers EXTRA_REQUIREMENTS "
+        "now and update the match"
+    )
+    for line in extras_install:
+        assert "-c " in line, (
+            "the extras layer installs without a constraints file, so it can "
+            "silently move a pin the base layer holds deliberately "
+            f"(cryptography, pyopenssl, certbot):\n  {line}"
+        )
+
+
+def test_every_advertised_combination_is_resolved_in_ci():
+    """The drift guard.
+
+    The CI step's own comment claims it resolves "every file and every
+    combination the Dockerfile and docker-compose.yml advertise". That claim
+    was false: both advertise `requirements-storage-all.txt`, alone and
+    alongside `requirements-azure.txt`, and neither was in the list. Nothing
+    connected the two places, so nothing said so.
+    """
+    advertised = set()
+    for name in ("Dockerfile", "docker-compose.yml"):
+        text = (REPO_ROOT / name).read_text(encoding="utf-8")
+        for match in re.finditer(
+                r'EXTRA_REQUIREMENTS[=:]\s*"?([a-z0-9.\- ]*\.txt)"?', text):
+            files = match.group(1).split()
+            if files:
+                advertised.add(tuple(sorted(files)))
+
+    assert advertised, (
+        "no EXTRA_REQUIREMENTS combinations were parsed out of the Dockerfile "
+        "or docker-compose.yml — the advertising format changed and this test "
+        "is passing over nothing"
+    )
+
+    ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8")
+    resolved = {
+        tuple(sorted(line.strip().strip('"').split()))
+        for line in ci.splitlines()
+        if line.strip().startswith('"requirements') and '.txt' in line
+    }
+
+    # An advertisement names only the extras; a CI entry also names the base
+    # file it layers onto. So an entry covers a combination when it is that
+    # combination plus exactly one base file — not merely a superset of it.
+    #
+    # The distinction is the whole point. Resolving azure+storage-all together
+    # proves storage-all is *installable*, since a subset of requirements is
+    # easier to satisfy than a superset. It does not prove that the resolution
+    # someone actually gets from `EXTRA_REQUIREMENTS=requirements-storage-all
+    # .txt` is the one that was checked: fewer constraints means a wider
+    # solution space, and the certbot-version assertion in that CI step is
+    # about which version pip lands on, not whether it lands at all.
+    bases = {"requirements.txt", "requirements-minimal.txt"}
+    missing = []
+    for combo in sorted(advertised):
+        if not any(set(entry) - set(combo) in ({b} for b in bases)
+                   and set(combo) <= set(entry) for entry in resolved):
+            missing.append(" ".join(combo))
+
+    assert not missing, (
+        "these EXTRA_REQUIREMENTS combinations are advertised but never "
+        "resolved by the CI step, so nothing proves they can be installed:\n  "
+        + "\n  ".join(missing)
+    )


### PR DESCRIPTION
Closes #686.

The issue asked for `--require-hashes` **or** an explicit decision not to. The
answer is **not now, recorded as a decision** — and the reachable half of the
gap it was standing in for is closed here.

### The reachable half

Each `EXTRA_REQUIREMENTS` file is a separate pip resolution that knows nothing
about what the base layer pinned, so it is free to move those pins. Measured,
not reasoned about — with the base stack installed:

```
$ pip install --dry-run "cryptography<46"      # as a second layer
  cryptography 46.0.7 -> 45.0.7
```

45.0.7 is below the floor `pyopenssl==26.0.0` requires, so that build ships an
interpreter where `certbot --version` no longer answers. With the constraint:

```
$ pip install --dry-run -c requirements.txt "cryptography<46"
  ERROR: Cannot install cryptography<46 because these package versions have
  conflicting dependencies.
```

**This has already happened here once.** CI's own comment records it:
`requirements-aws.txt` pinned a plugin above the certbot pin and pip upgraded
certbot 2.10.0 → 3.3.0 *in a build that reported success*. That was fixed by
correcting the pin; the mechanism that allowed it stayed open. The storage
extras walk straight back into it — they carry unbounded `>=` requirements on
`azure-identity`, `boto3` and `azure-keyvault-*`, any of which can ask for a
newer `cryptography` in a future release.

Every documented combination was resolved under the constraint before changing
anything:

| base | extras | |
| --- | --- | --- |
| `requirements.txt` | `requirements-azure.txt requirements-storage-all.txt` | ok |
| `requirements.txt` | `requirements-aws.txt requirements-gcp.txt` | ok |
| `requirements-minimal.txt` | `requirements-azure.txt requirements-storage-all.txt` | ok |

The trade is real and worth stating: a variant build that would previously have
shipped a broken stack now fails loudly at build time.

### Two advertised combinations were never resolved

The CI step's comment claims it resolves *"every file and every combination the
Dockerfile and docker-compose.yml advertise"*. Both advertise
`requirements-storage-all.txt`, alone and alongside `requirements-azure.txt`,
and neither was in the list. Nothing connected the two places, so nothing said
so. Both are added (checked: both resolve, certbot stays at 2.10.0), and
`test_every_advertised_combination_is_resolved_in_ci` now ties them together.

That test accepts a CI entry only when it is the advertised combination plus one
base file — **not** merely a superset. Resolving azure+storage-all together
proves storage-all is *installable*, since a subset of requirements is easier to
satisfy; it does not prove the narrower resolution someone actually gets is the
one that was checked.

### The decision, on record

`SECURITY.md` gains a **Supply-chain posture for Python dependencies** section:
what is guaranteed (exact pins, cross-file pin agreement, digest-pinned base,
SBOM + provenance, and now a constrained extras layer), what is **not** (no hash
verification — a re-published artifact at the same version is undetected), why
hash pinning is not attempted incrementally (all-or-nothing per install × 12
files × layered variants × 2 architectures × 121 resolved packages, and a
half-hashed set gets routed around with `--no-deps`), and what would change the
answer.

The honest summary, written into the file: **auditability, not integrity.**

### Checks

Two new tests, both mutated to confirm they bite — reverting the Dockerfile to
an unconstrained extras install, and removing either newly-added CI combination.
A control confirms the drift guard stays quiet for CI entries that are extra
rather than advertised. Full unit suite 3774 passed / 31 skipped, gated flake8
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)