### PR TITLE
security: scan the dependency set that actually ships, not the manifests

### DIFF
--- a/.github/required-checks.yml
+++ b/.github/required-checks.yml
@@ -12,11 +12,17 @@
 # a pull request is missing from it, so a new job cannot arrive unclassified,
 # and `advisory` has to carry a reason someone can argue with.
 #
-# To apply this file to the repository (needs admin on the repo):
+# To apply this file to the repository (needs admin on the repo). Run it from
+# the repository root; it was used to set the current protection on
+# 2026-09-08, taking `main` from five required contexts to nine:
 #
-#   gh api -X PUT repos/fabriziosalmi/certmate/branches/main/protection/required_status_checks \
-#     -f strict=true \
-#     "$(python3 -c "import yaml,sys;print(' '.join('-f contexts[]='+c['context'] for c in yaml.safe_load(open('.github/required-checks.yml'))['gating']))")"
+#   python3 -c "import yaml,json;g=yaml.safe_load(open('.github/required-checks.yml'))['gating'];print(json.dumps({'strict':True,'contexts':[c['context'] for c in g]}))" > /tmp/protection.json
+#   gh api -X PATCH repos/fabriziosalmi/certmate/branches/main/protection/required_status_checks --input /tmp/protection.json
+#
+# PATCH is the verb for this sub-resource (PUT belongs to the parent
+# /protection endpoint, which would need the whole protection object), and the
+# JSON body is used because a context with a space in it — `test (3.12)`,
+# `MCP server` — does not survive `-f contexts[]=`.
 #
 # The `context` of each entry is the name GitHub shows in the merge box, which
 # is the job's `name:` when it has one, the job id when it does not, and gets a
@@ -68,10 +74,14 @@ gating:
     workflow: docker-multiplatform.yml
     job: security-scan
     why: >-
-      Fails on a fixable CRITICAL in the published image. This one can go red
-      without the PR changing — Trivy's database moves daily — and that is the
-      point: a fixable CRITICAL in the base image is the maintainer's problem
-      the day it is published, not the day someone notices.
+      Fails on a fixable CRITICAL in the published image, and reconciles the
+      advisories against the image's resolved Python set with SECURITY.md
+      (scripts/check_resolved_advisories.py). Both halves can go red without
+      the PR changing — Trivy's database moves daily and OSV is queried live —
+      and both fail closed on an unreachable database rather than reporting a
+      scan nobody performed. That is the intended trade: an advisory against
+      something that ships is the maintainer's problem the day it is
+      published, not the day someone notices.
 
   - context: frontend-css
     workflow: ci.yml

--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -223,6 +223,23 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'HIGH,CRITICAL'
 
+    - name: Capture the dependency set that actually ships
+      # From inside the image, so every version is the one pip resolved.
+      # Scanning the requirements files instead resolves each transitive
+      # constraint to the lowest version it admits: on 2026-09-08 that
+      # reported pyjwt 2.9.0 with seven advisories against an image holding
+      # 2.13.0 with none, and the same for requests, idna, filelock,
+      # protobuf and a pygments that is not installed at all.
+      run: |
+        docker run --rm --entrypoint /opt/venv/bin/pip \
+          certmate:scan freeze > resolved-requirements.txt
+        wc -l < resolved-requirements.txt
+
+    - name: Every advisory against a shipped package is in SECURITY.md
+      # The other half of scripts/check_advisories.py, which reconciles
+      # SECURITY.md with Dependabot — and Dependabot reads the manifests.
+      run: python3 scripts/check_resolved_advisories.py resolved-requirements.txt
+
     - name: Fail on a fixable CRITICAL
       # The reporting step above deliberately does not gate: the image
       # carries a long tail of unfixable base-image findings tracked in #403,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -235,6 +235,46 @@ can be closed. Until then they remain open by choice, not by oversight, and
 this section is the record of that choice: an advisory against `cryptography`
 that is not listed here has not been assessed, and should be treated as new.
 
