### PR TITLE
fix: three ways the instance started without knowing its own state

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -953,6 +953,23 @@ class CertificateManager:
             lock.release()
 
     def _metadata_path(self, domain: str) -> Path:
+        """Where a domain's metadata lives, screened here rather than upstream.
+
+        This is the single place the metadata path is built — every read and
+        every one of the seven `_save_metadata` call sites goes through it —
+        and it used to build the path from `domain` unchecked, leaving the
+        no-escape property distributed across those callers. The write at the
+        end of that path is `open(tmp, 'w')`, so a domain carrying path
+        characters would put attacker-influenced JSON at an arbitrary location.
+
+        Every caller does screen today. That is the problem: the guarantee is
+        only as good as the least careful of them, and this repository has
+        already shipped the same shape once — `_reject_path_escaping_domain`
+        exists because extracting code out of `create_certificate` produced a
+        unit that no longer enforced its own precondition (#666). Enforcing it
+        where the path is built makes the property local and keeps it that way.
+        """
+        _reject_path_escaping_domain(domain)
         return self.cert_dir / domain / 'metadata.json'
 
     def _store_in_backend(self, domain, cert_files, metadata):

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -113,6 +113,32 @@ _KNOWN_METADATA_KEYS = _REISSUE_OWNED_METADATA_KEYS | frozenset({
 })
 
 
