### PR TITLE
perf: bound the event dispatch, and make a backlog visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1545,6 +1545,7 @@ main "$@"
 | `CERTMATE_CERT_INFO_CACHE_TTL` | | `60`        | Seconds a parsed certificate's details stay cached. `0` re-reads from disk on every request. Clamped to 0-3600 |
 | `CERTMATE_ISSUANCE_WORKERS` | | `2`            | Threads serving asynchronous issuance jobs. Clamped to 1-16; each one can be running a certbot subprocess |
 | `CERTMATE_ISSUANCE_JOB_HISTORY` | | `200`      | How many finished issuance jobs stay queryable via `/api/certificates/jobs`. Clamped to 20-2000 |
+| `CERTMATE_EVENT_WORKERS` |    | `4`            | Threads dispatching event listeners (deploy hooks, cache invalidation). Clamped to 1-32. Nothing is dropped when they are busy; the backlog is logged instead |
 | `CERTMATE_PROBE_TIMEOUT_SECONDS` | | `5`       | Deployment-probe connection timeout. Clamped to 1-30 |
 | `CERTMATE_LAST_USED_PERSIST_SECONDS` | | `60`  | How often a session's "last used" timestamp is written to disk. `0` writes on every request, which is the original behaviour and one write per request |
 | `CERTMATE_SLOW_REQUEST_LOGGING` | | `true`       | Log a warning, with the thread's stack, for requests that outlive the threshold below. The stack is what makes a hung request diagnosable after the fact |

--- a/modules/core/events.py
+++ b/modules/core/events.py
@@ -5,6 +5,7 @@ Provides real-time updates to connected browser clients.
 
 import json
 import logging
+import os
 import queue
 import time
 import threading
@@ -13,18 +14,105 @@ from typing import Optional, Dict, Any
 logger = logging.getLogger(__name__)
 
 
+# How many listener invocations run at once. A listener can be slow on
+# purpose: DeployManager.on_certificate_event runs deploy hooks, each of which
+# may take up to MAX_TIMEOUT (300s), so one worker would serialise a burst of
+# renewals behind the slowest target. Four is a working default; the ceiling is
+# what matters, not the number.
+DEFAULT_DISPATCH_WORKERS = 4
+
+# Log when the backlog passes this, so "the listeners cannot keep up" is a line
+# in the log rather than something an operator infers from latency.
+BACKLOG_WARN_AT = 50
+
+
 class EventBus:
     """Simple in-process event bus with SSE streaming support."""
 
-    def __init__(self):
+    def __init__(self, workers: Optional[int] = None):
         self._subscribers = []
         self._listeners = []
         self._lock = threading.Lock()
+
+        # Listener dispatch used to be `threading.Thread(...).start()` per
+        # listener per event, with no pool, no queue and no ceiling — so the
+        # process's thread count was a function of event volume rather than of
+        # anything it controlled. A renewal sweep over many domains, each
+        # publishing to several listeners, decided how many threads existed.
+        #
+        # This is a fixed set of daemon workers reading one queue. Three
+        # properties are deliberate:
+        #
+        # * the publisher NEVER blocks. It is a request thread on the issuance
+        #   path and the scheduler on the renewal path; making certificate
+        #   issuance wait behind a deploy hook would trade a thread problem
+        #   for a latency problem on the product's main job.
+        # * nothing is dropped. The SSE path drops the oldest message and then
+        #   the subscriber, which is right for a browser that fell behind and
+        #   wrong for a deploy that has to happen. Certificate events are rare
+        #   and each one matters, so the backlog is unbounded in length and
+        #   bounded in *cost* — a small dict per queued call.
+        # * the backlog is visible. An instance past its capacity says so.
+        #
+        # Workers stay daemon, as the per-event threads were: a
+        # ThreadPoolExecutor's threads are joined at interpreter exit, which
+        # would let a 300-second deploy hook hold up shutdown until the
+        # container runtime SIGKILLs it anyway.
+        self._work = queue.Queue()
+        self._workers = []
+        self._worker_count = self._resolve_worker_count(workers)
+        self._backlog_warned = False
+
+    @staticmethod
+    def _resolve_worker_count(workers) -> int:
+        if workers is None:
+            workers = os.environ.get('CERTMATE_EVENT_WORKERS',
+                                     DEFAULT_DISPATCH_WORKERS)
+        try:
+            return max(1, min(32, int(workers)))
+        except (TypeError, ValueError):
+            return DEFAULT_DISPATCH_WORKERS
+
+    def _ensure_workers(self) -> None:
+        """Start the dispatch workers on first use.
+
+        Lazily, because a bus with no listeners — which is what most of the
+        test suite builds — should cost no threads at all.
+        """
+        if self._workers:
+            return
+        for index in range(self._worker_count):
+            worker = threading.Thread(
+                target=self._dispatch_forever,
+                name=f'certmate-events-{index}',
+                daemon=True,
+            )
+            worker.start()
+            self._workers.append(worker)
+
+    def _dispatch_forever(self) -> None:
+        while True:
+            listener, event, data = self._work.get()
+            try:
+                listener(event, data)
+            except Exception as e:
+                # A listener that raises must not take the worker with it, or
+                # the pool bleeds capacity one bad event at a time until
+                # nothing is dispatched and nothing says why.
+                logger.error(
+                    "Event listener failed for %s: %s", event, e, exc_info=True)
+            finally:
+                self._work.task_done()
 
     def add_listener(self, callback) -> None:
         """Register a callback invoked on every publish(). Signature: callback(event, data)."""
         with self._lock:
             self._listeners.append(callback)
