### PR TITLE
fix: an unreadable credential file leaves the instance locked, not open

### DIFF
--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -88,6 +88,22 @@ def validate_username(username):
         return None, f'Username cannot exceed {USERNAME_MAX_LENGTH} characters'
     return clean, None
 
+class BearerTokenFileUnreadable(Exception):
+    """API_BEARER_TOKEN_FILE is set and cannot be read.
+
+    Exists so that "the operator configured no bearer token" and "the operator
+    configured one in a file we cannot read right now" stop being the same
+    value. They lead to opposite decisions: the first is a fresh install that
+    must stay open so it can be bootstrapped, the second is a configured
+    instance that must stay closed.
+    """
+
+    def __init__(self, path, cause):
+        self.path = path
+        self.cause = cause
+        super().__init__(f"{path}: {cause}")
+
+
 class AuthManager:
     """Class to handle authentication and authorization"""
     
@@ -1027,8 +1043,12 @@ class AuthManager:
             try:
                 from pathlib import Path
                 token = Path(token_file).read_text().strip()
-            except Exception:
-                return False
+            except Exception as e:
+                # NOT "no token was configured". The operator named this file
+                # as the source of the credential, so failing to read it is a
+                # configuration error, and the two answers must not collapse
+                # into the same False — see BearerTokenFileUnreadable.
+                raise BearerTokenFileUnreadable(token_file, e)
             return bool(token) and validate_api_token(token)[0]
         env_token = os.getenv('API_BEARER_TOKEN')
         if env_token:
@@ -1036,12 +1056,40 @@ class AuthManager:
         return False
 
     def has_operator_bearer_token(self):
-        """Memoised wrapper over _detect_operator_bearer_token (env/file are
-        fixed for the process lifetime)."""
+        """Memoised wrapper over _detect_operator_bearer_token.
+
+        Two things this deliberately does NOT do.
+
+        It does not treat an unreadable API_BEARER_TOKEN_FILE as "no operator
+        token". That answer feeds setup_mode_for, and on a deployment whose
+        only credential is that file it would open the instance: setup mode
+        makes _authenticate_request return an admin identity for a caller with
+        no credential at all. A read failure therefore keeps the instance
+        LOCKED — the operator configured a credential, we simply cannot read
+        it this instant — and is logged at ERROR rather than swallowed.
+
+        And it does not memoise that failure. The docstring here used to say
+        env and file are fixed for the process lifetime; the variable is, the
+        file it names is not. A Kubernetes secret mounted a moment after the
+        container starts, a remount with different ownership, an SELinux
+        relabel — each produces one unreadable read followed by readable ones,
+        and caching the first would fix the wrong answer in place until the
+        next restart. Only a determination that actually read the file (or
+        found no file configured) is cached.
+        """
         cached = getattr(self, '_operator_bearer_token', _UNSET)
-        if cached is _UNSET:
+        if cached is not _UNSET:
+            return cached
+        try:
             cached = self._detect_operator_bearer_token()
-            self._operator_bearer_token = cached
+        except BearerTokenFileUnreadable as e:
+            logger.error(
+                "API_BEARER_TOKEN_FILE is set but could not be read (%s). "
+                "Treating this instance as CONFIGURED so it stays locked; it "
+                "will not accept the bearer token until the file is readable. "
+                "This is deliberately not cached — the next check retries.", e)
+            return True
+        self._operator_bearer_token = cached
         return cached
 
     def _operator_supplied_token(self):

--- a/tests/test_auth_setup_mode.py
+++ b/tests/test_auth_setup_mode.py
@@ -82,10 +82,26 @@ def test_detect_token_file_is_true(monkeypatch, tmp_path):
     assert AuthManager._detect_operator_bearer_token() is True
 
 
-def test_detect_missing_token_file_is_false(monkeypatch, tmp_path):
+def test_detect_missing_token_file_raises_rather_than_reporting_absence(
+        monkeypatch, tmp_path):
+    """This used to assert False, and False was the defect.
+
+    The detector's answer feeds setup_mode_for, where False means "no operator
+    credential exists" — which on a token-file-only deployment opens the
+    instance. A file the operator NAMED and that cannot be read is not an
+    absence of configuration; it is a configuration that cannot be honoured
+    right now, and the two must reach opposite decisions.
+
+    tests/test_bearer_token_file_failures_fail_closed.py carries the rest,
+    including the control that a genuinely unconfigured install still opens.
+    """
+    from modules.core.auth import BearerTokenFileUnreadable
+
     _clear_token_env(monkeypatch)
     monkeypatch.setenv('API_BEARER_TOKEN_FILE', str(tmp_path / 'does-not-exist'))
-    assert AuthManager._detect_operator_bearer_token() is False
+
+    with pytest.raises(BearerTokenFileUnreadable):
+        AuthManager._detect_operator_bearer_token()
 
 
 # --- is_setup_mode ----------------------------------------------------------

