### PR TITLE
fix: an interrupted deploy leaves a record, instead of leaving nothing

### DIFF
--- a/modules/core/deployer.py
+++ b/modules/core/deployer.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 import threading
 import time
+import uuid
 from pathlib import Path
 
 from .structured_logging import sanitize_text, JSONFormatter
@@ -26,6 +27,16 @@ logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT = 30
 MAX_TIMEOUT = 300
 MAX_HISTORY_ENTRIES = 500
+
+# A deploy run's lifecycle in the history file. `running` is written before the
+# command starts, so an interrupted hook leaves a record instead of nothing;
+# `success`/`failure` supersede it. `interrupted` is never written — it is what
+# `get_history` reports for a `running` record no live run owns, which after a
+# restart is every one of them.
+STATUS_RUNNING = 'running'
+STATUS_SUCCESS = 'success'
+STATUS_FAILURE = 'failure'
+STATUS_INTERRUPTED = 'interrupted'
 
 # Redacts sensitive-keyed fields recursively before a deploy result is persisted
 # to the history JSONL — a deploy hook command / target config can carry a
@@ -55,6 +66,13 @@ class DeployManager:
         # the EventBus listener threads and read by the scheduler's drain.
         self._pending_path = Path(data_dir) / 'pending_deploys.json'
         self._pending_lock = threading.Lock()
+        # Run ids of hooks this process has started and not yet finished. A
+        # `running` record in the history belongs to one of two situations,
+        # and only this set tells them apart: the run is still going (its id
+        # is in here), or the process that started it died (it is not, because
+        # this set does not survive a restart). See `_run_hook`.
+        self._in_flight = set()
+        self._in_flight_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # EventBus listener
@@ -494,10 +512,47 @@ class DeployManager:
             self._record_target(failure, domain, event_type)
             return [failure]
 
-        results = run_targets(targets, domain, cert_pem, key_pem, event_type)
-        for result in results:
-            self._record_target(result, domain, event_type)
-        return results
+        # Typed targets have the same gap shell hooks had: `run_targets`
+        # publishes to every target and only then returns, so a process killed
+        # part-way through leaves nothing in the history and an operator with
+        # no reason to go and look at a cluster that may hold a half-published
+        # certificate. One `running` record covers the batch — per-target
+        # records would need the results matched back to the targets that
+        # produced them, and `run_targets` filters as it goes, so the two lists
+        # are not the same length. The batch is the honest unit: what the
+        # interrupted record says is "publishing to targets was in progress",
+        # which is exactly what is known.
+        batch_id = uuid.uuid4().hex
+        with self._in_flight_lock:
+            self._in_flight.add(batch_id)
+        self._log_history({
+            'run_id': batch_id,
+            'kind': 'target-batch',
+            'status': STATUS_RUNNING,
+            'success': False,
+            'domain': domain,
+            'event': event_type,
+            'targets': len(targets or []),
+            'timestamp': utc_now_iso(),
+        })
+        try:
+            results = run_targets(targets, domain, cert_pem, key_pem, event_type)
+            for result in results:
+                self._record_target(result, domain, event_type)
+            return results
+        finally:
+            with self._in_flight_lock:
+                self._in_flight.discard(batch_id)
+            self._log_history({
+                'run_id': batch_id,
+                'kind': 'target-batch',
+                'status': STATUS_SUCCESS,
+                'success': True,
+                'domain': domain,
+                'event': event_type,
+                'targets': len(targets or []),
+                'timestamp': utc_now_iso(),
+            })
 
     def _record_target(self, result, domain, event_type):
         """Audit + history + failure-event for one typed-target result."""
@@ -588,7 +643,9 @@ class DeployManager:
         })
 
         start = time.time()
+        run_id = uuid.uuid4().hex
         result = {
+            'run_id': run_id,
             'hook_id': hook_id,
             'hook_name': hook_name,
             'domain': domain,
@@ -598,11 +655,29 @@ class DeployManager:
             'stdout': '',
             'stderr': '',
             'success': False,
+            'status': STATUS_RUNNING,
             'duration_ms': 0,
             'timestamp': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
             'error': None,
             'dry_run': dry_run,
         }
