### PR TITLE
ci: make the gate set visible, and gate on the work CI already does

### DIFF
--- a/.github/required-checks.yml
+++ b/.github/required-checks.yml
@@ -1,0 +1,120 @@
+# Which CI jobs gate a merge, and which only report.
+#
+# Branch protection lives in GitHub's settings, where it is invisible to
+# everyone without admin rights and drifts without leaving a trace. An audit
+# found the consequence: the repository ran a Playwright UI suite, a Trivy
+# image scan, a CSS staleness check and an MCP suite on every pull request, and
+# not one of them could block a merge. The work was being done and thrown away.
+#
+# This file is the reviewable copy of that decision. It is not read by GitHub —
+# branch protection still has to be set through the API — but
+# tests/test_required_checks_registry.py fails when a workflow job that runs on
+# a pull request is missing from it, so a new job cannot arrive unclassified,
+# and `advisory` has to carry a reason someone can argue with.
+#
+# To apply this file to the repository (needs admin on the repo):
+#
+#   gh api -X PUT repos/fabriziosalmi/certmate/branches/main/protection/required_status_checks \
+#     -f strict=true \
+#     "$(python3 -c "import yaml,sys;print(' '.join('-f contexts[]='+c['context'] for c in yaml.safe_load(open('.github/required-checks.yml'))['gating']))")"
+#
+# The `context` of each entry is the name GitHub shows in the merge box, which
+# is the job's `name:` when it has one, the job id when it does not, and gets a
+# `(value)` suffix for every matrix dimension.
+
+version: 1
+
+gating:
+  - context: build
+    workflow: docker-multiplatform.yml
+    job: build
+    why: >-
+      The image has to build for both published architectures. Nothing else
+      ships if this is red.
+
+  - context: test (3.12)
+    workflow: ci.yml
+    job: test
+    why: >-
+      The Python suite, minus the UI marker. The per-module coverage floors
+      from #662 live here.
+
+  - context: Analyze python
+    workflow: codeql.yml
+    job: analyze
+    why: Static analysis on the code that issues certificates.
+
+  - context: Analyze javascript
+    workflow: codeql.yml
+    job: analyze
+    why: Static analysis on the frontend that drives it.
+
+  - context: emoji
+    workflow: lint-emoji.yml
+    job: emoji
+    why: House style; cheap, deterministic, and it never has a false positive.
+
+  - context: ui-gate
+    workflow: ui-tests.yml
+    job: ui-gate
+    why: >-
+      The Playwright suite is the only thing that exercises the templates, and
+      two settings tests once rotted for months behind a green board. `ui`
+      itself is deliberately NOT the required context: it is limited to
+      frontend changes, and a required context that never starts leaves a PR
+      pending forever. `ui-gate` always runs and turns "skipped" into a pass.
+
+  - context: security-scan
+    workflow: docker-multiplatform.yml
+    job: security-scan
+    why: >-
+      Fails on a fixable CRITICAL in the published image. This one can go red
+      without the PR changing — Trivy's database moves daily — and that is the
+      point: a fixable CRITICAL in the base image is the maintainer's problem
+      the day it is published, not the day someone notices.
+
+  - context: frontend-css
+    workflow: ci.yml
+    job: frontend-css
+    why: >-
+      Catches a committed CSS bundle that no longer matches its source, and the
+      theme-token regression gate. A stale bundle ships a UI nobody reviewed.
+
+  - context: MCP server
+    workflow: ci.yml
+    job: mcp
+    why: >-
+      The MCP server is a published surface with its own suite. Deterministic,
+      hosted, and there is no reason for it to be advisory.
+
+advisory:
+  - context: storage-live
+    workflow: ci.yml
+    job: storage-live
+    why: >-
+      Boots MinIO and Vault as service containers pulled at run time. A
+      registry rate-limit or an upstream image change fails it with nothing
+      wrong in the PR, so it reports rather than blocks. Read it before
+      merging anything that touches modules/core/storage.
+
+  - context: acme-dns-live
+    workflow: ci.yml
+    job: acme-dns-live
+    why: >-
+      Same shape: acme-dns plus the postgres it needs, both pulled at run time.
+      It exists because acme-dns had never worked in any release (v2.24.1), so
+      a red run here is worth stopping for even though it does not block.
+
+  - context: ui
+    workflow: ui-tests.yml
+    job: ui
+    why: >-
+      The real Playwright suite, reported through `ui-gate`. Not required
+      directly because it does not run on every pull request.
+
+  - context: changes
+    workflow: ui-tests.yml
+    job: changes
+    why: >-
+      Decides whether `ui` has anything to look at. Its failure already fails
+      `ui-gate`, so requiring it too would add nothing.