+### How this list is kept complete
+
+Two checks reconcile this section with reality, because a list that claims to
+be complete and is not is worse than no list.
+
+- **`scripts/check_advisories.py`** (scheduled) asks GitHub which Dependabot
+  alerts the repository is carrying — open, or dismissed as `tolerable_risk` —
+  and fails when one of them is not named above. It was written after this
+  section documented one advisory while three more, published against the same
+  pin, sat open and unmentioned through a release.
+- **`scripts/check_resolved_advisories.py`** (on every pull request, inside
+  `security-scan`) asks OSV about the packages that are **actually installed in
+  the image**, captured with `pip freeze` from inside it, and fails the same
+  way.
+
+The second exists because the first cannot see what ships. Dependabot reads the
+manifests, and so does any scanner pointed at the repository; both then resolve
+each transitive constraint to the **lowest version it admits**, which is not
+what `pip install` produces. Measured against v2.29.0 on 2026-09-08:
+
+| package | manifest scan reports | actually in the image |
+|---|---|---|
+| `pyjwt` | 2.9.0 — 7 advisories | **2.13.0 — none** |
+| `requests` | 2.9.2 — 5 | **2.34.2 — none** |
+| `pygments` | 2.9.0 — 2 | **not installed** |
+| `idna` | 3.9.0 — 1 | **3.19 — none** |
+| `filelock` | 3.9.1 — 2 | **3.32.5 — none** |
+| `protobuf` | 4.25.9 — 1 | **7.36.1 — none** |
+
+All eighteen were false positives. `pyjwt` is the one worth naming: it arrives
+transitively through `msal` (Azure DNS), the floor `msal` declares is 2.9.0,
+and an audit reported those seven advisories as shipping in the default image.
+They do not — so no reachability argument is needed for them, and none is
+recorded here. **If you are looking at a manifest-level alert against a package
+that is not in the table above, check the version in the image before assessing
+it.**
+
+Scanning the resolved set gives the answer this section can actually stand
+behind: four advisories, all `cryptography==46.0.7`, all documented above.
+
 ## Supply-chain posture for Python dependencies
 
 This section exists so the absence of hash pinning is a **decision on record**

