### PR TITLE
ci: two gates that reported without measuring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,19 @@ jobs:
         # Complexity RATCHET, not a standard. The previous line computed every
         # function over --max-complexity=10 and then threw the exit code away
         # with --exit-zero, so all 85 over-threshold functions were measured and
-        # ignored (#652). 559 is the current worst (create_api_resources, the
-        # 3.7k-line closure in modules/api/resources.py); this gate exists so
-        # nothing can get WORSE than the worst thing already here. Lower the
-        # number as the decomposition issues land — never raise it.
-        flake8 . --count --select=C901 --max-complexity=559 --statistics
+        # ignored (#652). This gate exists so nothing can get WORSE than the
+        # worst thing already here.
+        #
+        # A ratchet only ratchets if someone lowers it. This one was set to 559
+        # for create_api_resources, the 3.7k-line closure in
+        # modules/api/resources.py; #667 decomposed that function to 1 and the
+        # number stayed at 559, five times the real worst, permitting anything
+        # a contributor could plausibly write. It is now 115, which is
+        # register_settings_routes in modules/web/settings_routes.py, and
+        # tests/test_complexity_ratchet_is_tight.py fails if the tree gets
+        # simpler than the pin — so lowering it is not something to remember,
+        # it is something the suite asks for.
+        flake8 . --count --select=C901 --max-complexity=115 --statistics
         # Style is reported, never enforced: line length is not a defect class.
         flake8 . --count --exit-zero --max-line-length=127 --statistics
 

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -91,6 +91,11 @@ jobs:
         CERTMATE_TEST_EMAIL: ${{ secrets.CERTMATE_TEST_EMAIL }}
         # Belt-and-suspenders: the tests default to staging, pin it here too.
         CERTMATE_E2E_CA_PROVIDER: letsencrypt_staging
+        # This job exists to run the credential-gated tests. Without this they
+        # would skip on a token the runner failed to see, and the job would go
+        # green having issued nothing — the shape of the defect this gate was
+        # built to catch, in the gate itself.
+        CERTMATE_REQUIRE_CREDENTIALED: '1'
       run: |
         python -m pytest -v -m e2e \
           tests/test_health_ready_e2e.py \

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,7 @@ markers =
     ui: Playwright browser tests
     network: needs outbound HTTPS (CA directory reachability)
     live: needs a real MinIO / Vault (storage backends)
+    credentialed: needs a real third-party credential (applied automatically by conftest, not by hand)
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -27,3 +27,9 @@ PyYAML==6.0.3
 # today (pip, build tooling), so relying on that would break the test the day
 # something drops it, for reasons unrelated to what it checks.
 packaging==26.2
+
+# Read by tests/test_complexity_ratchet_is_tight.py, which shells out to flake8
+# to measure the tree's worst cyclomatic complexity and compares it with the
+# number CI enforces. Pinned to the version the lint step installs so the test
+# job and the lint job cannot disagree about what "too complex" means.
+flake8==7.3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,11 +267,90 @@ def api(docker_container):
 
 @pytest.fixture(scope="session")
 def cloudflare_token():
-    """Return the Cloudflare API token or skip if not set."""
+    """Return the Cloudflare API token, or skip — loudly, and countably.
+
+    Ten test files hang off this fixture. When the token is absent they all
+    skip, and a skip in a green run is indistinguishable from a pass: the
+    class had been reporting as "skipped" rather than as "never executed",
+    which is how a test can rot for years while the board stays green.
+
+    Two things change that. `CERTMATE_REQUIRE_CREDENTIALED=1` turns the skip
+    into a failure, so a job that exists to run these cannot silently run
+    none of them — the same mechanism `CERTMATE_UI_REQUIRE_BROWSER` already
+    provides for the Playwright suite. And the skip reason carries a marker
+    the terminal summary counts, so every ordinary run ends with a line
+    saying how many tests were not executed and why.
+    """
     token = os.environ.get("CLOUDFLARE_API_TOKEN")
     if not token:
-        pytest.skip("CLOUDFLARE_API_TOKEN not set — skipping real DNS tests")
+        _credential_missing("CLOUDFLARE_API_TOKEN", "real DNS-01 tests")
     return token
