### PR TITLE
security: a key file that cannot be read is not permission to invent a key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1503,7 +1503,7 @@ main "$@"
 | `API_BEARER_TOKEN`      |          | auto-generated | Bearer token for API authentication |
 | `API_BEARER_TOKEN_FILE` |          | -              | Path to a file containing the API bearer token (takes precedence over `API_BEARER_TOKEN`) |
 | `SECRET_KEY`            |          | auto-generated | Flask secret key for sessions       |
-| `SECRET_KEY_FILE`       |          | -              | Path to a file containing the Flask secret key (takes precedence over `SECRET_KEY`) |
+| `SECRET_KEY_FILE`       |          | -              | Path to a file containing the Flask secret key (takes precedence over `SECRET_KEY`). **If set and unreadable or empty, CertMate refuses to start** rather than inventing one: a secret that failed to mount is a configuration error, and a fresh key would sign out every user on every restart |
 | `PORT`             |          | `8000`         | Server port (honoured by the container entrypoint) |
 | `FLASK_ENV`        |          | `production`   | Flask environment. `production` refuses `--debug`  |
 | `CERTMATE_LOG_FILE` |         | -              | Also write logs to this path. Off by default: the container logs to stdout, which is what `docker logs` and log shippers expect. Set it (e.g. `/app/logs/certmate.log`) to keep a file on the mounted volume — it is what the web UI's log stream reads |

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -101,7 +101,7 @@ docker run -d --name certmate \
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `SECRET_KEY` | No | Flask secret key for sessions (auto-generated if unset) |
-| `SECRET_KEY_FILE` | No | Path to a file containing the Flask secret key (takes precedence over `SECRET_KEY`) |
+| `SECRET_KEY_FILE` | No | Path to a file containing the Flask secret key (takes precedence over `SECRET_KEY`). If set and the file cannot be read or is empty, CertMate refuses to start: a secret that failed to mount is a configuration error, and generating a key instead would sign out every user, on every restart, with sessions signed by a key you did not choose. |
 | `API_BEARER_TOKEN` | No (auto-generated) | API auth token. Auto-generated if unset, but set it before exposing a not-yet-onboarded instance to a network; when set, paste it once on the first-run screen to create the admin. **This value is authoritative:** if it differs from the token already stored, the stored one is replaced at startup and stops working. That is what makes adding or rotating the variable on an existing install take effect — previously enforcement used this value while authentication still checked the old one, and the first-run screen asked for a token it then rejected |
 | `API_BEARER_TOKEN_FILE` | No | Path to a file containing the API bearer token (takes precedence over `API_BEARER_TOKEN`) |
 | `LOG_LEVEL` | No | `INFO` (default), `DEBUG`, `WARNING`, `ERROR` |

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -397,13 +397,50 @@ def setup_directories(container: AppContainer, test_config=None):
             )
 
 