--- a/scripts/check_resolved_advisories.py
+++ b/scripts/check_resolved_advisories.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Every advisory against a package that actually ships must be written down.
+
+`scripts/check_advisories.py` reconciles SECURITY.md with Dependabot. This one
+reconciles it with the image, and the two answer different questions because
+they read different things.
+
+**Dependabot reads the manifests.** So does `osv-scanner` run over the
+repository. Both then resolve transitive dependencies to the *lowest* version
+each constraint admits, which is not what `pip install` produces. Measured
+against v2.29.0 on 2026-09-08 — the manifest scan against the resolved set from
+inside the published image:
+
+    package     manifest scan says   actually ships
+    pyjwt       2.9.0 (7 advisories) 2.13.0 (none)
+    requests    2.9.2 (5)            2.34.2 (none)
+    pygments    2.9.0 (2)            not installed at all
+    idna        3.9.0 (1)            3.19   (none)
+    filelock    3.9.1 (2)            3.32.5 (none)
+    protobuf    4.25.9 (1)           7.36.1 (none)
+
+Every one of those was a false positive, and an audit had already turned the
+pyjwt group into a finding against this repository. Scanning manifests here
+produces a list that is loud, wrong in both directions, and impossible to keep
+assessed — so nobody assesses it, and a real advisory would land in the middle
+of the noise unnoticed.
+
+This script therefore takes a `pip freeze` captured **inside the built image**,
+where every version is exact, asks OSV about that, and fails when a package
+that ships carries an advisory SECURITY.md does not name. Against the same
+image the answer was four advisories, all `cryptography`, all already
+documented under "Known dependency constraint".
+
+The OSV API is queried directly rather than through `osv-scanner` so there is
+no extra binary to install and pin, and so the network layer can be replaced in
+tests. Alias groups matter: OSV returns GHSA, CVE and PYSEC records for the
+same flaw, and counting them separately is how "four advisories" becomes
+"seven". Records are collapsed by the transitive closure of their aliases.
+
+Usage:
+    check_resolved_advisories.py <freeze-file>
+
+where the freeze file comes from the image under test, e.g.
+
+    docker run --rm --entrypoint /opt/venv/bin/pip certmate:scan freeze
+"""
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from check_advisories import documented_advisories  # noqa: E402
+
+OSV_QUERYBATCH = "https://api.osv.dev/v1/querybatch"
+OSV_VULN = "https://api.osv.dev/v1/vulns/"
+BATCH = 500
+
+# A freeze line pins exactly. Anything else (an editable install, a URL, a
+# bare name) is not a version this check can reason about.
+PINNED = re.compile(r"^([A-Za-z0-9._-]+)==([^\s;#]+)")
+
+# Advisory ids come back from OSV and are then interpolated into a URL. They
+# are remote data: check the shape before building a request out of one.
+ADVISORY_ID = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+
+
+def parse_freeze(text):
+    """The (name, version) pairs a `pip freeze` describes.
+
+    Lines that are not exact pins are skipped, and the caller is told how many
+    so a freeze that silently stopped pinning cannot read as "nothing to
+    scan".
+    """
+    pinned, skipped = [], []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("-"):
+            continue
+        match = PINNED.match(line)
+        if match:
+            pinned.append((match.group(1), match.group(2)))
+        else:
+            skipped.append(line)
+    return pinned, skipped
+
+
+def _post(url, payload):
+    request = urllib.request.Request(
+        url, data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json",
+                 "User-Agent": "certmate-resolved-advisory-check"})
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _get(url):
+    request = urllib.request.Request(
+        url, headers={"User-Agent": "certmate-resolved-advisory-check"})
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def query_osv(packages, post=_post, get=_get):
+    """Advisory ids per package, with the aliases of each.
+
+    Returns [(name, version, id, frozenset(ids_in_the_same_group))]. The batch
+    endpoint answers with ids only, so each distinct id is then fetched once
+    for its aliases — currently a handful of requests, not one per package.
+    """
+    found = []
+    for start in range(0, len(packages), BATCH):
+        chunk = packages[start:start + BATCH]
+        payload = {"queries": [
+            {"package": {"name": name, "ecosystem": "PyPI"}, "version": version}
+            for name, version in chunk]}
+        results = post(OSV_QUERYBATCH, payload).get("results", [])
+        if len(results) != len(chunk):
+            raise SystemExit(
+                f"OSV returned {len(results)} results for {len(chunk)} "
+                f"queries; refusing to guess which package each belongs to")
+        for (name, version), result in zip(chunk, results):
+            for vuln in result.get("vulns") or []:
+                found.append((name, version, vuln["id"]))
+
+    aliases = {}
+    for _, _, vuln_id in found:
+        if not ADVISORY_ID.match(vuln_id):
+            raise SystemExit(
+                f"OSV returned an advisory id this check will not put in a "
+                f"URL: {vuln_id!r}")
+        if vuln_id not in aliases:
+            record = get(OSV_VULN + vuln_id)
+            aliases[vuln_id] = frozenset(
+                [vuln_id, *(record.get("aliases") or [])])
+    return [(n, v, i, aliases[i]) for n, v, i in found]
+
+
+def group_by_alias(rows):
+    """Collapse rows naming the same flaw under different identifier schemes.
+
+    OSV publishes GHSA, CVE and PYSEC records for one advisory and lists them
+    as each other's aliases. Counting them apart is how `cryptography`'s four
+    advisories present as seven.
+    """
+    groups = []
+    for name, version, vuln_id, ids in rows:
+        keys, packages = set(ids), {(name, version)}
+        merged = []
+        for existing_keys, existing_packages in groups:
+            if existing_keys & keys:
+                keys |= existing_keys
+                packages |= existing_packages
+            else:
+                merged.append((existing_keys, existing_packages))
+        merged.append((keys, packages))
+        groups = merged
+    return groups
+
+
+def canonical(ids):
+    """The identifier to report a group by: GHSA if there is one, since that
+    is what SECURITY.md and Dependabot both speak."""
+    ghsa = sorted(i for i in ids if i.startswith("GHSA-"))
+    return ghsa[0] if ghsa else sorted(ids)[0]
+
+
+def undocumented(groups, documented):
+    return [(canonical(ids), sorted(ids), sorted(packages))
+            for ids, packages in groups
+            if not (ids & documented)]
+
+
+def main(argv):
+    if len(argv) != 2:
+        raise SystemExit(__doc__)
+
+    try:
+        with open(argv[1], encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError as error:
+        raise SystemExit(f"cannot read the freeze file ({error}) — this check "
+                         f"has lost its subject and must not pass quietly")
+
+    packages, skipped = parse_freeze(text)
+    if not packages:
+        raise SystemExit(
+            "the freeze file pins no packages. That is not a clean image, it "
+            "is a broken measurement: check that pip freeze ran inside the "
+            "image and that its output was captured.")
+    print(f"{len(packages)} pinned package(s) from {argv[1]}")
+    if skipped:
+        print(f"  {len(skipped)} line(s) not exact pins, not scanned: "
+              + ", ".join(skipped[:5]))
+
+    try:
+        rows = query_osv(packages)
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
+        raise SystemExit(f"could not reach OSV ({e}) — failing rather than "
+                         f"reporting a clean scan nobody performed")
+
+    groups = group_by_alias(rows)
+    print(f"{len(rows)} advisory record(s) -> {len(groups)} distinct "
+          f"advisory(ies) after merging aliases")
+
+    documented = documented_advisories()
+    for ids, packages_hit in sorted(groups, key=lambda g: canonical(g[0])):
+        mark = "documented" if ids & documented else "NOT DOCUMENTED"
+        names = ", ".join(f"{n}=={v}" for n, v in sorted(packages_hit))
+        print(f"  {canonical(ids):24s} {names:32s} {mark}")
+
+    missing = undocumented(groups, documented)
+    if missing:
+        lines = "\n".join(
+            f"  {ghsa}  ({', '.join(f'{n}=={v}' for n, v in packages_hit)})"
+            f"\n      also known as: {', '.join(ids)}"
+            for ghsa, ids, packages_hit in missing)
+        raise SystemExit(
+            f"\n{len(missing)} advisory(ies) affect a package that ships in "
+            f"the image and are not named in SECURITY.md:\n{lines}\n\n"
+            f"Either fix the dependency, or add it to SECURITY.md under "
+            f"'Known dependency constraint' with the reachability argument "
+            f"and the fix path. An advisory nobody wrote down is "
+            f"indistinguishable from one nobody noticed.")
+
+    print(f"\nAll {len(groups)} advisory(ies) against shipped packages are "
+          f"documented in SECURITY.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/test_resolved_advisories_check.py
+++ b/tests/test_resolved_advisories_check.py
@@ -1,0 +1,309 @@
+"""The advisory check must read the versions that ship, not the manifests.
+
+An audit reported that `pyjwt 2.9.0` ships in the default image carrying seven
+unassessed advisories. It does not ship. The published v2.29.0 image contains
+`PyJWT 2.13.0`, which carries none. The auditor had scanned the repository's
+requirements files, and a manifest scan resolves each transitive constraint to
+the *lowest* version it admits — not to what `pip install` produces. Measured
+on 2026-09-08, every package the manifest scan flagged was a false positive:
+
+    package     manifest scan says   image actually has
+    pyjwt       2.9.0 (7 advisories) 2.13.0 (none)
+    requests    2.9.2 (5)            2.34.2 (none)
+    pygments    2.9.0 (2)            not installed at all
+    idna        3.9.0 (1)            3.19   (none)
+    filelock    3.9.1 (2)            3.32.5 (none)
+    protobuf    4.25.9 (1)           7.36.1 (none)
+
+The finding was wrong and the gap behind it was real: nothing scanned the set
+that ships, so the correct answer — four advisories, all `cryptography`, all
+already documented — was nobody's measurement either.
+
+`scripts/check_resolved_advisories.py` takes a `pip freeze` from inside the
+built image and reconciles it with SECURITY.md. These tests cover the parts
+that can be wrong without the network: the freeze parser, the alias grouping
+that turns seven records into four advisories, and the reconciliation. The
+network layer is injected, so nothing here reaches OSV.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(
+        name, REPO / 'scripts' / (name + '.py'))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load('check_resolved_advisories')
+
+# The four advisories the published v2.29.0 image actually carries, measured
+# with `pip freeze` inside it. All four are `cryptography==46.0.7`.
+SHIPPED = [
+    'GHSA-537c-gmf6-5ccf',
+    'GHSA-g6cj-pr64-35w5',
+    'GHSA-jwv3-5hgf-82ww',
+    'GHSA-m2h6-j472-rp4c',
+]
+
+
+# --- the freeze parser ---------------------------------------------------
+
+def test_a_freeze_is_read_as_exact_pins():
+    pinned, skipped = check.parse_freeze(
+        'Flask==3.1.3\ncryptography==46.0.7\nPyJWT==2.13.0\n')
+    assert pinned == [('Flask', '3.1.3'), ('cryptography', '46.0.7'),
+                      ('PyJWT', '2.13.0')]
+    assert skipped == []
+
+
+def test_anything_that_is_not_an_exact_pin_is_reported_not_dropped():
+    """A freeze that stops pinning is a broken measurement, and silence about
+    it would read as a clean scan."""
+    pinned, skipped = check.parse_freeze(
+        'Flask==3.1.3\n'
+        'certmate\n'                                  # bare name
+        'requests>=2.34.2\n'                          # a range
+        '-e git+https://example.invalid/x#egg=x\n'     # editable
+        '# a comment\n'
+        '\n')
+    assert pinned == [('Flask', '3.1.3')]
+    assert skipped == ['certmate', 'requests>=2.34.2']
+
+
+def test_an_empty_freeze_is_a_failure_not_a_clean_scan(tmp_path):
+    """The failure mode that would matter most: `pip freeze` ran against the
+    wrong path, produced nothing, and the check congratulated the image."""
+    empty = tmp_path / 'resolved.txt'
+    empty.write_text('# nothing here\n')
+    with pytest.raises(SystemExit, match='pins no packages'):
+        check.main(['check', str(empty)])
+
+
+def test_a_missing_freeze_file_is_a_failure(tmp_path):
+    with pytest.raises(SystemExit, match='lost its subject'):
+        check.main(['check', str(tmp_path / 'absent.txt')])
+
+
+# --- alias grouping ------------------------------------------------------
+
+def test_the_same_flaw_under_three_names_counts_once():
+    """This is the whole reason the count is four and not seven: OSV publishes
+    a GHSA, a CVE and a PYSEC record for one advisory."""
+    rows = [
+        ('cryptography', '46.0.7', 'GHSA-g6cj-pr64-35w5',
+         frozenset({'GHSA-g6cj-pr64-35w5', 'CVE-2026-69247',
+                    'PYSEC-2026-3552'})),
+        ('cryptography', '46.0.7', 'PYSEC-2026-3552',
+         frozenset({'PYSEC-2026-3552', 'CVE-2026-69247',
+                    'GHSA-g6cj-pr64-35w5'})),
+    ]
+    groups = check.group_by_alias(rows)
+    assert len(groups) == 1
+    assert check.canonical(groups[0][0]) == 'GHSA-g6cj-pr64-35w5'
+
+
+def test_aliases_are_merged_transitively():
+    """A links to B, B links to C, and A never mentions C. Treating these as
+    two advisories would double-count, and reporting either as undocumented
+    would fail a build over an advisory that is written down."""
+    rows = [
+        ('p', '1', 'A', frozenset({'A', 'B'})),
+        ('p', '1', 'C', frozenset({'C', 'B'})),
+    ]
+    groups = check.group_by_alias(rows)
+    assert len(groups) == 1
+    assert groups[0][0] == {'A', 'B', 'C'}
+
+
+def test_distinct_flaws_stay_distinct():
+    """CONTROL: over-merging would hide a real advisory behind a documented
+    one, which fails in the direction that matters."""
+    rows = [
+        ('p', '1', 'GHSA-aaaa-aaaa-aaaa', frozenset({'GHSA-aaaa-aaaa-aaaa'})),
+        ('p', '1', 'GHSA-bbbb-bbbb-bbbb', frozenset({'GHSA-bbbb-bbbb-bbbb'})),
+    ]
+    assert len(check.group_by_alias(rows)) == 2
+
+
+def test_a_group_remembers_every_package_it_hits():
+    rows = [
+        ('alpha', '1', 'GHSA-aaaa-aaaa-aaaa', frozenset({'GHSA-aaaa-aaaa-aaaa'})),
+        ('beta', '2', 'GHSA-aaaa-aaaa-aaaa', frozenset({'GHSA-aaaa-aaaa-aaaa'})),
+    ]
+    groups = check.group_by_alias(rows)
+    assert len(groups) == 1
+    assert groups[0][1] == {('alpha', '1'), ('beta', '2')}
+
+
+def test_a_group_with_no_ghsa_is_still_reportable():
+    """PYSEC-2025-183 has a CVE alias and no GHSA. Reporting it as `None`
+    would make the failure message useless."""
+    ids = {'PYSEC-2025-183', 'CVE-2025-45768'}
+    assert check.canonical(ids) == 'CVE-2025-45768'
+
+
+# --- reconciliation with SECURITY.md ------------------------------------
+
+def test_an_advisory_named_in_security_md_is_accepted():
+    groups = [({'GHSA-537c-gmf6-5ccf'}, {('cryptography', '46.0.7')})]
+    assert check.undocumented(groups, set(SHIPPED)) == []
+
+
+def test_an_advisory_not_named_in_security_md_is_reported():
+    groups = [({'GHSA-zzzz-zzzz-zzzz', 'CVE-2026-1'}, {('newpkg', '1.0')})]
+    missing = check.undocumented(groups, set(SHIPPED))
+    assert len(missing) == 1
+    ghsa, ids, packages = missing[0]
+    assert ghsa == 'GHSA-zzzz-zzzz-zzzz'
+    assert packages == [('newpkg', '1.0')]
+    assert 'CVE-2026-1' in ids
+
+
+def test_documentation_by_any_alias_counts():
+    """SECURITY.md names GHSA ids, but a group is one flaw: matching on the
+    group rather than on the canonical id means renaming which alias the file
+    happens to quote does not turn a documented advisory into a build break."""
+    groups = [({'PYSEC-2026-3552', 'GHSA-g6cj-pr64-35w5'}, {('c', '1')})]
+    assert check.undocumented(groups, {'GHSA-g6cj-pr64-35w5'}) == []
+
+
+def test_the_four_advisories_the_image_carries_are_all_in_security_md():
+    """The regression guard with teeth. If SECURITY.md loses one of these,
+    the scheduled scan would start failing against the published image — this
+    catches it offline, at the commit that removed it."""
+    documented = _load('check_advisories').documented_advisories()
+    missing = [g for g in SHIPPED if g not in documented]
+    assert not missing, (
+        'SECURITY.md no longer documents %s, which the published image '
+        'carries' % ', '.join(missing)
+    )
+
+
+# --- the network layer, with the network replaced -----------------------
+
+def _fake_osv(hits, aliases):
+    """A stand-in for OSV: `hits` maps (name, version) to advisory ids."""
+    calls = {'batch': 0, 'vulns': []}
+
+    def post(url, payload):
+        calls['batch'] += 1
+        return {'results': [
+            {'vulns': [{'id': i}
+                       for i in hits.get((q['package']['name'], q['version']),
+                                         [])]}
+            for q in payload['queries']]}
+
+    def get(url):
+        vuln_id = url.rsplit('/', 1)[1]
+        calls['vulns'].append(vuln_id)
+        return {'id': vuln_id, 'aliases': aliases.get(vuln_id, [])}
+
+    return post, get, calls
+
+
+def test_only_the_packages_that_hit_are_looked_up_in_detail():
+    post, get, calls = _fake_osv(
+        hits={('cryptography', '46.0.7'): ['GHSA-a', 'PYSEC-a']},
+        aliases={'GHSA-a': ['PYSEC-a'], 'PYSEC-a': ['GHSA-a']})
+    rows = check.query_osv(
+        [('Flask', '3.1.3'), ('cryptography', '46.0.7')], post=post, get=get)
+
+    assert calls['batch'] == 1, 'one batch request should cover every package'
+    assert sorted(calls['vulns']) == ['GHSA-a', 'PYSEC-a']
+    assert len(check.group_by_alias(rows)) == 1
+
+
+def test_each_advisory_is_fetched_once_however_many_packages_it_hits():
+    post, get, calls = _fake_osv(
+        hits={('alpha', '1'): ['GHSA-a'], ('beta', '2'): ['GHSA-a']},
+        aliases={})
+    check.query_osv([('alpha', '1'), ('beta', '2')], post=post, get=get)
+    assert calls['vulns'] == ['GHSA-a']
+
+
+def test_a_short_answer_from_osv_is_refused_not_realigned():
+    """CONTROL: `zip` would silently pair each result with the wrong package
+    and report advisories against packages that do not have them — or, worse,
+    drop the tail of the list and pass."""
+    def post(url, payload):
+        return {'results': [{'vulns': []}]}      # one answer, two questions
+
+    with pytest.raises(SystemExit, match='refusing to guess'):
+        check.query_osv([('alpha', '1'), ('beta', '2')],
+                        post=post, get=lambda url: {})
+
+
+def test_a_package_with_no_advisories_produces_no_rows():
+    post, get, _ = _fake_osv(hits={}, aliases={})
+    assert check.query_osv([('PyJWT', '2.13.0')], post=post, get=get) == []
+
+
+@pytest.mark.parametrize('bad_id', [
+    '../../etc/passwd',
+    'GHSA-a/../../x',
+    'GHSA a',
+    '',
+    'x' * 65,
+])
+def test_an_advisory_id_is_not_put_into_a_url_unchecked(bad_id):
+    """The id is remote data and the next thing done with it is string
+    concatenation into a request URL."""
+    post, get, _ = _fake_osv(hits={('p', '1'): [bad_id]}, aliases={})
+    with pytest.raises(SystemExit, match='will not put in a URL'):
+        check.query_osv([('p', '1')], post=post, get=get)
+
+
+def test_the_real_advisory_ids_still_pass_the_shape_check():
+    """CONTROL: a guard that rejects the ids OSV actually returns would turn
+    every scan into a failure, which reads as a broken build, not a finding."""
+    post, get, _ = _fake_osv(
+        hits={('cryptography', '46.0.7'):
+              ['GHSA-537c-gmf6-5ccf', 'PYSEC-2026-3552', 'CVE-2026-69247']},
+        aliases={})
+    assert len(check.query_osv([('cryptography', '46.0.7')],
+                               post=post, get=get)) == 3
+
+
+# --- the wiring ----------------------------------------------------------
+
+def test_ci_captures_the_freeze_from_inside_the_image_and_runs_this_check():
+    """The script is worth nothing if nothing calls it, and worth less than
+    nothing if what calls it feeds it a manifest."""
+    import yaml
+    workflow = yaml.safe_load(
+        (REPO / '.github' / 'workflows'
+         / 'docker-multiplatform.yml').read_text())
+    steps = workflow['jobs']['security-scan']['steps']
+    scripts = [s for s in steps
+               if 'scripts/check_resolved_advisories.py' in (s.get('run') or '')]
+    assert len(scripts) == 1, 'the check is not wired into security-scan'
+
+    capture = [s for s in steps
+               if 'freeze' in (s.get('run') or '')
+               and 'certmate:scan' in (s.get('run') or '')]
+    assert capture, (
+        'the freeze must be captured from the image under test; pointing this '
+        'at a requirements file would reintroduce exactly the false positives '
+        'it replaces'
+    )
+    assert steps.index(capture[0]) < steps.index(scripts[0]), (
+        'the check runs before the freeze it reads is written'
+    )
+
+
+def test_the_check_gates_a_merge():
+    """security-scan is the job that hosts it, and it is a required context."""
+    import yaml
+    registry = yaml.safe_load(
+        (REPO / '.github' / 'required-checks.yml').read_text())
+    gating = {e['context'] for e in registry['gating']}
+    assert 'security-scan' in gating