--- a/.github/required-checks.yml
+++ b/.github/required-checks.yml
@@ -118,3 +118,31 @@ advisory:
     why: >-
       Decides whether `ui` has anything to look at. Its failure already fails
       `ui-gate`, so requiring it too would add nothing.
+
+# Status contexts posted on pull requests by GitHub Apps rather than by a job
+# in this repository. Nothing here can be checked against the workflow files,
+# so the list is maintained by hand — but leaving them out would have repeated
+# the mistake this file exists to fix: two coverage checks report on every pull
+# request and it was not written down anywhere that they do not gate.
+external:
+  - context: codecov/patch
+    source: Codecov
+    why: >-
+      Coverage on the diff. Advisory because coverage is already gated inside
+      `test (3.12)` by scripts/check_coverage_floors.py (#662), which enforces
+      per-module floors rather than one repository-wide percentage. A second,
+      weaker gate on the same property would only add flakiness — Codecov also
+      goes red when its upload is rate-limited.
+
+  - context: codecov/project
+    source: Codecov
+    why: >-
+      Repository-wide coverage. Same reason as codecov/patch: the floors in
+      scripts/check_coverage_floors.py are the gate, and they are stricter.
+
+  - context: CodeQL
+    source: GitHub code scanning
+    why: >-
+      The umbrella check the code-scanning app posts alongside the per-language
+      analyses. `Analyze python` and `Analyze javascript` are the required
+      contexts; requiring the umbrella as well would gate twice on one result.

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -2,8 +2,15 @@ name: UI tests
 
 # Runs the Playwright UI suite (-m ui) so it cannot rot silently the way two
 # settings tests did. The main CI job runs `-m "not ui"`, so without this the
-# UI tests would never execute. Path-filtered to frontend changes to spare the
-# single self-hosted host, plus a nightly run to catch drift, plus manual.
+# UI tests would never execute. Limited to frontend changes to spare the single
+# self-hosted host, plus a nightly run to catch drift, plus manual.
+#
+# That limit used to be a `paths:` filter on the trigger, which made this
+# workflow unusable as a required check: a required context that never starts
+# leaves the PR pending forever, so the suite ran on every frontend PR and
+# gated none of them. The filter now lives in the `changes` job, and `ui-gate`
+# runs unconditionally and reports the outcome — including "skipped, and that
+# is a pass". `ui-gate` is the required context; `ui` is not.
 #
 # Shares the host-global container lock with ci.yml's `test` job and
 # e2e-staging: all three bind the fixed-name test container on port 18888 and
@@ -12,13 +19,6 @@ name: UI tests
 on:
   pull_request:
     branches: [ main, develop ]
-    paths:
-      - 'templates/**'
-      - 'static/**'
-      - 'tests/test_ui.py'
-      - 'tests/conftest.py'
-      - 'Dockerfile'
-      - '.github/workflows/ui-tests.yml'
   schedule:
     - cron: '41 4 * * *'  # nightly drift catch
   workflow_dispatch:
@@ -30,8 +30,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    # Decides whether this PR can affect the UI. Cheap, hosted, and always
+    # runs, so `ui-gate` always has an answer. Anything that is not a pull
+    # request (nightly, manual) runs the suite unconditionally.
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      ui: ${{ steps.filter.outputs.ui }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        fetch-depth: 0
+
+    - name: Decide whether the UI suite has anything to say about this PR
+      id: filter
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      run: |
+        if [ "${{ github.event_name }}" != "pull_request" ]; then
+          echo "not a pull request - running the full suite"
+          echo "ui=true" >> "$GITHUB_OUTPUT"
+        else
+          python scripts/ui_paths_changed.py "$BASE_SHA" >> "$GITHUB_OUTPUT"
+        fi
+
   ui:
     name: ui
+    needs: changes
+    if: needs.changes.outputs.ui == 'true'
     runs-on: [self-hosted, Linux, X64]
     # Same host-global lock ci.yml's `test` job uses: the UI suite binds the
     # fixed-name test container on port 18888, so it must queue behind (never
@@ -121,3 +149,29 @@ jobs:
         if skipped == total:
             sys.exit("every UI test skipped - the suite proved nothing")
         PY
+
+  ui-gate:
+    # The required context. It exists because `ui` does not run on every PR,
+    # and a required context that never starts blocks the PR forever. This one
+    # always runs and translates the three outcomes an operator cares about:
+    # the suite passed, the suite had nothing to look at, or the suite failed.
+    name: ui-gate
+    needs: [changes, ui]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Report the UI suite outcome
+      env:
+        DECISION: ${{ needs.changes.result }}
+        RESULT: ${{ needs.ui.result }}
+        RAN: ${{ needs.changes.outputs.ui }}
+      run: |
+        echo "changes=$DECISION (ui=$RAN)  ui=$RESULT"
+        if [ "$DECISION" != "success" ]; then
+          echo "::error::could not decide whether to run the UI suite"; exit 1
+        fi
+        case "$RESULT" in
+          success) echo "UI suite passed." ;;
+          skipped) echo "No frontend paths changed; UI suite not needed." ;;
+          *) echo "::error::UI suite $RESULT"; exit 1 ;;
+        esac

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,26 @@ Branch protection is on, and admins are not exempt:
 - CI must be green. Auto-merge is disabled repo-wide, so merging is a deliberate
   act by a human.
 
