### PR TITLE
build: the image carries what the process runs, not the working tree

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,8 +146,36 @@ RUN apt-get update && \
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Copy application code
-COPY . .
+# Copy application code.
+#
+# An allowlist, not `COPY . .` plus a .dockerignore denylist. The denylist
+# worked the way denylists do: the published image carried a 188K licensing
+# PDF, an 856K demo directory, the Helm chart, the client SDK sources, the MCP
+# server, the monitoring dashboards, seven build and test shell scripts, and
+# pytest's own configuration — none of which the runtime reads, all of which
+# are either build-time (already consumed by the builder stage) or separate
+# deliverables published on their own channels. A denylist ships whatever
+# nobody remembered to add to it, and the thing nobody remembers is always the
+# thing that arrived last.
+#
+# What is here is what the running process actually touches:
+#   app.py, modules/, templates/, static/  the application
+#   scripts/                               solidserver_hook.py is executed by
+#                                          the SolidServer DNS strategy
+#                                          (modules/core/dns_strategies.py)
+#   requirements*.txt                      two error paths tell the operator to
+#                                          install one of these into a running
+#                                          container to add a DNS or storage
+#                                          backend
+#
+# tests/test_image_ships_only_what_it_runs.py checks this against the built
+# image rather than against this comment.
+COPY app.py ./
+COPY requirements*.txt ./
+COPY modules/ ./modules/
+COPY templates/ ./templates/
+COPY static/ ./static/
+COPY scripts/ ./scripts/
 
 # Create the runtime-writable directories and make them arbitrary-UID ready.
 #

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -319,6 +319,26 @@ hand, a refresh cadence so the lockfiles do not become a reason not to patch,
 and a drift guard tying each lockfile to its requirements file. That is a
 project, not a cleanup, and it is tracked rather than half-started.
 
+**A rebuild is not expected to be bit-identical.** The runtime stage installs
+three OS packages (`bash`, `curl`, `tini`) with an unpinned `apt-get install`,
+so two builds of the same commit, days apart, can carry different versions of
+them. That is deliberate: pinning the three would break the build on every
+base-image bump, and a genuinely reproducible OS layer needs a snapshot mirror,
+which is a project rather than a line. The consequence is recorded here so
+nobody reads a digest mismatch between two builds of one commit as evidence of
+tampering — it is the expected outcome. What the image actually contains is
+answerable from the SBOM that ships with it.
+
+**What the image contains is an allowlist, not a denylist.** The runtime stage
+names what it copies — `app.py`, `modules/`, `templates/`, `static/`,
+`scripts/` and the requirements files — rather than copying the tree and
+subtracting. Until v2.29.0 it did the latter, and the published image carried
+the Helm chart, the client SDK sources, the MCP server, the monitoring assets,
+a demo directory and a licensing PDF. None of it was reachable by the process,
+but a denylist ships whatever nobody remembered to add to it.
+`tests/test_image_ships_only_what_it_runs.py` checks the built image, not the
+Dockerfile.
+
 **If you are threat-modelling against this**, the honest summary is:
 auditability, not integrity. The SBOM tells you what you got; it does not prove
 it is what was intended.