### PR DESCRIPTION
## The finding was wrong, and the gap behind it was real

An audit reported that `pyjwt 2.9.0` ships in the default image carrying seven
unassessed advisories, "while the project maintains a careful per-advisory
assessment for `cryptography` only."

**It does not ship.** The published v2.29.0 image contains `PyJWT 2.13.0`,
which carries none:

```
$ docker run --rm --entrypoint /opt/venv/bin/pip fabriziosalmi/certmate:latest freeze | grep -i pyjwt
PyJWT==2.13.0
```

The finding came from scanning the requirements files. A manifest scan resolves
every transitive constraint to the **lowest version it admits**, not to what
`pip install` produces. Every package it flagged was a false positive —
eighteen advisories in total:

| package | manifest scan reports | actually in the image |
|---|---|---|
| `pyjwt` | 2.9.0 — 7 advisories | **2.13.0 — none** |
| `requests` | 2.9.2 — 5 | **2.34.2 — none** |
| `pygments` | 2.9.0 — 2 | **not installed** |
| `idna` | 3.9.0 — 1 | **3.19 — none** |
| `filelock` | 3.9.1 — 2 | **3.32.5 — none** |
| `protobuf` | 4.25.9 — 1 | **7.36.1 — none** |

But the gap the finding was pointing at is real. `scripts/check_advisories.py`
reconciles SECURITY.md with **Dependabot**, and Dependabot reads the manifests
too. Nothing looked at the set that ships — so the correct answer (four
advisories, all `cryptography`, all already documented) was nobody's
measurement either, and a real advisory would have landed in the middle of
eighteen false ones.