+def _fsync_directory(directory: Path) -> None:
+    """Persist a directory entry, so a rename into it survives a power loss.
+
+    Syncing the file only persists its contents. The link between the name and
+    those contents lives in the directory, and until the directory is synced a
+    crash can replay as "the rename never happened" — or, worse on some
+    filesystems, as the new name pointing at nothing.
+
+    Never raises. Some filesystems refuse to open a directory for this
+    (Windows, a few network mounts); the write has already succeeded and
+    degrading to the old, weaker guarantee is better than failing an issuance
+    over the sync of an entry.
+    """
+    try:
+        fd = os.open(str(directory), os.O_RDONLY)
+    except OSError as error:
+        logger.debug("Cannot open %s to fsync it: %s", directory, error)
+        return
+    try:
+        os.fsync(fd)
+    except OSError as error:
+        logger.debug("Cannot fsync %s: %s", directory, error)
+    finally:
+        os.close(fd)
+
+
 def _remove_temp_files(artifacts):
     """Delete every temp file an issuance or renewal created.
 
@@ -800,14 +826,100 @@ class CertificateManager:
                 published[dest_file.name] = dest_file.read_bytes()
             return published
 
+    def reconcile_served_copies(self) -> dict:
+        """Republish any domain whose served files disagree with certbot's.
+
+        `_publish_flat_files` stages all four PEMs and then promotes them with
+        four separate renames. That is not a transaction: a crash between the
+        second and the third leaves the served directory holding a mixed
+        generation — most damagingly a new `cert.pem` beside the previous
+        `privkey.pem`, a pair that cannot complete a handshake and which is
+        served straight off local disk by `/api/certificates/<domain>/download`
+        and pushed to every deploy hook.
+
+        Until now the only thing that healed that state was the renewal check,
+        which reconciles in its not-yet-due branch. That closes the window, but
+        only at the next sweep — up to a day later. A torn promote happens
+        precisely when the process dies, and a process that dies is a process
+        about to be restarted, so startup is the first moment the state can be
+        noticed and the cheapest one at which to fix it.
+
+        Never raises. A domain that cannot be repaired is logged at ERROR and
+        the others are still attempted: refusing to start would turn a
+        one-certificate problem into a total outage, and the instance is more
+        useful serving the rest while an operator reads the log.
+        """
+        summary = {'checked': 0, 'republished': [], 'failed': {}}
+        if not self.cert_dir.is_dir():
+            return summary
+
+        for domain_dir in sorted(self.cert_dir.iterdir()):
+            if not domain_dir.is_dir():
+                continue
+            domain = domain_dir.name
+            live_dir = domain_dir / 'live' / domain
+            if not live_dir.is_dir():
+                # Imported or externally managed: nothing to reconcile against.
+                continue
+            summary['checked'] += 1
+            try:
+                stale = self._stale_flat_files(live_dir, domain_dir)
+                if not stale:
+                    continue
+                logger.warning(
+                    "Served copy for %s disagrees with certbot's on startup: "
+                    "%s. Republishing — this is the state a promote "
+                    "interrupted mid-way leaves behind, and where a new "
+                    "certificate can sit beside the previous private key.",
+                    domain, ", ".join(stale))
+                self._publish_flat_files(live_dir, domain_dir)
+                summary['republished'].append(domain)
+            except Exception as error:
+                summary['failed'][domain] = str(error)
+                logger.error(
+                    "Could not repair the served copy for %s on startup: %s. "
+                    "This domain may be serving a certificate that does not "
+                    "match its private key.", domain, error)
+
+        if summary['republished']:
+            logger.warning("Republished %d served copy(ies) on startup: %s",
+                           len(summary['republished']),
+                           ", ".join(summary['republished']))
+        return summary
+
     @staticmethod
     def _atomic_json_write(path: Path, data: dict) -> None:
-        """Write JSON atomically via a temp file + rename to avoid partial writes on crash."""
+        """Write JSON atomically and durably: temp file, fsync, rename, fsync dir.
+
+        The rename alone gives atomicity — a reader sees the old file or the
+        new one, never a half-written one. It does not give crash safety,
+        which is what this file needs: `metadata.json` records key custody
+        (`private_key_state`, the CSR fingerprint, the CA the certificate came
+        from), and a rename whose data has not reached the platter can be
+        replayed by the filesystem as a rename onto an empty or truncated
+        file. The docstring here used to claim crash safety while doing only
+        the rename.
+
+        Three syncs, each for a different loss:
+
+        * `flush()` moves the bytes out of Python's buffer;
+        * `os.fsync(file)` moves them out of the kernel's page cache, so the
+          temp file's *contents* survive;
+        * `os.fsync(directory)` persists the rename itself, so the *name*
+          survives — without it the file can be durable under a name that is
+          gone after a power loss.
+
+        Same recipe `modules.core.file_operations` uses for settings.json.
+        """
         import json
         tmp = path.with_suffix('.tmp')
         try:
-            tmp.write_text(json.dumps(data, indent=2), encoding='utf-8')
+            with open(tmp, 'w', encoding='utf-8') as handle:
+                json.dump(data, handle, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
             tmp.replace(path)
+            _fsync_directory(path.parent)
         except Exception:
             tmp.unlink(missing_ok=True)
             raise

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -1427,5 +1427,59 @@ def create_app(test_config=None):
     # starting the scheduler so recovered misfired jobs can push an app context.
     _flask_app = app
     setup_scheduler(container)
+    reconcile_served_copies(container)
+    check_issuance_readiness(container)
 
     return app, container
+
+
+def check_issuance_readiness(container: AppContainer):
+    """Find out at startup whether certbot can run, not at the first renewal.
+
+    certbot is the one dependency without which nothing works, and it was the
+    one dependency nothing checked: a broken certbot produced an instance that
+    started, reported ready, scheduled renewals and failed at the first one.
+    The probe records its answer in `managers['issuance_status']`, which
+    /health reports and /health/ready gates on — so a certbot that cannot run
+    flips the pod out of rotation for the same reason a dead scheduler does.
+
+    See modules.core.issuance_readiness for why this runs the command rather
+    than checking that the file exists.
+    """
+    from . import issuance_readiness
+    try:
+        status = issuance_readiness.probe(
+            container.managers.get('shell_executor'))
+    except Exception as e:
+        logger.error(f"certbot readiness probe itself failed: {e}")
+        status = issuance_readiness.get_status()
+    container.managers['issuance_status'] = status
+    return status
+
+
+def reconcile_served_copies(container: AppContainer):
+    """Repair any served certificate copy that a crash left half-published.
+
+    Promoting a renewed certificate is four renames, so a process killed
+    between the second and the third leaves a mixed generation on disk — a new
+    certificate beside the previous private key, which is served and deployed
+    exactly as if it were valid. The renewal sweep already reconciles this, but
+    only when it next visits the domain. A torn promote is caused by a process
+    dying, and a process that dies gets restarted: startup is the first moment
+    anyone can notice, so it is where the repair belongs.
+
+    Never raises and never blocks startup. The manager logs each repair; this
+    wrapper exists so that a certificate manager which failed to build, or a
+    filesystem that cannot be walked, does not stop the app from serving.
+    """
+    certificates = container.managers.get('certificates')
+    if certificates is None or not hasattr(certificates,
+                                           'reconcile_served_copies'):
+        return
+    try:
+        certificates.reconcile_served_copies()
+    except Exception as e:
+        logger.error(
+            f"Could not reconcile served certificate copies at startup: {e}. "
+            f"A certificate interrupted mid-publish may still be serving a "
+            f"key that does not match it.")

--- a/modules/core/issuance_readiness.py
+++ b/modules/core/issuance_readiness.py
@@ -1,0 +1,155 @@
+"""Is certbot actually able to run? Answered at startup, not at first renewal.
+
+CertMate drives certbot as a subprocess. It is the one dependency without
+which nothing the product exists for works — and it was the one dependency
+nothing checked. A broken certbot produced an instance that started, reported
+`/health` 200 and `/health/ready` 200, scheduled its renewals, and discovered
+the problem at the first one: hours later, in a log line, on a certificate
+that was by then closer to expiry.
+
+"Broken" here is not hypothetical and not usually "not installed". The failure
+this project has actually hit twice is subtler: pip resolves the dependency
+set cleanly, the binary is present and executable, and then
+
+    certbot --version
+
+dies on `AttributeError: module 'OpenSSL.crypto' has no attribute 'X509Req'`
+
+because a `cryptography` or `pyOpenSSL` version moved under the pinned ACME
+stack. Nothing short of running it detects that — a path check, an `os.access`
+or an `importlib.util.find_spec` all say the installation is fine.
+
+So the probe runs the command. Three properties keep that affordable:
+
+* **Once per process.** certbot does not change under a running interpreter,
+  so the result is a module-level value. Repeated `create_app()` calls — the
+  test suite makes dozens — pay for one subprocess between them.
+* **Bounded.** A timeout, and a timeout is a failure: a certbot that cannot
+  answer `--version` inside the bound cannot issue a certificate. The bound is
+  thirty seconds, which is not generous — it is measured. `certbot --version`
+  in the published image imports the whole ACME stack and takes 2-3 seconds
+  cold; the first version of this probe used five, and the full test suite
+  (many containers on one host) drove it past that and reported a working
+  certbot as broken. A startup probe that produces false failures is worse
+  than no probe, because the next person to see it red learns to ignore it.
+* **Never fatal.** A failed probe records `failed` and lets the app start.
+  Refusing to boot would take away the UI an operator needs to diagnose it,
+  and would take a working instance offline over a probe that might itself be
+  wrong. `/health/ready` returning 503 is the loud part: an orchestrator flips
+  the pod out of rotation, for the same reason a dead scheduler does.
+
+A `MockShellExecutor` reports `produces_artifacts = False` — it answers from a
+canned script rather than running anything, so its answer about certbot means
+nothing. That case records `skipped`, which readiness treats as ready: a
+probe that did not run must not be reported as a probe that failed.
+"""
+import logging
+
+logger = logging.getLogger(__name__)
+
+# certbot lives in the venv in a source checkout and on PATH in the image.
+CERTBOT_CANDIDATES = ('.venv/bin/certbot', 'certbot')
+PROBE_TIMEOUT_SECONDS = 30
+
+# States. `ok` and `skipped` are ready; `failed` is not.
+OK = 'ok'
+FAILED = 'failed'
+SKIPPED = 'skipped'
+UNKNOWN = 'unknown'
+
+_status = None
+
+
+def reset():
+    """Forget the cached probe result. For tests, and for nothing else."""
+    global _status
+    _status = None
+
+
+def get_status():
+    """The recorded probe result, or an `unknown` placeholder before it runs."""
+    if _status is None:
+        return {'state': UNKNOWN, 'version': None, 'error': None,
+                'timestamp': None}
+    return dict(_status)
+
+
+def is_ready(status=None):
+    """Whether issuance readiness should hold a probe out of rotation.
+
+    Only a probe that ran and failed says no. `unknown` (not yet probed) and
+    `skipped` (nothing real was run) are both "no evidence of a problem", and
+    reporting no-evidence as a failure would flip every test app and every
+    startup window out of rotation.
+    """
+    return (status or get_status()).get('state') != FAILED
+
+
+def _read_version(result):
+    """certbot prints its version to stdout on current releases and to stderr
+    on older ones; take whichever carries text."""
+    out = ''
+    for stream in (getattr(result, 'stdout', ''), getattr(result, 'stderr', '')):
+        if isinstance(stream, str):
+            out += stream
+    return out.strip()
+
+
+def _run_once(shell_executor, path):
+    """Try one candidate. Returns (version, error); exactly one is truthy."""
+    try:
+        result = shell_executor.run([path, '--version'],
+                                    timeout=PROBE_TIMEOUT_SECONDS)
+    except Exception as error:                     # FileNotFoundError, timeout
+        return None, f'{path}: {error}'
+
+    text = _read_version(result)
+    code = getattr(result, 'returncode', 0)
+    if code:
+        # The failure that matters most lands here: certbot is installed,
+        # starts, and dies importing its own ACME stack. Keep the tail of the
+        # output — the exception type and message are in it, and an operator
+        # reading /health should not have to go and reproduce it.
+        return None, f'{path}: exited {code}: {text[-400:] or "no output"}'
+    if not text:
+        return None, f'{path}: exited 0 but printed no version'
+    return text, None
+
+
+def probe(shell_executor, force=False):
+    """Run `certbot --version` once per process and record what happened.
+
+    Returns the status dict. Never raises: every failure mode this can hit is
+    a thing to report, not a thing to crash the application over.
+    """
+    global _status
+    if _status is not None and not force:
+        return dict(_status)
+
+    from .utils import utc_now_iso
+    stamp = utc_now_iso()
+
+    if shell_executor is None or not getattr(shell_executor,
+                                             'produces_artifacts', True):
+        _status = {'state': SKIPPED, 'version': None, 'timestamp': stamp,
+                   'error': 'no executing shell was available to probe with'}
+        return dict(_status)
+
+    errors = []
+    for path in CERTBOT_CANDIDATES:
+        version, error = _run_once(shell_executor, path)
+        if version:
+            logger.info("certbot is available: %s (via %s)", version, path)
+            _status = {'state': OK, 'version': version, 'error': None,
+                       'timestamp': stamp}
+            return dict(_status)
+        errors.append(error)
+
+    detail = '; '.join(e for e in errors if e)
+    logger.critical(
+        "certbot cannot run, so this instance cannot issue or renew any "
+        "certificate: %s. /health/ready will report 503 until this is fixed.",
+        detail)
+    _status = {'state': FAILED, 'version': None, 'error': detail,
+               'timestamp': stamp}
+    return dict(_status)

--- a/modules/web/misc_routes.py
+++ b/modules/web/misc_routes.py
@@ -258,6 +258,19 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
             checks['scheduler'] = 'not_running'
             overall = 'degraded'
 
+        # certbot. The one dependency without which nothing works, probed
+        # once at startup because a broken certbot is invisible until the
+        # first renewal — hours later, on a certificate closer to expiry.
+        issuance = managers.get('issuance_status') or {}
+        issuance_state = issuance.get('state')
+        if issuance_state:
+            checks['certbot'] = issuance_state
+            if issuance.get('version'):
+                checks['certbot_version'] = issuance['version']
+            if issuance_state == 'failed':
+                checks['certbot_error'] = issuance.get('error')
+                overall = 'degraded'
+
         # Cert directory
         file_ops = managers.get('file_ops')
         if file_ops:
@@ -307,16 +320,31 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
         so the failure becomes loud: a deploy gate fails, a readiness probe
         flips the pod out of rotation, an alert fires.
         """