+class SecretKeyUnreadableError(RuntimeError):
+    """SECRET_KEY_FILE is set and cannot be used, so the process must stop.
+
+    Reading it failed, or it is empty. Both are configuration errors — the
+    operator named a file as the source of this key, usually a Docker or
+    Kubernetes secret mount — and neither is an invitation to invent a
+    different key.
+
+    Inventing one used to be the behaviour, behind a WARNING, and it has two
+    consequences the warning did not state. Every existing session cookie
+    becomes invalid, so every logged-in user is signed out; and because the key
+    is regenerated on each start, a restart loop signs them out again each
+    time, with nothing in the message connecting the symptom to the unmounted
+    secret. Worse, the operator believes sessions are signed with a key they
+    control — perhaps one shared across replicas — and they are not.
+
+    Refusing to start is what this repository already does for an unreadable
+    settings.json (SettingsUnreadableError) and for an unreadable
+    API_BEARER_TOKEN_FILE. app.py wraps create_app and exits 1, so the operator
+    gets one clear line and a container that stops.
+    """
+
+    def __init__(self, path, cause):
+        self.path = path
+        self.cause = cause
+        super().__init__(
+            f"SECRET_KEY_FILE is set to {path} but cannot be used: {cause}. "
+            f"Refusing to start. Generating a key instead would sign out every "
+            f"logged-in user, would do it again on every restart, and would "
+            f"leave sessions signed by a key you did not choose. Fix the mount "
+            f"or the permissions, or unset SECRET_KEY_FILE to let CertMate "
+            f"manage the key in its data directory."
+        )
+
+
 def _secret_key_from_env_or_generate(data_dir: Path) -> str:
     """Return a Flask secret key.
 
     Resolution order (mutually exclusive):
-    1. SECRET_KEY_FILE — if set, read the key from that file. Any read error
-       or empty result generates a fresh key immediately; SECRET_KEY is never
-       consulted (to avoid encouraging both vars).
+    1. SECRET_KEY_FILE — if set, read the key from that file. A read error or
+       an empty file raises SecretKeyUnreadableError and the process stops:
+       the operator named a file as the source, and failing to read it is a
+       configuration error, not an invitation to invent a different key.
+       SECRET_KEY is never consulted (to avoid encouraging both vars).
     2. SECRET_KEY — only checked when SECRET_KEY_FILE is absent. Insecure
        defaults ('', 'your-secret-key-here', 'change-me', 'secret') are
        treated as unset and fall through to step 3.
@@ -418,12 +455,11 @@ def _secret_key_from_env_or_generate(data_dir: Path) -> str:
     if explicit_key_file:
         try:
             key = Path(explicit_key_file).read_text().strip()
-            if key:
-                return key
-            logger.warning(f"SECRET_KEY_FILE ({explicit_key_file}) is empty; generating a fresh secret key.")
         except Exception as e:
-            logger.warning(f"Could not read SECRET_KEY_FILE ({explicit_key_file}): {e}; generating a fresh secret key.")
-        return secrets.token_hex(32)
+            raise SecretKeyUnreadableError(explicit_key_file, e) from e
+        if not key:
+            raise SecretKeyUnreadableError(explicit_key_file, 'the file is empty')
+        return key
 
     env_key = os.getenv('SECRET_KEY', '')
     if env_key and env_key not in insecure_defaults:

--- a/tests/test_secret_key_env.py
+++ b/tests/test_secret_key_env.py
@@ -2,14 +2,17 @@
 Unit tests for _secret_key_from_env_or_generate() in factory.py.
 
 Covers the three-step resolution order:
-1. SECRET_KEY_FILE (mutually exclusive with SECRET_KEY)
+1. SECRET_KEY_FILE (mutually exclusive with SECRET_KEY; a read error or an
+   empty file refuses to start rather than generating a key)
 2. SECRET_KEY (skipped when SECRET_KEY_FILE is set)
 3. Persisted generated key in data_dir/.secret_key
 """
 
 import pytest
 
-from modules.core.factory import _secret_key_from_env_or_generate
+from modules.core.factory import (
+    SecretKeyUnreadableError, _secret_key_from_env_or_generate,
+)
 
 pytestmark = [pytest.mark.unit]
 
@@ -36,27 +39,38 @@ def test_file_var_takes_precedence_over_env_var(monkeypatch, tmp_path):
     assert _secret_key_from_env_or_generate(tmp_path) == GOOD_KEY
 
 
-def test_file_read_error_generates_immediately(monkeypatch, tmp_path, caplog):
-    """File read failure must generate a fresh key without consulting SECRET_KEY."""
+def test_file_read_error_refuses_rather_than_consulting_secret_key(monkeypatch,
+                                                                   tmp_path):
+    """A file failure must not fall through to SECRET_KEY.
+
+    This test used to assert that a fresh key was generated. The property it
+    was protecting is the one asserted here — the two variables are mutually
+    exclusive, and a broken file must not be silently answered by a variable
+    the operator forgot was set. Generating was how that was achieved, not
+    what was wanted: it signed out every user, did it again on every restart,
+    and left sessions signed by a key nobody chose. Refusing to start keeps
+    the mutual exclusivity and drops the silent rotation. See
+    tests/test_secret_key_file_failures_fail_closed.py.
+    """
     monkeypatch.setenv("SECRET_KEY_FILE", "/nonexistent/path/secret.txt")
-    monkeypatch.setenv("SECRET_KEY", "Z" * 32)  # must be ignored
-    with caplog.at_level("WARNING"):
-        key = _secret_key_from_env_or_generate(tmp_path)
-    assert key != "Z" * 32, "SECRET_KEY must not be consulted after file failure"
-    assert len(key) > 0
-    assert any("SECRET_KEY_FILE" in rec.message for rec in caplog.records)
+    monkeypatch.setenv("SECRET_KEY", "Z" * 32)  # must never be consulted
+    with pytest.raises(SecretKeyUnreadableError) as caught:
+        _secret_key_from_env_or_generate(tmp_path)
+    assert "Z" * 32 not in str(caught.value)
+    assert "SECRET_KEY_FILE" in str(caught.value)
 
 
-def test_file_empty_generates_immediately(monkeypatch, tmp_path, caplog):
-    """An empty file must generate a fresh key without consulting SECRET_KEY."""
+def test_file_empty_refuses_rather_than_consulting_secret_key(monkeypatch,
+                                                              tmp_path):
+    """Same contract for an empty file: a Kubernetes secret that exists but
+    has not been populated reads as empty, not as missing."""
     key_file = tmp_path / "secret.txt"
     key_file.write_text("   \n")  # whitespace only → strips to empty
     monkeypatch.setenv("SECRET_KEY_FILE", str(key_file))
