### PR TITLE
feat: deploy hooks can be held for a maintenance window (#632)

### DIFF
--- a/docs/deploy-hooks.md
+++ b/docs/deploy-hooks.md
@@ -9,10 +9,11 @@ This guide walks through:
 1. [What a hook is](#what-a-hook-is)
 2. [Configuring hooks (UI + JSON)](#configuring-hooks)
 3. [Environment variables passed to your command](#environment-variables-passed-to-your-command)
-4. [Manual triggering](#manual-triggering)
-5. [Security model: why some commands are rejected](#security-model)
-6. [Common recipes](#common-recipes)
-7. [Audit, history, and debugging](#audit-history-and-debugging)
+4. [Maintenance windows](#maintenance-windows)
+5. [Manual triggering](#manual-triggering)
+6. [Security model: why some commands are rejected](#security-model)
+7. [Common recipes](#common-recipes)
+8. [Audit, history, and debugging](#audit-history-and-debugging)
 
 ---
 
@@ -28,6 +29,7 @@ A hook is a JSON object with five fields:
 | `enabled` | boolean | no | Defaults to `true`. Disabled hooks are skipped during automatic firing but can still be tested manually. |
 | `timeout` | integer | no | Seconds. Default 30, capped at the system `MAX_TIMEOUT` (currently 300). |
 | `on_events` | string array | no | Subset of `["created", "renewed", "revoked"]`. If absent, the hook runs on all three. |
+| `window` | object | no | A [maintenance window](#maintenance-windows). If absent, the hook runs as soon as the certificate is issued or renewed — the behaviour every hook has had until now. |
 
 Hooks live under two keys in `deploy_hooks`:
 
@@ -114,6 +116,66 @@ Every invocation sets these in the hook's process environment:
 Your command can reference these as `$CERTMATE_DOMAIN`, `"$CERTMATE_FULLCHAIN_PATH"`, etc. The values are passed by environment, not by string interpolation, so quoting works the same as in any normal shell.
 
 The hook runs as the CertMate process user (in the Docker image: `certmate`, UID/GID 1000:1000) inside the container. Anything you `cp`, `curl`, `ssh`, etc. needs to be reachable from there.
+
+---
+
+## Maintenance windows
+
+Closes [#632](https://github.com/fabriziosalmi/certmate/issues/632).
+
+A certificate renews when it is due, which is a time nobody chose: the renewal sweep runs at 02:00 with an hour of jitter, and only for the certificates inside the threshold that night. The hook then ran immediately. For a hook that restarts a database or reloads a load balancer, that is an outage at an unpredictable hour.
+
+A `window` separates the two. The certificate still renews whenever it is due — that is driven by expiry and is not negotiable — but the **deploy** is held until the next time the window is open.
+
+```jsonc
+"window": {
+  "start": "02:00",          // required, 24-hour HH:MM
+  "end": "04:00",            // required, exclusive
+  "days": ["sat", "sun"],    // optional; omit or leave empty for every day
+  "timezone": "Europe/Rome"  // optional IANA name, defaults to UTC
+}
+```
+
+The same field works on typed deploy targets, which is usually where you want it: a Kubernetes secret rollout is exactly the kind of deploy that belongs in a maintenance window.
+
+### What the rules are
+
+- **`end` is exclusive.** `02:00`–`04:00` and `04:00`–`06:00` are adjacent, not overlapping.
+- **A window may cross midnight**, and belongs to the day it **starts** on. A `22:00`–`04:00` window on `["fri"]` is open at 02:00 on Saturday morning. Reading it the other way would silently require you to tick Saturday as well.
+- **`start` and `end` may not be equal.** That reads equally well as "always open" and "never open", so it is refused rather than guessed. Use `00:00`–`23:59` for a whole day.
+- **The timezone is an IANA name** (`Europe/Rome`, `America/New_York`), validated when you save. A typo is refused at that moment rather than silently holding every deploy for a window that never opens.
+- **Daylight saving is handled by the zone, not by arithmetic.** On the spring-forward day a `02:00`–`04:00` Rome window opens at the local 03:00, because 02:00–02:59 does not happen; on the autumn day it is open across both passes of 02:00–02:59.
+
+### What happens while a deploy is held
+
+The queue lives at `data/pending_deploys.json` and survives a restart — the window is typically hours away.
+
+- A second renewal before the window opens does **not** queue a second deploy. The hook reads the certificate from disk when it runs, so one deferred run always publishes the newest one.
+- If the hook is deleted or disabled, or deploy hooks are switched off entirely, the queued deploy is **dropped** at the next drain. Your current configuration says not to run it.
+- If you remove the window, the deploy is released at the next drain rather than waiting one more time.
+- A hook that fails inside its window is **not** re-queued. It is recorded in the history like any other failure; re-queuing would retry every minute for as long as the window stayed open.
+- A deploy still waiting after seven days is logged as a warning. That is not a limit — waiting is the feature — but a week means the window has not opened at all, which usually means the days or the timezone are not what you meant.
+
+Deploys held for a window are invisible everywhere else: the certificate renewed, the history shows nothing, and nothing failed. `GET /api/deploy/pending` lists them with the window they are waiting for and when it next opens.
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" https://certmate.local/api/deploy/pending
+```
+
+```json
+[
+  {
+    "kind": "hook", "id": "6f0…", "domain": "api.example.com",
+    "event": "renewed", "queued_at": "2026-09-08T13:12:04+00:00",
+    "window": "02:00-04:00 Europe/Rome (sat, sun)",
+    "next_run": "2026-09-12T00:00:00+00:00", "orphaned": false
+  }
+]
+```
+
+### What ignores the window
+
+**Deploy Now** does. Pressing it is choosing this moment; holding the deploy until 02:00 would make the button do nothing visible. The same is true of `POST /api/deploy/test/<id>`.
 
 ---
 

--- a/modules/core/deploy_window.py
+++ b/modules/core/deploy_window.py
@@ -1,0 +1,211 @@
+"""Maintenance windows for deploy hooks (#632).
+
+A certificate renews when it is due, which is a time nobody chose: the renewal
+sweep fires at 02:00 with an hour of jitter, and only for the certificates that
+happen to be inside the threshold that night. The deploy hook then runs
+immediately. For a hook that restarts a database or reloads a load balancer,
+that is an outage at an unpredictable hour.
+
+A window separates the two. The certificate still renews whenever it is due —
+that is not negotiable, it is driven by expiry — but the *deploy* is held until
+the next time the window is open.
+
+The whole decision is here, as pure functions over an explicit `now`, because
+the interesting cases are all calendar edge cases: a window that wraps past
+midnight, a window on days the queue was not drained, a DST transition that
+makes 02:30 happen twice or not at all. Testing those through a scheduler and a
+pending queue would mean staging a renewal to ask what time it is.
+
+Shape of a window::
+
+    {"start": "02:00", "end": "04:00",
+     "days": ["mon", "tue", "wed", "thu", "fri"],   # optional, default: all
+     "timezone": "Europe/Rome"}                      # optional, default: UTC
+
+`start == end` is rejected rather than read as "always" or "never" — both
+readings are defensible, which is exactly why an operator must not have to
+guess which one was implemented.
+"""
+import datetime
+import re
+
+# Order matters: index is what datetime.weekday() returns.
+_DAYS = ('mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun')
+_DAY_INDEX = {name: i for i, name in enumerate(_DAYS)}
+
+_TIME_RE = re.compile(r'\A([01]\d|2[0-3]):([0-5]\d)\Z')
+
+# A window can be held at most this long before it is reported as stuck. Not a
+# limit on deferral — the operator asked for a window and waiting for it is the
+# feature — but a pending deploy older than a week means the window has never
+# opened since, and something is misconfigured (a Sunday-only window on an
+# instance that is stopped at weekends, a timezone nobody meant).
+STALE_AFTER_DAYS = 7
+
+
+class WindowError(ValueError):
+    """A maintenance window that cannot be applied as written."""
+
+
+def _parse_hhmm(value, field):
+    if not isinstance(value, str):
+        raise WindowError(f"{field} must be a string like '02:00'")
+    match = _TIME_RE.match(value.strip())
+    if not match:
+        raise WindowError(
+            f"{field} must be HH:MM in 24-hour form, got {value!r}")
+    return int(match.group(1)), int(match.group(2))
+
+
+def _resolve_timezone(name):
+    """An IANA zone name, or UTC.
+
+    The image resolves these from the system tzdata rather than the `tzdata`
+    wheel, so an unknown name is refused here with the name in the message —
+    an operator typing 'CET' or 'Europe/Milano' should be told that at save
+    time, not have their deploys held for a window that never opens.
+    """
+    if name is None or name == '':
+        return datetime.timezone.utc
+    if not isinstance(name, str):
+        raise WindowError('timezone must be a string like "Europe/Rome"')
+    name = name.strip()
+    if name.upper() == 'UTC':
+        return datetime.timezone.utc
+    try:
+        from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+    except ImportError:  # pragma: no cover - stdlib since 3.9
+        raise WindowError('named timezones are unavailable on this platform')
+    try:
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError):
+        raise WindowError(
+            f"unknown timezone {name!r} — use an IANA name such as "
+            f"'Europe/Rome' or 'America/New_York'")
+
+
+def normalize_window(window):
+    """Validate *window* and return it in canonical form, or raise.
+
+    Returns None for an absent window, which means "deploy immediately" — the
+    behaviour every existing hook has and keeps.
+    """
+    if window is None or window == {} or window == '':
+        return None
+    if not isinstance(window, dict):
+        raise WindowError('window must be an object')
+
+    start = _parse_hhmm(window.get('start'), 'window.start')
+    end = _parse_hhmm(window.get('end'), 'window.end')
+    if start == end:
+        raise WindowError(
+            'window.start and window.end are the same time, which could mean '
+            'either "always open" or "never open" — use 00:00 to 23:59 for a '
+            'whole day instead')
+
+    days = window.get('days')
+    if days in (None, []):
+        day_set = set(range(7))
+    else:
+        if not isinstance(days, list):
+            raise WindowError('window.days must be a list of day names')
+        day_set = set()
+        for day in days:
+            key = str(day).strip().lower()[:3]
+            if key not in _DAY_INDEX:
+                raise WindowError(
+                    f"unknown day {day!r} — use mon, tue, wed, thu, fri, sat, "
+                    f"sun")
+            day_set.add(_DAY_INDEX[key])
+
+    timezone_name = window.get('timezone') or 'UTC'
+    if isinstance(timezone_name, str):
+        timezone_name = timezone_name.strip() or 'UTC'
+        if timezone_name.upper() == 'UTC':
+            timezone_name = 'UTC'
+    _resolve_timezone(timezone_name)  # raises if unusable
+
+    return {
+        'start': '%02d:%02d' % start,
+        'end': '%02d:%02d' % end,
+        'days': [_DAYS[i] for i in sorted(day_set)],
+        'timezone': timezone_name,
+    }
+
+
+def _local(window, moment):
+    """*moment* (aware) as a naive local time in the window's zone."""
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=datetime.timezone.utc)
+    return moment.astimezone(_resolve_timezone(window.get('timezone')))
+
+
+def is_open(window, moment):
+    """True when *moment* falls inside *window*.
+
+    A window that wraps past midnight (22:00 to 04:00) belongs to the day its
+    START falls on, so a Friday 22:00-04:00 window is open at 02:00 on
+    Saturday. Reading it the other way would make a Friday-night window
+    silently require Saturday to be selected too.
+    """
+    if window is None:
+        return True
+    window = normalize_window(window)
+    local = _local(window, moment)
+    start_h, start_m = (int(x) for x in window['start'].split(':'))
+    end_h, end_m = (int(x) for x in window['end'].split(':'))
+    days = {_DAY_INDEX[d] for d in window['days']}
+
+    minutes = local.hour * 60 + local.minute
+    start = start_h * 60 + start_m
+    end = end_h * 60 + end_m
+
+    if start < end:
+        return local.weekday() in days and start <= minutes < end
+    # Wrapped. Either late on a selected day, or early on the day after one.
+    if minutes >= start:
+        return local.weekday() in days
+    if minutes < end:
+        return (local.weekday() - 1) % 7 in days
+    return False
+
+
+def next_open(window, moment, horizon_days=8):
+    """The first instant at or after *moment* when *window* is open.
+
+    Returns an aware UTC datetime, or None if the window does not open within
+    *horizon_days*. Seven days is provably enough for any window this module
+    accepts — the longest possible wait is a week minus the window's own
+    length, since every window recurs weekly and is at least a minute long. The
+    default is 8 as margin, not because 7 is known to be short, and None is
+    therefore a "this should not happen" answer rather than a routine one.
+
+    Minute resolution: a window is a maintenance period, and searching by the
+    minute over eight days is 11520 cheap comparisons — small enough not to
+    matter and simple enough to be obviously right, which a closed-form
+    calculation across a DST boundary is not.
+    """
+    if window is None:
+        return moment
+    window = normalize_window(window)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=datetime.timezone.utc)
+    probe = moment.replace(second=0, microsecond=0)
+    if probe < moment:
+        probe += datetime.timedelta(minutes=1)
+    for _ in range(horizon_days * 24 * 60):
+        if is_open(window, probe):
+            return probe.astimezone(datetime.timezone.utc)
+        probe += datetime.timedelta(minutes=1)
+    return None
+
+
+def describe(window):
+    """One line an operator can check against what they meant."""
+    if window is None:
+        return 'immediately'
+    window = normalize_window(window)
+    days = window['days']
+    when = 'every day' if len(days) == 7 else ', '.join(days)
+    return (f"{window['start']}-{window['end']} {window['timezone']} "
+            f"({when})")

--- a/modules/core/deployer.py
+++ b/modules/core/deployer.py
@@ -4,16 +4,22 @@ Runs shell commands after certificate issuance or renewal.
 Hooks are configured in settings under 'deploy_hooks'.
 """
 
+import datetime
 import json
 import logging
 import os
 import subprocess
+import threading
 import time
 from pathlib import Path
 
 from .structured_logging import sanitize_text, JSONFormatter
 from .utils import utc_now_iso
 from .deploy_targets import run_targets, target_applies, TARGET_TYPES
+from .deploy_window import (
+    STALE_AFTER_DAYS, WindowError, describe as describe_window, is_open,
+    next_open, normalize_window,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +33,11 @@ MAX_HISTORY_ENTRIES = 500
 _HISTORY_SANITIZER = JSONFormatter(include_hostname=False, include_pid=False)
 
 
+def _utc_now():
+    """Wall-clock now, aware. One definition so tests can pin it in one place."""
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
 class DeployManager:
     """Manages post-issuance deploy hooks."""
 
@@ -38,6 +49,12 @@ class DeployManager:
         self.event_bus = event_bus
         self.cert_dir = Path(cert_dir)
         self._history_path = Path(data_dir) / 'deploy_history.jsonl'
+        # Deploys held for a maintenance window (#632). On disk because the
+        # window is typically hours away and a restart in between must not
+        # lose the deploy; guarded by a lock because the queue is written from
+        # the EventBus listener threads and read by the scheduler's drain.
+        self._pending_path = Path(data_dir) / 'pending_deploys.json'
+        self._pending_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # EventBus listener
@@ -79,6 +96,11 @@ class DeployManager:
         hooks applicable to this domain right now", regardless of whether
         they'd normally only run on create or renew. Hooks see
         CERTMATE_EVENT=manual so they can branch if they care.
+
+        Maintenance windows (#632) are ignored for the same reason. An operator
+        who presses Deploy Now has chosen this moment; holding the deploy until
+        02:00 would make the button do nothing visible, which is worse than
+        deploying outside the window they configured for the automatic path.
 
         Returns a dict {ok, total, succeeded, failed, results} with
         per-hook results. ok is True iff all hooks exited 0 and at least
@@ -129,7 +151,12 @@ class DeployManager:
         }
 
     def _execute_hooks(self, domain, event_type):
-        """Collect and run all matching hooks for a domain/event."""
+        """Collect and run all matching hooks for a domain/event.
+
+        A hook or target carrying a maintenance window that is closed right now
+        is not run and not skipped — it is queued, and `drain_pending` runs it
+        when the window next opens (#632).
+        """
         config = self.get_config()
         if not config.get('enabled'):
             return []
@@ -144,23 +171,293 @@ class DeployManager:
             if hook.get('enabled') and event_type in hook.get('on_events', []):
                 hooks.append(hook)
 
+        now = _utc_now()
         results = []
         for hook in hooks:
-            result = self._run_hook(hook, domain, event_type)
-            results.append(result)
-        # Typed deploy targets fire from the same lifecycle points (#475).
-        results.extend(self._execute_targets(domain, event_type, config))
+            if self._defer_if_closed('hook', hook, domain, event_type, now):
+                continue
+            results.append(self._run_hook(hook, domain, event_type))
+
+        # Typed deploy targets fire from the same lifecycle points (#475), and
+        # take the same windows — a Kubernetes secret rollout is exactly the
+        # kind of deploy an operator wants inside a maintenance window.
+        targets = [t for t in (config.get('targets') or [])
+                   if target_applies(t, domain, event_type)]
+        runnable = [t for t in targets
+                    if not self._defer_if_closed('target', t, domain,
+                                                 event_type, now)]
+        results.extend(
+            self._execute_targets(domain, event_type, config, targets=runnable))
         return results
 
-    def _execute_targets(self, domain, event_type, config=None):
+    # ------------------------------------------------------------------
+    # Maintenance windows (#632)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _entity_id(kind, entity):
+        """Stable identity for a queue entry.
+
+        Hooks carry an id; targets are identified by name, which is what
+        `target_applies` and the history already key on.
+        """
+        return entity.get('id') if kind == 'hook' else entity.get('name')
+
+    def _defer_if_closed(self, kind, entity, domain, event_type, now):
+        """Queue this deploy if its window is shut. True when it was queued.
+
+        A window that cannot be read is treated as absent — deploying at the
+        wrong hour is a disruption, but never deploying at all is an expired
+        certificate. `save_config` refuses an invalid window, so reaching this
+        means the file was edited by hand.
+        """
+        window = entity.get('window')
+        if not window:
+            return False
+        try:
+            if is_open(window, now):
+                return False
+        except WindowError as e:
+            logger.warning(
+                "Deploy %s %r for %s has an unusable maintenance window (%s); "
+                "running it now rather than holding it indefinitely.",
+                kind, self._entity_id(kind, entity), domain, e)
+            return False
+
+        identity = self._entity_id(kind, entity)
+        if not identity:
+            logger.warning(
+                "Deploy %s for %s has a maintenance window but no %s to queue "
+                "it under; running it now.", kind, domain,
+                'id' if kind == 'hook' else 'name')
+            return False
+
+        key = f'{kind}:{identity}:{domain}'
+        with self._pending_lock:
+            pending = self._read_pending()
+            existing = pending.get(key)
+            # A second renewal before the window opens must not queue a second
+            # deploy: the hook reads the certificate from disk when it runs, so
+            # one deferred run always publishes the newest one.
+            # Stamped from the same `now` the window was judged against, not
+            # from a second call to the clock. `_warn_if_stale` compares these
+            # against the drain's `now`, and two clocks that can disagree is
+            # how a queue entry ends up looking as if it were made in the
+            # future — which is silent, because a negative age is never stale.
+            stamp = now.isoformat()
+            pending[key] = {
+                'kind': kind,
+                'id': identity,
+                'domain': domain,
+                'event': event_type,
+                'queued_at': (existing or {}).get('queued_at') or stamp,
+                'last_event_at': stamp,
+            }
+            self._write_pending(pending)
+
+        logger.info(
+            "Deploy %s %r for %s held for its maintenance window (%s); "
+            "next opening %s", kind, identity, domain,
+            describe_window(window),
+            (next_open(window, now) or 'never').isoformat()
+            if next_open(window, now) else 'never')
+        return True
+
+    def _read_pending(self):
+        """The queue as a dict, or {}. Callers hold `_pending_lock`."""
+        try:
+            with open(self._pending_path) as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            return {}
+        except (OSError, ValueError) as e:
+            # A corrupt queue must not stop the drain from running the entries
+            # that come after it, and it must not be silent — a lost queue is
+            # a deploy that never happens.
+            logger.error(
+                "Pending deploy queue at %s is unreadable (%s); starting from "
+                "an empty queue. Certificates are unaffected, but any deploy "
+                "waiting for a maintenance window has been lost and will not "
+                "run until the next renewal.", self._pending_path, e)
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _write_pending(self, pending):
+        """Replace the queue atomically. Callers hold `_pending_lock`."""
+        import tempfile as _tmpmod
+        try:
+            self._pending_path.parent.mkdir(parents=True, exist_ok=True)
+            if not pending:
+                # An empty file and no file mean the same thing; removing it
+                # keeps the drain a true no-op on an instance that uses no
+                # windows.
+                try:
+                    self._pending_path.unlink()
+                except FileNotFoundError:
+                    pass
+                return
+            tmp_fd, tmp_path = _tmpmod.mkstemp(
+                dir=str(self._pending_path.parent), suffix='.tmp')
+            try:
+                with os.fdopen(tmp_fd, 'w') as f:
+                    json.dump(pending, f, indent=2)
+                os.replace(tmp_path, str(self._pending_path))
+            except Exception:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+        except OSError as e:
+            logger.error(
+                "Cannot write the pending deploy queue to %s: %s. A deploy "
+                "waiting for a maintenance window will be lost on restart. "
+                "Check that the data volume is writable by uid 1000.",
+                self._pending_path, e)
+
+    def get_pending(self, now=None):
+        """Queued deploys, newest event first, annotated for display."""
+        now = now or _utc_now()
+        config = self.get_config()
+        with self._pending_lock:
+            pending = self._read_pending()
+
+        rows = []
+        for key, entry in pending.items():
+            entity = self._find_windowed(config, entry)
+            window = (entity or {}).get('window')
+            try:
+                when = next_open(window, now) if window else now
+                description = describe_window(window)
+            except WindowError:
+                when, description = None, 'unusable window'
+            rows.append({
+                **entry,
+                'key': key,
+                'window': description,
+                'next_run': when.isoformat() if when else None,
+                'orphaned': entity is None,
+            })
+        rows.sort(key=lambda r: r.get('last_event_at') or '', reverse=True)
+        return rows
+
+    def _find_windowed(self, config, entry):
+        """The hook or target an entry refers to, or None if it is gone."""
+        if entry.get('kind') == 'hook':
+            return self._find_hook(config, entry.get('id'))
+        for target in config.get('targets') or []:
+            if target.get('name') == entry.get('id'):
+                return target
+        return None
+
+    def drain_pending(self, now=None):
+        """Run every queued deploy whose window is open. Scheduler entry point.
+
+        Returns a summary dict. Never raises: it runs from a scheduler job, and
+        one bad entry must not stop the rest of the queue.
+        """
+        now = now or _utc_now()
+        with self._pending_lock:
+            pending = self._read_pending()
+        if not pending:
+            return {'ran': 0, 'held': 0, 'dropped': 0, 'results': []}
+
+        config = self.get_config()
+        enabled = bool(config.get('enabled'))
+        remaining, results, dropped = {}, [], 0
+
+        for key, entry in pending.items():
+            entity = self._find_windowed(config, entry)
+            if entity is None or not enabled or (
+                    entry.get('kind') == 'hook' and not entity.get('enabled')):
+                # The hook was deleted, disabled, or deploy hooks were turned
+                # off while this waited. Dropping is the honest answer: the
+                # operator's current configuration says do not run it.
+                logger.info(
+                    "Dropping queued deploy %s: its %s is gone or disabled.",
+                    key, entry.get('kind'))
+                dropped += 1
+                continue
+
+            window = entity.get('window')
+            try:
+                open_now = is_open(window, now) if window else True
+            except WindowError:
+                open_now = True
+
+            if not open_now:
+                self._warn_if_stale(key, entry, now)
+                remaining[key] = entry
+                continue
+
+            domain, event_type = entry.get('domain'), entry.get('event')
+            try:
+                if entry.get('kind') == 'hook':
+                    results.append(self._run_hook(entity, domain, event_type))
+                else:
+                    results.extend(self._execute_targets(
+                        domain, event_type, config, targets=[entity]))
+            except Exception as e:
+                # Failure-isolated like every other deploy path: record it and
+                # move on. It is NOT re-queued — a hook that fails inside its
+                # window would otherwise retry at every drain for a week.
+                logger.error("Queued deploy %s failed: %s", key, e)
+                results.append({'success': False, 'hook': entry.get('id'),
+                                'domain': domain, 'error': str(e)})
+
+        with self._pending_lock:
+            current = self._read_pending()
+            # Only drop what this drain actually handled. An event that queued
+            # a deploy while the loop above was running keeps its entry.
+            for key in pending:
+                if key not in remaining:
+                    current.pop(key, None)
+            for key, entry in remaining.items():
+                current.setdefault(key, entry)
+            self._write_pending(current)
+
+        succeeded = sum(1 for r in results if r.get('success'))
+        for domain in {r.get('domain') for r in results if r.get('success')}:
+            self.event_bus.publish('certificate_deployed', {
+                'domain': domain, 'event': 'window', 'count': succeeded,
+            })
+        return {'ran': len(results), 'held': len(remaining),
+                'dropped': dropped, 'results': results}
+
+    def _warn_if_stale(self, key, entry, now):
+        """A deploy that has waited a week is not waiting, it is stuck."""
+        queued_at = entry.get('queued_at')
+        if not queued_at:
+            return
+        try:
+            queued = datetime.datetime.fromisoformat(
+                queued_at.replace('Z', '+00:00'))
+        except ValueError:
+            return
+        if queued.tzinfo is None:
+            queued = queued.replace(tzinfo=datetime.timezone.utc)
+        if now - queued > datetime.timedelta(days=STALE_AFTER_DAYS):
+            logger.warning(
+                "Queued deploy %s has been waiting since %s — more than %s "
+                "days. Its maintenance window has not opened in that time; "
+                "check the window's days and timezone.",
+                key, queued_at, STALE_AFTER_DAYS)
+
+    def _execute_targets(self, domain, event_type, config=None, targets=None):
         """Run every applicable typed deploy target for a domain/event.
 
         Failure-isolated (like shell hooks): reads the current fullchain +
         private key from disk and applies them via each configured target,
         recording audit + history per target. Never raises into the caller.
+
+        *targets*, when given, is an already-filtered list — the caller has
+        applied `target_applies` and removed anything held for a maintenance
+        window (#632). Passing it is not an optimisation: re-deriving the list
+        here would run the targets the caller deliberately deferred.
         """
         config = config if config is not None else self.get_config()
-        targets = config.get('targets') or []
+        if targets is None:
+            targets = config.get('targets') or []
         if not any(target_applies(t, domain, event_type) for t in targets):
             return []
 
@@ -485,6 +782,15 @@ class DeployManager:
         identifies the offending hook + reason when validation fails so the
         UI can show why a save was rejected (issue #102) instead of a
         generic "save failed".
+
+        A key the payload does not mention is left as it was. This is not
+        politeness: `deploy_hooks` also holds `targets`, the typed deploy
+        targets from #475, and the Settings -> Deploy screen has no editor for
+        them — `loadConfig` never reads them and `saveConfig` posts a body
+        without them. Replacing the whole block therefore meant that opening
+        that screen and pressing Save silently deleted every configured
+        Kubernetes secret target. Absent leaves alone; an explicit value,
+        including an empty list, replaces.
         """
         if not isinstance(config, dict):
             return False, "Configuration must be an object"
@@ -499,7 +805,10 @@ class DeployManager:
         # (e.g. one editing deploy hooks, another editing DNS providers)
         # cannot lose each other's changes.
         def _mutate(settings):
-            settings['deploy_hooks'] = config
+            existing = settings.get('deploy_hooks')
+            merged = dict(existing) if isinstance(existing, dict) else {}
+            merged.update(config)
+            settings['deploy_hooks'] = merged
         self.settings_manager.update(_mutate, "deploy_hooks_save")
         return True, None
 
@@ -555,6 +864,15 @@ class DeployManager:
         ttype = target.get('type')
         if ttype not in TARGET_TYPES:
             return False, f"unknown target type {ttype!r} (expected one of {TARGET_TYPES})"
+        # Same window rule as a shell hook, refused at the same moment (#632).
+        try:
+            window = normalize_window(target.get('window'))
+        except WindowError as e:
+            return False, f"target {target.get('name')!r} window: {e}"
+        if window is None:
+            target.pop('window', None)
+        else:
+            target['window'] = window
         cfg = target.get('config') or {}
         if not isinstance(cfg, dict):
             return False, "target.config must be an object"
@@ -673,6 +991,19 @@ class DeployManager:
             hook['on_events'] = ['created', 'renewed']
         if not isinstance(hook.get('enabled'), bool):
             hook['enabled'] = True
+
+        # A maintenance window is refused here, at save time, rather than
+        # discovered when the queue is drained (#632). A window that cannot be
+        # read is one that never opens, and the symptom — deploys silently not
+        # happening — would surface days after the change that caused it.
+        try:
+            window = normalize_window(hook.get('window'))
+        except WindowError as e:
+            return False, f"hook '{hook_label}' window: {e}"
+        if window is None:
+            hook.pop('window', None)
+        else:
+            hook['window'] = window
         return True, None
 
     # ------------------------------------------------------------------

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -899,6 +899,24 @@ def _ct_monitor_job():
         _run_manager_job('ct_monitor', 'run_poll')
 
 
+def _deploy_window_drain_job():
+    """Run deploys held for a maintenance window (#632).
+
+    Every minute, and deliberately so. A window is at least one minute long —
+    `normalize_window` refuses start == end — so minute polling means no window
+    can ever be missed entirely. At a coarser interval a short window would be
+    stepped over and its deploy held until the next day, which is exactly the
+    kind of silent, hours-late failure the feature exists to prevent.
+
+    It costs nothing on an instance that configures no windows: the queue file
+    does not exist, and `drain_pending` returns without reading anything else.
+    No process lock, unlike the renewal jobs — running a queued deploy twice is
+    the same shape as the manual Deploy Now button, whereas a lock held by a
+    dead process would silently stop deploys altogether.
+    """
+    _run_manager_job('deployer', 'drain_pending')
+
+
 def setup_scheduler(container: AppContainer):
     """Set up APScheduler for background tasks with persistent store."""
     assert _flask_app is not None, "setup_scheduler called before _flask_app was set"
@@ -992,6 +1010,16 @@ def setup_scheduler(container: AppContainer):
             func=_ct_monitor_job,
             trigger="cron", hour=5, minute=0,
             id='ct_log_monitor', replace_existing=True
+        )
+        # Deploy maintenance windows (#632). See the job's docstring for why
+        # this is every minute. `coalesce` from job_defaults collapses a burst
+        # of missed fires into one, and the 6-hour misfire grace would let a
+        # long-delayed drain still run — both harmless here, because the drain
+        # re-reads the window and does nothing when it is shut.
+        scheduler.add_job(
+            func=_deploy_window_drain_job,
+            trigger="cron", minute='*',
+            id='deploy_window_drain', replace_existing=True
         )
         container.scheduler = scheduler
         container.managers['scheduler'] = scheduler

--- a/modules/web/settings_routes.py
+++ b/modules/web/settings_routes.py
@@ -651,6 +651,27 @@ def register_settings_routes(app, managers, require_web_auth, auth_manager,
             logger.error(f"Failed to test deploy hook {hook_id}: {e}")
             return jsonify({'error': 'Failed to test deploy hook'}), 500
 
+    @app.route('/api/deploy/pending', methods=['GET'])
+    @auth_manager_ref.require_role('admin')
+    def api_deploy_pending():
+        """Deploys held for a maintenance window (#632).
+
+        A held deploy is invisible everywhere else: the certificate renewed,
+        the history has no entry, and nothing failed. Without this an operator
+        cannot tell "waiting for 02:00" from "the hook never fired", which are
+        the same picture and very different problems.
+
+        Returns a bare list, like the sibling history endpoint.
+        """
+        if not deploy_manager:
+            return jsonify({'error': 'Deploy manager not available'}), 503
+
+        try:
+            return jsonify(deploy_manager.get_pending())
+        except Exception as e:
+            logger.error(f"Failed to list pending deploys: {e}")
+            return jsonify({'error': 'Failed to list pending deploys'}), 500
+
     @app.route('/api/deploy/history', methods=['GET'])
     @auth_manager_ref.require_role('admin')
     def api_deploy_history():

--- a/static/js/settings-deploy.js
+++ b/static/js/settings-deploy.js
@@ -151,6 +151,52 @@
                 else hook.on_events.splice(idx, 1);
             },
 
+            // --- Maintenance windows (#632) ---------------------------------
+            // Absent means "deploy immediately", which is what every existing
+            // hook does. The toggle adds and removes the whole object rather
+            // than leaving an empty one behind: the server treats any window
+            // object as a reason to defer, so a leftover {} would hold every
+            // deploy for a window with no hours in it.
+
+            windowDays: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+
+            toggleWindow: function (hook) {
+                if (hook.window) {
+                    delete hook.window;
+                } else {
+                    // Defaults to the small hours, every day, in the browser's
+                    // own zone — the answer an operator opening this almost
+                    // always wants, and the zone they are thinking in.
+                    var zone = 'UTC';
+                    try {
+                        zone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+                    } catch (e) {
+                        zone = 'UTC';
+                    }
+                    hook.window = {
+                        start: '02:00', end: '04:00', days: [], timezone: zone
+                    };
+                }
+            },
+
+            toggleWindowDay: function (hook, day) {
+                if (!hook.window) return;
+                if (!hook.window.days) hook.window.days = [];
+                var idx = hook.window.days.indexOf(day);
+                if (idx === -1) hook.window.days.push(day);
+                else hook.window.days.splice(idx, 1);
+            },
+
+            describeWindow: function (hook) {
+                if (!hook.window) return 'Runs as soon as the certificate is issued or renewed.';
+                var w = hook.window;
+                var days = (w.days && w.days.length) ? w.days.join(', ') : 'every day';
+                var wraps = w.start > w.end
+                    ? ' (crosses midnight into the next morning)' : '';
+                return 'Held until ' + w.start + '-' + w.end + ' ' +
+                    (w.timezone || 'UTC') + ', ' + days + wraps + '.';
+            },
+
             testHook: function (hook) {
                 var hookLabel = hook.name || hook.id || 'unnamed';
                 var btn = event && event.target ? event.target.closest('button') : null;

--- a/templates/partials/settings_deploy.html
+++ b/templates/partials/settings_deploy.html
@@ -113,6 +113,56 @@
                                         <span>Renewed</span>
                                     </label>
                                 </div>
+                                <!-- Maintenance window (#632). Absent means "deploy immediately",
+                                     which is what every hook did before this existed. -->
+                                <div class="mt-2 pt-2 border-t border-border">
+                                    <label class="flex items-center gap-2 text-xs text-muted">
+                                        <input type="checkbox" :checked="!!hook.window" @change="toggleWindow(hook)"
+                                               class="rounded border-gray-300 text-primary focus:ring-primary">
+                                        <span class="font-medium text-foreground">Only deploy during a maintenance window</span>
+                                    </label>
+                                    <p class="text-xs text-muted mt-1" x-text="describeWindow(hook)"></p>
+                                    <!-- x-if, not x-show: x-show keeps the inner bindings alive, so
+                                         `hook.window.start` is evaluated for every hook that has no
+                                         window and Alpine logs an error per binding per hook. -->
+                                    <template x-if="hook.window">
+                                    <div class="mt-2 space-y-2">
+                                        <div class="flex flex-wrap items-center gap-2 text-xs">
+                                            <label class="flex items-center gap-1 text-muted">
+                                                <span>From</span>
+                                                <input type="time" x-model="hook.window.start" aria-label="Maintenance window start"
+                                                       class="border border-border bg-input text-foreground rounded px-2 py-1 text-xs">
+                                            </label>
+                                            <label class="flex items-center gap-1 text-muted">
+                                                <span>to</span>
+                                                <input type="time" x-model="hook.window.end" aria-label="Maintenance window end"
+                                                       class="border border-border bg-input text-foreground rounded px-2 py-1 text-xs">
+                                            </label>
+                                            <label class="flex items-center gap-1 text-muted">
+                                                <span>Timezone</span>
+                                                <input type="text" x-model="hook.window.timezone" placeholder="Europe/Rome"
+                                                       aria-label="Maintenance window timezone"
+                                                       class="w-40 border border-border bg-input text-foreground rounded px-2 py-1 text-xs">
+                                            </label>
+                                        </div>
+                                        <div class="flex flex-wrap items-center gap-2 text-xs">
+                                            <span class="text-muted">Days:</span>
+                                            <template x-for="day in windowDays" :key="day">
+                                                <label class="flex items-center gap-1 text-muted">
+                                                    <input type="checkbox" @change="toggleWindowDay(hook, day)"
+                                                           :checked="hook.window.days && hook.window.days.indexOf(day) !== -1"
+                                                           :aria-label="'Maintenance window on ' + day"
+                                                           class="rounded border-gray-300 text-primary focus:ring-primary">
+                                                    <span x-text="day"></span>
+                                                </label>
+                                            </template>
+                                            <span class="text-muted italic" x-show="!hook.window.days || !hook.window.days.length">
+                                                none selected means every day
+                                            </span>
+                                        </div>
+                                    </div>
+                                    </template>
+                                </div>
                             </div>
                         </template>
                         <button type="button" @click="addGlobalHook()"
@@ -183,6 +233,56 @@
                                                        @change="toggleEvent(hook, 'renewed')" class="rounded border-gray-300 text-primary focus:ring-primary" title="Trigger on renewed">
                                                 <span>Renewed</span>
                                             </label>
+                                        </div>
+                                        <!-- Maintenance window (#632). Absent means "deploy immediately",
+                                             which is what every hook did before this existed. -->
+                                        <div class="mt-2 pt-2 border-t border-border">
+                                            <label class="flex items-center gap-2 text-xs text-muted">
+                                                <input type="checkbox" :checked="!!hook.window" @change="toggleWindow(hook)"
+                                                       class="rounded border-gray-300 text-primary focus:ring-primary">
+                                                <span class="font-medium text-foreground">Only deploy during a maintenance window</span>
+                                            </label>
+                                            <p class="text-xs text-muted mt-1" x-text="describeWindow(hook)"></p>
+                                            <!-- x-if, not x-show: x-show keeps the inner bindings alive, so
+                                                 `hook.window.start` is evaluated for every hook that has no
+                                                 window and Alpine logs an error per binding per hook. -->
+                                            <template x-if="hook.window">
+                                            <div class="mt-2 space-y-2">
+                                                <div class="flex flex-wrap items-center gap-2 text-xs">
+                                                    <label class="flex items-center gap-1 text-muted">
+                                                        <span>From</span>
+                                                        <input type="time" x-model="hook.window.start" aria-label="Maintenance window start"
+                                                               class="border border-border bg-input text-foreground rounded px-2 py-1 text-xs">
+                                                    </label>
+                                                    <label class="flex items-center gap-1 text-muted">
+                                                        <span>to</span>
+                                                        <input type="time" x-model="hook.window.end" aria-label="Maintenance window end"
+                                                               class="border border-border bg-input text-foreground rounded px-2 py-1 text-xs">
+                                                    </label>
+                                                    <label class="flex items-center gap-1 text-muted">
+                                                        <span>Timezone</span>
+                                                        <input type="text" x-model="hook.window.timezone" placeholder="Europe/Rome"
+                                                               aria-label="Maintenance window timezone"
+                                                               class="w-40 border border-border bg-input text-foreground rounded px-2 py-1 text-xs">
+                                                    </label>
+                                                </div>
+                                                <div class="flex flex-wrap items-center gap-2 text-xs">
+                                                    <span class="text-muted">Days:</span>
+                                                    <template x-for="day in windowDays" :key="day">
+                                                        <label class="flex items-center gap-1 text-muted">
+                                                            <input type="checkbox" @change="toggleWindowDay(hook, day)"
+                                                                   :checked="hook.window.days && hook.window.days.indexOf(day) !== -1"
+                                                                   :aria-label="'Maintenance window on ' + day"
+                                                                   class="rounded border-gray-300 text-primary focus:ring-primary">
+                                                            <span x-text="day"></span>
+                                                        </label>
+                                                    </template>
+                                                    <span class="text-muted italic" x-show="!hook.window.days || !hook.window.days.length">
+                                                        none selected means every day
+                                                    </span>
+                                                </div>
+                                            </div>
+                                            </template>
                                         </div>
                                     </div>
                                 </template>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,39 +295,59 @@ def _no_browser(reason):
     pytest.skip(reason)
 
 
-@pytest.fixture(scope="module")
-def browser_page(docker_container):
-    """Provide a Playwright browser page."""
+@pytest.fixture(scope="session")
+def ui_session_cookie(docker_container):
+    """Log the UI suite in ONCE, for every module.
+
+    This used to run per module, and that coupled the suite to the login rate
+    limit: `modules/web/routes` allows 5 attempts per IP per 60 seconds, the
+    whole UI suite runs in about two minutes, and every test module logged in
+    again. The sixth UI test module therefore made the sixth login inside that
+    window, which was refused — so the fixture got no cookie, every page
+    redirected to /login, and the LAST module in alphabetical order failed with
+    "the panel is empty" while the change that broke it was the addition of an
+    unrelated test file.
+
+    Session-scoped, so the number of UI modules no longer has anything to do
+    with it. And a login that fails now fails the run loudly rather than
+    yielding a cookie-less page: a browser suite silently testing the login
+    screen is worse than a red fixture.
+    """
     import requests
 
-    session_cookie = None
-    try:
-        # Step 1: Create admin user (no auth required in setup mode)
-        requests.post(f"{BASE_URL}/api/web/settings/users", json={
-            "username": "admin", "password": "Password123!", "role": "admin"
-        })
+    # Setup mode: no auth required for these two.
+    requests.post(f"{BASE_URL}/api/web/settings/users", json={
+        "username": "admin", "password": "Password123!", "role": "admin"
+    })
+    requests.post(f"{BASE_URL}/api/auth/config", json={
+        "local_auth_enabled": True
+    })
 
-        # Step 2: Enable local auth (still bypassed -- auth not enabled yet)
-        requests.post(f"{BASE_URL}/api/auth/config", json={
-            "local_auth_enabled": True
-        })
+    login_r = requests.post(f"{BASE_URL}/api/auth/login", json={
+        "username": "admin", "password": "Password123!"
+    })
+    session_cookie = login_r.cookies.get("certmate_session")
+    if not session_cookie:
+        pytest.fail(
+            f"UI suite could not log in (HTTP {login_r.status_code}): "
+            f"{login_r.text[:200]}. Without a session every page redirects to "
+            f"/login and the tests would silently exercise the login screen."
+        )
 
-        # Step 3: Login to get session cookie (auth is now enabled)
-        login_r = requests.post(f"{BASE_URL}/api/auth/login", json={
-            "username": "admin", "password": "Password123!"
-        })
-        session_cookie = login_r.cookies.get("certmate_session")
+    s = requests.Session()
+    s.cookies.set("certmate_session", session_cookie)
+    r = s.get(f"{BASE_URL}/api/web/settings")
+    if r.status_code == 200:
+        data = r.json()
+        data["setup_completed"] = True
+        s.post(f"{BASE_URL}/api/web/settings", json=data)
+    return session_cookie
 
-        # Step 4: Mark setup as completed (using session cookie)
-        s = requests.Session()
-        s.cookies.set("certmate_session", session_cookie)
-        r = s.get(f"{BASE_URL}/api/web/settings")
-        if r.status_code == 200:
-            data = r.json()
-            data["setup_completed"] = True
-            s.post(f"{BASE_URL}/api/web/settings", json=data)
-    except Exception as e:
-        print(f"Warning: could not complete setup via API: {e}")
+
+@pytest.fixture(scope="module")
+def browser_page(docker_container, ui_session_cookie):
+    """Provide a Playwright browser page, already logged in."""
+    session_cookie = ui_session_cookie
 
     from playwright.sync_api import sync_playwright
     pw = sync_playwright().start()

--- a/tests/test_deploy_is_held_for_its_window.py
+++ b/tests/test_deploy_is_held_for_its_window.py
@@ -1,0 +1,425 @@
+"""A deploy with a maintenance window waits for it (#632).
+
+`modules/core/deploy_window` decides *when* a window is open; this decides what
+the deploy manager does about it. The two halves are separated because the
+calendar questions are pure and the queue questions are not: this file is about
+a deploy surviving a restart, two renewals collapsing into one deploy, and a
+hook that was deleted while its deploy waited.
+
+The property that matters more than any of them: a hook with no window runs
+immediately, exactly as it always has. Every existing installation is in that
+case, and a release that quietly started deferring their deploys would be an
+outage of a different shape.
+"""
+import datetime
+import json
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.deployer import DeployManager
+
+pytestmark = [pytest.mark.unit]
+
+UTC = datetime.timezone.utc
+NIGHT = {'start': '02:00', 'end': '04:00'}
+
+
+def _at(day, hour, minute=0):
+    return datetime.datetime(2026, 9, day, hour, minute, tzinfo=UTC)
+
+
+@pytest.fixture
+def manager(tmp_path):
+    settings = MagicMock()
+    manager = DeployManager(
+        settings_manager=settings, shell_executor=MagicMock(),
+        audit_logger=MagicMock(), event_bus=MagicMock(),
+        cert_dir=tmp_path / 'certs', data_dir=str(tmp_path / 'data'))
+    manager.ran = []
+    manager._run_hook = lambda hook, domain, event, dry_run=False: (
+        manager.ran.append((hook['id'], domain, event))
+        or {'success': True, 'hook': hook['id'], 'domain': domain})
+    return manager
+
+
+def _configure(manager, hooks, enabled=True, targets=None):
+    config = {'enabled': enabled, 'global_hooks': hooks, 'domain_hooks': {},
+              'targets': targets or []}
+    manager.get_config = lambda: config
+    return config
+
+
+def _hook(hook_id='h1', window=None, **extra):
+    hook = {'id': hook_id, 'name': hook_id, 'command': 'echo hi',
+            'enabled': True, 'on_events': ['created', 'renewed'], **extra}
+    if window is not None:
+        hook['window'] = window
+    return hook
+
+
+# ---------------------------------------------------------------------------
+# The default is unchanged
+# ---------------------------------------------------------------------------
+
+def test_a_hook_without_a_window_runs_immediately(manager):
+    _configure(manager, [_hook()])
+    manager._execute_hooks('example.com', 'renewed')
+    assert manager.ran == [('h1', 'example.com', 'renewed')]
+    assert not manager._pending_path.exists(), (
+        'an un-windowed hook wrote to the queue'
+    )
+
+
+def test_a_hook_whose_window_is_open_runs_immediately(manager, monkeypatch):
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 3))
+    manager._execute_hooks('example.com', 'renewed')
+    assert manager.ran == [('h1', 'example.com', 'renewed')]
+
+
+# ---------------------------------------------------------------------------
+# Held, then run
+# ---------------------------------------------------------------------------
+
+def test_a_closed_window_queues_instead_of_running(manager, monkeypatch):
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+
+    manager._execute_hooks('example.com', 'renewed')
+
+    assert manager.ran == [], 'the deploy ran outside its window'
+    queued = json.loads(manager._pending_path.read_text())
+    assert list(queued) == ['hook:h1:example.com']
+    assert queued['hook:h1:example.com']['event'] == 'renewed'
+
+
+def test_the_drain_runs_it_once_the_window_opens(manager, monkeypatch):
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+    manager._execute_hooks('example.com', 'renewed')
+
+    assert manager.drain_pending(now=_at(8, 23))['ran'] == 0, 'still shut'
+    assert manager.ran == []
+
+    summary = manager.drain_pending(now=_at(9, 2, 30))
+    assert summary['ran'] == 1
+    assert manager.ran == [('h1', 'example.com', 'renewed')]
+    assert not manager._pending_path.exists(), 'the entry was not cleared'
+
+
+def test_the_queue_survives_a_restart(manager, monkeypatch, tmp_path):
+    """The whole reason it is on disk. The window is hours away, and a
+    container restart in between is ordinary."""
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+    manager._execute_hooks('example.com', 'renewed')
+
+    reborn = DeployManager(
+        settings_manager=MagicMock(), shell_executor=MagicMock(),
+        audit_logger=MagicMock(), event_bus=MagicMock(),
+        cert_dir=tmp_path / 'certs', data_dir=str(tmp_path / 'data'))
+    reborn.ran = []
+    reborn._run_hook = lambda hook, domain, event, dry_run=False: (
+        reborn.ran.append((hook['id'], domain, event))
+        or {'success': True, 'hook': hook['id'], 'domain': domain})
+    _configure(reborn, [_hook(window=NIGHT)])
+
+    assert reborn.drain_pending(now=_at(9, 2, 30))['ran'] == 1
+    assert reborn.ran == [('h1', 'example.com', 'renewed')]
+
+
+def test_two_renewals_before_the_window_produce_one_deploy(manager, monkeypatch):
+    """The hook reads the certificate from disk when it runs, so one deferred
+    run always publishes the newest one. Queueing twice would restart the
+    database twice for no gain."""
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+    manager._execute_hooks('example.com', 'renewed')
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 19))
+    manager._execute_hooks('example.com', 'renewed')
+
+    assert len(json.loads(manager._pending_path.read_text())) == 1
+    assert manager.drain_pending(now=_at(9, 2, 30))['ran'] == 1
+
+
+def test_the_first_queue_time_is_kept_across_repeats(manager, monkeypatch):
+    """`queued_at` is what the stale warning measures. Refreshing it on every
+    renewal would mean a deploy stuck for a month never looks stuck."""
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+    manager._execute_hooks('example.com', 'renewed')
+    first = json.loads(manager._pending_path.read_text())[
+        'hook:h1:example.com']['queued_at']
+
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(9, 13))
+    manager._execute_hooks('example.com', 'renewed')
+    entry = json.loads(manager._pending_path.read_text())['hook:h1:example.com']
+
+    assert entry['queued_at'] == first
+    assert entry['last_event_at'] >= first
+
+
+def test_each_domain_queues_separately(manager, monkeypatch):
+    """A global hook applies to every domain, and two domains renewing on the
+    same night are two deploys, not one."""
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+    manager._execute_hooks('a.example.com', 'renewed')
+    manager._execute_hooks('b.example.com', 'renewed')
+
+    assert manager.drain_pending(now=_at(9, 2, 30))['ran'] == 2
+    assert {d for _id, d, _e in manager.ran} == {'a.example.com', 'b.example.com'}
+
+
+# ---------------------------------------------------------------------------
+# What the drain refuses to run
+# ---------------------------------------------------------------------------
+
+def test_a_hook_deleted_while_its_deploy_waited_is_dropped(manager, monkeypatch):
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+    manager._execute_hooks('example.com', 'renewed')
+
+    _configure(manager, [])  # the operator removed it
+    summary = manager.drain_pending(now=_at(9, 2, 30))
+
+    assert summary == {'ran': 0, 'held': 0, 'dropped': 1, 'results': []}
+    assert manager.ran == []
+    assert not manager._pending_path.exists()
+
+
+def test_a_hook_disabled_while_its_deploy_waited_is_dropped(manager, monkeypatch):
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+    manager._execute_hooks('example.com', 'renewed')
+
+    _configure(manager, [_hook(window=NIGHT, enabled=False)])
+    assert manager.drain_pending(now=_at(9, 2, 30))['dropped'] == 1
+    assert manager.ran == []
+
+
+def test_turning_deploy_hooks_off_drops_the_queue(manager, monkeypatch):
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+    manager._execute_hooks('example.com', 'renewed')
+
+    _configure(manager, [_hook(window=NIGHT)], enabled=False)
+    assert manager.drain_pending(now=_at(9, 2, 30))['dropped'] == 1
+    assert manager.ran == []
+
+
+def test_removing_the_window_releases_the_deploy_at_the_next_drain(
+        manager, monkeypatch):
+    """An operator who decides the window was a mistake should not have to wait
+    for it one last time."""
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+    manager._execute_hooks('example.com', 'renewed')
+
+    _configure(manager, [_hook()])
+    assert manager.drain_pending(now=_at(8, 14))['ran'] == 1
+
+
+def test_a_failing_hook_is_not_retried_every_minute(manager, monkeypatch):
+    """Failure-isolated like every other deploy path. Re-queueing would retry
+    at every drain for as long as the window is open."""
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+    manager._execute_hooks('example.com', 'renewed')
+
+    def _boom(hook, domain, event, dry_run=False):
+        raise RuntimeError('hook blew up')
+    manager._run_hook = _boom
+
+    summary = manager.drain_pending(now=_at(9, 2, 30))
+    assert summary['ran'] == 1
+    assert summary['results'][0]['success'] is False
+    assert not manager._pending_path.exists(), 'a failed deploy was re-queued'
+
+
+# ---------------------------------------------------------------------------
+# Robustness of the queue itself
+# ---------------------------------------------------------------------------
+
+def test_an_empty_queue_is_a_no_op(manager):
+    _configure(manager, [_hook()])
+    assert manager.drain_pending(now=_at(9, 3)) == {
+        'ran': 0, 'held': 0, 'dropped': 0, 'results': []}
+
+
+def test_a_corrupt_queue_does_not_raise(manager, monkeypatch, caplog):
+    """It is read by a scheduler job. Raising there would stop the job, and a
+    stopped job means deploys silently stop happening."""
+    manager._pending_path.parent.mkdir(parents=True, exist_ok=True)
+    manager._pending_path.write_text('{ not json')
+    _configure(manager, [_hook(window=NIGHT)])
+
+    with caplog.at_level('ERROR'):
+        assert manager.drain_pending(now=_at(9, 3))['ran'] == 0
+    assert 'unreadable' in caplog.text, 'a lost queue was silent'
+
+
+def test_an_unusable_window_deploys_rather_than_holding_forever(
+        manager, monkeypatch, caplog):
+    """save_config refuses these, so reaching this means a hand-edited file.
+    Deploying at the wrong hour is a disruption; never deploying is an expired
+    certificate on the far end.
+    """
+    _configure(manager, [_hook(window={'start': '02:00', 'end': 'nonsense'})])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+
+    with caplog.at_level('WARNING'):
+        manager._execute_hooks('example.com', 'renewed')
+
+    assert manager.ran == [('h1', 'example.com', 'renewed')]
+    assert 'unusable maintenance window' in caplog.text
+
+
+def test_a_deploy_stuck_for_a_week_is_reported(manager, monkeypatch, caplog):
+    _configure(manager, [_hook(window={'start': '02:00', 'end': '04:00',
+                                       'days': ['sun']})])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(1, 13))
+    manager._execute_hooks('example.com', 'renewed')
+
+    with caplog.at_level('WARNING'):
+        manager.drain_pending(now=_at(1, 13) + datetime.timedelta(days=8))
+    assert 'has been waiting since' in caplog.text
+
+
+def test_an_event_arriving_during_a_drain_is_not_lost(manager, monkeypatch):
+    """The drain rewrites the queue at the end. If it wrote back its own
+    snapshot, a deploy queued while it was running would vanish."""
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+    manager._execute_hooks('a.example.com', 'renewed')
+
+    def _run_and_queue_another(hook, domain, event, dry_run=False):
+        manager.ran.append((hook['id'], domain, event))
+        with manager._pending_lock:
+            queue = manager._read_pending()
+            queue['hook:h1:b.example.com'] = {
+                'kind': 'hook', 'id': 'h1', 'domain': 'b.example.com',
+                'event': 'renewed', 'queued_at': '2026-09-08T13:00:00Z',
+                'last_event_at': '2026-09-08T13:00:00Z'}
+            manager._write_pending(queue)
+        return {'success': True, 'hook': hook['id'], 'domain': domain}
+    manager._run_hook = _run_and_queue_another
+
+    manager.drain_pending(now=_at(9, 2, 30))
+
+    remaining = json.loads(manager._pending_path.read_text())
+    assert 'hook:h1:b.example.com' in remaining, (
+        'a deploy queued during the drain was discarded'
+    )
+
+
+def test_the_queue_is_written_under_a_lock(manager):
+    """Events are dispatched on daemon threads, so two certificates renewing at
+    once write this file concurrently. Last-writer-wins on a read-modify-write
+    would drop one of the deploys."""
+    _configure(manager, [_hook(window=NIGHT)])
+    import modules.core.deployer as mod
+    original = mod._utc_now
+    mod._utc_now = lambda: _at(8, 13)
+    try:
+        threads = [threading.Thread(target=manager._execute_hooks,
+                                    args=(f'd{i}.example.com', 'renewed'))
+                   for i in range(12)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+    finally:
+        mod._utc_now = original
+
+    assert len(json.loads(manager._pending_path.read_text())) == 12
+
+
+# ---------------------------------------------------------------------------
+# Manual deploy ignores windows
+# ---------------------------------------------------------------------------
+
+def test_deploy_now_ignores_the_window(manager, monkeypatch):
+    """An operator pressing Deploy Now has chosen this moment. Holding it until
+    02:00 would make the button do nothing visible."""
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+
+    result = manager.run_manual_deploy('example.com')
+
+    assert result['ok'] and result['succeeded'] == 1
+    assert manager.ran == [('h1', 'example.com', 'manual')]
+    assert not manager._pending_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# What the operator can see
+# ---------------------------------------------------------------------------
+
+def test_pending_deploys_can_be_listed(manager, monkeypatch):
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+    manager._execute_hooks('example.com', 'renewed')
+
+    rows = manager.get_pending(now=_at(8, 13))
+
+    assert len(rows) == 1
+    assert rows[0]['domain'] == 'example.com'
+    assert rows[0]['window'] == '02:00-04:00 UTC (every day)'
+    assert rows[0]['next_run'] == _at(9, 2).isoformat()
+    assert rows[0]['orphaned'] is False
+
+
+def test_a_listing_marks_an_orphaned_entry(manager, monkeypatch):
+    _configure(manager, [_hook(window=NIGHT)])
+    monkeypatch.setattr('modules.core.deployer._utc_now', lambda: _at(8, 13))
+    manager._execute_hooks('example.com', 'renewed')
+    _configure(manager, [])
+
+    assert manager.get_pending(now=_at(8, 13))[0]['orphaned'] is True
+
+
+# ---------------------------------------------------------------------------
+# Validation happens at save time
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('window,message', [
+    ({'start': '02:00', 'end': '02:00'}, 'same time'),
+    ({'start': 'midnight', 'end': '04:00'}, 'HH:MM'),
+    ({'start': '02:00', 'end': '04:00', 'timezone': 'Europe/Genova'},
+     'unknown timezone'),
+    ({'start': '02:00', 'end': '04:00', 'days': ['funday']}, 'unknown day'),
+])
+def test_an_unusable_window_is_refused_when_it_is_saved(manager, window, message):
+    ok, error = manager._validate_deploy_config(
+        {'global_hooks': [_hook(window=window)]})
+    assert not ok
+    assert message in error
+
+
+def test_a_valid_window_is_stored_in_canonical_form(manager):
+    hook = _hook(window={'start': '02:00', 'end': '04:00',
+                         'days': ['Monday', 'FRI'], 'timezone': ' Europe/Rome '})
+    ok, error = manager._validate_deploy_config({'global_hooks': [hook]})
+    assert ok, error
+    assert hook['window'] == {'start': '02:00', 'end': '04:00',
+                              'days': ['mon', 'fri'], 'timezone': 'Europe/Rome'}
+
+
+def test_an_absent_window_is_not_invented(manager):
+    """CONTROL: normalisation must not add an empty window to every hook, which
+    would make `entity.get('window')` truthy and defer everything."""
+    hook = _hook()
+    assert manager._validate_deploy_config({'global_hooks': [hook]})[0]
+    assert 'window' not in hook
+
+
+def test_a_target_window_is_validated_the_same_way(manager):
+    ok, error = manager._validate_deploy_config({'targets': [{
+        'name': 'k8s', 'type': 'kubernetes-secret',
+        'config': {'secret_name': 's', 'in_cluster': True},
+        'window': {'start': '02:00', 'end': '02:00'}}]})
+    assert not ok
+    assert 'same time' in error

--- a/tests/test_deploy_window.py
+++ b/tests/test_deploy_window.py
@@ -1,0 +1,290 @@
+"""When a deploy hook is allowed to run (#632).
+
+A certificate renews when it is due — 02:00 with an hour of jitter, and only
+for whatever is inside the threshold that night. The deploy hook then ran
+immediately, so a hook that restarts a database or reloads a load balancer
+caused an outage at an hour nobody chose. A maintenance window holds the deploy
+until the next time it is open, without touching when the certificate renews.
+
+Every case here is a calendar case: a window that wraps past midnight, a day
+filter, a timezone, and the two DST transitions where local time either skips
+an hour or repeats one. Those are exactly the cases that would be untestable if
+this decision lived inside the deploy manager, so it lives in
+`modules/core/deploy_window` as pure functions over an explicit `now`.
+"""
+import datetime
+
+import pytest
+
+from modules.core.deploy_window import (
+    WindowError,
+    describe,
+    is_open,
+    next_open,
+    normalize_window,
+)
+
+pytestmark = [pytest.mark.unit]
+
+UTC = datetime.timezone.utc
+
+
+def _at(year, month, day, hour, minute=0):
+    return datetime.datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# No window means what it always meant
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('absent', [None, {}, ''])
+def test_no_window_normalizes_to_none(absent):
+    assert normalize_window(absent) is None
+
+
+def test_no_window_is_always_open():
+    """The behaviour every existing hook has, and keeps. A release that
+    silently started deferring un-windowed hooks would be an outage of a
+    different shape."""
+    assert is_open(None, _at(2026, 9, 8, 13, 37))
+    assert next_open(None, _at(2026, 9, 8, 13, 37)) == _at(2026, 9, 8, 13, 37)
+    assert describe(None) == 'immediately'
+
+
+# ---------------------------------------------------------------------------
+# The ordinary window
+# ---------------------------------------------------------------------------
+
+SIMPLE = {'start': '02:00', 'end': '04:00'}
+
+
+@pytest.mark.parametrize('hour,minute,expected', [
+    (1, 59, False),
+    (2, 0, True),     # inclusive at the start
+    (3, 0, True),
+    (3, 59, True),
+    (4, 0, False),    # exclusive at the end, so 02:00-04:00 and 04:00-06:00
+    (4, 1, False),    # are adjacent rather than overlapping
+    (23, 0, False),
+])
+def test_the_edges_of_a_simple_window(hour, minute, expected):
+    assert is_open(SIMPLE, _at(2026, 9, 8, hour, minute)) is expected
+
+
+def test_next_open_from_before_the_window():
+    assert next_open(SIMPLE, _at(2026, 9, 8, 0, 30)) == _at(2026, 9, 8, 2, 0)
+
+
+def test_next_open_from_inside_the_window_is_now():
+    """A drain that runs while the window is open must not defer another day."""
+    now = _at(2026, 9, 8, 3, 0)
+    assert next_open(SIMPLE, now) == now
+
+
+def test_next_open_from_after_the_window_is_tomorrow():
+    assert next_open(SIMPLE, _at(2026, 9, 8, 5, 0)) == _at(2026, 9, 9, 2, 0)
+
+
+# ---------------------------------------------------------------------------
+# Wrapping past midnight
+# ---------------------------------------------------------------------------
+
+WRAPPED = {'start': '22:00', 'end': '04:00', 'days': ['fri']}
+
+
+@pytest.mark.parametrize('day,hour,expected,why', [
+    (11, 21, False, 'Friday, before it opens'),
+    (11, 22, True, 'Friday, open'),
+    (11, 23, True, 'Friday, still open'),
+    (12, 1, True, 'Saturday 01:00 belongs to the Friday window'),
+    (12, 3, True, 'Saturday 03:00 still belongs to it'),
+    (12, 4, False, 'Saturday 04:00, closed'),
+    (12, 22, False, 'Saturday 22:00 is not a Friday window'),
+])
+def test_a_wrapped_window_belongs_to_the_day_it_starts_on(day, hour, expected, why):
+    """2026-09-11 is a Friday.
+
+    The alternative reading — the window belongs to the day it ENDS on — would
+    make a "Friday night" window silently require Saturday to be selected too,
+    and an operator who checked only Friday would find their deploy held for a
+    week.
+    """
+    assert is_open(WRAPPED, _at(2026, 9, day, hour)) is expected, why
+
+
+def test_next_open_crosses_a_week_to_reach_a_single_day_window():
+    # Saturday 05:00: the Friday window just closed.
+    assert next_open(WRAPPED, _at(2026, 9, 12, 5, 0)) == _at(2026, 9, 18, 22, 0)
+
+
+# ---------------------------------------------------------------------------
+# Days
+# ---------------------------------------------------------------------------
+
+def test_a_day_filter_closes_the_other_days():
+    weekdays = {'start': '02:00', 'end': '04:00',
+                'days': ['mon', 'tue', 'wed', 'thu', 'fri']}
+    assert is_open(weekdays, _at(2026, 9, 11, 3))       # Friday
+    assert not is_open(weekdays, _at(2026, 9, 12, 3))   # Saturday
+    assert next_open(weekdays, _at(2026, 9, 12, 3)) == _at(2026, 9, 14, 2, 0)
+
+
+@pytest.mark.parametrize('written', ['Monday', 'MON', ' mon ', 'monday'])
+def test_day_names_are_forgiving_about_spelling(written):
+    assert normalize_window(
+        {'start': '02:00', 'end': '03:00', 'days': [written]})['days'] == ['mon']
+
+
+def test_an_omitted_day_list_means_every_day():
+    assert normalize_window(SIMPLE)['days'] == list(
+        ('mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'))
+
+
+# ---------------------------------------------------------------------------
+# Timezones
+# ---------------------------------------------------------------------------
+
+def test_the_window_is_read_in_its_own_timezone():
+    """The point of the field. 02:00 in Rome is 00:00 UTC in September, so a
+    UTC-only implementation would run this deploy two hours early."""
+    rome = {'start': '02:00', 'end': '04:00', 'timezone': 'Europe/Rome'}
+    assert is_open(rome, _at(2026, 9, 8, 0, 30))
+    assert not is_open(rome, _at(2026, 9, 8, 2, 30))
+
+
+def test_next_open_returns_utc_whatever_the_window_says():
+    """The queue stores instants, not wall clocks, so anything that leaks a
+    local time into it would compare wrong against the next drain."""
+    rome = {'start': '02:00', 'end': '04:00', 'timezone': 'Europe/Rome'}
+    when = next_open(rome, _at(2026, 9, 8, 12, 0))
+    assert when.tzinfo == UTC
+    assert when == _at(2026, 9, 9, 0, 0)
+
+
+def test_a_naive_moment_is_read_as_utc():
+    naive = datetime.datetime(2026, 9, 8, 3, 0)
+    assert is_open(SIMPLE, naive)
+
+
+# ---------------------------------------------------------------------------
+# Daylight saving, both directions
+# ---------------------------------------------------------------------------
+
+def test_a_window_inside_the_hour_that_does_not_exist_still_opens():
+    """Europe/Rome springs forward at 02:00 on 2026-03-29: local 02:00-02:59
+    never happens. A 02:00-04:00 window must open at 03:00 that day, not be
+    skipped for the year.
+    """
+    rome = {'start': '02:00', 'end': '04:00', 'timezone': 'Europe/Rome'}
+    # 2026-03-29 00:30 UTC is 01:30 local, just before the jump.
+    when = next_open(rome, _at(2026, 3, 29, 0, 30))
+    assert when == _at(2026, 3, 29, 1, 0), (
+        f'expected the window to open at the local 03:00 (01:00 UTC), got {when}'
+    )
+
+
+def test_a_window_inside_the_hour_that_happens_twice_is_open_for_both():
+    """Europe/Rome falls back at 03:00 on 2026-10-25: local 02:00-02:59 runs
+    twice. Both are inside the window, and a drain landing in either must
+    deploy rather than decide it already missed it.
+    """
+    rome = {'start': '02:00', 'end': '04:00', 'timezone': 'Europe/Rome'}
+    assert is_open(rome, _at(2026, 10, 25, 0, 30)), 'first pass (CEST)'
+    assert is_open(rome, _at(2026, 10, 25, 1, 30)), 'second pass (CET)'
+
+
+# ---------------------------------------------------------------------------
+# What is refused, and why
+# ---------------------------------------------------------------------------
+
+def test_a_window_whose_ends_are_equal_is_refused():
+    """It reads equally well as "always open" and "never open". An operator
+    must not have to discover by experiment which one was implemented."""
+    with pytest.raises(WindowError, match='same time'):
+        normalize_window({'start': '02:00', 'end': '02:00'})
+
+
+@pytest.mark.parametrize('window,message', [
+    ({'start': '2:00', 'end': '04:00'}, 'HH:MM'),
+    ({'start': '25:00', 'end': '04:00'}, 'HH:MM'),
+    ({'start': '02:60', 'end': '04:00'}, 'HH:MM'),
+    ({'start': '02:00', 'end': '04:00\n05:00'}, 'HH:MM'),
+    ({'start': 200, 'end': '04:00'}, 'must be a string'),
+    ({'end': '04:00'}, 'must be a string'),
+    ({'start': '02:00', 'end': '04:00', 'days': 'mon'}, 'must be a list'),
+    ({'start': '02:00', 'end': '04:00', 'days': ['funday']}, 'unknown day'),
+    ({'start': '02:00', 'end': '04:00', 'timezone': 'Europe/Milano'},
+     'unknown timezone'),
+    ({'start': '02:00', 'end': '04:00', 'timezone': 'Europe/Genova'},
+     'unknown timezone'),
+    ('02:00-04:00', 'must be an object'),
+])
+def test_what_a_window_may_not_say(window, message):
+    with pytest.raises(WindowError, match=message):
+        normalize_window(window)
+
+
+def test_an_unusable_timezone_is_refused_at_validation_not_at_drain_time():
+    """CONTROL for the case above. A typo'd zone that failed silently later
+    would hold every deploy for a window that never opens, and the failure
+    would surface days after the change that caused it.
+    """
+    with pytest.raises(WindowError) as excinfo:
+        normalize_window({'start': '02:00', 'end': '04:00',
+                          'timezone': 'Not/AZone'})
+    assert 'Not/AZone' in str(excinfo.value), (
+        'the message does not name the zone the operator typed'
+    )
+
+
+def test_utc_is_accepted_by_name():
+    assert normalize_window(
+        {'start': '02:00', 'end': '04:00', 'timezone': 'utc'})['timezone'] == 'UTC'
+
+
+@pytest.mark.parametrize('field,written', [
+    ('start', ' 02:00 '), ('end', ' 04:00\t'), ('timezone', ' Europe/Rome '),
+])
+def test_surrounding_whitespace_is_trimmed_not_refused(field, written):
+    """A form field picks up spaces; that is a typing accident, not an attack
+    surface. The `\\Z` anchor still refuses a value with a newline INSIDE it —
+    `test_what_a_window_may_not_say` covers that — so this trims the outside
+    without widening what the pattern accepts.
+    """
+    window = dict(SIMPLE, timezone='Europe/Rome')
+    window[field] = written
+    assert normalize_window(window)[field] == written.strip()
+
+
+# ---------------------------------------------------------------------------
+# The horizon
+# ---------------------------------------------------------------------------
+
+def test_next_open_crosses_days_for_a_weekly_window():
+    """A Monday-only window asked about on a Monday afternoon resolves to next
+    Monday rather than reporting "never"."""
+    monday_only = {'start': '02:00', 'end': '04:00', 'days': ['mon']}
+    # 2026-09-07 is a Monday; 15:00 is after that day's window.
+    assert next_open(monday_only, _at(2026, 9, 7, 15, 0)) == _at(2026, 9, 14, 2, 0)
+
+
+def test_the_worst_case_wait_fits_inside_the_search_horizon():
+    """Measured rather than asserted from the constant, because the constant is
+    the thing that could be wrong.
+
+    Every window recurs weekly and is at least a minute long, so the longest
+    possible wait is a week minus the window's length. The narrowest window
+    this module accepts — one minute, one day, wrapping midnight — is the worst
+    case, and it must still resolve.
+    """
+    narrowest = {'start': '23:59', 'end': '00:00', 'days': ['mon']}
+    # A minute after it closes, which is the furthest any caller can be from it.
+    when = next_open(narrowest, _at(2026, 9, 8, 0, 0))
+    assert when is not None, 'the worst-case window resolved to "never"'
+    assert when == _at(2026, 9, 14, 23, 59)
+    assert when - _at(2026, 9, 8, 0, 0) < datetime.timedelta(days=7)
+
+
+def test_describe_says_what_the_operator_configured():
+    assert describe(SIMPLE) == '02:00-04:00 UTC (every day)'
+    assert describe(WRAPPED) == '22:00-04:00 UTC (fri)'

--- a/tests/test_saving_deploy_hooks_keeps_the_targets.py
+++ b/tests/test_saving_deploy_hooks_keeps_the_targets.py
@@ -1,0 +1,168 @@
+"""Saving deploy hooks must not delete the deploy targets.
+
+Found while adding maintenance windows (#632), which apply to typed deploy
+targets as much as to shell hooks — and a window on a target is worth nothing
+if pressing Save removes the target.
+
+`deploy_hooks` in settings holds four keys: `enabled`, `global_hooks`,
+`domain_hooks`, and `targets` — the typed deploy targets from #475. The
+Settings -> Deploy screen manages the first three and has no editor for the
+fourth: `loadConfig` never reads `targets`, so `saveConfig` posts a body
+without them. `save_config` then assigned the whole block:
+
+    settings['deploy_hooks'] = config
+
+So opening Settings -> Deploy and pressing Save — without touching anything —
+silently deleted every configured Kubernetes secret target. No error, no audit
+entry naming the loss, and the next renewal simply stopped publishing to the
+cluster.
+
+The rule is the same one `CertificateService.update_config` already applies to
+certificate metadata: **absent leaves alone, an explicit value replaces** —
+including an explicit empty list, so a caller that means to clear the targets
+still can.
+"""
+import tempfile
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.deployer import DeployManager
+
+pytestmark = [pytest.mark.unit]
+
+TARGET = {'name': 'k8s-prod', 'type': 'kubernetes-secret',
+          'config': {'secret_name': 'tls', 'in_cluster': True}}
+HOOK = {'id': 'h1', 'name': 'reload', 'command': 'echo hi',
+        'enabled': True, 'on_events': ['renewed']}
+
+
+@pytest.fixture
+def stored():
+    return {'deploy_hooks': {
+        'enabled': True, 'global_hooks': [HOOK], 'domain_hooks': {},
+        'targets': [TARGET],
+    }}
+
+
+@pytest.fixture
+def manager(stored):
+    settings = MagicMock()
+    settings.update.side_effect = lambda mutate, reason: mutate(stored)
+    return DeployManager(settings, MagicMock(), MagicMock(), MagicMock(),
+                         cert_dir=Path(tempfile.mkdtemp()),
+                         data_dir=tempfile.mkdtemp())
+
+
+def _ui_payload():
+    """Exactly what the Settings -> Deploy screen posts: no `targets` key,
+    because `loadConfig` never put one in the component's state."""
+    return {'enabled': True, 'global_hooks': [dict(HOOK)], 'domain_hooks': {}}
+
+
+def test_a_save_from_the_hooks_screen_keeps_the_targets(manager, stored):
+    ok, error = manager.save_config(_ui_payload())
+
+    assert ok, error
+    assert stored['deploy_hooks'].get('targets') == [TARGET], (
+        'saving deploy hooks deleted the typed deploy targets, which that '
+        'screen has no editor for and the operator never touched'
+    )
+
+
+def test_the_hooks_themselves_are_still_replaced(manager, stored):
+    """CONTROL: preserving absent keys must not turn the whole save into a
+    merge that can never remove a hook."""
+    ok, error = manager.save_config(
+        {'enabled': True, 'global_hooks': [], 'domain_hooks': {}})
+
+    assert ok, error
+    assert stored['deploy_hooks']['global_hooks'] == [], (
+        'removing every hook no longer removes them'
+    )
+
+
+def test_an_explicit_empty_list_still_clears_the_targets(manager, stored):
+    """Absent and empty are different answers. A caller that means to clear
+    the targets says so, and is obeyed."""
+    ok, error = manager.save_config(dict(_ui_payload(), targets=[]))
+
+    assert ok, error
+    assert stored['deploy_hooks']['targets'] == []
+
+
+def test_the_master_switch_still_moves(manager, stored):
+    assert manager.save_config(dict(_ui_payload(), enabled=False))[0]
+    assert stored['deploy_hooks']['enabled'] is False
+
+
+def test_a_first_save_on_an_instance_with_no_deploy_block_works(manager):
+    """CONTROL: the merge must not assume something is already there."""
+    empty = {}
+    manager.settings_manager.update.side_effect = (
+        lambda mutate, reason: mutate(empty))
+
+    assert manager.save_config(_ui_payload())[0]
+    assert empty['deploy_hooks']['global_hooks'][0]['id'] == 'h1'
+
+
+def test_a_corrupt_existing_block_is_replaced_not_merged_into(manager):
+    """A hand-edited `deploy_hooks: "yes"` must not make the save crash or
+    quietly produce something that is neither."""
+    broken = {'deploy_hooks': 'yes'}
+    manager.settings_manager.update.side_effect = (
+        lambda mutate, reason: mutate(broken))
+
+    assert manager.save_config(_ui_payload())[0]
+    assert broken['deploy_hooks']['global_hooks'][0]['id'] == 'h1'
+    assert 'targets' not in broken['deploy_hooks']
+
+
+def test_a_window_on_a_target_survives_a_hooks_save(manager, stored):
+    """Why this was found. Maintenance windows (#632) apply to targets too,
+    and a window is worth nothing if saving hooks removes the target under it.
+    """
+    stored['deploy_hooks']['targets'] = [
+        dict(TARGET, window={'start': '02:00', 'end': '04:00',
+                             'days': ['sun'], 'timezone': 'UTC'})]
+
+    assert manager.save_config(_ui_payload())[0]
+    assert stored['deploy_hooks']['targets'][0]['window']['days'] == ['sun']
+
+
+def test_the_save_stays_atomic(manager):
+    """It goes through settings_manager.update, so a concurrent DNS-provider
+    save cannot lose it. A read-modify-write here would reintroduce exactly
+    the race that call exists to prevent."""
+    seen = []
+    manager.settings_manager.update.side_effect = (
+        lambda mutate, reason: seen.append(reason) or mutate({}))
+
+    manager.save_config(_ui_payload())
+    assert seen == ['deploy_hooks_save']
+    assert not manager.settings_manager.save_settings.called, (
+        'the save bypassed the atomic update path'
+    )
+
+
+def test_concurrent_saves_do_not_lose_the_targets(manager, stored):
+    """The merge reads and writes inside the mutate callback, which
+    settings_manager.update serialises. Doing it outside would restore the
+    lost-update this fix is about, only harder to see."""
+    lock = threading.Lock()
+
+    def _serialised(mutate, reason):
+        with lock:
+            mutate(stored)
+    manager.settings_manager.update.side_effect = _serialised
+
+    threads = [threading.Thread(target=manager.save_config,
+                                args=(_ui_payload(),)) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert stored['deploy_hooks']['targets'] == [TARGET]

--- a/tests/test_ui_deploy_window.py
+++ b/tests/test_ui_deploy_window.py
@@ -1,0 +1,183 @@
+"""The maintenance window is configurable from the UI (#632).
+
+The feature is worthless if the only way to set a window is to hand-edit
+`settings.json`, and its correctness is not visible from the JS source. Three
+things are pinned here, in the browser, against the real page:
+
+* the toggle exists and reveals the fields;
+* the window reaches the POST body, which is what the server validates and
+  stores — the DOM having the right values proves nothing on its own;
+* turning the toggle back off REMOVES the window rather than leaving an empty
+  object behind. That one matters more than it looks: the server treats any
+  window object as a reason to defer, so a leftover `{}` would hold every
+  deploy of that hook for a window with no hours in it.
+"""
+import json
+import os
+
+import pytest
+
+from tests.conftest import _REQUIRE_BROWSER
+
+if _REQUIRE_BROWSER:
+    import importlib.util
+    if importlib.util.find_spec("playwright") is None:
+        raise RuntimeError(
+            "playwright is not installed but CERTMATE_UI_REQUIRE_BROWSER=1"
+        )
+else:
+    pytest.importorskip("playwright")
+
+pytestmark = [pytest.mark.e2e, pytest.mark.ui]
+
+BASE_URL = f"http://localhost:{os.environ.get('CERTMATE_TEST_PORT', '18888')}"
+
+EXISTING = {
+    'enabled': True,
+    'global_hooks': [{
+        'id': 'hook-1', 'name': 'reload nginx', 'command': 'echo reload',
+        'enabled': True, 'timeout': 30, 'on_events': ['created', 'renewed'],
+    }],
+    'domain_hooks': {},
+    'targets': [],
+}
+
+
+def _open_deploy_tab(page, config=None):
+    """Settings → Deploy, with a known hook already configured.
+
+    /api/deploy/config is intercepted on GET so the panel has a hook to edit
+    without touching real settings; the POST is what the assertions read.
+    """
+    body = json.dumps(config if config is not None else EXISTING)
+
+    def _handle(route, request):
+        if request.method == 'GET':
+            route.fulfill(status=200, content_type='application/json',
+                          body=body)
+        else:
+            route.fulfill(status=200, content_type='application/json',
+                          body=json.dumps({'success': True}))
+
+    page.route('**/api/deploy/config', _handle)
+    page.add_init_script(
+        "try { window.localStorage.setItem('certmate_wizard_skipped', '1'); }"
+        " catch (e) {}")
+    page.goto(f'{BASE_URL}/settings')
+    page.click('#settings-tab-deploy')
+    page.wait_for_selector('#settings-panel-deploy', state='visible')
+
+
+def _capture_posts(page):
+    seen = []
+    page.on('request', lambda r: (
+        seen.append((r.url, r.post_data))
+        if r.method == 'POST' and '/api/deploy/config' in r.url else None))
+    return seen
+
+
+def _open_global_hooks(page, config=None):
+    """Settings -> Deploy, with the Global Hooks accordion expanded.
+
+    Opening the tab is part of this on purpose: the panel is behind
+    `x-show="tab === 'deploy'"`, and a locator that resolves inside a hidden
+    panel simply never becomes clickable — a 30-second timeout that reads like
+    a missing element.
+    """
+    _open_deploy_tab(page, config)
+    panel = page.locator('#settings-panel-deploy')
+    panel.locator('button:has-text("Global Hooks")').first.click()
+    page.wait_for_timeout(200)
+    return panel
+
+
+def test_the_hook_editor_offers_a_maintenance_window(browser_page):
+    panel = _open_global_hooks(browser_page)
+    toggle = panel.locator(
+        'label:has-text("Only deploy during a maintenance window") '
+        'input[type="checkbox"]')
+    assert toggle.count() >= 1, (
+        'the deploy hook editor has no maintenance-window control, so a window '
+        'can only be set by hand-editing settings.json'
+    )
+
+
+def test_the_fields_are_hidden_until_the_window_is_switched_on(browser_page):
+    """CONTROL: a window that is always visible would suggest every hook has
+    one, and the default — deploy immediately — is what nearly every hook
+    wants."""
+    panel = _open_global_hooks(browser_page)
+    start = panel.locator('input[aria-label="Maintenance window start"]')
+    assert start.count() == 0, (
+        'the window fields exist for a hook that has no window. They are '
+        'behind x-if rather than x-show for a reason: x-show leaves the '
+        'bindings live, so `hook.window.start` is evaluated for every '
+        'window-less hook and Alpine logs an error per binding per hook.'
+    )
+
+    panel.locator('label:has-text("Only deploy during a maintenance window") '
+                  'input[type="checkbox"]').first.click()
+    browser_page.wait_for_timeout(300)
+    assert start.count() >= 1 and start.first.is_visible(), (
+        'the toggle did not reveal the fields'
+    )
+
+
+def test_the_window_reaches_the_saved_configuration(browser_page):
+    """The fields existing is not the feature; the window arriving is."""
+    panel = _open_global_hooks(browser_page)
+    posts = _capture_posts(browser_page)
+
+    panel.locator('label:has-text("Only deploy during a maintenance window") '
+                  'input[type="checkbox"]').first.click()
+    browser_page.wait_for_timeout(200)
+    panel.locator('input[aria-label="Maintenance window start"]').first.fill('23:00')
+    panel.locator('input[aria-label="Maintenance window end"]').first.fill('01:30')
+    panel.locator('input[aria-label="Maintenance window timezone"]').first.fill(
+        'Europe/Rome')
+    panel.locator('label:has-text("Maintenance window on sat"), '
+                  'input[aria-label="Maintenance window on sat"]').last.click()
+    browser_page.wait_for_timeout(200)
+
+    browser_page.locator(
+        '#settings-panel-deploy button:has-text("Save")').first.click()
+    browser_page.wait_for_timeout(600)
+
+    assert posts, 'the deploy configuration was never saved'
+    hook = json.loads(posts[-1][1] or '{}')['global_hooks'][0]
+    assert hook.get('window') == {
+        'start': '23:00', 'end': '01:30', 'days': ['sat'],
+        'timezone': 'Europe/Rome',
+    }, f'the window did not reach the request body: {hook.get("window")!r}'
+
+
+def test_switching_the_window_off_removes_it_rather_than_emptying_it(
+        browser_page):
+    """The one that would be silent. The server defers on the PRESENCE of a
+    window object, so a hook left with `window: {}` would be held for a window
+    that has no hours in it — every deploy, forever, with nothing logged.
+    """
+    with_window = json.loads(json.dumps(EXISTING))
+    with_window['global_hooks'][0]['window'] = {
+        'start': '02:00', 'end': '04:00', 'days': [], 'timezone': 'UTC'}
+
+    panel = _open_global_hooks(browser_page, with_window)
+    posts = _capture_posts(browser_page)
+
+    toggle = panel.locator(
+        'label:has-text("Only deploy during a maintenance window") '
+        'input[type="checkbox"]').first
+    assert toggle.is_checked(), 'the stored window was not reflected in the UI'
+    toggle.click()
+    browser_page.wait_for_timeout(200)
+
+    browser_page.locator(
+        '#settings-panel-deploy button:has-text("Save")').first.click()
+    browser_page.wait_for_timeout(600)
+
+    assert posts, 'the deploy configuration was never saved'
+    hook = json.loads(posts[-1][1] or '{}')['global_hooks'][0]
+    assert 'window' not in hook, (
+        f'switching the window off left {hook.get("window")!r} behind, which '
+        f'the server reads as a window and defers on'
+    )


### PR DESCRIPTION
Closes #632.

> We have a need to deploy to multiple locations but at a specific time. Right now it will run the renewal when it's ready, but we don't know exactly when... certificate changes on RDS-server deployment, this will disrupt end user connectivity.

The diagnosis is right. A certificate renews when it is **due** — the sweep fires at 02:00 with an hour of jitter, and only for whatever is inside the threshold that night — and the deploy hook then ran immediately. For a hook that restarts a database or reloads a load balancer, that is an outage at an hour nobody chose.

A `window` separates the two. The certificate still renews whenever it is due, which is driven by expiry and not negotiable. The **deploy** is held until the window next opens.

```jsonc
"window": {
  "start": "02:00",          // required, 24-hour HH:MM
  "end": "04:00",            // required, exclusive
  "days": ["sat", "sun"],    // optional; omit for every day
  "timezone": "Europe/Rome"  // optional IANA name, defaults to UTC
}
```

Absent means **immediately** — what every existing hook does, and keeps doing. The same field works on typed deploy targets (#475), which is usually where it is wanted: a Kubernetes secret rollout is exactly that kind of deploy.

### The calendar lives on its own

`modules/core/deploy_window.py` is pure functions over an explicit `now`, because every interesting case here is a calendar case and none of them is testable through a queue and a scheduler:

* a window may **cross midnight**, and belongs to the day it **starts** on — a `22:00`-`04:00` Friday window is open at 02:00 Saturday. The other reading would silently require Saturday to be ticked as well;
* `end` is **exclusive**, so `02:00`-`04:00` and `04:00`-`06:00` are adjacent rather than overlapping;
* `start == end` is **refused**. It reads equally well as "always open" and "never open", and an operator should not discover by experiment which one was implemented;
* the timezone is an IANA name validated **at save time** — a typo'd zone that failed later would hold every deploy for a window that never opens, surfacing days after the change;
* **DST in both directions**: on Rome's spring-forward day a `02:00`-`04:00` window opens at the local 03:00, because 02:00-02:59 does not happen; on the autumn day it is open across both passes of 02:00-02:59.

### The queue

`data/pending_deploys.json`, on disk because the window is hours away and a restart in between is ordinary. Written under a lock — events dispatch on daemon threads, so two certificates renewing at once write it concurrently.

| Situation | What happens |
| --- | --- |
| A second renewal before the window opens | One deploy, not two. The hook reads the certificate from disk when it runs. |
| The hook was deleted or disabled while waiting | Dropped. The current configuration says not to run it. |
| The window was removed | Released at the next drain, not one window later. |
| The hook fails inside its window | Recorded, **not** re-queued — otherwise it retries every minute for as long as the window is open. |
| Still waiting after 7 days | Logged as stuck. Not a limit — waiting is the feature — but a week means the days or the timezone are not what was meant. |
| The queue file is corrupt | Logged at error and the drain continues. A lost queue must not be silent. |
| An unreadable window (hand-edited file) | Deploys now. A disruption beats a certificate that never reaches the far end. |

Drained **every minute**, deliberately: a window is at least a minute long, so minute polling means no window can be missed. It is a true no-op when the queue file does not exist.

**Deploy Now** and `POST /api/deploy/test/<id>` ignore windows. Pressing the button is choosing this moment.

Held deploys are invisible everywhere else — the certificate renewed, the history shows nothing, nothing failed — so `GET /api/deploy/pending` lists them with their window and its next opening.

### Two defects found on the way

**Saving deploy hooks deleted every typed deploy target.** Settings → Deploy has no editor for `targets`: `loadConfig` never reads them, so `saveConfig` posts a body without them, and `save_config` assigned the whole `deploy_hooks` block. Opening that screen and pressing Save — *without touching anything* — silently removed every configured Kubernetes secret target. No error, no audit entry naming the loss, and the next renewal simply stopped publishing to the cluster. Absent now leaves alone; an explicit value, including an empty list, replaces. Same rule `CertificateService.update_config` already applies.

**The window fields were behind `x-show`**, which keeps the inner bindings live, so `hook.window.start` was evaluated for every hook *without* a window — one Alpine error per binding per hook in the console. `x-if` now.

### Checks

53 tests on the calendar, 29 on the queue, 9 on target preservation, 4 in a real browser. Each load-bearing decision was mutated to confirm a test fails: making the end inclusive, attributing a wrapped window to the day it ends on, dropping the equal-ends refusal, letting an unknown timezone become UTC in silence, ignoring the timezone entirely, and restoring the whole-block save. Full unit suite 3866 passed / 31 skipped, gated flake8 clean, coverage floors met, bandit and the theme codemod clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)