+        from modules.core import issuance_readiness
+
         scheduler = managers.get('scheduler')
         scheduler_status = managers.get('scheduler_status') or {}
         running = bool(scheduler and getattr(scheduler, 'running', False))
-        ready = running and scheduler_status.get('state') != 'failed'
+        scheduler_ok = running and scheduler_status.get('state') != 'failed'
+
+        # A scheduler that never runs means nothing renews. A certbot that
+        # cannot run means nothing renews either, and it was invisible to
+        # every probe: the instance started, said ready, and failed at the
+        # first renewal. Only a probe that RAN AND FAILED withholds readiness
+        # — `skipped` and `unknown` are absence of evidence, not evidence.
+        issuance = managers.get('issuance_status') or {}
+        issuance_ok = issuance_readiness.is_ready(issuance)
+
+        ready = scheduler_ok and issuance_ok
         body = {
             'ready': ready,
             'scheduler': 'running' if running else (scheduler_status.get('state') or 'not_running'),
+            'certbot': issuance.get('state') or 'unknown',
         }
-        if not ready and scheduler_status.get('error'):
+        if not scheduler_ok and scheduler_status.get('error'):
             body['scheduler_error'] = scheduler_status.get('error')
+        if not issuance_ok and issuance.get('error'):
+            body['certbot_error'] = issuance.get('error')
         return jsonify(body), (200 if ready else 503)
 
     @app.route('/api/events/stream')