+
+
+# Marks a skip caused by an absent third-party credential, so
+# pytest_terminal_summary can count them. Matched as a substring of the skip
+# reason: pytest does not carry structured metadata on a skip.
+CREDENTIAL_SKIP_MARK = "[no-credential]"
+_REQUIRE_CREDENTIALED = os.environ.get("CERTMATE_REQUIRE_CREDENTIALED") == "1"
+
+
+def _credential_missing(variable, what):
+    """Fail when the credential is mandatory, skip countably when it is not."""
+    if _REQUIRE_CREDENTIALED:
+        pytest.fail(
+            f"{variable} is not set, so {what} cannot run. "
+            f"CERTMATE_REQUIRE_CREDENTIALED=1 means this must not be skipped."
+        )
+    pytest.skip(f"{CREDENTIAL_SKIP_MARK} {variable} not set — {what} not run")
+
+
+CREDENTIALED_FIXTURES = frozenset({"cloudflare_token"})
+
+
+def pytest_collection_modifyitems(config, items):
+    """Mark every test that needs a third-party credential, by derivation.
+
+    `-m credentialed` then selects exactly this class. Derived from the
+    fixtures a test requests rather than written on each file: a marker
+    maintained by hand drifts the first time someone adds the fixture and
+    forgets the decorator, and the fixture is what actually gates the test.
+    """
+    for item in items:
+        if CREDENTIALED_FIXTURES & set(getattr(item, "fixturenames", ())):
+            item.add_marker(pytest.mark.credentialed)
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """End every run by saying what it did not measure.
+
+    pytest's own tail says "N skipped" without saying what N was, and a
+    number with no subject reads as housekeeping. This names the class,
+    counts it, and says how to run it — so the difference between "the suite
+    passed" and "the suite passed the parts it could reach" is on the screen
+    of whoever reads the run.
+    """
+    skipped = terminalreporter.stats.get("skipped", [])
+    missing = [r for r in skipped
+               if CREDENTIAL_SKIP_MARK in str(getattr(r, "longrepr", ""))]
+    if not missing:
+        return
+
+    variables = sorted({
+        word for report in missing
+        for word in str(report.longrepr).split()
+        if word.isupper() and "_" in word
+    })
+    terminalreporter.write_sep("=", "not executed: missing credentials",
+                               yellow=True, bold=True)
+    terminalreporter.write_line(
+        f"{len(missing)} test(s) did not run because "
+        f"{', '.join(variables) or 'a credential'} is unset. They are not "
+        f"passing; they are unmeasured."
+    )
+    terminalreporter.write_line(
+        "Set the credential to run them, or CERTMATE_REQUIRE_CREDENTIALED=1 "
+        "to make their absence a failure (used by the real-certificate gate)."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ci_marker_coverage.py
+++ b/tests/test_ci_marker_coverage.py
@@ -125,16 +125,25 @@ def test_every_test_file_declares_a_marker():
 
 
 def _markers_in_use():
-    """Marker names any test file actually applies.
+    """Marker names actually applied to tests.
 
     Read from the sources rather than by shelling out to pytest once per
     marker: that was slower, and it judged a run by grepping stdout for a
     message pytest can also emit on stderr — a check that can miss its own
     signal is not one worth keeping.
+
+    ``conftest.py`` counts as a source. A marker applied there by
+    ``pytest_collection_modifyitems`` is applied to real tests — ``credentialed``
+    is derived from the fixtures a test requests, precisely so it cannot drift
+    the way a hand-written decorator does — and reading only ``test_*.py``
+    would report it as a category nobody is in while ``-m credentialed``
+    selects fifteen tests.
     """
     used = set()
     declared = _declared_markers()
-    for path in _test_files():
+    for path in [*_test_files(), TESTS_DIR / "conftest.py"]:
+        if not path.exists():
+            continue
         src = path.read_text(encoding="utf-8")
         for match in re.finditer(r"pytest\.mark\.(\w+)", src):
             if match.group(1) in declared:

--- a/tests/test_complexity_ratchet_is_tight.py
+++ b/tests/test_complexity_ratchet_is_tight.py
@@ -1,0 +1,129 @@
+"""A ratchet that nobody lowers is a gate that permits everything.
+
+CI runs `flake8 --select=C901 --max-complexity=N` so that no function can be
+worse than the worst one already in the tree. The number was 559 — set for
+`create_api_resources`, the 3.7k-line closure in `modules/api/resources.py`.
+Issue #667 decomposed that function to a complexity of 1, and the number stayed
+at 559: nearly five times the real worst, permitting anything a contributor
+could plausibly write, while reading in review like an enforced limit.
+
+That is the failure mode of every ratchet maintained by memory. This file
+removes the memory: it measures the tree and fails when the pin is looser than
+what the tree actually contains, so lowering it is not something to remember —
+it is something the suite asks for, in the commit that earned it.
+
+Deliberately one-directional. Getting *worse* is caught by CI itself (a new
+function above the pin fails the lint step). Getting *better* without lowering
+the pin is what this catches, and it is the direction nothing else looks at.
+"""
+import pathlib
+import re
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+WORKFLOW = REPO / '.github' / 'workflows' / 'ci.yml'
+COMPLEXITY = re.compile(r"is too complex \((\d+)\)")
+PIN = re.compile(r"--select=C901\s+--max-complexity=(\d+)")
+
+
+def ci_pin():
+    """The number CI enforces."""
+    match = PIN.search(WORKFLOW.read_text())
+    assert match, (
+        'the C901 ratchet is gone from ci.yml. If it was removed on purpose, '
+        'remove this file too; if it was renamed, this needs renaming with it.'
+    )
+    return int(match.group(1))
+
+
+def measured_worst():
+    """The highest cyclomatic complexity in the tree, from flake8 itself.
+
+    Run rather than reimplemented: an independent complexity calculation would
+    disagree with the gate at the margins, and the number that matters is the
+    one CI computes.
+    """
+    result = subprocess.run(
+        [sys.executable, '-m', 'flake8', '.', '--select=C901',
+         '--max-complexity=1', '--exit-zero'],
+        cwd=REPO, capture_output=True, text=True, timeout=600)
+
+    if 'No module named flake8' in result.stderr:
+        pytest.fail(
+            'flake8 is not installed, so the ratchet cannot be checked. It is '
+            'in requirements-test.txt precisely so this cannot skip quietly — '
+            'a check that disappears with its dependency is worse than none.')
+    assert result.returncode == 0, result.stderr
+
+    scores = [int(m.group(1)) for m in COMPLEXITY.finditer(result.stdout)]
+    assert scores, (
+        'flake8 reported no complexity at all against --max-complexity=1, '
+        'which cannot be true of this codebase. The measurement is broken, '
+        'not the tree.'
+    )
+    return max(scores)
+
+
+def worst_function():
+    """(name, path, score) of the most complex function, for the message."""
+    result = subprocess.run(
+        [sys.executable, '-m', 'flake8', '.', '--select=C901',
+         '--max-complexity=1', '--exit-zero'],
+        cwd=REPO, capture_output=True, text=True, timeout=600)
+    worst, best_score = None, -1
+    for line in result.stdout.splitlines():
+        match = COMPLEXITY.search(line)
+        if match and int(match.group(1)) > best_score:
+            best_score = int(match.group(1))
+            worst = line
+    return worst
+
+
+def test_the_pin_is_not_looser_than_the_tree():
+    """The one that would have caught #667's leftover: 559 against a real
+    worst of 115."""
+    pin, worst = ci_pin(), measured_worst()
+    assert pin <= worst, (
+        f'the CI complexity ratchet is set to {pin} but nothing in the tree '
+        f'is worse than {worst}, so the gate permits any function up to '
+        f'{pin / worst:.1f}x the current worst and cannot fail on anything a '
+        f'contributor is likely to write.\n\n'
+        f'Lower --max-complexity in .github/workflows/ci.yml to {worst}. The '
+        f'function that sets it:\n  {worst_function()}'
+    )
+
+
+def test_the_pin_is_not_tighter_than_the_tree():
+    """CONTROL, and a real failure mode: a pin BELOW the worst means CI is red
+    on main and every PR inherits a failure it did not cause."""
+    pin, worst = ci_pin(), measured_worst()
+    assert pin >= worst, (
+        f'the CI complexity ratchet is {pin} but the tree contains a function '
+        f'at {worst}, so the lint step fails on main:\n  {worst_function()}'
+    )
+
+
+def test_the_measurement_finds_something_to_measure():
+    """CONTROL for the instrument. A regex that stops matching, or a flake8
+    invocation that reports nothing, would make both tests above agree with
+    each other about a tree they never looked at."""
+    assert measured_worst() > 10, (
+        'the highest complexity measured is implausibly low; the parse is '
+        'probably matching nothing'
+    )
+
+
+def test_flake8_is_a_declared_test_dependency():
+    """The check above shells out to flake8. If it were only present because
+    the lint step happens to install it, this file would fail in the test job
+    for a reason unrelated to complexity."""
+    declared = (REPO / 'requirements-test.txt').read_text()
+    assert 'flake8' in declared, (
+        'flake8 is not in requirements-test.txt, so the ratchet check depends '
+        'on a package the test job does not install'
+    )

--- a/tests/test_credential_skips_are_visible.py
+++ b/tests/test_credential_skips_are_visible.py
@@ -1,0 +1,165 @@
+"""A skipped test is not a passing test, and the run has to say so.
+
+Ten test files hang off the `cloudflare_token` fixture. Without the token they
+all skip, and `9 skipped` at the end of a green run is indistinguishable from
+`9 passed` to anyone reading quickly — which is how a whole class of tests can
+rot for years while the board stays green. The audit found the class; nothing
+in the repository made it visible.
+
+Three mechanisms, and each one can be wrong on its own:
+
+* the skip reason carries a mark the terminal summary counts, so the run ends
+  by naming what it did not measure;
+* `CERTMATE_REQUIRE_CREDENTIALED=1` turns those skips into failures, so a job
+  that exists to run them cannot silently run none — the same mechanism
+  `CERTMATE_UI_REQUIRE_BROWSER` already provides for the Playwright suite;
+* the `credentialed` marker is applied by derivation from the fixtures a test
+  requests, so `-m credentialed` selects exactly this class and cannot drift
+  the way a hand-written marker does.
+
+These tests drive the conftest helpers directly rather than through a nested
+pytest run: the logic is small, and a subprocess run would need the container
+fixture for reasons that have nothing to do with what is being checked.
+"""
+import pytest
+
+from tests import conftest
+
+pytestmark = [pytest.mark.unit]
+
+
+class _Reporter:
+    """Enough of a terminal reporter to record what the summary writes."""
+
+    def __init__(self, skipped):
+        self.stats = {'skipped': skipped}
+        self.lines = []
+        self.seps = []
+
+    def write_sep(self, char, title, **kw):
+        self.seps.append(title)
+
+    def write_line(self, line, **kw):
+        self.lines.append(line)
+
+
+class _Report:
+    def __init__(self, reason):
+        self.longrepr = ('some/path.py', 12, reason)
+
+
+def _summary(skipped):
+    reporter = _Reporter(skipped)
+    conftest.pytest_terminal_summary(reporter, 0, None)
+    return reporter
+
+
+# --- the skip carries something countable --------------------------------
+
+def test_a_missing_credential_skips_with_a_countable_mark(monkeypatch):
+    monkeypatch.setattr(conftest, '_REQUIRE_CREDENTIALED', False)
+    with pytest.raises(pytest.skip.Exception) as caught:
+        conftest._credential_missing('CLOUDFLARE_API_TOKEN', 'real DNS tests')
+
+    message = str(caught.value)
+    assert conftest.CREDENTIAL_SKIP_MARK in message
+    assert 'CLOUDFLARE_API_TOKEN' in message
+    assert 'real DNS tests' in message
+
+
+def test_the_skip_is_a_skip_and_not_a_pass(monkeypatch):
+    """CONTROL: a helper that returned instead of raising would let every one
+    of these tests run against a None token and fail somewhere unrelated.
+
+    `Skipped` and `Failed` derive from BaseException, so `pytest.raises(
+    Exception)` does not catch them — it lets the outcome propagate and the
+    test itself is reported as skipped. Which is exactly the confusion this
+    whole file is about, arrived at from the other direction."""
+    monkeypatch.setattr(conftest, '_REQUIRE_CREDENTIALED', False)
+    with pytest.raises(pytest.skip.Exception) as caught:
+        conftest._credential_missing('X_TOKEN', 'something')
+    assert type(caught.value).__name__ == 'Skipped'
+
+
+def test_requiring_the_credential_turns_the_skip_into_a_failure(monkeypatch):
+    monkeypatch.setattr(conftest, '_REQUIRE_CREDENTIALED', True)
+    with pytest.raises(pytest.fail.Exception) as caught:
+        conftest._credential_missing('CLOUDFLARE_API_TOKEN', 'real DNS tests')
+
+    assert type(caught.value).__name__ == 'Failed'
+    assert 'CERTMATE_REQUIRE_CREDENTIALED=1' in str(caught.value)
+
+
+# --- the run says what it did not measure --------------------------------
+
+def test_the_summary_names_the_count_and_the_variable():
+    reporter = _summary([
+        _Report(f'{conftest.CREDENTIAL_SKIP_MARK} CLOUDFLARE_API_TOKEN not set'),
+        _Report(f'{conftest.CREDENTIAL_SKIP_MARK} CLOUDFLARE_API_TOKEN not set'),
+    ])
+    text = ' '.join(reporter.lines)
+    assert '2 test(s) did not run' in text
+    assert 'CLOUDFLARE_API_TOKEN' in text
+    assert 'unmeasured' in text, (
+        'the summary reports a number without saying what it means; "skipped" '
+        'reading as "fine" is the whole defect'
+    )
+    assert 'CERTMATE_REQUIRE_CREDENTIALED=1' in text, (
+        'the summary does not say how to make this fail instead'
+    )
+
+
+def test_a_run_with_no_credential_skips_says_nothing():
+    """CONTROL: a banner on every run is a banner nobody reads."""
+    assert _summary([]).lines == []
+    assert _summary([_Report('needs a browser')]).lines == []
+
+
+def test_ordinary_skips_are_not_counted_as_missing_credentials():
+    """CONTROL: over-counting would make the number meaningless in the other
+    direction — every platform skip would look like an unmeasured test."""
+    reporter = _summary([
+        _Report('not supported on this platform'),
+        _Report(f'{conftest.CREDENTIAL_SKIP_MARK} CLOUDFLARE_API_TOKEN not set'),
+    ])
+    assert '1 test(s) did not run' in ' '.join(reporter.lines)
+
+
+# --- the marker is derived, not written by hand --------------------------
+
+class _Item:
+    def __init__(self, fixtures):
+        self.fixturenames = fixtures
+        self.markers = []
+
+    def add_marker(self, marker):
+        self.markers.append(marker)
+
+
+def test_a_test_that_asks_for_the_token_is_marked():
+    item = _Item(['cloudflare_token', 'api'])
+    conftest.pytest_collection_modifyitems(None, [item])
+    assert [m.name for m in item.markers] == ['credentialed']
+
+
+def test_a_test_that_does_not_is_left_alone():
+    item = _Item(['tmp_path'])
+    conftest.pytest_collection_modifyitems(None, [item])
+    assert item.markers == []
+
+
+def test_the_marker_is_declared_so_strict_markers_accepts_it():
+    """pytest.ini runs with --strict-markers, so an undeclared marker is a
+    collection error rather than a typo nobody notices."""
+    import pathlib
+    ini = (pathlib.Path(__file__).resolve().parent.parent
+           / 'pytest.ini').read_text()
+    assert 'credentialed:' in ini
+
+
+def test_the_real_fixture_is_the_one_that_is_derived_from():
+    """CONTROL: renaming the fixture without updating the derivation would
+    silently stop marking anything, and -m credentialed would select zero
+    tests while still exiting 0."""
+    assert hasattr(conftest, 'cloudflare_token')
+    assert 'cloudflare_token' in conftest.CREDENTIALED_FIXTURES


### PR DESCRIPTION
Two CI gates that reported without measuring.

## 1. The complexity ratchet permitted everything

CI runs `flake8 --select=C901 --max-complexity=N` so that nothing can be worse
than the worst function already here. N was **559** — set for
`create_api_resources`, the 3.7k-line closure in `modules/api/resources.py`.

**#667 decomposed that function to a complexity of 1, and the number stayed at
559.** Measured today, the worst in the tree is **115**
(`register_settings_routes`). So the gate permitted any function up to **4.9×**
the real worst — it could not fail on anything a contributor is likely to
write — while reading in review like an enforced limit.

That is the failure mode of every ratchet maintained by memory, so the memory
is removed. `tests/test_complexity_ratchet_is_tight.py` measures the tree with
flake8 itself and fails when the pin is looser than what the tree contains.
Lowering it stops being something to remember and becomes something the suite
asks for, in the commit that earned it.

Deliberately one-directional. Getting *worse* is already caught by the lint
step; getting *better* without lowering the pin is the direction nothing looked
at.

**Verified by mutation, both ways:**

```
pin 559 → the CI complexity ratchet is set to 559 but nothing in the tree is
          worse than 115, so the gate permits any function up to 4.9x …
pin 100 → the CI complexity ratchet is 100 but the tree contains a function
          at 115, so the lint step fails on main
```

## 2. A class of tests reported as skipped rather than as unrun

Ten test files hang off the `cloudflare_token` fixture. Without the token they
all skip, and `13 skipped` at the end of a green run is indistinguishable from
`13 passed` to anyone reading quickly. That is how a class of tests rots for
years while the board stays green.

Three changes, none of which touch the ten files:

**The run says what it did not measure.**

```
====================== not executed: missing credentials =======================
13 test(s) did not run because CLOUDFLARE_API_TOKEN is unset. They are not
passing; they are unmeasured.
Set the credential to run them, or CERTMATE_REQUIRE_CREDENTIALED=1 to make
their absence a failure (used by the real-certificate gate).
```

**`CERTMATE_REQUIRE_CREDENTIALED=1` makes the absence a failure** — the same
mechanism `CERTMATE_UI_REQUIRE_BROWSER` already provides for the Playwright
suite. `e2e-staging.yml` now sets it, so the gate that exists to issue a real
certificate cannot go green having issued nothing. That is the shape of the
defect this gate was built to catch, appearing in the gate itself.

**The `credentialed` marker is derived, not written.** It is applied from the
fixtures a test requests, so `-m credentialed` selects exactly this class
(15 tests) and cannot drift the first time someone adds the fixture and forgets
the decorator.

## An existing control caught the derived marker, correctly

`tests/test_ci_marker_coverage.py` asserts no marker is declared without tests,
by grepping `test_*.py` for `pytest.mark.X`. A marker applied in `conftest.py`
by `pytest_collection_modifyitems` never appears there, so `credentialed` was
reported as a category nobody is in while `-m credentialed` selected fifteen
tests. The reader now includes `conftest.py`, which is where a programmatically
applied marker legitimately lives.

## What is deliberately NOT here

The finding's third ask was to run the credential-gated tests on a schedule.
That would commit a Cloudflare token and Let's Encrypt staging quota to a
nightly run against a real zone — a maintainer's call, not a code change. The
mechanism it would need (`CERTMATE_REQUIRE_CREDENTIALED`) is in place, so
adding a `schedule:` trigger to `e2e-staging.yml` is a two-line change whenever
you want it.

## Checks run locally

- 14 new tests; `pytest -m "not ui"` — **4203 passed, 59 skipped**
- Both ratchet mutations killed
- `flake8` with CI's selector set, `actionlint` on both edited workflows — clean
- `flake8==7.3.0` added to `requirements-test.txt`, pinned to the version the
  lint step installs, so the test job and the lint job cannot disagree about
  what "too complex" means — and the ratchet check **fails** rather than skips
  if it is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