--- a/tests/test_image_ships_only_what_it_runs.py
+++ b/tests/test_image_ships_only_what_it_runs.py
@@ -1,0 +1,163 @@
+"""The published image carries what the process runs, and nothing else.
+
+The runtime stage used to be `COPY . .` with a `.dockerignore` denylist. That
+worked the way denylists work. Measured against the published v2.29.0 image on
+2026-09-08, `/app` contained:
+
+    licensing.pdf         188K   a licensing document
+    demo/                 856K   a demo directory
+    charts/                64K   the Helm chart, published on its own channel
+    clients/               96K   the SDK and CLI sources, published to PyPI
+    mcp/                   80K   the MCP server, published separately
+    monitoring/            36K   Grafana and Prometheus assets
+    conftest.py, pytest.ini, codecov.yml, .flake8, Makefile, .airgap.yml
+    build-docker.sh, build-multiplatform.sh, debug-docker.sh, quick_test.sh,
+    run-docker.sh, run-tests.sh, test-multiplatform.sh, start-certmate.sh
+    certmate.service, nginx.conf.example
+
+None of it is read by the running process. All of it is either build-time —
+already consumed by the builder stage, which is the whole point of a
+multi-stage build — or a separate deliverable that ships on its own channel.
+
+The problem with a denylist is not the size. It is that it ships whatever
+nobody remembered to add to it, and the thing nobody remembers is always the
+thing that arrived last: every one of those directories was added by a feature
+that had no reason to think about the Dockerfile.
+
+The Dockerfile now names what it copies. These tests check the image rather
+than the Dockerfile, because a `COPY` line that is right and a `.dockerignore`
+that quietly re-adds a path look identical in review.
+
+Marked `e2e`: they need the built image, which the session fixture provides.
+
+Verified against the published v2.29.0 image by listing `/app` in it directly:
+all sixteen names below are present there, and the "only what it needs" check
+finds twenty-three entries too many. Note that `CERTMATE_IMAGE` is NOT a way to
+run these against a published image — `docker_container` *builds* the working
+tree and tags it with that name, so pointing it at a published tag rebuilds
+locally under that tag and the tests pass on a fresh build while appearing to
+test the release. Set `CERTMATE_SKIP_BUILD=1` as well, or list the image by
+hand.
+"""
+import subprocess
+
+import pytest
+
+pytestmark = [pytest.mark.e2e]
+
+# What the running process actually touches.
+EXPECTED = {
+    'app.py',            # the entry point gunicorn loads
+    'modules',           # the application
+    'templates',         # rendered by it
+    'static',            # served by it
+    'scripts',           # solidserver_hook.py is executed by the SolidServer
+                         # DNS strategy (modules/core/dns_strategies.py)
+    # Runtime-writable trees the Dockerfile creates, not copies.
+    'backups', 'certificates', 'data', 'logs',
+}
+
+# Two error paths tell the operator to install one of these into a running
+# container to add a DNS or storage backend, so they are part of the runtime
+# surface even though the builder stage is what consumes them at build time.
+REQUIREMENTS_PREFIX = 'requirements'
+
+# Things whose presence in the image was the finding. Named individually so a
+# failure says which one came back, rather than "the set changed".
+MUST_NOT_SHIP = [
+    ('licensing.pdf', 'a licensing document the process never opens'),
+    ('demo', 'the demo directory'),
+    ('charts', 'the Helm chart, published on its own channel'),
+    ('clients', 'the SDK and CLI sources, published to PyPI'),
+    ('mcp', 'the MCP server, published separately'),
+    ('monitoring', 'Grafana and Prometheus assets'),
+    ('conftest.py', "pytest's own configuration"),
+    ('pytest.ini', "pytest's own configuration"),
+    ('codecov.yml', 'coverage reporting configuration'),
+    ('Makefile', 'developer targets'),
+    ('build-docker.sh', 'a build script, already consumed by the builder'),
+    ('build-multiplatform.sh', 'a build script'),
+    ('run-tests.sh', 'a test runner'),
+    ('quick_test.sh', 'a test runner'),
+    ('test-multiplatform.sh', 'a test runner'),
+    ('debug-docker.sh', 'a debugging script'),
+]
+
+
+@pytest.fixture(scope='module')
+def app_dir(docker_container):
+    """What `/app` holds in the image under test."""
+    from tests.conftest import IMAGE_NAME
+    result = subprocess.run(
+        ['docker', 'run', '--rm', '--entrypoint', 'sh', IMAGE_NAME,
+         '-c', 'ls -A /app'],
+        capture_output=True, text=True, timeout=120)
+    assert result.returncode == 0, result.stderr
+    entries = set(result.stdout.split())
+    assert entries, 'listing /app in the image produced nothing'
+    return entries
+
+
+@pytest.mark.parametrize('name, what', MUST_NOT_SHIP)
+def test_a_build_time_or_separate_deliverable_does_not_ship(app_dir, name, what):
+    assert name not in app_dir, (
+        f'{name} is in the published image ({what}). It is either build-time '
+        f'or published on its own channel; add it to nothing, and remove the '
+        f'COPY that brought it back.'
+    )
+
+
+def test_everything_that_ships_is_something_the_process_uses(app_dir):
+    """The other direction. Without this the tests above are a denylist too —
+    the exact structure the change replaced."""
+    unexpected = sorted(
+        name for name in app_dir
+        if name not in EXPECTED and not name.startswith(REQUIREMENTS_PREFIX))
+    assert not unexpected, (
+        'these are in the image and nothing in the runtime reads them:\n  '
+        + '\n  '.join(unexpected)
+        + '\n\nIf one of them is genuinely needed, add it to EXPECTED with '
+          'the reason. If not, it should not be copied.'
+    )
+
+
+def test_what_the_runtime_needs_is_actually_there(app_dir):
+    """CONTROL: an allowlist that copies too little produces an image that
+    boots and then fails on a path nobody exercised in CI."""
+    missing = sorted(EXPECTED - app_dir)
+    assert not missing, f'the image is missing {", ".join(missing)}'
+
+    assert any(n.startswith(REQUIREMENTS_PREFIX) for n in app_dir), (
+        'no requirements file shipped, but two error messages tell the '
+        'operator to install one into a running container'
+    )
+
+
+def test_the_solidserver_hook_is_where_the_code_looks_for_it(docker_container):
+    """The one runtime dependency outside app/modules/templates/static, and
+    the reason `scripts/` is copied at all. `dns_strategies.py` resolves
+    `scripts/solidserver_hook.py` relative to the working directory."""
+    from tests.conftest import IMAGE_NAME
+    result = subprocess.run(
+        ['docker', 'run', '--rm', '--entrypoint', 'sh', IMAGE_NAME,
+         '-c', 'test -f /app/scripts/solidserver_hook.py && echo present'],
+        capture_output=True, text=True, timeout=120)
+    assert 'present' in result.stdout, (
+        'scripts/solidserver_hook.py is not in the image; the SolidServer DNS '
+        'provider would fail at issuance time with a missing-file error'
+    )
+
+
+def test_the_dockerfile_does_not_copy_the_whole_tree():
+    """Checked as well as the image, because a `COPY . .` that reappears is
+    the specific regression, and it would take a rebuild to see it otherwise.
+    """
+    import pathlib
+    dockerfile = (pathlib.Path(__file__).resolve().parent.parent
+                  / 'Dockerfile').read_text()
+    runtime = dockerfile.split('FROM')[-1]
+    for line in runtime.splitlines():
+        stripped = line.strip()
+        if stripped.startswith('COPY') and '--from=' not in stripped:
+            assert stripped.split()[1] != '.', (
+                'the runtime stage copies the whole tree again: ' + stripped)