--- a/tests/test_certbot_is_a_startup_condition.py
+++ b/tests/test_certbot_is_a_startup_condition.py
@@ -1,0 +1,303 @@
+"""A certbot that cannot run must be visible at startup, not at the first renewal.
+
+CertMate drives certbot as a subprocess. It is the one dependency without which
+nothing the product exists for works, and it was the one dependency nothing
+checked. A broken certbot produced an instance that started, answered `/health`
+200 and `/health/ready` 200, scheduled its renewals, and found out at the first
+one — hours later, in a log line, on a certificate by then closer to expiry.
+
+The failure is not usually "not installed". Twice on this project it has been:
+pip resolves cleanly, the binary is present and executable, and then
+
+    certbot --version
+
+dies on `AttributeError: module 'OpenSSL.crypto' has no attribute 'X509Req'`
+
+because a `cryptography` or `pyOpenSSL` version moved under the pinned ACME
+stack. That is why the probe runs the command instead of checking the path —
+`os.access` says the installation is fine in exactly that case, which is the
+one that has actually happened.
+
+These tests pin the three things that can each independently make the check
+worthless: what counts as failure, that the answer reaches `/health/ready`, and
+that a probe which never ran is not reported as a probe that failed.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from modules.core import issuance_readiness as readiness
+from modules.web.misc_routes import register_misc_routes
+
+pytestmark = [pytest.mark.unit]
+
+X509REQ_TRACEBACK = (
+    'Traceback (most recent call last):\n'
+    '  File "/opt/venv/lib/python3.12/site-packages/acme/crypto_util.py", '
+    'line 32, in <module>\n'
+    "AttributeError: module 'OpenSSL.crypto' has no attribute 'X509Req'\n")
+
+
+@pytest.fixture(autouse=True)
+def clean_probe():
+    """The probe result is process-global on purpose — certbot does not change
+    under a running interpreter. Tests must not inherit each other's."""
+    readiness.reset()
+    yield
+    readiness.reset()
+
+
+def _executor(results):
+    """A shell that answers from `results`, keyed by the binary path."""
+    calls = []
+
+    class Executor:
+        produces_artifacts = True
+
+        def run(self, cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            answer = results.get(cmd[0])
+            if isinstance(answer, Exception):
+                raise answer
+            return answer
+
+    return Executor(), calls
+
+
+def _result(returncode=0, stdout='', stderr=''):
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# --- what the probe decides ---------------------------------------------
+
+def test_a_working_certbot_is_ok_and_its_version_is_kept():
+    executor, _ = _executor({'.venv/bin/certbot': _result(stdout='certbot 2.10.0\n')})
+    status = readiness.probe(executor)
+
+    assert status['state'] == 'ok'
+    assert status['version'] == 'certbot 2.10.0'
+    assert readiness.is_ready(status)
+
+
+def test_the_version_is_read_from_stderr_when_that_is_where_it_lands():
+    """Older certbot releases print --version to stderr."""
+    executor, _ = _executor({'.venv/bin/certbot': _result(stderr='certbot 1.21.0\n')})
+    assert readiness.probe(executor)['version'] == 'certbot 1.21.0'
+
+
+def test_a_certbot_that_starts_and_dies_importing_its_stack_is_a_failure():
+    """The failure this exists for. The binary runs; the process exits
+    non-zero. A path check calls this installation healthy."""
+    executor, _ = _executor({
+        '.venv/bin/certbot': _result(returncode=1, stderr=X509REQ_TRACEBACK),
+        'certbot': _result(returncode=1, stderr=X509REQ_TRACEBACK),
+    })
+    status = readiness.probe(executor)
+
+    assert status['state'] == 'failed'
+    assert not readiness.is_ready(status)
+    assert 'X509Req' in status['error'], (
+        'the cause was dropped, so /health says only that something is wrong'
+    )
+
+
+def test_a_missing_certbot_is_a_failure():
+    executor, _ = _executor({
+        '.venv/bin/certbot': FileNotFoundError('no such file'),
+        'certbot': FileNotFoundError('no such file'),
+    })
+    assert readiness.probe(executor)['state'] == 'failed'
+
+
+def test_a_certbot_that_cannot_answer_in_time_is_a_failure():
+    """A timeout is not "unknown": a certbot that cannot print its version
+    inside the bound cannot issue a certificate."""
+    import subprocess
+    executor, _ = _executor({
+        '.venv/bin/certbot': subprocess.TimeoutExpired('certbot', 30),
+        'certbot': subprocess.TimeoutExpired('certbot', 30),
+    })
+    assert readiness.probe(executor)['state'] == 'failed'
+
+
+def test_exit_zero_with_no_output_is_a_failure_not_a_pass():
+    """CONTROL: reading the version out of an empty string and calling that
+    success is how a stubbed binary passes this check."""
+    executor, _ = _executor({'.venv/bin/certbot': _result(stdout=''),
+                             'certbot': _result(stdout='')})
+    assert readiness.probe(executor)['state'] == 'failed'
+
+
+def test_the_path_fallback_is_tried_when_the_venv_copy_is_absent():
+    """A source checkout has .venv/bin/certbot; the image has it on PATH."""
+    executor, calls = _executor({
+        '.venv/bin/certbot': FileNotFoundError('no venv here'),
+        'certbot': _result(stdout='certbot 2.10.0\n'),
+    })
+    assert readiness.probe(executor)['state'] == 'ok'
+    assert [c[0][0] for c in calls] == ['.venv/bin/certbot', 'certbot']
+
+
+def test_the_probe_is_bounded_in_time():
+    """Unbounded, a hung certbot hangs startup instead of reporting it."""
+    executor, calls = _executor({'.venv/bin/certbot': _result(stdout='certbot 2.10.0')})
+    readiness.probe(executor)
+    assert calls[0][1]['timeout'] == readiness.PROBE_TIMEOUT_SECONDS
+
+
+# --- once per process ----------------------------------------------------
+
+def test_the_probe_runs_once_however_many_apps_are_built():
+    """certbot does not change under a running interpreter, and the test
+    suite builds dozens of applications."""
+    executor, calls = _executor({'.venv/bin/certbot': _result(stdout='certbot 2.10.0')})
+    readiness.probe(executor)
+    readiness.probe(executor)
+    readiness.probe(executor)
+    assert len(calls) == 1
+
+
+def test_a_double_that_runs_nothing_is_skipped_not_failed():
+    """MockShellExecutor answers from a canned script. Its answer about
+    certbot means nothing, and reporting nothing as a failure would take every
+    test instance out of rotation."""
+    class Mock:
+        produces_artifacts = False
+
+        def run(self, cmd, **kwargs):            # pragma: no cover - not called
+            raise AssertionError('the probe ran against a non-executing double')
+
+    status = readiness.probe(Mock())
+    assert status['state'] == 'skipped'
+    assert readiness.is_ready(status)
+
+
+def test_no_shell_at_all_is_skipped():
+    assert readiness.probe(None)['state'] == 'skipped'
+
+
+def test_before_the_probe_runs_the_state_is_unknown_and_ready():
+    """A startup window in which nothing has been measured must not read as a
+    failure — otherwise every instance is unready for its first moment."""
+    assert readiness.get_status()['state'] == 'unknown'
+    assert readiness.is_ready()
+
+
+# --- the answer has to reach the probes ---------------------------------
+
+def _app(managers):
+    app = Flask(__name__)
+    app.config['VERSION'] = 'test'
+    auth = MagicMock()
+    auth.require_role = lambda role: (lambda fn: fn)
+    auth.is_local_auth_enabled.return_value = False
+    auth.has_any_users.return_value = False
+    register_misc_routes(app, managers, require_web_auth=None,
+                         auth_manager=auth)
+    return app
+
+
+def _running_scheduler():
+    scheduler = MagicMock()
+    scheduler.running = True
+    return scheduler
+
+
+def test_readiness_is_503_when_certbot_cannot_run():
+    """The whole point: an orchestrator takes the instance out of rotation."""
+    app = _app({'scheduler': _running_scheduler(),
+                'scheduler_status': {'state': 'running'},
+                'issuance_status': {'state': 'failed',
+                                    'error': "no attribute 'X509Req'"}})
+    response = app.test_client().get('/health/ready')
+
+    assert response.status_code == 503
+    assert response.get_json()['ready'] is False
+    assert response.get_json()['certbot'] == 'failed'
+    assert 'X509Req' in response.get_json()['certbot_error']
+
+
+def test_readiness_is_200_when_certbot_works():
+    app = _app({'scheduler': _running_scheduler(),
+                'scheduler_status': {'state': 'running'},
+                'issuance_status': {'state': 'ok', 'version': 'certbot 2.10.0'}})
+    assert app.test_client().get('/health/ready').status_code == 200
+
+
+def test_readiness_is_200_when_the_probe_was_skipped():
+    """CONTROL: a probe that did not run must not fail readiness, or every
+    instance built with a shell double is permanently unready."""
+    app = _app({'scheduler': _running_scheduler(),
+                'scheduler_status': {'state': 'running'},
+                'issuance_status': {'state': 'skipped'}})
+    assert app.test_client().get('/health/ready').status_code == 200
+
+
+def test_readiness_is_200_when_nothing_recorded_a_probe_at_all():
+    """Backwards compatibility with an app built before this existed."""
+    app = _app({'scheduler': _running_scheduler(),
+                'scheduler_status': {'state': 'running'}})
+    assert app.test_client().get('/health/ready').status_code == 200
+
+
+def test_a_dead_scheduler_still_fails_readiness_on_its_own():
+    """CONTROL: the new condition must be additional, not a replacement."""
+    app = _app({'scheduler': None,
+                'scheduler_status': {'state': 'failed', 'error': 'boom'},
+                'issuance_status': {'state': 'ok'}})
+    assert app.test_client().get('/health/ready').status_code == 503
+
+
+def test_health_reports_certbot_and_degrades_on_failure():
+    app = _app({'scheduler': _running_scheduler(),
+                'scheduler_status': {'state': 'running'},
+                'issuance_status': {'state': 'failed', 'error': 'X509Req'}})
+    body = app.test_client().get('/health').get_json()
+
+    assert body['checks']['certbot'] == 'failed'
+    assert body['checks']['certbot_error'] == 'X509Req'
+    assert body['status'] == 'degraded'
+
+
+def test_health_reports_the_certbot_version_when_it_works():
+    app = _app({'scheduler': _running_scheduler(),
+                'scheduler_status': {'state': 'running'},
+                'issuance_status': {'state': 'ok', 'version': 'certbot 2.10.0'}})
+    body = app.test_client().get('/health').get_json()
+
+    assert body['checks']['certbot'] == 'ok'
+    assert body['checks']['certbot_version'] == 'certbot 2.10.0'
+    assert body['status'] == 'healthy'
+
+
+# --- the wiring ----------------------------------------------------------
+
+def test_startup_records_the_probe_where_the_probes_read_it():
+    from modules.core import factory
+
+    class Container:
+        managers = {'shell_executor': _executor(
+            {'.venv/bin/certbot': _result(stdout='certbot 2.10.0')})[0]}
+
+    status = factory.check_issuance_readiness(Container())
+    assert status['state'] == 'ok'
+    assert Container.managers['issuance_status']['state'] == 'ok'
+
+
+def test_a_probe_that_itself_explodes_does_not_stop_startup(monkeypatch):
+    """CONTROL: a readiness check that can crash the boot is worse than the
+    blindness it removes — the instance would not come back at all."""
+    from modules.core import factory
+
+    monkeypatch.setattr(readiness, 'probe',
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError('x')))
+
+    class Container:
+        managers = {'shell_executor': None}
+
+    status = factory.check_issuance_readiness(Container())
+    assert status['state'] == 'unknown'
+    assert readiness.is_ready(status), (
+        'a probe that crashed must not be reported as certbot being broken'
+    )