## What this adds

`scripts/check_resolved_advisories.py` takes a `pip freeze` captured **inside
the built image**, asks OSV about those exact versions, and fails when a
shipped package carries an advisory SECURITY.md does not name.

- **Alias grouping matters.** OSV publishes a GHSA, a CVE and a PYSEC record
  for one flaw. Collapsing them by the transitive closure of their aliases is
  what turns seven records into four advisories — and what stops a documented
  advisory from being reported as new because SECURITY.md quotes a different
  alias.
- **OSV is queried directly**, not through `osv-scanner`: no binary to install
  and pin, and the network layer is injectable so the tests never leave the
  machine.
- **It fails closed.** An unreachable OSV is a failure, not a clean scan.

Wired into `security-scan`, which already builds the image and is now a
required context.

## Measured, not reasoned

Against the published image:

```
120 pinned package(s)
7 advisory record(s) -> 4 distinct advisory(ies) after merging aliases
  GHSA-537c-gmf6-5ccf   cryptography==46.0.7   documented
  GHSA-g6cj-pr64-35w5   cryptography==46.0.7   documented
  GHSA-jwv3-5hgf-82ww   cryptography==46.0.7   documented
  GHSA-m2h6-j472-rp4c   cryptography==46.0.7   documented
rc=0
```

