### PR TITLE
data: metadata.json carries the schema it was written with

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from cryptography import x509
 from .shell import ShellExecutor
 from .dns_strategies import DNSStrategyFactory, HTTP01Strategy, acme_webroot_dir, check_certbot_plugin_installed
-from .constants import CERTIFICATE_FILES, DEFAULT_RENEWAL_THRESHOLD_DAYS
+from .constants import METADATA_SCHEMA_VERSION, CERTIFICATE_FILES, DEFAULT_RENEWAL_THRESHOLD_DAYS
 from .csr_issuance import (
     CSR_OUTPUT_DIRNAME, CSR_OUTPUT_FILES, CSRError, csr_domains,
     csr_fingerprint, read_csr, to_csr_command,
@@ -1066,6 +1066,18 @@ class CertificateManager:
             with open(metadata_file, 'r', encoding='utf-8') as f:
                 metadata = json.load(f)
             if isinstance(metadata, dict):
+                version = metadata.get('metadata_schema_version')
+                if isinstance(version, int) and version > METADATA_SCHEMA_VERSION:
+                    # Reading a newer record destroys nothing, and the UI
+                    # should still show the certificate — so this reads and
+                    # warns rather than refusing. The refusal is on the write
+                    # (see _save_metadata), which is where fields are lost.
+                    logger.warning(
+                        "Metadata for %s declares schema v%s and this build "
+                        "understands v%s. Reading it, but this process will "
+                        "refuse to write it back: it would drop the fields it "
+                        "cannot read.", domain, version,
+                        METADATA_SCHEMA_VERSION)
                 return metadata
             # Valid JSON of the wrong shape (a list, a string) is as unusable
             # as a syntax error and was the one corruption that still came
@@ -1114,14 +1126,79 @@ class CertificateManager:
             return {}
 
     def _save_metadata(self, domain: str, metadata: dict) -> bool:
+        """Write a domain's metadata, stamping the schema it was written with.
+
+        The stamp is applied HERE rather than by the seven callers, for the
+        reason `save_settings` stamps `settings_schema_version` itself: a
+        caller that assembles the dict without the field silently strips it,
+        and #669 shipped exactly that defect once already.
+
+        The check before the write is the point. `metadata.json` records key
+        custody — `private_key_state`, the CSR fingerprint, the CA a private-CA
+        certificate cannot renew without — and a downgrade reads a record
+        written by a newer build, understands the fields it knows, and writes
+        it back without the rest. Silently. That is the failure settings.json
+        was versioned to prevent, on a file that had no version.
+
+        Refusing at the WRITE rather than at startup is deliberate.
+        settings.json is one file and refusing to start is proportionate.
+        Metadata is one file per domain, and taking the whole instance down
+        over one certificate would turn a data-loss risk into an outage.
+        Reading stays allowed — reading destroys nothing, and the UI should
+        still show the certificate — so what is refused is exactly the
+        operation that loses fields.
+
+        `CERTMATE_ALLOW_SCHEMA_DOWNGRADE=1` overrides it, the same variable
+        and the same meaning as for settings.json: proceed, and accept that
+        this process may drop fields it does not know about.
+        """
         metadata_file = self._metadata_path(domain)
         try:
-            self._atomic_json_write(metadata_file, metadata)
+            on_disk = self._metadata_schema_on_disk(metadata_file)
+            if (on_disk is not None
+                    and on_disk > METADATA_SCHEMA_VERSION
+                    and os.getenv('CERTMATE_ALLOW_SCHEMA_DOWNGRADE') != '1'):
+                logger.error(
+                    "Refusing to write metadata for %s: the file on disk "
+                    "declares schema v%s and this build understands v%s. An "
+                    "older process writing it would drop the fields it cannot "
+                    "read, and %s records which private key belongs to this "
+                    "certificate. Run the newer version, or set "
+                    "CERTMATE_ALLOW_SCHEMA_DOWNGRADE=1 to overwrite it anyway.",
+                    domain, on_disk, METADATA_SCHEMA_VERSION, metadata_file)
+                return False
+
+            stamped = dict(metadata)
+            stamped['metadata_schema_version'] = METADATA_SCHEMA_VERSION
+            self._atomic_json_write(metadata_file, stamped)
             self._invalidate_certificate_info_cache(domain)
             return True
         except Exception as e:
             logger.warning(f"Failed to save metadata for {domain}: {e}")
             return False
+
+    @staticmethod
+    def _metadata_schema_on_disk(metadata_file: Path):
+        """The schema version the file currently declares, or None.
+
+        Read from disk immediately before writing rather than carried from
+        whatever `_load_metadata` returned: the caller may have assembled its
+        dict minutes ago, across a certbot run, and the question being asked
+        is about the bytes that are about to be replaced.
+
+        A file that is absent, unreadable or not a JSON object answers None —
+        "nothing here declares a schema". Those are handled by the write
+        itself; this is not the place to decide about them.
+        """
+        try:
+            with open(metadata_file, 'r', encoding='utf-8') as handle:
+                on_disk = json.load(handle)
+        except (OSError, ValueError):
+            return None
+        if not isinstance(on_disk, dict):
+            return None
+        version = on_disk.get('metadata_schema_version')
+        return version if isinstance(version, int) else None
 
     def _write_pfx(self, domain: str) -> None:
         """(Re)generate <domain>/cert.pfx from the on-disk PEMs when a PFX

--- a/modules/core/constants.py
+++ b/modules/core/constants.py
@@ -73,6 +73,20 @@ DEFAULT_SESSION_TIMEOUT_HOURS = 8
 # rollback actually produces, and it is silent.
 SETTINGS_SCHEMA_VERSION = 1
 
+# Shape of each certificate's metadata.json, on the same terms as
+# SETTINGS_SCHEMA_VERSION above: bumped only when the shape changes, never with
+# the product version. The file records key custody — private_key_state, the
+# CSR fingerprint, the CA a private-CA certificate cannot renew without — so a
+# downgrade that reads it, understands the fields it knows and writes back the
+# rest as absent is a silent data loss on exactly the record that says which
+# private key belongs to which certificate.
+#
+# Enforced at the WRITE, not at startup: there is one of these files per
+# domain, and refusing to start over one certificate would turn a data-loss
+# risk into an outage. Reading a newer file stays allowed. See
+# CertificateManager._save_metadata.
+METADATA_SCHEMA_VERSION = 1
+
 # Protocols the deployment probe can speak. A domain fact, not an API one: the
 # service validates against it and modules/api/tls_probe drives it (#672 — it
 # lived in the API layer, which core could not reach without importing api and

--- a/tests/test_metadata_carries_its_schema_version.py
+++ b/tests/test_metadata_carries_its_schema_version.py
@@ -1,0 +1,216 @@
+"""A downgrade must not quietly strip the fields it does not understand.
+
+`settings.json` was versioned for exactly this: an older build reads a file
+written by a newer one, understands the fields it knows, writes it back without
+the rest, and says nothing. `metadata.json` had no version at all — and it is
+the file that records key custody:
+
+* `private_key_state`, including the `external` value that stops a CSR-only
+  certificate being reissued nightly (#599);
+* the CSR fingerprint;
+* the CA a private-CA certificate cannot renew without.
+
+Losing it does not lose a certificate. It loses the instance's knowledge of
+what that certificate is, which is worse, because nothing looks broken.
+
+Two decisions worth stating, because both could reasonably have gone the other
+way:
+
+**The stamp is applied in `_save_metadata`, not by its seven callers.** #669
+shipped the caller-stamps version of this for settings.json and it silently
+stripped the field whenever a payload omitted it.
+
+**The refusal is on the write, not at startup.** settings.json is one file and
+refusing to boot is proportionate. Metadata is one file per domain: taking the
+whole instance down over one certificate would turn a data-loss risk into an
+outage. Reading a newer record destroys nothing and the UI should still show
+the certificate, so reading warns and writing refuses — which is exactly the
+operation that loses fields.
+"""
+import json
+import logging
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from modules.core.certificates import CertificateManager
+from modules.core.constants import METADATA_SCHEMA_VERSION
+
+pytestmark = [pytest.mark.unit]
+
+RECORD = {
+    'domain': 'example.com',
+    'private_key_state': 'external',
+    'ca': 'private',
+    'csr_fingerprint': 'ab' * 32,
+}
+
+
+@pytest.fixture
+def manager():
+    return CertificateManager(Path(tempfile.mkdtemp()), None, dns_manager=None)
+
+
+def _domain_dir(manager, domain):
+    """Real callers save into a directory certbot already created; a bare
+    `_save_metadata` does not make one, and nothing here should pretend it
+    does."""
+    path = manager.cert_dir / domain
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write(manager, domain, record):
+    path = manager.cert_dir / domain / 'metadata.json'
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(record))
+    return path
+
+
+def _read(manager, domain):
+    return json.loads(
+        (manager.cert_dir / domain / 'metadata.json').read_text())
+
+
+# --- the stamp -----------------------------------------------------------
+
+def test_a_saved_record_carries_the_schema_it_was_written_with(manager):
+    _domain_dir(manager, 'example.com')
+    assert manager._save_metadata('example.com', dict(RECORD))
+    assert _read(manager, 'example.com')['metadata_schema_version'] == \
+        METADATA_SCHEMA_VERSION
+
+
+def test_the_stamp_does_not_depend_on_the_caller_passing_it(manager):
+    """The #669 defect, applied to this file: a caller that assembles the dict
+    without the field would strip it on every save."""
+    _domain_dir(manager, 'example.com')
+    assert manager._save_metadata('example.com', dict(RECORD))
+    stored = _read(manager, 'example.com')
+    assert 'metadata_schema_version' in stored
+    assert stored['csr_fingerprint'] == RECORD['csr_fingerprint']
+
+
+def test_stamping_does_not_mutate_the_caller_s_dict(manager):
+    """CONTROL: several callers reuse the dict they passed — one of them
+    writes it to a storage backend afterwards."""
+    _domain_dir(manager, 'example.com')
+    payload = dict(RECORD)
+    manager._save_metadata('example.com', payload)
+    assert 'metadata_schema_version' not in payload
+
+
+def test_an_unstamped_record_is_stamped_on_the_next_write(manager):
+    """Upgrade path: every existing installation has unstamped metadata."""
+    _write(manager, 'example.com', dict(RECORD))
+    assert manager._save_metadata('example.com', dict(RECORD, renewed_at='x'))
+    assert _read(manager, 'example.com')['metadata_schema_version'] == \
+        METADATA_SCHEMA_VERSION
+
+
+# --- the refusal ---------------------------------------------------------
+
+def test_a_record_from_the_future_is_not_overwritten(manager, caplog):
+    """The failure this exists for. An older build must not write back a
+    record whose fields it cannot see."""
+    future = dict(RECORD, metadata_schema_version=METADATA_SCHEMA_VERSION + 1,
+                  a_field_this_build_never_heard_of='keep me')
+    _write(manager, 'example.com', future)
+
+    with caplog.at_level(logging.ERROR):
+        saved = manager._save_metadata('example.com', dict(RECORD))
+
+    assert saved is False
+    assert _read(manager, 'example.com') == future, (
+        'the newer record was overwritten and its unknown field is gone'
+    )
+    assert any('example.com' in (r.args or ()) for r in caplog.records), (
+        'the refusal was not logged at ERROR naming the domain'
+    )
+
+
+def test_the_refusal_can_be_overridden_deliberately(manager, monkeypatch):
+    """Same variable and same meaning as settings.json's downgrade escape: an
+    operator who understands the trade can proceed."""
+    _write(manager, 'example.com',
+           dict(RECORD, metadata_schema_version=METADATA_SCHEMA_VERSION + 1))
+    monkeypatch.setenv('CERTMATE_ALLOW_SCHEMA_DOWNGRADE', '1')
+
+    assert manager._save_metadata('example.com', dict(RECORD, ca='letsencrypt'))
+    assert _read(manager, 'example.com')['ca'] == 'letsencrypt'
+
+
+def test_an_older_record_is_written_normally(manager):
+    """CONTROL: the check must only fire on NEWER. An off-by-one that refused
+    equal or older versions would make every save fail after the first."""
+    _write(manager, 'example.com',
+           dict(RECORD, metadata_schema_version=METADATA_SCHEMA_VERSION))
+    assert manager._save_metadata('example.com', dict(RECORD, ca='letsencrypt'))
+    assert _read(manager, 'example.com')['ca'] == 'letsencrypt'
+
+
+def test_a_first_write_with_nothing_on_disk_succeeds(manager):
+    """CONTROL: no file means no declared schema, not a refusal."""
+    _domain_dir(manager, 'brand-new.example.com')
+    assert manager._save_metadata('brand-new.example.com', dict(RECORD))
+
+
+@pytest.mark.parametrize('junk', ['not json at all', '[1, 2, 3]', '"a string"'])
+def test_an_unreadable_file_does_not_block_the_write(manager, junk):
+    """CONTROL: corruption is handled elsewhere (quarantine on load). The
+    schema check must not turn it into a second, silent failure mode that
+    stops issuance from recording anything."""
+    path = manager.cert_dir / 'example.com' / 'metadata.json'
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(junk)
+
+    assert manager._save_metadata('example.com', dict(RECORD))
+
+
+@pytest.mark.parametrize('version', ['2', 2.5, None, {'v': 2}])
+def test_a_version_that_is_not_an_integer_is_not_a_version(manager, version):
+    """A hand-edited or truncated field must not be read as "from the future"
+    and lock the domain out of every future write."""
+    _write(manager, 'example.com', dict(RECORD, metadata_schema_version=version))
+    assert manager._save_metadata('example.com', dict(RECORD))
+
+
+def test_the_check_reads_the_disk_not_the_dict_it_was_handed(manager):
+    """The version that matters belongs to the bytes about to be replaced.
+    A caller may have assembled its dict before a certbot run that took
+    minutes, so trusting the in-memory copy would check a stale answer."""
+    _write(manager, 'example.com',
+           dict(RECORD, metadata_schema_version=METADATA_SCHEMA_VERSION + 1))
+
+    # The dict being saved claims the current version. The file does not.
+    assert manager._save_metadata(
+        'example.com',
+        dict(RECORD, metadata_schema_version=METADATA_SCHEMA_VERSION)) is False
+
+
+# --- reading stays possible ---------------------------------------------
+
+def test_a_record_from_the_future_can_still_be_read(manager, caplog):
+    """Refusing to read would blank the certificate in the UI and in every
+    API response, over a risk that only exists when writing."""
+    future = dict(RECORD, metadata_schema_version=METADATA_SCHEMA_VERSION + 1)
+    _write(manager, 'example.com', future)
+
+    with caplog.at_level(logging.WARNING):
+        loaded = manager._load_metadata('example.com')
+
+    assert loaded == future
+    assert any('refuse to write it back' in r.getMessage()
+               for r in caplog.records), (
+        'reading a newer record said nothing about what happens next'
+    )
+
+
+def test_reading_an_ordinary_record_is_silent(manager, caplog):
+    """CONTROL: a warning on every load is a warning nobody reads."""
+    _write(manager, 'example.com',
+           dict(RECORD, metadata_schema_version=METADATA_SCHEMA_VERSION))
+    with caplog.at_level(logging.WARNING):
+        manager._load_metadata('example.com')
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]

--- a/tests/test_metadata_corruption_handling.py
+++ b/tests/test_metadata_corruption_handling.py
@@ -92,7 +92,11 @@ def test_save_after_corrupt_does_not_clobber_quarantine(tmp_path):
 
     assert meta_path.exists(), "fresh metadata.json must be written"
     fresh = json.loads(meta_path.read_text())
-    assert fresh == {"dns_provider": "route53"}
+    # The schema stamp is added by _save_metadata itself, so it is present in
+    # every written record; what this test is about is the content the caller
+    # asked for, and the quarantine surviving underneath it.
+    assert fresh["dns_provider"] == "route53"
+    assert set(fresh) - {"metadata_schema_version"} == {"dns_provider"}
 
     assert quarantined[0].exists(), "quarantine file must survive the save"
     assert quarantined[0].read_bytes() == original_bytes, (


### PR DESCRIPTION
See the commit message for the reasoning; the short version:

`settings.json` was versioned so a downgrade could not silently strip fields it does not understand. `metadata.json` had no version at all — and it is the file that records **key custody**: `private_key_state` (including the `external` value that stops a CSR-only certificate being reissued nightly), the CSR fingerprint, and the CA a private-CA certificate cannot renew without.

Losing it does not lose a certificate. It loses the instance’s knowledge of what that certificate *is*, which is worse, because nothing looks broken.

## Two decisions that could have gone the other way

**The stamp is applied in `_save_metadata`, not by its seven callers.** #669 shipped the caller-stamps version of this for `settings.json` and it silently stripped the field whenever a payload omitted it.

**The refusal is on the write, not at startup.** `settings.json` is one file and refusing to boot is proportionate. Metadata is one file *per domain* — taking the whole instance down over one certificate would turn a data-loss risk into an outage. Reading a newer record destroys nothing and the UI should still show the certificate, so **reading warns and writing refuses**, which is exactly the operation that loses fields. `CERTMATE_ALLOW_SCHEMA_DOWNGRADE=1` overrides it: same variable, same meaning as for settings.json.

## The version is read from disk, not from the dict

The caller may have assembled its dict before a certbot run that took minutes. The question is about the bytes *about to be replaced*, so the check re-reads the file. A test pins it by passing a dict that claims the current version while the file on disk claims a newer one.

## Controls

A schema check that fires too eagerly would be worse than none — every save after the first would fail, silently, on the file that records key custody. So:

- an **older or equal** version writes normally;
- **no file** means no declared schema, not a refusal;
- a **corrupt** file does not block the write (corruption is handled by the existing quarantine-on-load, and this must not become a second silent failure mode);
- a version that is **not an integer** (hand-edited, truncated) is not a version;
- stamping does not mutate the caller’s dict — several callers reuse it, one writes it to a storage backend afterwards.

## One existing test adapted

`test_save_after_corrupt_does_not_clobber_quarantine` asserted the written record equalled the callers dict exactly. Its subject is the quarantine surviving a save, which it still asserts; the equality is now on the content the caller asked for, with the stamp allowed.

## Checks run locally

- 18 new tests; `pytest -m "not ui"` — **4240 passed, 59 skipped**
- Verified by mutation: removing the refusal fails 2 tests, removing the stamp fails 3
- `flake8` with CIs selector set, `C901` at the real max — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)