--- a/tests/test_health_ready_e2e.py
+++ b/tests/test_health_ready_e2e.py
@@ -36,3 +36,28 @@ def test_health_ready_scheduler_running(api):
     body = r.json()
     assert body.get("ready") is True, body
     assert body.get("scheduler") == "running", body
+
+
+def test_health_ready_certbot_actually_runs(api):
+    """The other half of "this container can do its job".
+
+    A scheduler that runs and a certbot that cannot are the same outcome: no
+    certificate ever renews. The startup probe runs `certbot --version` inside
+    the container, which is the only check that catches the failure this
+    project has actually hit twice — pip resolves cleanly, the binary is
+    present, and certbot dies importing its own ACME stack because a
+    `cryptography` or `pyOpenSSL` version moved under the pinned certbot.
+
+    `skipped` is not accepted here. In the real image the shell executes, so
+    anything other than `ok` means the probe did not measure what it claims.
+    """
+    body = api.get("/health/ready").json()
+    assert body.get("certbot") == "ok", (
+        f"certbot is not usable in the built image: {body}"
+    )
+
+    health = api.get("/health").json()
+    version = health.get("checks", {}).get("certbot_version", "")
+    assert version.startswith("certbot "), (
+        f"the image reports certbot ok without a version: {health}"
+    )