+        self._ensure_workers()
+
+    def pending_dispatches(self) -> int:
+        """How many listener invocations are waiting for a worker."""
+        return self._work.qsize()
 
     def subscribe(self) -> queue.Queue:
         """Create a new subscriber queue."""
@@ -74,18 +162,30 @@ class EventBus:
                 except ValueError:
                     pass
 
-        # Snapshot listeners under lock, then invoke in background threads
+        # Snapshot listeners under lock, then hand them to the worker pool.
+        # Never inline: a listener runs deploy hooks, and running one on the
+        # publisher's thread would put a 300-second timeout on the issuance
+        # request that triggered it.
         with self._lock:
             listeners = list(self._listeners)
+        if not listeners:
+            return
+        self._ensure_workers()
+
+        payload = message.get('data', {})
         for listener in listeners:
-            try:
-                threading.Thread(
-                    target=listener,
-                    args=(event, message.get('data', {})),
-                    daemon=True
-                ).start()
-            except Exception as e:
-                logger.debug(f"Event listener invocation failed: {e}")
+            self._work.put((listener, event, payload))
+
+        backlog = self._work.qsize()
+        if backlog >= BACKLOG_WARN_AT and not self._backlog_warned:
+            self._backlog_warned = True
+            logger.warning(
+                "Event listener backlog is %d with %d worker(s): listeners "
+                "are not keeping up with events. Deploy hooks and cache "
+                "invalidations will lag. Raise CERTMATE_EVENT_WORKERS or find "
+                "the slow listener.", backlog, self._worker_count)
+        elif backlog == 0:
+            self._backlog_warned = False
 
     def stream(self, q: queue.Queue):
         """

--- a/tests/test_event_dispatch_is_bounded.py
+++ b/tests/test_event_dispatch_is_bounded.py
@@ -1,0 +1,308 @@
+"""Thread count must be a property of the process, not of event volume.
+
+Every `publish()` started one new thread per registered listener — no pool, no
+queue, no ceiling. So a renewal sweep across many domains, each publishing to
+several listeners, decided how many threads the process had. Nothing in
+CertMate chose that number, and nothing reported it.
+
+The replacement is a fixed set of daemon workers reading one queue. Three
+properties were chosen deliberately, and each one is a test below because each
+could reasonably have gone the other way:
+
+**The publisher never blocks.** It is a request thread on the issuance path and
+the scheduler on the renewal path. `DeployManager.on_certificate_event` runs
+deploy hooks, each up to a 300-second timeout — putting that on the publisher's
+thread would trade a thread problem for a latency problem on the product's main
+job.
+
+**Nothing is dropped.** The SSE path drops the oldest message and then the
+subscriber, which is right for a browser that fell behind and wrong for a
+deploy that has to happen. Certificate events are rare and each matters, so the
+backlog is unbounded in length and bounded in cost — one small tuple per
+queued call.
+
+**The backlog is visible.** An instance past its capacity says so, once, rather
+than being inferred from latency.
+
+The workers stay daemon, as the per-event threads were. A `ThreadPoolExecutor`
+would have been fewer lines, but its threads are joined at interpreter exit,
+which would let a 300-second deploy hook hold up shutdown until the container
+runtime SIGKILLs it anyway.
+"""
+import logging
+import threading
+import time
+
+import pytest
+
+from modules.core.events import (
+    BACKLOG_WARN_AT, DEFAULT_DISPATCH_WORKERS, EventBus,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def _eventually(predicate, timeout=10):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+# --- the ceiling ---------------------------------------------------------
+
+def test_two_hundred_events_do_not_start_two_hundred_threads():
+    """The finding, measured — and measured WHILE the work is outstanding.
+
+    The first version of this test counted threads after the events had been
+    delivered. Under the old thread-per-event dispatch that passes: the
+    threads finish as fast as they are created and the count is back to
+    baseline by the time anything looks. Mutating the code back to
+    `threading.Thread(...).start()` did not fail it, which is how the
+    measurement was found to be wrong rather than the code right.
+
+    Holding every listener open makes the peak observable, which is the number
+    the finding is actually about.
+    """
+    release = threading.Event()
+    before = threading.active_count()
+    bus = EventBus(workers=4)
+    seen = []
+
+    def listener(event, data):
+        release.wait(20)
+        seen.append(data)
+
+    bus.add_listener(listener)
+    try:
+        for i in range(200):
+            bus.publish('certificate_renewed', {'domain': f'd{i}.example.com'})
+
+        # Every listener is blocked, so whatever threads exist now are the
+        # peak. Give the pool a moment to be fully occupied.
+        time.sleep(0.3)
+        peak = threading.active_count() - before
+        assert peak <= 4 + 1, (
+            f'{peak} threads for 200 outstanding events; the dispatch is not '
+            f'bounded'
+        )
+    finally:
+        release.set()
+
+    assert _eventually(lambda: len(seen) == 200, timeout=20), (
+        f'only {len(seen)} delivered')
+
+
+def test_the_worker_count_is_configurable_and_clamped(monkeypatch):
+    assert EventBus(workers=8)._worker_count == 8
+    assert EventBus(workers=0)._worker_count == 1
+    assert EventBus(workers=1000)._worker_count == 32
+
+    monkeypatch.setenv('CERTMATE_EVENT_WORKERS', '7')
+    assert EventBus()._worker_count == 7
+
+    monkeypatch.setenv('CERTMATE_EVENT_WORKERS', 'not a number')
+    assert EventBus()._worker_count == DEFAULT_DISPATCH_WORKERS
+
+
+def test_a_bus_with_no_listeners_starts_no_threads():
+    """Most of the test suite builds one of these. A pool that materialises
+    on construction would put four idle threads behind every app."""
+    before = threading.active_count()
+    bus = EventBus()
+    for i in range(10):
+        bus.publish('certificate_created', {'domain': f'd{i}.example.com'})
+    assert threading.active_count() == before
+
+
+# --- the publisher never blocks -----------------------------------------
+
+def test_publishing_returns_before_a_slow_listener_finishes():
+    """The property that matters most: issuance must not wait on a deploy."""
+    started = threading.Event()
+    release = threading.Event()
+
+    bus = EventBus(workers=1)
+    bus.add_listener(lambda event, data: (started.set(), release.wait(10)))
+
+    began = time.time()
+    bus.publish('certificate_created', {'domain': 'slow.example.com'})
+    elapsed = time.time() - began
+
+    assert started.wait(5), 'the listener never ran'
+    assert elapsed < 1.0, (
+        f'publish() took {elapsed:.2f}s — it is waiting for the listener, so '
+        f'a deploy hook now delays the issuance that triggered it'
+    )
+    release.set()
+
+
+def test_a_saturated_pool_does_not_block_the_publisher_either():
+    """With every worker busy, publish() still returns immediately; the work
+    waits in the queue instead of on the caller's thread."""
+    release = threading.Event()
+    bus = EventBus(workers=1)
+    bus.add_listener(lambda event, data: release.wait(10))
+
+    bus.publish('certificate_created', {'domain': 'first.example.com'})
+    began = time.time()
+    for i in range(20):
+        bus.publish('certificate_created', {'domain': f'd{i}.example.com'})
+    elapsed = time.time() - began
+
+    assert elapsed < 1.0, f'publishing into a busy pool blocked for {elapsed:.2f}s'
+    assert bus.pending_dispatches() > 0
+    release.set()
+
+
+# --- nothing is dropped --------------------------------------------------
+
+def test_every_event_reaches_every_listener():
+    bus = EventBus(workers=2)
+    first, second = [], []
+    bus.add_listener(lambda event, data: first.append(data['domain']))
+    bus.add_listener(lambda event, data: second.append(data['domain']))
+
+    for i in range(50):
+        bus.publish('certificate_renewed', {'domain': f'd{i}.example.com'})
+
+    assert _eventually(lambda: len(first) == 50 and len(second) == 50), (
+        f'delivered {len(first)} and {len(second)} of 50 — events were dropped'
+    )
+    assert sorted(first) == sorted(second)
+
+
+def test_work_queued_before_the_pool_drains_is_still_delivered():
+    """CONTROL for the choice not to drop: a bounded queue with a discard
+    policy would silently lose deploys here."""
+    release = threading.Event()
+    delivered = []
+    bus = EventBus(workers=1)
+    bus.add_listener(lambda event, data: (release.wait(10),
+                                          delivered.append(data['domain'])))
+
+    for i in range(100):
+        bus.publish('certificate_renewed', {'domain': f'd{i}.example.com'})
+    release.set()
+
+    assert _eventually(lambda: len(delivered) == 100, timeout=20), (
+        f'{len(delivered)} of 100 arrived after the pool was released'
+    )
+
+
+# --- a bad listener must not cost capacity ------------------------------
+
+def test_a_listener_that_raises_does_not_kill_its_worker():
+    """One worker, one exploding listener, then real work. Without the
+    try/except the pool bleeds capacity one bad event at a time until nothing
+    is dispatched and nothing says why."""
+    calls = []
+
+    def listener(event, data):
+        calls.append(data['domain'])
+        if data['domain'] == 'boom.example.com':
+            raise RuntimeError('listener exploded')
+
+    bus = EventBus(workers=1)
+    bus.add_listener(listener)
+
+    bus.publish('certificate_created', {'domain': 'boom.example.com'})
+    assert _eventually(lambda: 'boom.example.com' in calls)
+
+    bus.publish('certificate_created', {'domain': 'after.example.com'})
+    assert _eventually(lambda: 'after.example.com' in calls), (
+        'the worker died with the listener, so every later event is lost'
+    )
+
+
+def test_a_failing_listener_is_logged_at_error(caplog):
+    bus = EventBus(workers=1)
+    bus.add_listener(
+        lambda event, data: (_ for _ in ()).throw(RuntimeError('nope')))
+
+    with caplog.at_level(logging.ERROR):
+        bus.publish('certificate_created', {'domain': 'x.example.com'})
+        _eventually(lambda: any(r.levelno >= logging.ERROR
+                                for r in caplog.records))
+
+    assert any('certificate_created' in str(r.args or ())
+               for r in caplog.records), 'the failure did not name the event'
+
+
+# --- the backlog is visible ---------------------------------------------
+
+def test_a_backlog_is_reported_once(caplog):
+    release = threading.Event()
+    bus = EventBus(workers=1)
+    bus.add_listener(lambda event, data: release.wait(10))
+
+    with caplog.at_level(logging.WARNING):
+        for i in range(BACKLOG_WARN_AT + 20):
+            bus.publish('certificate_renewed', {'domain': f'd{i}.example.com'})
+
+    warnings = [r for r in caplog.records
+                if 'backlog' in r.getMessage().lower()]
+    assert warnings, 'an instance past its capacity said nothing'
+    assert len(warnings) == 1, (
+        f'{len(warnings)} backlog warnings for one episode — a line per event '
+        f'is a line nobody reads'
+    )
+    assert 'CERTMATE_EVENT_WORKERS' in warnings[0].getMessage(), (
+        'the warning does not say what to do about it'
+    )
+    release.set()
+
+
+def test_an_ordinary_publish_says_nothing(caplog):
+    """CONTROL: a warning on normal traffic would train an operator to ignore
+    the one that matters."""
+    bus = EventBus(workers=4)
+    bus.add_listener(lambda event, data: None)
+
+    with caplog.at_level(logging.WARNING):
+        for i in range(10):
+            bus.publish('certificate_renewed', {'domain': f'd{i}.example.com'})
+        time.sleep(0.2)
+
+    assert not [r for r in caplog.records
+                if 'backlog' in r.getMessage().lower()]
+
+
+# --- what must not change -----------------------------------------------
+
+def test_sse_subscribers_still_receive_events():
+    """CONTROL: the SSE path and the listener path are separate, and this
+    change touched only one of them."""
+    bus = EventBus(workers=1)
+    q = bus.subscribe()
+    bus.publish('certificate_created', {'domain': 'sse.example.com'})
+
+    message = q.get(timeout=5)
+    assert message['event'] == 'certificate_created'
+    assert message['data']['domain'] == 'sse.example.com'
+
+
+def test_sse_still_drops_the_oldest_when_a_subscriber_falls_behind():
+    """The queue is bounded at 50 on purpose: a browser that stopped reading
+    must not grow the process. Unchanged, and asserted so it stays that way
+    while the listener path deliberately does the opposite."""
+    bus = EventBus(workers=1)
+    q = bus.subscribe()
+    for i in range(80):
+        bus.publish('certificate_renewed', {'domain': f'd{i}.example.com'})
+
+    assert q.qsize() <= 50
+    assert q.get_nowait()['data']['domain'] != 'd0.example.com', (
+        'the oldest message survived, so the SSE queue is no longer bounded'
+    )
+
+
+def test_the_workers_are_daemon_threads():
+    """A ThreadPoolExecutor would join at interpreter exit, letting a
+    300-second deploy hook hold up shutdown until the runtime SIGKILLs it."""
+    bus = EventBus(workers=2)
+    bus.add_listener(lambda event, data: None)
+    assert bus._workers, 'no workers started'
+    assert all(worker.daemon for worker in bus._workers)