--- a/tests/test_bearer_token_file_failures_fail_closed.py
+++ b/tests/test_bearer_token_file_failures_fail_closed.py
@@ -1,0 +1,199 @@
+"""An unreadable credential file leaves the instance locked, not open.
+
+`setup_mode_for` decides whether this instance requires a credential at all.
+Its first question is whether the operator provided an API bearer token, and
+when that token is supplied as a file — the documented Docker and Kubernetes
+pattern — the answer came from reading it.
+
+A read failure was reported as "the operator provided no token". On a
+deployment whose only credential is that file, with no local users and no
+OIDC, that is the difference between a locked instance and one where
+`_authenticate_request` hands an anonymous caller an admin identity. The
+decision was also memoised, so a file that was unreadable for one instant at
+startup stayed unreadable in effect until the process was restarted.
+
+The two answers are now separate values. "No token was configured" is still
+False, because a fresh install must stay open long enough to be bootstrapped —
+that case is a CONTROL here, and it is the one these tests could most easily
+break. "A token was configured and cannot be read right now" raises, and the
+caller treats it as configured: locked, logged at ERROR, and not cached, so the
+next check retries.
+"""
+import logging
+import pathlib
+import secrets
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.auth import AuthManager, BearerTokenFileUnreadable
+
+pytestmark = [pytest.mark.unit]
+
+UNCONFIGURED = {'local_auth_enabled': False, 'users': {}, 'oidc': {}}
+
+
+@pytest.fixture
+def token_file(monkeypatch):
+    path = pathlib.Path(tempfile.mkdtemp()) / 'api_bearer_token'
+    path.write_text(secrets.token_urlsafe(48))
+    monkeypatch.setenv('API_BEARER_TOKEN_FILE', str(path))
+    monkeypatch.delenv('API_BEARER_TOKEN', raising=False)
+    return path
+
+
+def _manager():
+    manager = AuthManager.__new__(AuthManager)
+    manager.settings_manager = MagicMock()
+    return manager
+
+
+# ---------------------------------------------------------------------------
+# The two answers that must not be the same
+# ---------------------------------------------------------------------------
+
+def test_a_readable_token_file_locks_the_instance(token_file):
+    """CONTROL for everything below: the ordinary configured case."""
+    assert _manager().setup_mode_for(UNCONFIGURED) is False
+
+
+def test_no_token_configured_at_all_still_opens_setup_mode(monkeypatch):
+    """THE control. A fresh install has no credential of any kind and must
+    stay open long enough for an operator to create one — that is what setup
+    mode is for. A fix that locked this case would make the product
+    unbootstrappable, which is a worse failure than the one being fixed."""
+    monkeypatch.delenv('API_BEARER_TOKEN_FILE', raising=False)
+    monkeypatch.delenv('API_BEARER_TOKEN', raising=False)
+
+    assert _manager().setup_mode_for(UNCONFIGURED) is True
+
+
+@pytest.mark.parametrize('break_it,label', [
+    (lambda p: p.chmod(0o000), 'permissions changed'),
+    (lambda p: p.unlink(), 'file not there yet'),
+])
+def test_an_unreadable_token_file_keeps_the_instance_locked(
+        token_file, break_it, label):
+    """The defect. Both shapes are ordinary operational events — a secret
+    remounted with different ownership, a volume that is not ready when the
+    container starts — and neither may open the instance."""
+    break_it(token_file)
+
+    assert _manager().setup_mode_for(UNCONFIGURED) is False, (
+        f'an unreadable token file ({label}) put the instance into setup mode, '
+        f'where an anonymous caller is admin'
+    )
+
+
+def test_the_read_failure_is_distinguishable_from_absence(token_file):
+    """The mechanism, asserted directly: the detector raises rather than
+    returning the same False it returns for 'nothing was configured'."""
+    token_file.chmod(0o000)
+
+    with pytest.raises(BearerTokenFileUnreadable) as excinfo:
+        AuthManager._detect_operator_bearer_token()
+
+    assert str(token_file) in str(excinfo.value), (
+        'the error does not name the file the operator configured'
+    )
+
+
+def test_the_failure_is_logged_at_error(token_file, caplog):
+    """A decision this consequential must not be silent. The previous code
+    discarded the exception without a line, so the only evidence that the
+    instance had decided it was unconfigured was its behaviour."""
+    token_file.unlink()
+
+    with caplog.at_level(logging.ERROR):
+        _manager().setup_mode_for(UNCONFIGURED)
+
+    assert 'API_BEARER_TOKEN_FILE' in caplog.text
+    assert 'locked' in caplog.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# The failure must not be cached
+# ---------------------------------------------------------------------------
+
+def test_a_transient_read_failure_is_not_remembered(token_file):
+    """The memoisation was justified on the premise that env and file are
+    fixed for the process lifetime. The variable is; the file it names is not.
+    A secret mounted a moment late produced one failed read, and caching it
+    fixed the wrong state in place until a restart."""
+    manager = _manager()
+    token_file.chmod(0o000)
+    assert manager.setup_mode_for(UNCONFIGURED) is False
+
+    # The cache must be EMPTY, not holding the failure's answer. Asserting the
+    # answer alone cannot see this: a cached failure and a fresh failure both
+    # say "locked", so only the absence of the cache entry distinguishes them.
+    assert not hasattr(manager, '_operator_bearer_token'), (
+        'the read failure was cached, so a secret mounted one instant late '
+        'stays unreadable in effect until the process restarts'
+    )
+
+    token_file.chmod(0o600)
+    assert manager.has_operator_bearer_token() is True
+    assert manager._operator_bearer_token is True, (
+        'the successful read was not cached, so every request re-reads the file'
+    )
+
+
+def test_a_successful_determination_is_still_cached(token_file, caplog):
+    """CONTROL: the memoisation exists for a reason — this is on the path of
+    every authorization decision. Only the failure is exempt from it."""
+    manager = _manager()
+    assert manager.has_operator_bearer_token() is True
+
+    # Deleting the file must now be invisible, because the cache answers.
+    # Asserting the return value alone cannot see a missing cache — an
+    # uncached call would read, fail, and return True as well. The absence of
+    # the ERROR line is what proves the file was not consulted.
+    token_file.unlink()
+    with caplog.at_level(logging.ERROR):
+        assert manager.has_operator_bearer_token() is True
+    assert 'API_BEARER_TOKEN_FILE' not in caplog.text, (
+        'the cached determination was discarded and the file was read again'
+    )
+
+
+def test_an_absent_configuration_is_cached_too(monkeypatch):
+    """CONTROL: 'no token configured' is a determination, not a failure, and
+    caching it is what keeps the common path cheap."""
+    monkeypatch.delenv('API_BEARER_TOKEN_FILE', raising=False)
+    monkeypatch.delenv('API_BEARER_TOKEN', raising=False)
+    manager = _manager()
+
+    assert manager.has_operator_bearer_token() is False
+    assert manager._operator_bearer_token is False
+
+
+# ---------------------------------------------------------------------------
+# The environment-variable form is unaffected
+# ---------------------------------------------------------------------------
+
+def test_the_environment_variable_form_still_works(monkeypatch):
+    monkeypatch.delenv('API_BEARER_TOKEN_FILE', raising=False)
+    monkeypatch.setenv('API_BEARER_TOKEN', secrets.token_urlsafe(48))
+
+    assert _manager().setup_mode_for(UNCONFIGURED) is False
+
+
+def test_an_invalid_environment_token_does_not_count_as_configured(monkeypatch):
+    """CONTROL: fail-closed on a read failure must not become fail-closed on
+    anything. A token that does not pass validation is not a configured
+    credential, and the instance must still open so it can be fixed."""
+    monkeypatch.delenv('API_BEARER_TOKEN_FILE', raising=False)
+    monkeypatch.setenv('API_BEARER_TOKEN', 'short')
+
+    assert _manager().setup_mode_for(UNCONFIGURED) is True
+
+
+def test_an_empty_token_file_is_not_a_configured_credential(token_file):
+    """An empty file is readable and says nothing. That is a determination
+    (no usable token) rather than a failure, so it does not lock the instance
+    — otherwise touching the file by mistake would brick onboarding."""
+    token_file.write_text('')
+
+    assert _manager().setup_mode_for(UNCONFIGURED) is True