--- a/tests/test_metadata_write_is_durable.py
+++ b/tests/test_metadata_write_is_durable.py
@@ -170,3 +170,49 @@ def test_a_failing_fsync_on_the_directory_still_closes_it(tmp_path,
 
     _fsync_directory(tmp_path)
     assert closed, 'the directory descriptor leaked when fsync failed'
+
+
+# --- where the write is allowed to land ---------------------------------
+# Durability is only half of "this write is safe". The other half is that it
+# lands where it is supposed to, and `_metadata_path` used to build the path
+# from an unchecked `domain` — leaving the no-escape property spread across
+# the seven `_save_metadata` call sites. CodeQL flagged the sink; every caller
+# did in fact screen, which is exactly the problem: the guarantee was only as
+# good as the least careful of them, and this repository has already shipped
+# that shape once (#666).
+
+class _Screened:
+    """A manager built without touching the filesystem."""
+
+    def __init__(self, tmp_path):
+        self.cert_dir = tmp_path
+
+
+def _path_for(tmp_path, domain):
+    return CertificateManager._metadata_path(_Screened(tmp_path), domain)
+
+
+def test_a_normal_domain_still_resolves_where_it_always_did(tmp_path):
+    assert _path_for(tmp_path, 'example.com') == \
+        tmp_path / 'example.com' / 'metadata.json'
+
+
+def test_a_wildcard_domain_is_still_allowed(tmp_path):
+    """CONTROL: `*.example.com` is a legitimate directory name here, and a
+    screen that rejected it would break every wildcard certificate."""
+    assert _path_for(tmp_path, '*.example.com').parent.name == '*.example.com'
+
+
+@pytest.mark.parametrize('domain', [
+    '../../etc',
+    'a/../../b',
+    'x/y',
+    '/absolute',
+    '..',
+])
+def test_a_domain_that_could_escape_is_refused_where_the_path_is_built(
+        tmp_path, domain):
+    """The sink at the end of this path is `open(tmp, 'w')`, so an escape
+    means attacker-influenced JSON at an arbitrary location."""
+    with pytest.raises(ValueError):
+        _path_for(tmp_path, domain)

--- a/tests/test_metadata_write_is_durable.py
+++ b/tests/test_metadata_write_is_durable.py
@@ -1,0 +1,172 @@
+"""`metadata.json` must survive a power loss, not just a concurrent reader.
+
+`_atomic_json_write` wrote a temp file and renamed it, and its docstring said
+the mechanism existed "to avoid partial writes on crash". The rename gives
+*atomicity* — a reader sees the old file or the new one — and says nothing
+about crash safety: neither the temp file's contents nor the rename itself had
+been pushed out of the page cache, so a power loss between the write and the
+data reaching the platter can be replayed as a rename onto an empty or
+truncated file.
+
+That file is not incidental. It records key custody: `private_key_state` (the
+`external` value that tells the renewal path a CSR-only certificate has no key
+here and must not be reissued nightly), the CSR fingerprint, and the CA the
+certificate came from — the value without which a private-CA certificate cannot
+renew at all. Losing it does not lose a certificate; it loses the instance's
+knowledge of what that certificate is.
+
+Three syncs, three different losses, and the tests below pin each one
+separately because dropping any of them still passes a naive "the file has the
+right contents" assertion:
+
+* `flush()`      — bytes leave Python's buffer
+* `fsync(file)`  — bytes leave the kernel's page cache: the CONTENTS survive
+* `fsync(dir)`   — the rename is persisted: the NAME survives
+
+The same recipe `modules/core/file_operations.py` already uses for
+settings.json, which is why the file that records key custody should not have
+had a weaker one.
+"""
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from modules.core.certificates import CertificateManager, _fsync_directory
+
+pytestmark = [pytest.mark.unit]
+
+PAYLOAD = {
+    'domain': 'example.com',
+    'private_key_state': 'external',
+    'ca': 'private',
+    'csr_fingerprint': 'ab' * 32,
+}
+
+
+@pytest.fixture
+def synced(monkeypatch):
+    """Record every fsync, tagged with what kind of object it was called on."""
+    calls = []
+    real_fsync = os.fsync
+
+    def spy(fd):
+        try:
+            kind = 'dir' if os.path.isdir('/proc/self/fd/%d' % fd) else 'file'
+        except Exception:                      # pragma: no cover - non-Linux
+            kind = 'file'
+        try:
+            kind = 'dir' if os.fstat(fd).st_mode & 0o040000 else 'file'
+        except OSError:                        # pragma: no cover
+            pass
+        calls.append(kind)
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, 'fsync', spy)
+    return calls
+
+
+def test_the_contents_are_written(tmp_path):
+    target = tmp_path / 'metadata.json'
+    CertificateManager._atomic_json_write(target, PAYLOAD)
+    assert json.loads(target.read_text()) == PAYLOAD
+
+
+def test_the_file_is_fsynced_before_the_rename(tmp_path, synced):
+    """Without this the rename can land on a file whose bytes never left the
+    page cache: the name is right and the contents are empty."""
+    CertificateManager._atomic_json_write(tmp_path / 'metadata.json', PAYLOAD)
+    assert 'file' in synced, 'the temp file was renamed without being fsynced'
+
+
+def test_the_directory_is_fsynced_after_the_rename(tmp_path, synced):
+    """Syncing the file persists its contents. The link between the name and
+    those contents lives in the directory, and until that is synced the rename
+    itself can be lost."""
+    CertificateManager._atomic_json_write(tmp_path / 'metadata.json', PAYLOAD)
+    assert 'dir' in synced, 'the rename was never persisted'
+
+
+def test_the_order_is_file_then_rename_then_directory(tmp_path, monkeypatch):
+    """CONTROL: fsyncing the directory *before* the rename would pass both
+    tests above and guarantee nothing."""
+    order = []
+    real_fsync, real_replace = os.fsync, os.replace
+
+    def fsync(fd):
+        order.append('dir' if os.fstat(fd).st_mode & 0o040000 else 'file')
+        return real_fsync(fd)
+
+    def replace(src, dst, *a, **kw):
+        order.append('rename')
+        return real_replace(src, dst, *a, **kw)
+
+    monkeypatch.setattr(os, 'fsync', fsync)
+    monkeypatch.setattr(os, 'replace', replace)
+    monkeypatch.setattr(Path, 'replace',
+                        lambda self, target: replace(str(self), str(target)))
+
+    CertificateManager._atomic_json_write(tmp_path / 'metadata.json', PAYLOAD)
+    assert order == ['file', 'rename', 'dir']
+
+
+def test_no_temp_file_is_left_behind(tmp_path):
+    target = tmp_path / 'metadata.json'
+    CertificateManager._atomic_json_write(target, PAYLOAD)
+    assert sorted(p.name for p in tmp_path.iterdir()) == ['metadata.json']
+
+
+def test_a_failed_write_removes_the_temp_and_leaves_the_old_file(tmp_path,
+                                                                 monkeypatch):
+    """The property the rename buys, which must not be lost while adding the
+    syncs: a failure leaves the previous metadata intact."""
+    target = tmp_path / 'metadata.json'
+    target.write_text('{"domain": "old"}')
+
+    def boom(fd):
+        raise OSError('disk full')
+
+    monkeypatch.setattr(os, 'fsync', boom)
+    with pytest.raises(OSError):
+        CertificateManager._atomic_json_write(target, PAYLOAD)
+
+    assert json.loads(target.read_text()) == {'domain': 'old'}
+    assert sorted(p.name for p in tmp_path.iterdir()) == ['metadata.json']
+
+
+# --- the directory helper on its own ------------------------------------
+
+def test_fsyncing_a_directory_that_cannot_be_opened_is_not_an_error(tmp_path):
+    """Some filesystems refuse to open a directory for fsync. The write has
+    already succeeded by then; failing an issuance over the sync of a
+    directory entry would trade a rare loss for a common one."""
+    _fsync_directory(tmp_path / 'does-not-exist')
+
+
+def test_fsyncing_a_directory_closes_its_descriptor(tmp_path, monkeypatch):
+    """CONTROL: a leaked fd per metadata write is a slow death on a busy
+    instance, and nothing else in the write path would notice."""
+    opened, closed = [], []
+    real_open, real_close = os.open, os.close
+    monkeypatch.setattr(os, 'open',
+                        lambda *a, **k: opened.append(real_open(*a, **k))
+                        or opened[-1])
+    monkeypatch.setattr(os, 'close',
+                        lambda fd: closed.append(fd) or real_close(fd))
+
+    _fsync_directory(tmp_path)
+    assert opened and closed == opened
+
+
+def test_a_failing_fsync_on_the_directory_still_closes_it(tmp_path,
+                                                          monkeypatch):
+    closed = []
+    real_close = os.close
+    monkeypatch.setattr(os, 'close',
+                        lambda fd: closed.append(fd) or real_close(fd))
+    monkeypatch.setattr(os, 'fsync',
+                        lambda fd: (_ for _ in ()).throw(OSError('nope')))
+
+    _fsync_directory(tmp_path)
+    assert closed, 'the directory descriptor leaked when fsync failed'