--- a/tests/test_event_dispatch_is_bounded.py
+++ b/tests/test_event_dispatch_is_bounded.py
@@ -209,12 +209,17 @@ def test_a_listener_that_raises_does_not_kill_its_worker():
     bus.add_listener(listener)
 
     bus.publish('certificate_created', {'domain': 'boom.example.com'})
-    assert _eventually(lambda: 'boom.example.com' in calls)
+    assert _eventually(lambda: len(calls) == 1)
+    assert calls == ['boom.example.com']
 
     bus.publish('certificate_created', {'domain': 'after.example.com'})
-    assert _eventually(lambda: 'after.example.com' in calls), (
+    assert _eventually(lambda: len(calls) == 2), (
         'the worker died with the listener, so every later event is lost'
     )
+    # Exact, and in order: the second event must be delivered ONCE, by the
+    # worker that survived — not re-delivered by a replacement, and not
+    # swallowed. Membership would accept both.
+    assert calls == ['boom.example.com', 'after.example.com']
 
 
 def test_a_failing_listener_is_logged_at_error(caplog):


### PR DESCRIPTION
## The finding

Every `publish()` started one new thread **per listener, per event** — no pool,
no queue, no ceiling:

```python
for listener in listeners:
    threading.Thread(target=listener, args=(event, data), daemon=True).start()
```

So the process's thread count was a function of *event volume*. A renewal sweep
across many domains, each publishing to several listeners, decided how many
threads existed. Nothing in CertMate chose that number and nothing reported it.

## Three properties, each chosen deliberately, each a test

A fixed set of daemon workers reading one queue. The interesting part is not
the pool — it is what happens when it is full, and each answer could reasonably
have gone the other way.

**The publisher never blocks.** It is a request thread on the issuance path and
the scheduler on the renewal path. `DeployManager.on_certificate_event` runs
deploy hooks, each up to a **300-second** timeout — putting that on the
publisher's thread would trade a thread problem for a latency problem on the
product's main job.

**Nothing is dropped.** The SSE path drops the oldest message and then the
subscriber, which is right for a browser that fell behind and wrong for a
deploy that has to happen. Certificate events are rare and each one matters, so
the backlog is unbounded in *length* and bounded in *cost* — one small tuple
per queued call. There is a control test that queues 100 events behind a
blocked worker and asserts all 100 arrive.

**The backlog is visible.** Past the threshold the bus says so — **once per
episode**, not once per event — and names `CERTMATE_EVENT_WORKERS`, so the line
says what to do about it.

## Not a ThreadPoolExecutor

Fewer lines, but its threads are **joined at interpreter exit**, which would let
a 300-second deploy hook hold up shutdown until the container runtime SIGKILLs
it anyway. The workers stay daemon, exactly as the per-event threads were, and
that is asserted.

They also start **lazily**: a bus with no listeners — which is what most of the
test suite builds — costs no threads at all.

## A listener that raises no longer takes its worker with it

With one thread per event that was survivable. With a pool it would bleed
capacity one bad event at a time until nothing is dispatched and nothing says
why. One worker, one exploding listener, then real work: the test asserts the
later event still arrives.

## The measurement was wrong before the code was right

The first version of the thread-count test counted threads **after** delivery.
Mutating the dispatch back to `threading.Thread(...).start()` did **not** fail
it — the threads finish as fast as they are created, so the count is back to
baseline by the time anything looks.

It now holds every listener open and measures the **peak**, which is the number
the finding is actually about. With the mutation restored it fails, along with
three others. The reason is recorded in the test rather than quietly fixed.

## Checks run locally

- 14 new tests; `pytest -m "not ui"` — **4266 passed, 59 skipped**
- Measured: 200 events with every listener blocked → **4 threads**, all 200 delivered
- Verified by mutation: restoring thread-per-event fails 4 of the 14
- `flake8` with CI's selector set, `C901` at the real max — clean

## Follow-up in this stack

`CERTMATE_EVENT_WORKERS` is a new variable, and #766 adds the test that every
variable the code reads is documented. Whichever of the two lands second picks
up the other; the table row goes in on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