-    monkeypatch.setenv("SECRET_KEY", "Z" * 32)  # must be ignored
-    with caplog.at_level("WARNING"):
-        key = _secret_key_from_env_or_generate(tmp_path)
-    assert key != "Z" * 32
-    assert any("SECRET_KEY_FILE" in rec.message for rec in caplog.records)
+    monkeypatch.setenv("SECRET_KEY", "Z" * 32)  # must never be consulted
+    with pytest.raises(SecretKeyUnreadableError) as caught:
+        _secret_key_from_env_or_generate(tmp_path)
+    assert "empty" in str(caught.value)
 
 
 def test_file_strips_whitespace(monkeypatch, tmp_path):

--- a/tests/test_secret_key_file_failures_fail_closed.py
+++ b/tests/test_secret_key_file_failures_fail_closed.py
@@ -1,0 +1,206 @@
+"""A key file that cannot be read is not permission to invent a key.
+
+`SECRET_KEY_FILE` names where the Flask session-signing key comes from —
+usually a Docker or Kubernetes secret mount. When that file could not be read,
+or was empty, CertMate logged a WARNING and generated a fresh key.
+
+The warning said "generating a fresh secret key". It did not say what that
+means, and what it means is three things:
+
+* every existing session cookie becomes invalid, so every logged-in user is
+  signed out;
+* the key is regenerated on each start, so a restart loop signs them out again
+  every time, with nothing connecting the symptom to the unmounted secret;
+* the operator believes sessions are signed with a key they control — possibly
+  one deliberately shared across replicas — and they are not.
+
+An unmounted secret is a configuration error. This repository already refuses
+to start on an unreadable `settings.json` (`SettingsUnreadableError`) and on an
+unreadable `API_BEARER_TOKEN_FILE`; `SECRET_KEY_FILE` is the same shape and now
+gets the same answer. `app.py` wraps `create_app` and exits 1, so the operator
+gets one line and a container that stops instead of an instance running with a
+key nobody chose.
+
+The tests below separate the two things that can be wrong independently: what
+the resolver decides, and whether the exception actually stops the process.
+"""
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from modules.core.factory import (
+    SecretKeyUnreadableError, _secret_key_from_env_or_generate,
+)
+
+pytestmark = [pytest.mark.unit]
+
+KEY = 'a' * 64
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    monkeypatch.delenv('SECRET_KEY_FILE', raising=False)
+    monkeypatch.delenv('SECRET_KEY', raising=False)
+
+
+# --- what the resolver decides ------------------------------------------
+
+def test_a_readable_key_file_is_used(tmp_path, monkeypatch):
+    key_file = tmp_path / 'secret'
+    key_file.write_text(KEY + '\n')
+    monkeypatch.setenv('SECRET_KEY_FILE', str(key_file))
+
+    assert _secret_key_from_env_or_generate(tmp_path) == KEY
+
+
+def test_a_missing_key_file_refuses_to_start(tmp_path, monkeypatch):
+    monkeypatch.setenv('SECRET_KEY_FILE', str(tmp_path / 'not-mounted'))
+
+    with pytest.raises(SecretKeyUnreadableError) as caught:
+        _secret_key_from_env_or_generate(tmp_path)
+    assert 'not-mounted' in str(caught.value)
+
+
+def test_an_unreadable_key_file_refuses_to_start(tmp_path, monkeypatch):
+    """The shape a wrong-uid mount actually takes: the file is there and the
+    process cannot read it."""
+    key_file = tmp_path / 'secret'
+    key_file.write_text(KEY)
+    key_file.chmod(0o000)
+    monkeypatch.setenv('SECRET_KEY_FILE', str(key_file))
+
+    try:
+        if os.access(str(key_file), os.R_OK):
+            pytest.skip('running as a user that ignores file modes (root)')
+        with pytest.raises(SecretKeyUnreadableError):
+            _secret_key_from_env_or_generate(tmp_path)
+    finally:
+        key_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+def test_an_empty_key_file_refuses_to_start(tmp_path, monkeypatch):
+    """A Kubernetes secret that exists but has not been populated yet reads as
+    an empty file, not as a missing one."""
+    key_file = tmp_path / 'secret'
+    key_file.write_text('')
+    monkeypatch.setenv('SECRET_KEY_FILE', str(key_file))
+
+    with pytest.raises(SecretKeyUnreadableError) as caught:
+        _secret_key_from_env_or_generate(tmp_path)
+    assert 'empty' in str(caught.value)
+
+
+def test_a_key_file_of_whitespace_is_empty(tmp_path, monkeypatch):
+    key_file = tmp_path / 'secret'
+    key_file.write_text('   \n\t\n')
+    monkeypatch.setenv('SECRET_KEY_FILE', str(key_file))
+
+    with pytest.raises(SecretKeyUnreadableError):
+        _secret_key_from_env_or_generate(tmp_path)
+
+
+def test_the_message_states_the_consequence_not_just_the_cause(tmp_path,
+                                                               monkeypatch):
+    """The old warning said what it did, never what it cost. An operator
+    reading "generating a fresh secret key" has no way to connect it to users
+    being signed out."""
+    monkeypatch.setenv('SECRET_KEY_FILE', str(tmp_path / 'absent'))
+
+    with pytest.raises(SecretKeyUnreadableError) as caught:
+        _secret_key_from_env_or_generate(tmp_path)
+
+    message = str(caught.value)
+    assert 'sign out every' in message or 'sign out' in message
+    assert 'every restart' in message
+    assert 'unset SECRET_KEY_FILE' in message, (
+        'the message does not say how to get running again'
+    )
+
+
+# --- what must NOT change ------------------------------------------------
+
+def test_no_key_file_still_generates_and_persists(tmp_path):
+    """CONTROL: the failure is specific to a file the operator NAMED. An
+    instance that was never given one must keep managing its own key."""
+    key = _secret_key_from_env_or_generate(tmp_path)
+
+    assert len(key) == 64
+    assert (tmp_path / '.secret_key').read_text().strip() == key
+
+
+def test_a_persisted_key_is_reused_so_sessions_survive_a_restart(tmp_path):
+    first = _secret_key_from_env_or_generate(tmp_path)
+    second = _secret_key_from_env_or_generate(tmp_path)
+    assert first == second
+
+
+def test_the_secret_key_variable_still_works(tmp_path, monkeypatch):
+    monkeypatch.setenv('SECRET_KEY', KEY)
+    assert _secret_key_from_env_or_generate(tmp_path) == KEY
+
+
+@pytest.mark.parametrize('value', ['your-secret-key-here', 'change-me',
+                                   'secret'])
+def test_an_insecure_default_is_still_ignored(tmp_path, monkeypatch, value):
+    monkeypatch.setenv('SECRET_KEY', value)
+    assert _secret_key_from_env_or_generate(tmp_path) != value
+
+
+def test_the_key_file_still_wins_over_the_variable(tmp_path, monkeypatch):
+    """CONTROL: the two are mutually exclusive on purpose. If a broken
+    SECRET_KEY_FILE fell through to SECRET_KEY, the refusal could be bypassed
+    by a variable the operator forgot was set."""
+    key_file = tmp_path / 'secret'
+    key_file.write_text(KEY)
+    monkeypatch.setenv('SECRET_KEY_FILE', str(key_file))
+    monkeypatch.setenv('SECRET_KEY', 'b' * 64)
+
+    assert _secret_key_from_env_or_generate(tmp_path) == KEY
+
+
+def test_a_broken_key_file_does_not_fall_through_to_the_variable(tmp_path,
+                                                                 monkeypatch):
+    monkeypatch.setenv('SECRET_KEY_FILE', str(tmp_path / 'absent'))
+    monkeypatch.setenv('SECRET_KEY', 'b' * 64)
+
+    with pytest.raises(SecretKeyUnreadableError):
+        _secret_key_from_env_or_generate(tmp_path)
+
+
+# --- and it has to actually stop the process ----------------------------
+
+def test_create_app_propagates_the_refusal(tmp_path, monkeypatch):
+    """The resolver raising is worth nothing if create_app swallows it. app.py
+    catches whatever create_app raises and exits 1, so what matters is that
+    the exception gets out."""
+    from modules.core.factory import create_app
+
+    root = tmp_path / 'certmate'
+    module_dir = root / 'modules' / 'core'
+    module_dir.mkdir(parents=True)
+    anchor = module_dir / 'factory.py'
+    anchor.write_text('# test path anchor\n')
+    for shared in ('templates', 'static'):
+        source = Path(__file__).resolve().parent.parent / shared
+        if source.is_dir():
+            (root / shared).symlink_to(source)
+
+    monkeypatch.setattr('modules.core.factory.__file__', str(anchor))
+    monkeypatch.setenv('FLASK_ENV', 'testing')
+    monkeypatch.setenv('SECRET_KEY_FILE', str(tmp_path / 'never-mounted'))
+
+    with pytest.raises(SecretKeyUnreadableError):
+        create_app()
+
+
+def test_app_py_exits_rather_than_serving():
+    """The last link: app.py wraps create_app and exits 1. Read rather than
+    executed — importing app.py starts an application."""
+    source = (Path(__file__).resolve().parent.parent / 'app.py').read_text()
+    assert 'app, container = create_app()' in source
+    assert 'sys.exit(1)' in source, (
+        'app.py no longer stops on a create_app failure, so a refusal to '
+        'start would be logged and then ignored'
+    )