--- a/tests/test_served_copies_are_reconciled_at_startup.py
+++ b/tests/test_served_copies_are_reconciled_at_startup.py
@@ -1,0 +1,238 @@
+"""A promote interrupted half-way must not survive the restart that follows it.
+
+Publishing a renewed certificate stages four PEMs and then promotes them with
+four separate renames. That is not a transaction. A process killed between the
+second and the third leaves the served directory holding a mixed generation,
+and `privkey.pem` is last in `CERTIFICATE_FILES` — so the state a crash
+actually produces is a **new certificate beside the previous private key**: a
+pair that cannot complete a handshake, served straight off local disk by
+`/api/certificates/<domain>/download` and pushed to every deploy hook.
+
+That state was already reconciled, but only by the renewal sweep, in its
+not-yet-due branch — up to a day later. The cause of a torn promote is a
+process dying, and a process that dies is a process about to be restarted, so
+startup is the first moment the state can be noticed. `create_app` now calls
+`reconcile_served_copies`, which compares each domain's served files against
+certbot's `live/` copy and republishes the ones that disagree.
+
+The tests below build the torn state on disk directly rather than trying to
+kill a process mid-rename: the repair has to work from what is on disk, and
+what is on disk is the whole input.
+"""
+import logging
+
+import pytest
+
+from modules.core.certificates import CertificateManager
+
+pytestmark = [pytest.mark.unit]
+
+NEW = {
+    'cert.pem': b'-----BEGIN CERTIFICATE-----\nNEW\n',
+    'chain.pem': b'-----BEGIN CERTIFICATE-----\nNEWCHAIN\n',
+    'fullchain.pem': b'-----BEGIN CERTIFICATE-----\nNEWFULL\n',
+    'privkey.pem': b'-----BEGIN PRIVATE KEY-----\nNEWKEY\n',
+}
+OLD_KEY = b'-----BEGIN PRIVATE KEY-----\nOLDKEY\n'
+
+
+@pytest.fixture
+def manager(tmp_path):
+    return CertificateManager(tmp_path / 'certificates', None,
+                              dns_manager=None)
+
+
+def _domain(manager, domain='example.com', served=None, live=NEW):
+    """Lay out one domain: certbot's live/ copy, and what is being served."""
+    domain_dir = manager.cert_dir / domain
+    live_dir = domain_dir / 'live' / domain
+    live_dir.mkdir(parents=True)
+    for name, data in live.items():
+        (live_dir / name).write_bytes(data)
+    if served is not None:
+        for name, data in served.items():
+            (domain_dir / name).write_bytes(data)
+    return domain_dir
+
+
+def _served(domain_dir):
+    return {p.name: p.read_bytes()
+            for p in domain_dir.iterdir() if p.suffix == '.pem'}
+
+
+# --- the state a crash actually leaves ----------------------------------
+
+def test_a_new_certificate_beside_the_previous_key_is_repaired(manager):
+    """The exact torn state: three renames landed, the fourth did not."""
+    torn = dict(NEW, **{'privkey.pem': OLD_KEY})
+    domain_dir = _domain(manager, served=torn)
+
+    summary = manager.reconcile_served_copies()
+
+    assert summary['republished'] == ['example.com']
+    assert _served(domain_dir) == NEW, (
+        'the served copy still holds a certificate its key does not match'
+    )
+
+
+def test_the_repair_is_reported_so_it_is_not_silent(manager, caplog):
+    """An instance that quietly fixes itself teaches nobody that it broke."""
+    _domain(manager, served=dict(NEW, **{'privkey.pem': OLD_KEY}))
+    with caplog.at_level(logging.WARNING):
+        manager.reconcile_served_copies()
+
+    assert any('example.com' in r.message or 'example.com' in str(r.args)
+               for r in caplog.records), 'the repair was not logged'
+
+
+def test_a_consistent_domain_is_left_alone(manager):
+    """CONTROL: republishing on every start would rewrite four files per
+    domain per boot and hide the signal this exists to raise."""
+    domain_dir = _domain(manager, served=dict(NEW))
+    before = {p.name: p.stat().st_mtime_ns for p in domain_dir.iterdir()
+              if p.suffix == '.pem'}
+
+    summary = manager.reconcile_served_copies()
+
+    assert summary == {'checked': 1, 'republished': [], 'failed': {}}
+    after = {p.name: p.stat().st_mtime_ns for p in domain_dir.iterdir()
+             if p.suffix == '.pem'}
+    assert before == after, 'a healthy domain was rewritten'
+
+
+def test_a_missing_served_file_is_republished(manager):
+    """A crash between the first and second rename leaves files absent, not
+    merely different."""
+    domain_dir = _domain(manager,
+                         served={'cert.pem': NEW['cert.pem']})
+    manager.reconcile_served_copies()
+    assert _served(domain_dir) == NEW
+
+
+# --- what must not be touched -------------------------------------------
+
+def test_an_imported_certificate_with_no_live_directory_is_skipped(manager):
+    """Externally managed certificates have nothing to reconcile against, and
+    republishing them would mean deleting them."""
+    domain_dir = manager.cert_dir / 'imported.example.com'
+    domain_dir.mkdir(parents=True)
+    (domain_dir / 'cert.pem').write_bytes(b'imported')
+
+    summary = manager.reconcile_served_copies()
+
+    assert summary == {'checked': 0, 'republished': [], 'failed': {}}
+    assert (domain_dir / 'cert.pem').read_bytes() == b'imported'
+
+
+def test_a_stray_file_in_the_certificate_directory_is_not_a_domain(manager):
+    manager.cert_dir.mkdir(parents=True, exist_ok=True)
+    (manager.cert_dir / 'README.txt').write_text('not a domain')
+    assert manager.reconcile_served_copies()['checked'] == 0
+
+
+def test_no_certificate_directory_at_all_is_not_an_error(tmp_path):
+    manager = CertificateManager(tmp_path / 'never-created', None,
+                                 dns_manager=None)
+    assert manager.reconcile_served_copies() == {
+        'checked': 0, 'republished': [], 'failed': {}}
+
+
+# --- one bad domain must not take the instance down ---------------------
+
+def test_a_domain_that_cannot_be_repaired_does_not_stop_the_others(manager,
+                                                                   monkeypatch):
+    """Refusing to start would turn one broken certificate into a total
+    outage, and the instance is more useful serving the rest."""
+    _domain(manager, 'broken.example.com',
+            served=dict(NEW, **{'privkey.pem': OLD_KEY}))
+    good = _domain(manager, 'good.example.com',
+                   served=dict(NEW, **{'privkey.pem': OLD_KEY}))
+
+    real_publish = manager._publish_flat_files
+
+    def publish(src_dir, dest_dir):
+        if 'broken' in str(dest_dir):
+            raise OSError('read-only file system')
+        return real_publish(src_dir, dest_dir)
+
+    monkeypatch.setattr(manager, '_publish_flat_files', publish)
+
+    summary = manager.reconcile_served_copies()
+
+    assert summary['republished'] == ['good.example.com']
+    assert 'broken.example.com' in summary['failed']
+    assert _served(good) == NEW
+
+
+def test_a_failure_is_logged_at_error_naming_the_consequence(manager,
+                                                             monkeypatch,
+                                                             caplog):
+    _domain(manager, served=dict(NEW, **{'privkey.pem': OLD_KEY}))
+    monkeypatch.setattr(manager, '_publish_flat_files',
+                        lambda *a: (_ for _ in ()).throw(OSError('nope')))
+
+    with caplog.at_level(logging.ERROR):
+        manager.reconcile_served_copies()
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors, 'an unrepairable mismatch was not logged at ERROR'
+    assert 'private key' in errors[0].getMessage()
+
+
+# --- the wiring ----------------------------------------------------------
+
+def test_a_real_create_app_repairs_a_torn_publish(tmp_path, monkeypatch):
+    """The wiring, exercised rather than grepped for.
+
+    Lay the torn state down where a real `create_app` will find it, boot the
+    application, and check the served copy afterwards. A grep for the call
+    would pass just as well with the call in dead code.
+    """
+    from modules.core.factory import create_app
+
+    project_root = tmp_path / 'certmate'
+    module_dir = project_root / 'modules' / 'core'
+    module_dir.mkdir(parents=True)
+    (module_dir / 'factory.py').write_text('# test path anchor\n')
+    monkeypatch.setattr('modules.core.factory.__file__',
+                        str(module_dir / 'factory.py'))
+    monkeypatch.setenv('FLASK_ENV', 'testing')
+    monkeypatch.setenv('TESTING', 'true')
+
+    domain_dir = project_root / 'certificates' / 'torn.example.com'
+    live_dir = domain_dir / 'live' / 'torn.example.com'
+    live_dir.mkdir(parents=True)
+    for name, data in NEW.items():
+        (live_dir / name).write_bytes(data)
+        (domain_dir / name).write_bytes(data)
+    (domain_dir / 'privkey.pem').write_bytes(OLD_KEY)   # the fourth rename lost
+
+    create_app()
+
+    assert (domain_dir / 'privkey.pem').read_bytes() == NEW['privkey.pem'], (
+        'booting the application left a certificate beside the previous key'
+    )
+
+
+def test_the_startup_wrapper_never_raises(monkeypatch):
+    """CONTROL: a repair that can crash the boot is worse than the defect it
+    repairs — the instance would not come back at all."""
+    from modules.core import factory
+
+    class Boom:
+        def reconcile_served_copies(self):
+            raise RuntimeError('disk gone')
+
+    class Container:
+        managers = {'certificates': Boom()}
+
+    factory.reconcile_served_copies(Container())
+
+
+def test_the_startup_wrapper_tolerates_a_missing_manager():
+    from modules.core import factory
+
+    class Container:
+        managers = {}
+
+    factory.reconcile_served_copies(Container())

