### PR TITLE
api: give the certificate and download failures a code a client can branch on

### DIFF
--- a/modules/api/resources_downloads.py
+++ b/modules/api/resources_downloads.py
@@ -87,9 +87,9 @@ def create_download_resources(api, models, ctx: ApiContext,
                     return scope_err
                 cert_dir, err = _validate_domain_path(domain, ctx.file_ops.cert_dir)
                 if err:
-                    return {'error': err}, 400
+                    return {'error': err, 'code': 'INVALID_REQUEST'}, 400
                 if not cert_dir.exists():
-                    return {'error': f'Certificate not found for domain: {domain}'}, 404
+                    return {'error': f'Certificate not found for domain: {domain}', 'code': 'CERTIFICATE_NOT_FOUND'}, 404
 
                 user = getattr(request, 'current_user', None) or {}
                 download_format = request.args.get('format')
@@ -98,7 +98,7 @@ def create_download_resources(api, models, ctx: ApiContext,
                 include_private = str(request.args.get('include_private', '1')).lower() not in ('0', 'false', 'no', 'off')
 
                 if download_format and download_format not in ['json']:
-                    return {'error': 'Invalid format requested.'}, 400
+                    return {'error': 'Invalid format requested.', 'code': 'INVALID_FORMAT'}, 400
 
                 # Optional private-key serialization. Certbot stores PKCS#8
                 # ("BEGIN PRIVATE KEY"); some older stacks need the legacy
@@ -106,9 +106,10 @@ def create_download_resources(api, models, ctx: ApiContext,
                 # rather than duplicating key material on disk (issue #233).
                 key_format = request.args.get('key_format')
                 if key_format is not None and key_format not in ('pkcs1', 'pkcs8'):
-                    return {'error': "Invalid key_format; use 'pkcs1' or 'pkcs8'."}, 400
+                    return {'error': "Invalid key_format; use 'pkcs1' or 'pkcs8'.", 'code': 'INVALID_KEY_FORMAT'}, 400
                 if key_format and download_format != 'json' and requested_file != 'privkey.pem':
                     return {
+                        'code': 'KEY_FORMAT_NOT_APPLICABLE',
                         'error': 'key_format applies to ?file=privkey.pem or ?format=json.'
                     }, 400
 
@@ -136,7 +137,7 @@ def create_download_resources(api, models, ctx: ApiContext,
                     if not _user_has_role(user, 'operator'):
                         return _privkey_denied('format=json')
                     if requested_file:
-                        return {'error': 'format=json cannot be combined with file.'}, 400
+                        return {'error': 'format=json cannot be combined with file.', 'code': 'INCOMPATIBLE_PARAMETERS'}, 400
 
                     required_files = {
                         'cert_pem': 'cert.pem',
@@ -150,7 +151,7 @@ def create_download_resources(api, models, ctx: ApiContext,
                         for response_key, filename in required_files.items():
                             file_path = cert_dir / filename
                             if not file_path.exists():
-                                return {'error': f'Required cert file not found for domain {domain}: {filename}'}, 404
+                                return {'error': f'Required cert file not found for domain {domain}: {filename}', 'code': 'CERT_FILE_NOT_FOUND'}, 404
                             payload[response_key] = file_path.read_text(encoding='utf-8')
 
                         # ?key_format=pkcs1 adds the legacy/traditional form
@@ -180,19 +181,20 @@ def create_download_resources(api, models, ctx: ApiContext,
                                     str(e).replace('\r', ' ').replace('\n', ' '),
                                 )
                                 return {
+                                    'code': 'KEY_CONVERSION_FAILED',
                                     'error': 'Could not convert the private key to PKCS#1 '
                                              '(the key type may not support it).'
                                 }, 422
 
                         return jsonify(payload)
                     except FileNotFoundError:
-                        return {'error': f'Required cert file not found for domain {domain}'}, 404
+                        return {'error': f'Required cert file not found for domain {domain}', 'code': 'CERT_FILE_NOT_FOUND'}, 404
 
                 if requested_file:
                     # Security check: only allow specific certificate files
                     allowed_files = _PUBLIC_DOWNLOAD_FILES | _PRIVATE_KEY_FILES
                     if requested_file not in allowed_files:
-                        return {'error': 'Invalid file requested.'}, 400
+                        return {'error': 'Invalid file requested.', 'code': 'INVALID_FILE'}, 400
 
                     # Private-key files require operator+; public files
                     # remain viewer-accessible.
@@ -213,11 +215,11 @@ def create_download_resources(api, models, ctx: ApiContext,
                                 mimetype='application/x-pem-file'
                             )
                         except FileNotFoundError:
-                            return {'error': f'Required cert files not found for domain {domain}'}, 404
+                            return {'error': f'Required cert files not found for domain {domain}', 'code': 'CERT_FILE_NOT_FOUND'}, 404
 
                     file_path = cert_dir / requested_file
                     if not file_path.exists():
-                        return {'error': f'File {requested_file} not found for domain {domain}'}, 404
+                        return {'error': f'File {requested_file} not found for domain {domain}', 'code': 'CERT_FILE_NOT_FOUND'}, 404
 
                     if requested_file == 'privkey.pem' and key_format == 'pkcs1':
                         # Re-resolve with a constant filename and confirm the
@@ -226,7 +228,7 @@ def create_download_resources(api, models, ctx: ApiContext,
                         # file read off any tainted path component.
                         key_path = os.path.realpath(cert_dir / 'privkey.pem')
                         if not key_path.startswith(os.path.realpath(cert_dir) + os.sep):
-                            return {'error': 'Invalid path'}, 400
+                            return {'error': 'Invalid path', 'code': 'INVALID_PATH'}, 400
                         try:
                             with open(key_path, 'rb') as fh:
                                 pkcs1_pem = _privkey_to_pkcs1(fh.read())
@@ -240,6 +242,7 @@ def create_download_resources(api, models, ctx: ApiContext,
                                 str(e).replace('\r', ' ').replace('\n', ' '),
                             )
                             return {
+                                'code': 'KEY_CONVERSION_FAILED',
                                 'error': 'Could not convert the private key to PKCS#1 '
                                          '(the key type may not support it).'
                             }, 422
@@ -305,7 +308,7 @@ def create_download_resources(api, models, ctx: ApiContext,
 
             except Exception as e:
                 logger.error(f"Error downloading certificate for {domain}: {e}")
-                return {'error': 'Failed to download certificate'}, 500
+                return {'error': 'Failed to download certificate', 'code': 'CERTIFICATE_DOWNLOAD_ERROR'}, 500
 
     class DownloadCertificateFile(Resource):
         # Path-style alias for the query-string form on DownloadCertificate.
@@ -339,6 +342,7 @@ def create_download_resources(api, models, ctx: ApiContext,
             requested_file = self._SHORT_NAME_TO_FILE.get(file_type)
             if requested_file is None:
                 return {
+                    'code': 'INVALID_FILE_TYPE',
                     'error': f'Invalid file type: {file_type}',
                     'hint': f"Allowed: {sorted(self._SHORT_NAME_TO_FILE)}",
                 }, 400
@@ -349,9 +353,9 @@ def create_download_resources(api, models, ctx: ApiContext,
                     return scope_err
                 cert_dir, err = _validate_domain_path(domain, ctx.file_ops.cert_dir)
                 if err:
-                    return {'error': err}, 400
+                    return {'error': err, 'code': 'INVALID_REQUEST'}, 400
                 if not cert_dir.exists():
-                    return {'error': f'Certificate not found for domain: {domain}'}, 404
+                    return {'error': f'Certificate not found for domain: {domain}', 'code': 'CERTIFICATE_NOT_FOUND'}, 404
 
                 user = getattr(request, 'current_user', None) or {}
 
@@ -383,11 +387,11 @@ def create_download_resources(api, models, ctx: ApiContext,
                             mimetype='application/x-pem-file'
                         )
                     except FileNotFoundError:
-                        return {'error': f'Required cert files not found for domain {domain}'}, 404
+                        return {'error': f'Required cert files not found for domain {domain}', 'code': 'CERT_FILE_NOT_FOUND'}, 404
 
                 file_path = cert_dir / requested_file
                 if not file_path.exists():
-                    return {'error': f'File {requested_file} not found for domain {domain}'}, 404
+                    return {'error': f'File {requested_file} not found for domain {domain}', 'code': 'CERT_FILE_NOT_FOUND'}, 404
 
                 return send_file(
                     file_path,
@@ -397,7 +401,7 @@ def create_download_resources(api, models, ctx: ApiContext,
                 )
             except Exception as e:
                 logger.error(f"Error downloading {file_type} for {domain}: {e}")
-                return {'error': 'Failed to download certificate file'}, 500
+                return {'error': 'Failed to download certificate file', 'code': 'CERTIFICATE_DOWNLOAD_ERROR'}, 500
 
     return {
         'DownloadCertificate': DownloadCertificate,

--- a/modules/api/resources_lifecycle.py
+++ b/modules/api/resources_lifecycle.py
@@ -47,6 +47,7 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
                 san_domains = data.get('san_domains', [])
                 if not domain:
                     return {
+                        'code': 'DOMAIN_REQUIRED',
                         'error': 'Domain is required',
                         'hint': 'Please provide a valid domain name (e.g., example.com or *.example.com for wildcard)'
                     }, 400
@@ -138,6 +139,7 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
                 elif 'domain' in error_msg.lower() and 'email' in error_msg.lower():
                     hint = 'Both domain and email are required. Configure email in settings.'
                 return {
+                    'code': 'CERTIFICATE_CREATION_FAILED',
                     'error': error_msg,
                     'hint': hint
                 }, 400
@@ -154,12 +156,14 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
                 elif 'rate limit' in error_msg.lower():
                     hint = "You've hit the certificate authority's rate limit. Wait before trying again."
                 return {
+                    'code': 'CERTIFICATE_CREATION_FAILED',
                     'error': f'Certificate creation failed: {error_msg}',
                     'hint': hint
                 }, 422
             except Exception as e:
                 logger.error(f"Certificate creation failed: {str(e)}")
                 return {
+                    'code': 'CERTIFICATE_CREATION_ERROR',
                     'error': 'Certificate creation failed unexpectedly',
                     'hint': 'Check application logs for detailed error information.'
                 }, 500
@@ -174,7 +178,7 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
                 force = bool(payload.get('force', False))
                 _, err = _validate_domain_path(domain, ctx.file_ops.cert_dir)
                 if err:
-                    return {'error': err}, 400
+                    return {'error': err, 'code': 'INVALID_REQUEST'}, 400
                 user = getattr(request, 'current_user', None) or {}
                 audit_ctx = audit_context_from_request()
 
@@ -243,7 +247,7 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
                 event_bus = current_app.config.get('EVENT_BUS')
                 if event_bus:
                     event_bus.publish('certificate_failed', {'domain': domain, 'error': str(e)})
-                return {'error': 'Certificate renewal failed'}, 500
+                return {'error': 'Certificate renewal failed', 'code': 'CERTIFICATE_RENEWAL_ERROR'}, 500
 
     class CertificateReissue(Resource):
         @api.doc(security='Bearer')
@@ -261,7 +265,7 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
                 data = api.payload or {}
                 _, err = _validate_domain_path(domain, ctx.file_ops.cert_dir)
                 if err:
-                    return {'error': err}, 400
+                    return {'error': err, 'code': 'INVALID_REQUEST'}, 400
                 user = getattr(request, 'current_user', None) or {}
 
                 kwargs = dict(
@@ -312,7 +316,7 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
             except DomainOutOfScope as e:
                 return {'error': str(e), 'code': 'DOMAIN_OUT_OF_SCOPE'}, 403
             except ValueError as e:
-                return {'error': str(e)}, 400
+                return {'error': str(e), 'code': 'CERTIFICATE_REISSUE_REJECTED'}, 400
             except DomainOperationInProgress as e:
                 # Domain busy is not a failure; no failure event.
                 return {'error': str(e), 'code': 'DOMAIN_OPERATION_IN_PROGRESS'}, 409
@@ -325,6 +329,7 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
                 if event_bus:
                     event_bus.publish('certificate_failed', {'domain': domain, 'error': error_msg})
                 return {
+                    'code': 'CERTIFICATE_REISSUE_FAILED',
                     'error': f'Certificate reissue failed: {error_msg}',
                     'hint': hint + ' The previous certificate is still in place.'
                 }, 422
@@ -338,6 +343,7 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
                 if event_bus:
                     event_bus.publish('certificate_failed', {'domain': domain, 'error': str(e)})
                 return {
+                    'code': 'CERTIFICATE_REISSUE_ERROR',
                     'error': 'Certificate reissue failed unexpectedly',
                     'hint': 'Check application logs. The previous certificate is still in place.'
                 }, 500
@@ -348,10 +354,10 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
         def get(self, job_id):
             """Poll the status of an async create/renew job."""
             if ctx.cert_executor is None:
-                return {'error': 'Async issuance is not enabled'}, 404
+                return {'error': 'Async issuance is not enabled', 'code': 'ASYNC_ISSUANCE_DISABLED'}, 404
             job = ctx.cert_executor.get(job_id)
             if job is None:
-                return {'error': 'Job not found'}, 404
+                return {'error': 'Job not found', 'code': 'JOB_NOT_FOUND'}, 404
             # The caller must be in scope for the job's domain — a scoped key
             # cannot poll a job for a domain it could not have created.
             scope_err = _check_domain_scope(job.get('domain'), 'job_status')
@@ -375,7 +381,7 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
             represented by the certificate itself.
             """
             if ctx.cert_executor is None:
-                return {'error': 'Async issuance is not enabled'}, 404
+                return {'error': 'Async issuance is not enabled', 'code': 'ASYNC_ISSUANCE_DISABLED'}, 404
             # Same boundary as polling a single job: a scoped key sees only
             # jobs for domains it could have created itself. Filtered rather
             # than refused, so a scoped key still gets its own in-flight work.
@@ -399,16 +405,17 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
                 return scope_err
             _, err = _validate_domain_path(domain, ctx.file_ops.cert_dir)
             if err:
-                return {'error': err}, 400
+                return {'error': err, 'code': 'INVALID_REQUEST'}, 400
             try:
                 data = api.payload or {}
                 if 'enabled' not in data:
-                    return {'error': 'Missing "enabled" boolean in request body'}, 400
+                    return {'error': 'Missing "enabled" boolean in request body', 'code': 'AUTO_RENEW_FLAG_REQUIRED'}, 400
                 enabled = bool(data.get('enabled'))
 
                 updated = ctx.certificates.set_auto_renew(domain, enabled)
                 if not updated:
                     return {
+                        'code': 'DOMAIN_NOT_IN_SETTINGS',
                         'error': f'Domain {domain} not found in settings',
                         'hint': 'Only domains tracked in settings can have auto-renew toggled.'
                     }, 404
@@ -437,7 +444,7 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
                 }, 200
             except Exception as e:
                 logger.error(f"Failed to toggle auto-renew for {domain}: {e}")
-                return {'error': 'Failed to update auto-renew setting'}, 500
+                return {'error': 'Failed to update auto-renew setting', 'code': 'AUTO_RENEW_UPDATE_FAILED'}, 500
 
     return {
         'CreateCertificate': CreateCertificate,

--- a/tests/test_api_errors_carry_a_code.py
+++ b/tests/test_api_errors_carry_a_code.py
@@ -1,0 +1,203 @@
+"""A client should be able to branch on a failure without matching English.
+
+Machine-readable error codes existed for seven conditions and were absent from
+161 error returns under `modules/api`, so for almost every failure the only
+thing a caller could act on was the human message — which is not a contract:
+it gets reworded, translated, or has a domain interpolated into it.
+
+The plumbing was already there. `models.py` declares `code` on the error model,
+and the comment beside it records that marshalling strips anything undeclared.
+What was missing was the requirement.
+
+**This is a ratchet, not a rule.** Filling in 161 codes in one change would
+produce 161 identifiers chosen in a hurry, and a stable-looking identifier that
+means nothing is worse than none — a client would branch on it. So each file
+carries a ceiling, and the ceiling can only go down. Two files are at zero:
+`resources_lifecycle.py` (create, renew, reissue, the async job endpoints) and
+`resources_downloads.py`, which is what the SDK and the CLI actually call.
+
+Adding an error return without a code fails the build in every file, because
+every file's ceiling is the number it has today.
+"""
+import ast
+import collections
+import pathlib
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+API = REPO / 'modules' / 'api'
+
+# Error returns still carrying no code, per file, as of this commit. Lower a
+# number when you add codes; a file at 0 is done and must stay done. Never
+# raise one: that is what the test is for.
+UNCODED_CEILING = {
+    'resources_backup.py': 31,
+    'resources_certificates.py': 18,
+    'resources_inventory.py': 18,
+    'resources_storage.py': 18,
+    'resources_settings.py': 16,
+    'resources_deployment.py': 9,
+    'resources_discovery.py': 6,
+    'resources_ca.py': 3,
+    'resources_cache.py': 2,
+    'resources_health.py': 2,
+    'resources_lifecycle.py': 0,
+    'resources_downloads.py': 0,
+}
+
+
+def _error_returns(path):
+    """Every `return {...}, <4xx/5xx>` in a file, with whether it has a code.
+
+    Only literal dict returns are counted. A return of a variable cannot be
+    checked here and is not the shape this is about: the 161 were all literals.
+    """
+    tree = ast.parse(path.read_text(encoding='utf-8'))
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Return)
+                and isinstance(node.value, ast.Tuple)
+                and len(node.value.elts) == 2):
+            continue
+        body, status = node.value.elts
+        if not (isinstance(status, ast.Constant)
+                and isinstance(status.value, int)
+                and status.value >= 400):
+            continue
+        if not isinstance(body, ast.Dict):
+            continue
+        keys = {k.value for k in body.keys if isinstance(k, ast.Constant)}
+        yield node.lineno, status.value, 'code' in keys
+
+
+def uncoded():
+    """{filename: [(line, status)]} for every error return with no code."""
+    found = collections.defaultdict(list)
+    for path in sorted(API.glob('*.py')):
+        for lineno, status, has_code in _error_returns(path):
+            if not has_code:
+                found[path.name].append((lineno, status))
+    return found
+
+
+# --- the ratchet ---------------------------------------------------------
+
+def test_no_file_has_more_uncoded_errors_than_its_ceiling():
+    found = uncoded()
+    over = []
+    for name, sites in sorted(found.items()):
+        ceiling = UNCODED_CEILING.get(name)
+        if ceiling is None:
+            over.append(
+                f'{name}: {len(sites)} uncoded error return(s), and the file '
+                f'is not in UNCODED_CEILING at all')
+        elif len(sites) > ceiling:
+            lines = ', '.join(str(line) for line, _ in sites[:8])
+            over.append(
+                f'{name}: {len(sites)} uncoded, ceiling {ceiling} (lines '
+                f'{lines})')
+    assert not over, (
+        "these files gained an error return with no machine-readable 'code', "
+        "so a client can only string-match the message:\n  "
+        + '\n  '.join(over)
+        + "\n\nAdd a 'code' naming the condition — see the convention in "
+          "resources_lifecycle.py — or, if you removed codes deliberately, "
+          "raise the ceiling and say why in the commit."
+    )
+
+
+def test_a_ceiling_that_is_too_high_is_lowered():
+    """The half that makes it a ratchet. Without it a ceiling stays at its
+    original value forever and the file can regress back up to it silently
+    after someone does the work."""
+    found = uncoded()
+    slack = {name: (ceiling, len(found.get(name, [])))
+             for name, ceiling in UNCODED_CEILING.items()
+             if len(found.get(name, [])) < ceiling}
+    assert not slack, (
+        'these files have fewer uncoded error returns than their ceiling — '
+        'good, now lower it so the progress is locked in: '
+        + ', '.join(f'{name}: {actual} (ceiling {ceiling})'
+                    for name, (ceiling, actual) in sorted(slack.items())))
+
+
+def test_the_two_finished_files_stay_finished():
+    """Named separately so the failure says which surface regressed. These
+    two are what the SDK and the CLI call."""
+    found = uncoded()
+    for name in ('resources_lifecycle.py', 'resources_downloads.py'):
+        assert not found.get(name), (
+            f'{name} is meant to have a code on every error return; these do '
+            f'not: ' + ', '.join(str(line) for line, _ in found[name]))
+
+
+def test_a_ceiling_does_not_name_a_file_that_is_gone():
+    present = {path.name for path in API.glob('*.py')}
+    stale = sorted(set(UNCODED_CEILING) - present)
+    assert not stale, (
+        'UNCODED_CEILING names files that no longer exist: ' + ', '.join(stale))
+
+
+# --- controls on the census ---------------------------------------------
+
+def test_the_census_finds_error_returns_at_all():
+    """Without this, a parser that matches nothing reports every file clean
+    and the ratchet becomes decoration."""
+    total = sum(1 for path in API.glob('*.py')
+                for _ in _error_returns(path))
+    assert total > 150, (
+        f'only {total} error returns found across modules/api; the AST walk '
+        f'is reading the wrong thing')
+
+
+def test_the_census_can_tell_a_coded_return_from_an_uncoded_one():
+    """CONTROL: if `'code' in keys` were always true, every ceiling would be
+    satisfiable by doing nothing."""
+    coded = sum(1 for path in API.glob('*.py')
+                for _, _, has_code in _error_returns(path) if has_code)
+    plain = sum(1 for path in API.glob('*.py')
+                for _, _, has_code in _error_returns(path) if not has_code)
+    assert coded > 40, f'only {coded} coded returns seen'
+    assert plain > 40, f'only {plain} uncoded returns seen'
+
+
+def test_a_success_return_is_not_counted():
+    """CONTROL: 200s do not carry error codes, and counting them would make
+    every ceiling unreachable."""
+    module = ast.parse(
+        "def f():\n    return {'ok': True}, 200\n"
+        "def g():\n    return {'error': 'no'}, 404\n")
+    found = []
+    for node in ast.walk(module):
+        if (isinstance(node, ast.Return) and isinstance(node.value, ast.Tuple)
+                and len(node.value.elts) == 2):
+            body, status = node.value.elts
+            if (isinstance(status, ast.Constant)
+                    and isinstance(status.value, int)
+                    and status.value >= 400
+                    and isinstance(body, ast.Dict)):
+                found.append(status.value)
+    assert found == [404]
+
+
+# --- the codes themselves ------------------------------------------------
+
+def test_every_code_looks_like_a_code():
+    """A code is an identifier a client branches on. A sentence is not one."""
+    import re
+    pattern = re.compile(r'^[A-Z][A-Z0-9_]{2,48}$')
+    bad = []
+    for path in sorted(API.glob('*.py')):
+        tree = ast.parse(path.read_text(encoding='utf-8'))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Dict):
+                continue
+            for key, value in zip(node.keys, node.values):
+                if (isinstance(key, ast.Constant) and key.value == 'code'
+                        and isinstance(value, ast.Constant)
+                        and isinstance(value.value, str)
+                        and not pattern.match(value.value)):
+                    bad.append(f'{path.name}:{node.lineno} {value.value!r}')
+    assert not bad, 'these are not machine-readable codes: ' + ', '.join(bad)


### PR DESCRIPTION
## The finding

Machine-readable error codes existed for **seven** conditions and were absent from **161** error returns under `modules/api`. For almost every failure the only thing a caller could act on was the human message — which is not a contract: it gets reworded, translated, or has a domain interpolated into it.

The plumbing was already there. `models.py` declares `code` on the error model, and the comment beside it records that marshalling strips anything undeclared. What was missing was the requirement.

## What this does, and what it deliberately does not

**38 codes, on the two files the clients actually call.** `resources_lifecycle.py` (create, renew, reissue, async jobs) and `resources_downloads.py` now carry a code on every error return. Each names its condition, following the convention already in the file — `DOMAIN_OUT_OF_SCOPE`, `CERTIFICATE_ALREADY_EXISTS`.

**The remaining 123 are held by a ratchet, not filled in.** Doing all 161 in one change would produce 161 identifiers chosen in a hurry, and a stable-looking identifier that means nothing is *worse* than none — a client would branch on it.

So each file carries a ceiling equal to what it has today:

```
resources_backup.py        31    resources_deployment.py     9
resources_certificates.py  18    resources_discovery.py      6
resources_inventory.py     18    resources_ca.py             3
resources_storage.py       18    resources_cache.py          2
resources_settings.py      16    resources_health.py         2
resources_lifecycle.py      0    resources_downloads.py      0
```

Adding an uncoded error return fails the build **anywhere**. And a second test fails when a file drops *below* its ceiling — so progress is locked in rather than leaving room to silently regress back up to it.

## Controls

A census that measures nothing would make every ceiling satisfiable by doing nothing, so:

- the walk must find more than 150 error returns;
- it must see both coded and uncoded ones (if `code in keys` were always true, every ceiling passes for free);
- a `200` return is not counted, since success responses carry no code and counting them would make every ceiling unreachable;
- every code must look like a code — an identifier a client branches on, not a sentence.

## Verified by mutation, both directions

```
remove one code from a finished file  -> 2 tests fail
raise a ceiling above what is needed  -> the lock-in test fails
```

## Checks run locally

- 8 new tests; `pytest -m "not ui"` — **4278 passed, 59 skipped**
- `flake8` with CIs selector set — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)