+
+        # Record that the hook STARTED, before it runs. The record used to be
+        # written only after the command returned, so a hook interrupted by
+        # process termination — SIGKILL, OOM, the container stopped mid-deploy
+        # — left no history entry, no audit record and no failure event. An
+        # interrupted publish was indistinguishable from one that never began,
+        # which is the worse of the two: the target may hold a half-written
+        # certificate and nothing says to go and look.
+        #
+        # The file is append-only JSONL, so "updating" this record means
+        # appending a second one with the same run_id; `get_history` folds the
+        # pair and keeps the last. A record still at `running` when read, whose
+        # run_id this process does not have in flight, is reported as
+        # `interrupted` — which after a restart is every one of them.
+        with self._in_flight_lock:
+            self._in_flight.add(run_id)
+        self._log_history(result)
 
         try:
             # Defense in depth: re-validate command at execution time
@@ -640,6 +715,9 @@ class DeployManager:
             result['error'] = str(e)
 
         result['duration_ms'] = int((time.time() - start) * 1000)
+        result['status'] = STATUS_SUCCESS if result['success'] else STATUS_FAILURE
+        with self._in_flight_lock:
+            self._in_flight.discard(run_id)
 
         status = 'success' if result['success'] else 'failure'
         self.audit_logger.log_operation(
@@ -743,23 +821,39 @@ class DeployManager:
 
         Uses a bounded deque to avoid loading the entire file when only
         the tail is needed (the common case when domain=None).
+
+        Each run writes two records — `running` before the command and the
+        outcome after — so the pair is folded here by `run_id`, newest wins,
+        and the reader sees one entry per run exactly as before. A `running`
+        record that survives the fold is a run whose outcome was never
+        written; unless this process still has it in flight, that means the
+        process executing it died, and it is reported as `interrupted`.
+
+        Records written before run ids existed have no `run_id` and are passed
+        through untouched: the history file survives upgrades, and a deploy
+        that happened is not less true for predating this.
         """
         try:
             if not self._history_path.exists():
                 return []
 
             # When filtering by domain we must scan the whole file;
-            # otherwise read only the last `limit` lines.
+            # otherwise read only the tail. Two records per run now, so read
+            # twice as many lines to still be able to fill `limit` runs.
             from collections import deque
             if domain:
                 max_lines = None  # scan all
             else:
-                max_lines = limit
+                max_lines = limit * 2
 
             with open(self._history_path, 'r') as f:
                 tail = deque(f, maxlen=max_lines)
 
+            with self._in_flight_lock:
+                in_flight = set(self._in_flight)
+
             entries = []
+            seen_runs = set()
             for raw in reversed(tail):
                 raw = raw.strip()
                 if not raw:
@@ -776,6 +870,27 @@ class DeployManager:
                     continue
                 if domain and entry.get('domain') != domain:
                     continue
+
+                run_id = entry.get('run_id')
+                if run_id:
+                    # Reading newest-first, so the first record seen for a run
+                    # is its latest: the outcome if one was written, otherwise
+                    # the `running` record left behind.
+                    if run_id in seen_runs:
+                        continue
+                    seen_runs.add(run_id)
+                    if entry.get('status') == STATUS_RUNNING:
+                        entry = dict(entry)
+                        entry['status'] = (
+                            STATUS_RUNNING if run_id in in_flight
+                            else STATUS_INTERRUPTED)
+                        if entry['status'] == STATUS_INTERRUPTED:
+                            entry['error'] = (
+                                entry.get('error')
+                                or 'interrupted: CertMate stopped while this '
+                                   'hook was running, so its outcome is '
+                                   'unknown. Check the target.')
+
                 entries.append(entry)
                 if len(entries) >= limit:
                     break

--- a/templates/partials/settings_deploy.html
+++ b/templates/partials/settings_deploy.html
@@ -331,7 +331,7 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <template x-for="entry in history" :key="entry.timestamp + entry.hook_id">
+                                    <template x-for="entry in history" :key="entry.run_id || (entry.timestamp + entry.hook_id)">
                                         <tr class="border-b border-gray-100 dark:border-gray-700/50 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/30 transition"
                                             role="button"
                                             tabindex="0"
@@ -347,10 +347,22 @@
                                                       :class="entry.event === 'test' ? 'bg-info-surface text-info-fg' : 'bg-surface-2 text-label'"
                                                       x-text="entry.event"></span>
                                             </td>
+                                            {#
+                                                Three outcomes, not two. `interrupted` means CertMate
+                                                was killed while this hook was running: it is neither a
+                                                pass nor an exit code, and rendering it as "Exit err"
+                                                would say the hook ran and failed — the opposite of the
+                                                truth, which is that nobody knows what it did.
+                                            #}
                                             <td class="py-1.5 pr-3">
                                                 <span class="px-1.5 py-0.5 rounded text-[10px] font-medium"
-                                                      :class="entry.success ? 'bg-success-surface text-success-fg' : 'bg-danger-surface text-danger-fg'"
-                                                      x-text="entry.success ? 'OK' : ('Exit ' + (entry.exit_code !== null ? entry.exit_code : 'err'))"></span>
+                                                      :class="entry.status === 'interrupted' ? 'bg-warning-surface text-warning-fg'
+                                                              : (entry.status === 'running' ? 'bg-info-surface text-info-fg'
+                                                              : (entry.success ? 'bg-success-surface text-success-fg' : 'bg-danger-surface text-danger-fg'))"
+                                                      :title="entry.status === 'interrupted' ? (entry.error || 'Interrupted') : ''"
+                                                      x-text="entry.status === 'interrupted' ? 'Interrupted'
+                                                              : (entry.status === 'running' ? 'Running'
+                                                              : (entry.success ? 'OK' : ('Exit ' + (entry.exit_code !== null && entry.exit_code !== undefined ? entry.exit_code : 'err'))))"></span>
                                             </td>
                                             <td class="py-1.5 text-right text-muted" x-text="entry.duration_ms + 'ms'"></td>
                                         </tr>

--- a/tests/test_interrupted_deploy_leaves_a_record.py
+++ b/tests/test_interrupted_deploy_leaves_a_record.py
@@ -1,0 +1,315 @@
+"""A deploy killed part-way must be distinguishable from one that never began.
+
+The deploy history entry, the audit record and the failure event were all
+written *after* the command returned. So a hook interrupted by process
+termination — SIGKILL, an OOM kill, the container stopped mid-deploy — left
+none of them. The history showed nothing, and an operator reading it could not
+tell "this hook never ran" from "this hook was half-way through publishing a
+certificate when we died".
+
+Those are not the same, and the second is the dangerous one: the target may
+hold a partially written certificate, a reloaded service, a key without its
+chain — and nothing anywhere says to go and look.
+
+The fix is the shape a job runner uses. A `running` record is appended before
+the command starts and superseded by the outcome afterwards. The file is
+append-only JSONL, so "superseded" means a second record with the same
+`run_id`, folded by the reader.
+
+That leaves one thing to get right, and it is the whole value of the change: a
+`running` record means either *this run is going on right now* or *the process
+running it died*. Only the process that started it can tell — so the deployer
+keeps the ids it has in flight, and that set does not survive a restart. After
+a restart every leftover `running` record is reported as `interrupted`, which
+is exactly what it is.
+"""
+import json
+import tempfile
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.deployer import DeployManager
+
+pytestmark = [pytest.mark.unit]
+
+HOOK = {'id': 'h1', 'name': 'reload-nginx', 'command': 'echo deployed',
+        'enabled': True, 'timeout': 30, 'on_events': ['renewed']}
+TARGET = {'name': 'k8s-prod', 'type': 'kubernetes-secret', 'enabled': True,
+          'on_events': ['renewed'], 'config': {'secret_name': 'tls'}}
+
+
+@pytest.fixture
+def data_dir():
+    return tempfile.mkdtemp()
+
+
+@pytest.fixture
+def manager(data_dir):
+    settings = MagicMock()
+    settings.get_settings.return_value = {}
+    return DeployManager(settings, MagicMock(), MagicMock(), MagicMock(),
+                         cert_dir=Path(tempfile.mkdtemp()), data_dir=data_dir)
+
+
+def _raw_records(manager):
+    """Every line in the JSONL, unfolded — what is actually on disk."""
+    path = manager._history_path
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _completed(returncode=0, stdout='ok', stderr=''):
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# --- the record exists before the command does anything -----------------
+
+def test_the_start_is_recorded_before_the_command_runs(manager):
+    """The property everything else rests on: at the moment the subprocess is
+    executing, the history already knows about it."""
+    seen = []
+
+    def run(cmd, **kwargs):
+        seen.append(_raw_records(manager))
+        return _completed()
+
+    manager.shell_executor.run = run
+    manager._run_hook(HOOK, 'example.com', 'renewed')
+
+    assert seen, 'the command never ran'
+    assert len(seen[0]) == 1, (
+        'nothing was written to the history before the command started, so a '
+        'kill here would leave no trace at all'
+    )
+    assert seen[0][0]['status'] == 'running'
+    assert seen[0][0]['domain'] == 'example.com'
+    assert seen[0][0]['hook_name'] == 'reload-nginx'
+
+
+def test_a_completed_run_supersedes_its_own_start_record(manager):
+    manager.shell_executor.run = lambda cmd, **kw: _completed()
+    manager._run_hook(HOOK, 'example.com', 'renewed')
+
+    raw = _raw_records(manager)
+    assert len(raw) == 2, 'expected a start record and an outcome record'
+    assert [r['status'] for r in raw] == ['running', 'success']
+    assert raw[0]['run_id'] == raw[1]['run_id']
+
+    history = manager.get_history()
+    assert len(history) == 1, 'the pair was not folded into one entry'
+    assert history[0]['status'] == 'success'
+
+
+def test_a_failed_run_is_recorded_as_failure_not_interrupted(manager):
+    """CONTROL: a hook that ran and exited non-zero is a different fact from
+    one that was killed, and conflating them would make the new state
+    meaningless."""
+    manager.shell_executor.run = lambda cmd, **kw: _completed(
+        returncode=3, stdout='', stderr='nginx: configuration file test failed')
+    manager._run_hook(HOOK, 'example.com', 'renewed')
+
+    history = manager.get_history()
+    assert len(history) == 1
+    assert history[0]['status'] == 'failure'
+    assert history[0]['success'] is False
+    assert 'exit code 3' in history[0]['error']
+
+
+# --- what a kill actually leaves ----------------------------------------
+
+def test_a_run_the_process_did_not_finish_reads_as_interrupted(manager):
+    """Simulates the kill by doing what a kill does: the start record is on
+    disk, the outcome record never arrives, and the process that owned the run
+    is gone."""
+    manager.shell_executor.run = lambda cmd, **kw: _completed()
+    manager._run_hook(HOOK, 'example.com', 'renewed')
+
+    # Strip the outcome record. This is the on-disk state after a SIGKILL
+    # between the two writes.
+    raw = _raw_records(manager)
+    manager._history_path.write_text(json.dumps(raw[0]) + '\n')
+
+    # A restart: a fresh manager over the same data directory, with nothing
+    # in flight.
+    restarted = DeployManager(MagicMock(), MagicMock(), MagicMock(),
+                              MagicMock(),
+                              cert_dir=manager.cert_dir,
+                              data_dir=str(manager._history_path.parent))
+
+    history = restarted.get_history()
+    assert len(history) == 1
+    assert history[0]['status'] == 'interrupted'
+    assert history[0]['success'] is False
+    assert 'Check the target' in history[0]['error'], (
+        'the entry does not tell the operator what to do about it'
+    )
+
+
+def test_a_run_still_going_in_this_process_reads_as_running(manager):
+    """CONTROL, and the reason the in-flight set exists. Reporting a live
+    deploy as `interrupted` would cry wolf on every long hook."""
+    observed = {}
+
+    def run(cmd, **kwargs):
+        observed['during'] = manager.get_history()
+        return _completed()
+
+    manager.shell_executor.run = run
+    manager._run_hook(HOOK, 'example.com', 'renewed')
+
+    assert observed['during'][0]['status'] == 'running', (
+        'a hook that is executing right now was reported as interrupted'
+    )
+
+
+def test_the_in_flight_set_is_emptied_even_when_the_hook_raises(manager):
+    """A leaked id would keep a dead run reporting as `running` forever."""
+    manager.shell_executor.run = MagicMock(side_effect=OSError('fork failed'))
+    manager._run_hook(HOOK, 'example.com', 'renewed')
+
+    assert manager._in_flight == set()
+    assert manager.get_history()[0]['status'] == 'failure'
+
+
+def test_a_timeout_completes_the_record_rather_than_leaving_it_running(manager):
+    """A hook that hit its own timeout was not interrupted — CertMate stopped
+    it deliberately and knows the outcome."""
+    import subprocess
+    manager.shell_executor.run = MagicMock(
+        side_effect=subprocess.TimeoutExpired('sh', 30))
+    manager._run_hook(HOOK, 'example.com', 'renewed')
+
+    history = manager.get_history()
+    assert history[0]['status'] == 'failure'
+    assert 'timeout' in history[0]['error']
+
+
+# --- typed deploy targets have the same gap -----------------------------
+
+def test_an_interrupted_target_batch_leaves_a_record(manager, monkeypatch):
+    """`run_targets` publishes to every target and only then returns, so a
+    kill part-way through was equally invisible."""
+    domain = 'example.com'
+    domain_dir = manager.cert_dir / domain
+    domain_dir.mkdir(parents=True)
+    (domain_dir / 'fullchain.pem').write_bytes(b'cert')
+    (domain_dir / 'privkey.pem').write_bytes(b'key')
+
+    seen = []
+    monkeypatch.setattr('modules.core.deployer.run_targets',
+                        lambda *a, **k: seen.append(_raw_records(manager)) or [])
+
+    manager._execute_targets(domain, 'renewed',
+                             targets=[TARGET])
+
+    assert seen and len(seen[0]) == 1, (
+        'nothing recorded before publishing to the targets began'
+    )
+    assert seen[0][0]['kind'] == 'target-batch'
+    assert seen[0][0]['status'] == 'running'
+
+
+def test_a_finished_target_batch_supersedes_its_start(manager, monkeypatch):
+    domain = 'example.com'
+    domain_dir = manager.cert_dir / domain
+    domain_dir.mkdir(parents=True)
+    (domain_dir / 'fullchain.pem').write_bytes(b'cert')
+    (domain_dir / 'privkey.pem').write_bytes(b'key')
+
+    monkeypatch.setattr('modules.core.deployer.run_targets',
+                        lambda *a, **k: [])
+    manager._execute_targets(domain, 'renewed',
+                             targets=[TARGET])
+
+    batches = [e for e in manager.get_history() if e.get('kind') == 'target-batch']
+    assert len(batches) == 1
+    assert batches[0]['status'] == 'success'
+
+
+def test_a_target_batch_that_raises_still_closes_its_record(manager,
+                                                            monkeypatch):
+    """CONTROL: an exception inside run_targets must not leave a record that
+    reads as interrupted — the process is alive and knows what happened."""
+    domain = 'example.com'
+    domain_dir = manager.cert_dir / domain
+    domain_dir.mkdir(parents=True)
+    (domain_dir / 'fullchain.pem').write_bytes(b'cert')
+    (domain_dir / 'privkey.pem').write_bytes(b'key')
+
+    monkeypatch.setattr('modules.core.deployer.run_targets',
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError('x')))
+    with pytest.raises(RuntimeError):
+        manager._execute_targets(domain, 'renewed',
+                                 targets=[TARGET])
+
+    assert manager._in_flight == set()
+    batches = [e for e in manager.get_history() if e.get('kind') == 'target-batch']
+    assert batches[0]['status'] != 'interrupted'
+
+
+# --- the history the reader hands out -----------------------------------
+
+def test_history_written_before_run_ids_existed_still_reads(manager):
+    """The history file survives upgrades. A deploy that happened is not less
+    true for predating this change, and must not be relabelled."""
+    manager._history_path.parent.mkdir(parents=True, exist_ok=True)
+    manager._history_path.write_text(json.dumps({
+        'hook_id': 'old', 'hook_name': 'legacy', 'domain': 'old.example.com',
+        'success': True, 'exit_code': 0, 'timestamp': '2026-01-01T00:00:00Z',
+    }) + '\n')
+
+    history = manager.get_history()
+    assert len(history) == 1
+    assert history[0]['hook_name'] == 'legacy'
+    assert history[0]['success'] is True
+    assert 'status' not in history[0], (
+        'an old record was given a status it never had'
+    )
+
+
+def test_the_limit_still_counts_runs_not_lines(manager):
+    """Two records per run: a limit of 5 must still return 5 runs, not 2 and
+    a half."""
+    manager.shell_executor.run = lambda cmd, **kw: _completed()
+    for i in range(8):
+        manager._run_hook(dict(HOOK, id=f'h{i}'), f'd{i}.example.com', 'renewed')
+
+    history = manager.get_history(limit=5)
+    assert len(history) == 5
+    assert len({e['run_id'] for e in history}) == 5, 'a run appeared twice'
+    assert [e['domain'] for e in history] == [
+        'd7.example.com', 'd6.example.com', 'd5.example.com',
+        'd4.example.com', 'd3.example.com'], 'newest-first ordering broke'
+
+
+def test_filtering_by_domain_still_folds_the_pairs(manager):
+    manager.shell_executor.run = lambda cmd, **kw: _completed()
+    manager._run_hook(HOOK, 'a.example.com', 'renewed')
+    manager._run_hook(HOOK, 'b.example.com', 'renewed')
+
+    history = manager.get_history(domain='a.example.com')
+    assert len(history) == 1
+    assert history[0]['domain'] == 'a.example.com'
+    assert history[0]['status'] == 'success'
+
+
+def test_concurrent_hooks_do_not_confuse_each_others_records(manager):
+    """The in-flight set is written from EventBus listener threads."""
+    manager.shell_executor.run = lambda cmd, **kw: _completed()
+    threads = [threading.Thread(target=manager._run_hook,
+                                args=(dict(HOOK, id=f'h{i}'),
+                                      f'd{i}.example.com', 'renewed'))
+               for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    history = manager.get_history(limit=50)
+    assert manager._in_flight == set()
+    assert len(history) == 8
+    assert all(e['status'] == 'success' for e in history)


### PR DESCRIPTION
## The gap

The deploy history entry, the audit record and the failure event were all
written **after** the command returned:

```python
proc = self.shell_executor.run(['sh', '-c', command], ...)   # <- killed here
...
self._log_history(result)                                     # never reached
```

So a hook interrupted by process termination — SIGKILL, an OOM kill, the
container stopped mid-deploy — left **none of them**. An operator reading the
history could not tell *"this hook never ran"* from *"this hook was half-way
through publishing a certificate when we died"*.

Those are not the same fact, and the second is the dangerous one: the target
may hold a partially written certificate, a reloaded service, a key without its
chain — and nothing anywhere says to go and look.

## The fix, and the part that carries the value

A `running` record is appended **before** the command starts and superseded by
the outcome afterwards. The file is append-only JSONL, so "superseded" means a
second record with the same `run_id`; `get_history` folds the pair, so callers
still see one entry per run.

The part worth getting right is that `running` has two meanings:

> either **this run is going on right now**, or **the process running it died**

and only the process that started it can tell. The deployer keeps the run ids
it has in flight, and **that set does not survive a restart** — so after a
restart every leftover reads as `interrupted`, while a hook executing right now
still reads as `running`. `interrupted` is never written to disk; it is derived.

| on disk | in flight here? | reported |
|---|---|---|
| `running` + outcome | — | the outcome |
| `running` only | yes | `running` |
| `running` only | no | **`interrupted`** |

## Typed targets had the same gap

`run_targets` publishes to every target and only then returns, so a kill
part-way through was equally invisible. One `running` record covers the
**batch** — per-target records would need results matched back to the targets
that produced them, and `run_targets` filters as it goes, so the two lists are
not the same length. The batch is the honest unit: what an interrupted record
says is *"publishing to targets was in progress"*, which is exactly what is
known.

## The UI said the opposite of the truth

An interrupted entry has no exit code, and the history pane rendered
`entry.success ? 'OK' : 'Exit ' + (exit_code ?? 'err')` — so it displayed
**`Exit err`**, telling the operator the hook ran and failed. Three outcomes
now, with `interrupted` in the warning colour and the reason in its tooltip.

## Compatibility

- Records written before run ids existed have no `run_id` and are passed
  through **untouched** — the history file survives upgrades, and a deploy that
  happened is not less true for predating this. A test asserts no `status` is
  invented for them.
- Two records per run, so `get_history` reads twice as many lines: `limit=5`
  still returns 5 **runs**, asserted, in the right order.

## Checks run locally

- 14 new tests. The ones that matter are the controls: a hook that **ran and
  exited non-zero** is `failure`, not `interrupted`; a hook **executing right
  now** is `running`, not `interrupted`; a hook that hit **its own timeout** is
  `failure`, because CertMate stopped it and knows the outcome; the in-flight
  id is released even when the executor raises; and 8 concurrent hooks do not
  confuse each other's records.
- `pytest -m "not ui"` — **4182 passed, 59 skipped**
- `theme_codemod --check` and `npm run css:build` clean (the classes used were
  already in the bundle — no CSS diff)
- `flake8` with CI's selector set, `C901` at the real max — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)