--- a/tests/test_served_copies_are_reconciled_at_startup.py
+++ b/tests/test_served_copies_are_reconciled_at_startup.py
@@ -81,8 +81,13 @@ def test_the_repair_is_reported_so_it_is_not_silent(manager, caplog):
     with caplog.at_level(logging.WARNING):
         manager.reconcile_served_copies()
 
-    assert any('example.com' in r.message or 'example.com' in str(r.args)
-               for r in caplog.records), 'the repair was not logged'
+    # Assert on the record's arguments rather than searching its rendered
+    # text: the domain is passed as a lazy-formatting argument, so this pins
+    # that the message actually names the domain it repaired instead of
+    # matching a substring that could come from anywhere in the line.
+    assert any('example.com' in (r.args or ()) for r in caplog.records), (
+        'the repair was not logged, or was logged without naming the domain'
+    )
 
 
 def test_a_consistent_domain_is_left_alone(manager):
@@ -151,7 +156,7 @@ def test_a_domain_that_cannot_be_repaired_does_not_stop_the_others(manager,
     real_publish = manager._publish_flat_files
 
     def publish(src_dir, dest_dir):
-        if 'broken' in str(dest_dir):
+        if dest_dir.name == 'broken.example.com':
             raise OSError('read-only file system')
         return real_publish(src_dir, dest_dir)
 


### PR DESCRIPTION
Three audit findings that turn out to be the same question: **what does this
process know about itself at the moment it says it is ready?**

## 1. `metadata.json` was atomic but not durable

`_atomic_json_write` wrote a temp file and renamed it, and its own docstring
said the mechanism existed *"to avoid partial writes on crash"*. The rename
gives **atomicity** — a reader sees the old file or the new one — and says
nothing about **crash safety**: neither the temp file's contents nor the rename
had left the page cache.

That file is not incidental. It records key custody: `private_key_state` (the
`external` value that stops a CSR-only certificate being reissued nightly), the
CSR fingerprint, and the CA without which a private-CA certificate cannot renew
at all. Losing it does not lose a certificate; it loses the instance's
knowledge of what that certificate *is*.

Three syncs, three different losses:

| | what survives without it |
|---|---|
| `flush()` | bytes still in Python's buffer |
| `fsync(file)` | contents still in the page cache — the rename lands on an empty file |
| `fsync(directory)` | the **name** — the file is durable under a name that is gone |

Same recipe `modules/core/file_operations.py` already uses for `settings.json`.
Both syncs are pinned by their own test, and **both mutations were run**: with
the file fsync removed, 3 tests fail; with the directory fsync removed, 2 fail.

## 2. A torn publish outlived the restart that caused it

Promoting a renewed certificate is four renames and `privkey.pem` is **last**,
so a process killed between the second and the third leaves a **new certificate
beside the previous private key** — a pair that cannot complete a handshake,
served by `/api/certificates/<domain>/download` and pushed to every deploy hook.

The renewal sweep already reconciled this, but only when it next visited the
domain: up to a day later. A torn promote is *caused by a process dying*, and a
process that dies is a process about to be restarted — so startup is the first
moment anyone can notice. `create_app` now compares each domain's served files
against certbot's `live/` copy and republishes the ones that disagree.

- One unrepairable domain is logged at ERROR and does **not** stop the others,
  and does not stop the app starting: refusing to boot turns a one-certificate
  problem into a total outage.
- Imported certificates with no `live/` have nothing to reconcile against and
  are skipped — republishing them would mean deleting them.
- A healthy domain is not rewritten (asserted on mtimes).
- The wiring test **boots a real `create_app`** over a torn directory rather
  than grepping for the call; removing the call fails it.

## 3. certbot was never checked at startup

The one dependency without which nothing works was the one dependency nothing
checked. A broken certbot produced an instance that started, answered `/health`
200 **and `/health/ready` 200**, scheduled its renewals, and found out at the
first one.

The failure this project has actually hit twice is not "not installed":

```
$ certbot --version
AttributeError: module 'OpenSSL.crypto' has no attribute 'X509Req'
```

pip resolves cleanly, the binary is present and executable, and certbot dies
importing its own ACME stack because `cryptography` or `pyOpenSSL` moved under
the pinned certbot. `os.access` calls that installation healthy. Only running
it detects it — so the probe runs the command, once per process, and
`/health/ready` returns **503** when it failed, for the same reason a dead
scheduler does.

A probe that did **not** run is not a probe that failed: a `MockShellExecutor`
(`produces_artifacts = False`) records `skipped`, and `skipped`/`unknown` stay
ready. Otherwise every test instance would be permanently out of rotation.

### The bound was wrong, and the suite proved it

The first version used a five-second timeout. The full suite failed it: under
load, `certbot --version` inside the container took longer and a **working**
certbot was reported as broken, degrading `/health` and 503-ing `/health/ready`
in the real image.

```
$ docker run --rm --entrypoint certbot fabriziosalmi/certmate:latest --version
certbot 2.10.0   real 4.43 / 2.26 / 2.58
```

The bound is now thirty seconds — measured, not guessed. A startup check that
produces false failures is worse than no check, because the next person to see
it red learns to ignore it.

`tests/test_health_ready_e2e.py` now asserts `certbot: ok` **against the real
built image**, and refuses `skipped` there: in the real image the shell
executes, so anything else means the probe did not measure what it claims.

## Checks run locally

- 42 new tests (9 durability + 12 reconciliation + 21 readiness), plus the
  e2e health tests against the real container
- `pytest -m "not ui"` — **4168 passed, 59 skipped**
- Two real mutations on the fsyncs and one on the startup wiring, all killed
- `flake8` with CI's selector set, `C901` at the real max, `bandit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)