+### Which checks actually block a merge
+
+Not all of them, and the difference is written down in
+[`.github/required-checks.yml`](.github/required-checks.yml): every job that
+runs on a pull request is listed as **gating** (branch protection will not let
+the PR merge without it) or **advisory** (it reports, and the reason it does not
+block is next to it). `tests/test_required_checks_registry.py` fails if a job is
+missing from that file, so a new job cannot arrive unclassified.
+
+Read the advisory ones anyway. `storage-live` and `acme-dns-live` boot real
+service containers and do not gate because a registry hiccup would block
+unrelated work — but acme-dns shipped broken in every release up to v2.24.1
+precisely because nobody was looking.
+
+The UI suite is the one odd shape. `ui` only runs when a PR touches the
+frontend (`scripts/ui_paths_changed.py` decides), so the required context is
+`ui-gate`, which always runs and treats "skipped" as a pass. If you add a
+frontend directory, add it to that script's `PATTERNS` — otherwise changes to it
+silently skip the suite.
+
 ### Touching the issuance pipeline
 
 If your change touches certificate issuance, a DNS provider, or the ACME path,

--- a/scripts/ui_paths_changed.py
+++ b/scripts/ui_paths_changed.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Decide whether a pull request can affect the Playwright UI suite.
+
+This used to be a `paths:` filter on `ui-tests.yml`'s trigger. That made the
+whole workflow — and therefore any gate job inside it — fail to start on most
+pull requests, so the UI suite could never be a required check: a required
+context that never reports leaves the pull request pending forever.
+
+Moving the filter here keeps the same limit (the suite is heavy and the
+self-hosted host is single) while letting `ui-gate` run every time and answer
+"skipped, and that is a pass". Being a real file rather than a heredoc, the
+path list has one home and the matching is under test — see
+tests/test_required_checks_registry.py.
+
+Usage:
+    ui_paths_changed.py <base-sha>      # writes `ui=true|false` on stdout
+"""
+import fnmatch
+import subprocess
+import sys
+
+# A change to any of these can change what the UI suite sees. A trailing `/*`
+# means "this directory and everything under it".
+PATTERNS = [
+    'templates/*',
+    'static/*',
+    'tests/test_ui.py',
+    'tests/conftest.py',
+    'Dockerfile',
+    '.github/workflows/ui-tests.yml',
+    'scripts/ui_paths_changed.py',
+]
+
+
+def matches(path, patterns=PATTERNS):
+    """True when `path` is one of the watched files or lives under one of the
+    watched directories.
+
+    `fnmatch`'s `*` crosses `/`, so `templates/*` covers `templates/a/b.html`
+    as well as `templates/index.html` — which is what the trigger did.
+    """
+    return any(path == p or fnmatch.fnmatch(path, p) for p in patterns)
+
+
+def decide(changed):
+    """Whether to run the suite, given the files a pull request touched.
+
+    An empty list means the diff could not be computed — an unfetched base,
+    most often — not that nothing changed. Run the suite rather than report a
+    pass nobody measured.
+    """
+    if not changed:
+        return True, []
+    hit = [f for f in changed if matches(f)]
+    return bool(hit), hit
+
+
+def changed_files(base_sha):
+    return subprocess.run(
+        ['git', 'diff', '--name-only', f'{base_sha}...HEAD'],
+        capture_output=True, text=True, check=True).stdout.split()
+
+
+def main(argv):
+    if len(argv) != 2:
+        sys.exit(__doc__)
+    changed = changed_files(argv[1])
+    run, hit = decide(changed)
+    print(f'ui={"true" if run else "false"}')
+    print(f'::notice::UI suite {"runs" if run else "skipped"}; '
+          f'{len(changed)} file(s) changed, {len(hit)} of them frontend',
+          file=sys.stderr)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tests/test_required_checks_registry.py
+++ b/tests/test_required_checks_registry.py
@@ -1,0 +1,327 @@
+"""The set of merge-gating CI jobs must be visible in the repository.
+
+Branch protection lives in GitHub's settings. Nobody without admin rights can
+read it, nothing records why a job is or is not in it, and it drifts silently.
+An audit found what that costs here: the repository ran a Playwright UI suite,
+a Trivy image scan, a CSS staleness gate and an MCP suite on every pull
+request, and none of them could block a merge. Five contexts gated; four jobs
+did the work and were thrown away.
+
+`.github/required-checks.yml` is the reviewable copy of that decision. GitHub
+does not read it — protection still has to be set through the API — so on its
+own it is a comment that goes stale. These tests are what make it worth having:
+
+* every job that can run on a pull request is classified, so a new job cannot
+  arrive without someone saying whether it gates;
+* every classified job still exists, so deleting or renaming one is caught;
+* the context strings match what GitHub will actually publish, including the
+  matrix suffix — a required context that no job ever reports leaves every
+  pull request pending forever, which is the failure mode that hurts most;
+* nothing quietly drops out of the gating set.
+
+The one thing they cannot check is the live protection setting, which needs an
+admin token. `.github/required-checks.yml` carries the command that applies it.
+"""
+import importlib.util
+import itertools
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit]
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOWS = REPO / '.github' / 'workflows'
+REGISTRY = REPO / '.github' / 'required-checks.yml'
+
+
+def _load_script(name):
+    """`scripts/` is not a package; load the module from its path."""
+    spec = importlib.util.spec_from_file_location(
+        name, REPO / 'scripts' / (name + '.py'))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+uifilter = _load_script('ui_paths_changed')
+
+# What branch protection required on 2026-09-08, before this file existed. A
+# gate may be added, and one may be removed deliberately by editing this list —
+# but not by an edit to the registry alone.
+GATING_FLOOR = {
+    'build', 'test (3.12)', 'Analyze python', 'Analyze javascript', 'emoji',
+}
+
+
+def _load(path):
+    return yaml.safe_load(path.read_text())
+
+
+def _triggers(workflow):
+    """`on:` parses as the boolean True under YAML 1.1, not the string 'on'."""
+    return workflow.get(True) or workflow.get('on') or {}
+
+
+def _skipped_on_pull_request(condition):
+    """True when a job's `if` can only hold for events other than a PR.
+
+    `github.event_name != 'schedule'` still runs on a pull request; a guard
+    built only from `== 'schedule'` / `== 'workflow_dispatch'` never does.
+    """
+    if not condition:
+        return False
+    equals = re.findall(r"github\.event_name\s*==\s*'([a-z_]+)'",
+                        ' '.join(str(condition).split()))
+    return bool(equals) and 'pull_request' not in equals
+
+
+def _contexts(job_id, job):
+    """The check names GitHub publishes for one job definition.
+
+    GitHub appends the matrix values in parentheses only when the job has no
+    explicit `name:`. With one, the interpolated name is used verbatim. Both
+    halves are visible in this repository today: `test` has no name and reports
+    as `test (3.12)`, while `analyze` is named `Analyze ${{ matrix.language }}`
+    and reports as `Analyze python` with no suffix.
+    """
+    name = job.get('name')
+    matrix = (job.get('strategy') or {}).get('matrix') or {}
+    dims = {k: v for k, v in matrix.items()
+            if isinstance(v, list) and k not in ('include', 'exclude')}
+    if not dims:
+        return [name or job_id]
+    out = []
+    for combo in itertools.product(*dims.values()):
+        values = dict(zip(dims, combo))
+        if name:
+            label = name
+            for key, value in values.items():
+                label = label.replace('${{ matrix.%s }}' % key, str(value))
+                label = label.replace('${{matrix.%s}}' % key, str(value))
+        else:
+            label = '%s (%s)' % (job_id, ', '.join(str(v) for v in combo))
+        out.append(label)
+    return out
+
+
+def pull_request_jobs():
+    """Every (workflow file, job id, job body) that a pull request can run."""
+    found = []
+    for path in sorted(WORKFLOWS.glob('*.yml')):
+        workflow = _load(path)
+        if 'pull_request' not in _triggers(workflow):
+            continue
+        for job_id, job in (workflow.get('jobs') or {}).items():
+            if _skipped_on_pull_request(job.get('if')):
+                continue
+            found.append((path.name, job_id, job))
+    return found
+
+
+@pytest.fixture(scope='module')
+def registry():
+    return _load(REGISTRY)
+
+
+@pytest.fixture(scope='module')
+def entries(registry):
+    return [dict(e, gating=True) for e in registry['gating']] + \
+           [dict(e, gating=False) for e in registry['advisory']]
+
+
+def test_every_pull_request_job_is_classified(entries):
+    """A new job cannot arrive without someone deciding whether it gates."""
+    classified = {(e['workflow'], e['job']) for e in entries}
+    actual = {(wf, job_id) for wf, job_id, _ in pull_request_jobs()}
+
+    missing = actual - classified
+    assert not missing, (
+        'these jobs run on pull requests but .github/required-checks.yml does '
+        'not say whether they gate a merge: '
+        + ', '.join(sorted('%s:%s' % m for m in missing))
+    )
+
+
+def test_every_classified_job_still_exists(entries):
+    classified = {(e['workflow'], e['job']) for e in entries}
+    actual = {(wf, job_id) for wf, job_id, _ in pull_request_jobs()}
+
+    stale = classified - actual
+    assert not stale, (
+        'these entries name a job that no longer runs on pull requests: '
+        + ', '.join(sorted('%s:%s' % s for s in stale))
+    )
+
+
+def test_contexts_match_what_github_will_publish(entries):
+    """The failure this guards is silent and total: a required context that no
+    job ever reports keeps every pull request pending, with a green board."""
+    published = {}
+    for wf, job_id, job in pull_request_jobs():
+        for context in _contexts(job_id, job):
+            published[context] = (wf, job_id)
+
+    for entry in entries:
+        assert entry['context'] in published, (
+            '%s declares context %r, but %s:%s publishes %r'
+            % (REGISTRY.name, entry['context'], entry['workflow'],
+               entry['job'],
+               _contexts(entry['job'],
+                         _load(WORKFLOWS / entry['workflow'])
+                         ['jobs'][entry['job']]))
+        )
+
+
+def test_a_matrix_job_declares_every_context_it_publishes(entries):
+    """Half a matrix is worse than none: bumping Python to 3.12 and 3.13 with
+    only `test (3.12)` required means the new one gates nothing."""
+    declared = {e['context'] for e in entries}
+    for wf, job_id, job in pull_request_jobs():
+        for context in _contexts(job_id, job):
+            assert context in declared, (
+                '%s:%s publishes context %r, which is in neither list'
+                % (wf, job_id, context)
+            )
+
+
+def test_the_gating_set_never_silently_shrinks(registry):
+    gating = {e['context'] for e in registry['gating']}
+    lost = GATING_FLOOR - gating
+    assert not lost, (
+        'these contexts gated merges before the registry existed and are no '
+        'longer listed as gating: ' + ', '.join(sorted(lost))
+    )
+
+
+def test_every_advisory_job_says_why_it_does_not_gate(registry):
+    """Advisory is a decision, not a default. Whoever reads this file next
+    should be able to disagree with the reason."""
+    for entry in registry['advisory']:
+        why = (entry.get('why') or '').strip()
+        assert len(why) > 40, (
+            '%s is advisory with no usable reason: %r'
+            % (entry['context'], why)
+        )
+
+
+def test_no_context_is_declared_twice(entries):
+    seen = [e['context'] for e in entries]
+    assert len(seen) == len(set(seen)), 'duplicate context in %s' % REGISTRY.name
+
+
+def test_the_ui_gate_is_required_and_the_ui_job_is_not(registry):
+    """The specific arrangement that makes a path-limited suite gateable.
+    Requiring `ui` directly would leave every non-frontend PR pending."""
+    gating = {e['context'] for e in registry['gating']}
+    advisory = {e['context'] for e in registry['advisory']}
+    assert 'ui-gate' in gating
+    assert 'ui' in advisory
+
+    ui = _load(WORKFLOWS / 'ui-tests.yml')
+    assert 'paths' not in _triggers(ui)['pull_request'], (
+        'the path filter is back on the trigger, so the whole workflow — '
+        'ui-gate included — does not start on most PRs, and every PR that '
+        'requires ui-gate hangs'
+    )
+    assert ui['jobs']['ui-gate']['if'] == 'always()'
+
+
+def test_the_workflow_calls_the_filter_it_is_documented_to_call():
+    source = (WORKFLOWS / 'ui-tests.yml').read_text()
+    assert 'scripts/ui_paths_changed.py' in source, (
+        'the changes job no longer runs the filter these tests cover'
+    )
+
+
+def test_the_ui_path_list_still_names_real_paths():
+    """The filter used to be a trigger, where a renamed directory failed
+    loudly (the workflow stopped running and someone noticed). Here it fails
+    open — the suite is skipped and the gate reports a pass — so the list has
+    to be checked against the tree."""
+    assert {'templates/*', 'static/*', 'tests/test_ui.py'} <= set(uifilter.PATTERNS)
+    for pattern in uifilter.PATTERNS:
+        target = REPO / pattern.rstrip('/*')
+        assert target.exists(), (
+            '%r no longer exists, so changes to it would skip the UI suite'
+            % pattern
+        )
+
+
+@pytest.mark.parametrize('path, watched', [
+    ('templates/index.html', True),
+    ('templates/partials/settings_deploy.html', True),
+    ('static/js/settings-deploy.js', True),
+    ('static/css/dist/output.css', True),
+    ('Dockerfile', True),
+    ('tests/conftest.py', True),
+    ('.github/workflows/ui-tests.yml', True),
+    ('scripts/ui_paths_changed.py', True),
+    ('modules/core/auth.py', False),
+    ('tests/test_ui_helpers.py', False),
+    ('README.md', False),
+    ('Dockerfile.dev', False),
+    ('staticfiles/app.js', False),
+])
+def test_the_matcher_agrees_with_what_the_trigger_used_to_do(path, watched):
+    assert uifilter.matches(path) is watched
+
+
+def test_an_uncomputable_diff_runs_the_suite():
+    """Failing open here would report a UI pass on a PR nobody looked at. An
+    empty diff means the base was not fetched far more often than it means a
+    PR changed nothing."""
+    assert uifilter.decide([]) == (True, [])
+
+
+def test_a_backend_only_change_skips_the_suite():
+    """CONTROL: the filter must still be capable of saying no, or the whole
+    point of moving it (sparing the single self-hosted host) is lost."""
+    run, hit = uifilter.decide(['modules/core/auth.py', 'README.md'])
+    assert (run, hit) == (False, [])
+
+
+# --- controls on the helpers themselves ---------------------------------
+# These tests exist because the checks above are only as good as the two
+# functions they rest on, and a wrong helper would report a clean registry.
+
+@pytest.mark.parametrize('condition, skipped', [
+    (None, False),
+    ("github.event_name != 'schedule'", False),
+    ("needs.changes.outputs.ui == 'true'", False),
+    ('always()', False),
+    ("github.event_name == 'schedule'", True),
+    ("github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'",
+     True),
+    ("github.event_name == 'pull_request'", False),
+])
+def test_the_pull_request_guard_reader_is_right(condition, skipped):
+    assert _skipped_on_pull_request(condition) is skipped
+
+
+@pytest.mark.parametrize('job_id, job, expected', [
+    ('emoji', {}, ['emoji']),
+    ('mcp', {'name': 'MCP server'}, ['MCP server']),
+    ('test', {'strategy': {'matrix': {'python-version': ['3.12']}}},
+     ['test (3.12)']),
+    ('test', {'strategy': {'matrix': {'python-version': ['3.12', '3.13']}}},
+     ['test (3.12)', 'test (3.13)']),
+    ('analyze', {'name': 'Analyze ${{ matrix.language }}',
+                 'strategy': {'matrix': {'language': ['python', 'javascript']}}},
+     ['Analyze python', 'Analyze javascript']),
+])
+def test_the_context_deriver_matches_githubs_naming(job_id, job, expected):
+    assert _contexts(job_id, job) == expected
+
+
+def test_the_classification_check_would_actually_fail(monkeypatch, entries):
+    """CONTROL: prove the missing-job assertion is reachable. Two of these
+    suites have passed while measuring nothing; this one says why it passes."""
+    monkeypatch.setattr(
+        sys.modules[__name__], 'pull_request_jobs',
+        lambda: [('ci.yml', 'a-job-nobody-classified', {})])
+    with pytest.raises(AssertionError, match='a-job-nobody-classified'):
+        test_every_pull_request_job_is_classified(entries)

--- a/tests/test_required_checks_registry.py
+++ b/tests/test_required_checks_registry.py
@@ -200,7 +200,7 @@ def test_the_gating_set_never_silently_shrinks(registry):
 def test_every_advisory_job_says_why_it_does_not_gate(registry):
     """Advisory is a decision, not a default. Whoever reads this file next
     should be able to disagree with the reason."""
-    for entry in registry['advisory']:
+    for entry in registry['advisory'] + registry['external']:
         why = (entry.get('why') or '').strip()
         assert len(why) > 40, (
             '%s is advisory with no usable reason: %r'
@@ -208,8 +208,32 @@ def test_every_advisory_job_says_why_it_does_not_gate(registry):
         )
 
 
-def test_no_context_is_declared_twice(entries):
-    seen = [e['context'] for e in entries]
+def test_external_contexts_are_kept_separate_from_workflow_jobs(registry):
+    """Codecov and the code-scanning umbrella report on every pull request and
+    gate nothing, which is exactly the situation this file exists to record —
+    but they come from GitHub Apps, so no workflow file mentions them and the
+    cross-checks above are structurally blind to them. They get their own
+    section rather than being quietly omitted."""
+    for entry in registry['external']:
+        assert entry.get('source'), (
+            '%s does not say which app posts it' % entry['context'])
+        assert 'workflow' not in entry, (
+            '%s names a workflow; if a job in this repository posts it, it '
+            'belongs in gating or advisory where it can be cross-checked'
+            % entry['context'])
+
+    published = {c for wf, job_id, job in pull_request_jobs()
+                 for c in _contexts(job_id, job)}
+    overlap = {e['context'] for e in registry['external']} & published
+    assert not overlap, (
+        'these are listed as external but a workflow job publishes them: '
+        + ', '.join(sorted(overlap))
+    )
+
+
+def test_no_context_is_declared_twice(entries, registry):
+    seen = [e['context'] for e in entries] + \
+           [e['context'] for e in registry['external']]
     assert len(seen) == len(set(seen)), 'duplicate context in %s' % REGISTRY.name
 
 


### PR DESCRIPTION
## The problem

CI runs far more than it gates on. Branch protection requires `build`,
`test (3.12)`, `Analyze python`, `Analyze javascript` and `emoji`. Meanwhile
every pull request also runs:

| job | what it proves | could it block a merge? |
|---|---|---|
| `ui` | the Playwright suite — the only thing that exercises the templates | no |
| `security-scan` | fails on a **fixable CRITICAL** in the published image | no |
| `frontend-css` | the committed CSS bundle matches its source; theme tokens | no |
| `MCP server` | the published MCP surface still works | no |

Four jobs did the work and the result was thrown away. A red `security-scan`
or a stale CSS bundle merged exactly as easily as a green one.

## Why `ui` could not simply be added

It was path-filtered **on its trigger**. On a PR touching no frontend file the
workflow never starts, so the context never reports — and a required context
that never reports leaves the PR pending forever. Requiring `ui` as it stood
would have wedged every backend PR in the repository.

So the filter moves into [`scripts/ui_paths_changed.py`](scripts/ui_paths_changed.py),
the workflow runs on every PR, and a new `ui-gate` job runs unconditionally and
translates the outcome — including *"skipped, and that is a pass"*. **`ui-gate`
is the required context; `ui` stays advisory.** The heavy suite still only runs
on frontend changes, so the single self-hosted host is spared exactly as before.

Verified against real diffs rather than by reading:

```
backend-only commit  -> UI suite skipped; 1 file(s) changed, 0 of them frontend  ui=false
frontend commit      -> UI suite runs;    2 file(s) changed, 1 of them frontend  ui=true
```

## Making the decision reviewable

Branch protection lives in GitHub's settings: unreadable without admin,
unexplained, and it drifts without leaving a trace. That is how this gap opened.

`.github/required-checks.yml` is the copy that lives in the repository. Every
job that can run on a pull request is listed as **gating** or **advisory**, with
the reason next to it. GitHub does not read the file — protection is still set
through the API, and the file carries the command — so on its own it would go
stale. `tests/test_required_checks_registry.py` is what stops that. It fails
when:

- a job runs on a PR and the file does not classify it (a new job cannot arrive unclassified);
- a listed job no longer exists;
- a declared context does not match what GitHub will actually publish — **including the matrix-suffix rule**, so bumping the matrix to `[3.12, 3.13]` while only `test (3.12)` is required is caught;
- the gating set shrinks below the five contexts that gated before this file existed;
- an advisory entry has no reason long enough to argue with.

The two helpers those checks rest on (`_skipped_on_pull_request`,
`_contexts`) have their own control tests, and there is a control proving the
missing-job assertion is reachable — a suite that measures nothing has passed
here before.

## What stays advisory, and why

`storage-live` and `acme-dns-live` boot MinIO, Vault, acme-dns and a postgres
pulled at run time; a registry rate-limit would block unrelated work. The
reason is recorded next to them, along with the note that acme-dns shipped
broken in every release up to v2.24.1 precisely because nobody read it.

## Applying it

This PR does not change branch protection — merging it first is deliberate, so
that `ui-gate` exists on `main` before it becomes required and no in-flight PR
hangs. The command is in the header of `.github/required-checks.yml`.

## Checks run locally

- `flake8` with the exact selector set CI enforces — clean
- `bandit -r modules/ app.py --severity-level medium` — clean
- `actionlint .github/workflows/ui-tests.yml` — clean
- `pytest -m "not ui"` — **4087 passed, 59 skipped**
- the 38 new tests, and both directions of the path filter measured on real git diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)