Control — the same freeze with `PyJWT 2.9.0` spliced in:

```
20 advisory record(s) -> 11 distinct advisory(ies) after merging aliases
7 advisory(ies) affect a package that ships in the image and are not named in SECURITY.md
rc=1
```

## SECURITY.md

New subsection **"How this list is kept complete"** naming both checks, the
manifest-vs-resolved distinction with the table above, and the instruction that
matters for whoever reads the next alert: *if you are looking at a
manifest-level alert against a package that is not in the table, check the
version in the image before assessing it.*

`pyjwt` is named explicitly — it arrives through `msal` on the Azure DNS path,
`msal`'s declared floor is 2.9.0, and no reachability argument is recorded
because the shipped version has nothing to reach.

## Checks run locally

- 25 new tests, plus the 39 registry tests — the alias closure, the freeze
  parser, an empty freeze treated as a broken measurement rather than a pass,
  a short answer from OSV refused instead of realigned by `zip`, and an
  advisory id validated before it is concatenated into a URL
- `pytest -m "not ui"` — **4125 passed, 59 skipped**
- `flake8` with CI's selector set, `bandit`, `actionlint` — clean, and
  `actionlint` reports the same 6 pre-existing SC2086 notices as `main`

Also corrects the apply-command comment in `.github/required-checks.yml` to the
`PATCH --input` form actually used to set the current protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)