### PR DESCRIPTION
Hardening on the predicate that decides whether this instance requires a credential at all.

### The distinction that was missing

`setup_mode_for` asks first whether the operator provided an API bearer token. When that token is supplied as a **file** — the pattern the README and `docs/docker.md` both document for Docker and Kubernetes secrets — the answer came from reading it, and **any** read failure was reported as *"the operator provided no token"*.

Those are opposite situations:

* **no credential of any kind** — a fresh install, which must stay open long enough to be bootstrapped;
* **a credential the operator named, in a file we cannot read this instant** — a configured instance, which must stay closed.

Collapsing them into the same `False` meant the second was treated as the first.

### What changed

`_detect_operator_bearer_token` now raises `BearerTokenFileUnreadable` instead of returning a value that means something else. `has_operator_bearer_token` treats that as **configured** — instance stays locked, logged at ERROR rather than swallowed — and **does not cache it**.

That last part matters as much as the first. The memoisation was justified on the premise that the environment and the file are fixed for the process lifetime. The variable is; the file it names is not. A Kubernetes secret mounted a moment after the container starts, a remount with different ownership, an SELinux relabel — each produces one failed read followed by readable ones, and caching the first fixed that answer in place until the next restart. Now the next check retries and the instance recovers on its own.

### What deliberately did not change

The control the tests assert first: **a genuinely unconfigured install still opens setup mode.** A fix that locked that case would make the product unbootstrappable, which is a worse failure than the one being fixed. An empty token file and an invalid token also still count as unconfigured — those are determinations, not failures, so touching the file by mistake cannot brick onboarding.

`tests/test_auth_setup_mode.py::test_detect_missing_token_file_is_false` asserted the old behaviour. It is updated rather than deleted, with a note recording that the assertion was the defect.

### Checks

12 new tests. Four mutations, all killed: returning to the old value, lowering the log back to debug, caching the failure, and removing the memoisation entirely. The last two survived a first pass because the tests asserted the *answer*, which is identical either way — only the presence or absence of the cache entry distinguishes them, so the assertions were narrowed to that.

Full unit suite 3930 passed / 31 skipped, gated flake8 clean, coverage floors met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)