### PR DESCRIPTION
## What it did

`SECRET_KEY_FILE` names where the Flask session-signing key comes from —
usually a Docker or Kubernetes secret mount. When that file could not be read,
or was empty:

```python
except Exception as e:
    logger.warning(f"Could not read SECRET_KEY_FILE ({f}): {e}; generating a fresh secret key.")
return secrets.token_hex(32)
```

## What "generating a fresh secret key" means

The warning said what it did. It never said what it costs, and it costs three
things:

1. **Every logged-in user is signed out.** Existing session cookies were signed
   with the old key and stop validating.
2. **It happens again on every restart.** The key is invented each time, so a
   restart loop signs everyone out repeatedly — with nothing in the message
   connecting the symptom to an unmounted secret.
3. **The operator's belief is wrong.** They think sessions are signed with a
   key they control, possibly one deliberately shared across replicas. They are
   not.

An unmounted secret is a configuration error, not an invitation.

## What it does now

`SecretKeyUnreadableError`, and the process stops. `app.py` already wraps
`create_app` and exits 1, so the operator gets one line and a container that
stops instead of an instance running on a key nobody chose.

This is the answer the repository already gives to the same shape twice: an
unreadable `settings.json` (`SettingsUnreadableError`) and an unreadable
`API_BEARER_TOKEN_FILE` (#753). The message states the consequence *and* how to
get running again:

```
SECRET_KEY_FILE is set to /run/secrets/secret_key but cannot be used: [Errno 2]
No such file or directory. Refusing to start. Generating a key instead would
sign out every logged-in user, would do it again on every restart, and would
leave sessions signed by a key you did not choose. Fix the mount or the
permissions, or unset SECRET_KEY_FILE to let CertMate manage the key in its
data directory.
```

Empty counts as unusable: a Kubernetes secret that exists but has not been
populated reads as an empty file, not a missing one.

## Two existing tests pinned the old behaviour

`test_file_read_error_generates_immediately` and its empty-file twin. Read
rather than deleted — the property they were protecting is *"SECRET_KEY must
not be consulted after a file failure"*, since the two variables are mutually
exclusive on purpose. Generating was **how** that was achieved, not what was
wanted.

They now assert the refusal and keep the same claim, which the refusal
strengthens: a broken file can no longer be silently answered by a variable the
operator forgot was set. There is a test for exactly that.

## What deliberately does not change

A fail-closed change that also breaks the ordinary path would be a worse defect
than the one it fixes, so these are controls in the new file:

- an instance that never named a file still generates, persists to
  `data_dir/.secret_key`, and **reuses it** across restarts (asserted);
- `SECRET_KEY` still works, and its insecure defaults are still ignored;
- `SECRET_KEY_FILE` still wins over `SECRET_KEY`.

## Checks run locally

- 16 new tests + the 9 rewritten ones; `pytest -m "not ui"` — **4218 passed, 59 skipped**
- Verified by mutation: restoring the generate-on-failure branch fails **7 of the 16**
- README and `docs/docker.md` updated where the variable is documented
- `flake8` with CI's selector set, `C901` at the real max — clean

## Note for the release

This is a **behaviour change for a broken deployment**: an instance whose
`SECRET_KEY_FILE` never mounted was running (degraded, signing everyone out);
it will now fail to start until the mount is fixed or the variable is unset.
That is the intent, but it belongs in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