### PR DESCRIPTION
## What the published image actually contains

The runtime stage was `COPY . .` with a `.dockerignore` denylist. Listing
`/app` inside the published v2.29.0 image:

| shipped | size | what it is |
|---|---|---|
| `licensing.pdf` | 188K | a licensing document |
| `demo/` | 856K | a demo directory |
| `charts/` | 64K | the Helm chart, published on its own channel |
| `clients/` | 96K | the SDK and CLI sources, published to PyPI |
| `mcp/` | 80K | the MCP server, published separately |
| `monitoring/` | 36K | Grafana and Prometheus assets |
| + | | `conftest.py`, `pytest.ini`, `codecov.yml`, `.flake8`, `Makefile`, `.airgap.yml`, `certmate.service`, `nginx.conf.example`, and seven build/test shell scripts |

None of it is read by the running process. All of it is either **build-time** —
already consumed by the builder stage, which is the point of a multi-stage
build — or a **separate deliverable** that ships on its own channel.

**The size is not the problem.** A denylist ships whatever nobody remembered to
add to it, and the thing nobody remembers is always the thing that arrived
last: every one of those directories came from a feature that had no reason to
think about the Dockerfile.

## The allowlist, derived from the code

```dockerfile
COPY app.py ./
COPY requirements*.txt ./
COPY modules/ ./modules/
COPY templates/ ./templates/
COPY static/ ./static/
COPY scripts/ ./scripts/
```

Two of those are not obvious and were found by reading, not guessing:

- **`scripts/`** — `modules/core/dns_strategies.py` resolves
  `scripts/solidserver_hook.py` at issuance time. Dropping it would have
  produced an image that boots, passes CI, and fails on the SolidServer
  provider only.
- **`requirements*.txt`** — two error paths tell the operator to install one
  into a *running* container to add a DNS or storage backend
  (`dns_zone_discovery.py`, `certificates.py`). Dropping them breaks a
  documented instruction.

## Verified by running it

```
/health         healthy      (scheduler running, certbot ok)
GET /                    200
GET /static/css/…        200
GET /certmate_logo.png   200
GET /docs/               200
/app/scripts/solidserver_hook.py present
647MB  (was 659MB)
```

## The tests check the image, not the Dockerfile

A correct `COPY` line and a `.dockerignore` that quietly re-adds a path look
identical in review. So the tests list `/app` inside the built image — plus one
that *does* read the Dockerfile, because `COPY . .` coming back is the specific
regression and would otherwise take a rebuild to notice.

Both directions, so the tests are not a denylist either: sixteen named things
that must not ship, **and** an allowlist check that fails on anything present
the runtime does not use.

Confirmed against the published image by listing it by hand: all sixteen names
are there and the allowlist check finds twenty-three entries too many.

A footgun found on the way and written into the test file: `CERTMATE_IMAGE` is
not a way to point these at a release. `docker_container` *builds* the working
tree and tags it with that name, so aiming it at a published tag rebuilds
locally under that tag and the tests pass on a fresh build while appearing to
test the release.

## Also: the OS layer is not reproducible, and now says so

The runtime stage installs `bash`, `curl` and `tini` with an unpinned
`apt-get install`, so two builds of one commit can differ. Pinning breaks on
every base-image bump and a genuinely reproducible OS layer needs a snapshot
mirror — a project, not a line. SECURITY.md's supply-chain section now records
it, so nobody reads a digest mismatch between two builds of one commit as
evidence of tampering.

## Checks run locally

- 20 new tests; `pytest -m "not ui"` — **4159 passed, 59 skipped**
- `flake8` with CI's selector set — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
