### PR TITLE
ops: make the renewal sweep say what it did, and whether it finished

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -3273,13 +3273,17 @@ class CertificateManager:
         # Migrate settings format if needed
         settings = self.settings_manager.migrate_domains_format(settings)
 
-        logger.info("Checking for certificates that need renewal")
+        domains = settings.get('domains', [])
+        logger.info("Checking %d certificate(s) for renewal", len(domains))
 
         summary = {'checked': 0, 'renewed': 0, 'failed': 0,
                    'skipped_disabled': 0, 'skipped_invalid': 0,
                    'skipped_not_due': 0}
+        started = time.time()
+        self._report_unfinished_sweep()
+        self._mark_sweep_started(len(domains))
 
-        for domain_entry in settings.get('domains', []):
+        for domain_entry in domains:
             # Reset per iteration: the outer except reads `domain` to publish
             # certificate_failed, and a leftover value from the previous entry
             # would attribute the failure to the wrong certificate.
@@ -3319,6 +3323,13 @@ class CertificateManager:
                 # per run, so populating _certificate_info_cache would only
                 # add a deepcopy-on-set with no possible read hit.
                 summary['checked'] += 1
+                if summary['checked'] % self.SWEEP_PROGRESS_EVERY == 0:
+                    # Roughly where the sweep is, so a process that dies here
+                    # leaves a record of how far it got. Every tenth, not
+                    # every one: the marker must not cost the same order as
+                    # the work it describes.
+                    self._mark_sweep_progress(
+                        summary['checked'], len(domains), started)
                 cert_info = self.get_certificate_info(domain, settings=settings, use_cache=False)
 
                 if cert_info and cert_info.get('needs_renewal'):
@@ -3372,14 +3383,127 @@ class CertificateManager:
                 summary['skipped_invalid'],
                 'y' if summary['skipped_invalid'] == 1 else 'ies',
             )
+        duration = time.time() - started
+        summary['duration_seconds'] = round(duration, 2)
+        summary['examined'] = (
+            summary['checked'] + summary['skipped_disabled']
+            + summary['skipped_invalid'])
+        self._mark_sweep_finished(summary, duration)
         logger.info(
-            "Renewal check complete: %d checked, %d renewed, %d failed, "
-            "%d disabled, %d invalid, %d not-due",
+            "Renewal check complete in %.1fs: %d checked, %d renewed, "
+            "%d failed, %d disabled, %d invalid, %d not-due",
+            duration,
             summary['checked'], summary['renewed'], summary['failed'],
             summary['skipped_disabled'], summary['skipped_invalid'],
             summary['skipped_not_due'],
         )
         return summary
+
+    # ------------------------------------------------------------------
+    # Renewal sweep progress
+    # ------------------------------------------------------------------
+    #
+    # The sweep counted what it did and logged the counts, and that was the
+    # whole of its self-knowledge: no duration, nothing exported, and no way to
+    # tell "finished, with nothing due" from "died half way through". An
+    # instance whose sweep is taking longer every night — and will eventually
+    # stop finishing between runs — looked exactly like one that was fine,
+    # right up until certificates stopped renewing.
+    #
+    # Two artefacts fix that, and neither needs a capacity number to be chosen
+    # in advance. A small marker file records that a sweep is in progress and
+    # how far it has got, so the NEXT sweep can say the previous one did not
+    # finish and where it stopped. Four gauges make the same thing a graph.
+    #
+    # What this deliberately does not do is resume from where the last one
+    # stopped. Renewal is idempotent and ordered by settings.json, so a rerun
+    # from the start re-examines cheap not-due entries rather than losing work;
+    # reordering the sweep to resume would be a behaviour change for a problem
+    # nobody has reported yet. Recording the stopping point is what makes that
+    # decision possible later, with evidence.
+
+    SWEEP_PROGRESS_EVERY = 10
+
+    def _sweep_marker_path(self) -> Path:
+        return self.cert_dir.parent / 'data' / 'renewal_sweep.json'
+
+    def _report_unfinished_sweep(self) -> None:
+        """Say so if the previous sweep never reached the end.
+
+        Called at the start of a sweep, because that is the first moment
+        anyone is in a position to notice: the process that failed to finish
+        is by definition not around to report it.
+        """
+        marker = self._sweep_marker_path()
+        try:
+            if not marker.exists():
+                return
+            previous = json.loads(marker.read_text(encoding='utf-8'))
+        except (OSError, ValueError):
+            return
+        if not isinstance(previous, dict) or previous.get('finished'):
+            return
+
+        started_at = previous.get('started_at')
+        ago = ('%.0f minutes' % ((time.time() - started_at) / 60)
+               if isinstance(started_at, (int, float)) else 'an unknown time')
+        logger.warning(
+            "The previous renewal sweep did not finish. It started %s ago and "
+            "had examined %s of %s certificate(s). Either the process was "
+            "stopped mid-sweep, or the sweep is taking longer than the "
+            "interval between runs — which ends with certificates not being "
+            "renewed. certmate_renewal_sweep_duration_seconds is the number "
+            "to watch.",
+            ago, previous.get('examined', '?'), previous.get('total', '?'))
+        self._safe_metric(lambda c: c.record_renewal_sweep_unfinished())
+
+    def _mark_sweep_started(self, total: int) -> None:
+        self._write_sweep_marker(
+            {'started_at': time.time(), 'total': total, 'examined': 0,
+             'finished': False})
+
+    def _mark_sweep_progress(self, examined: int, total: int,
+                             started_at: float) -> None:
+        """Update the marker every SWEEP_PROGRESS_EVERY certificates.
+
+        Not on every one: the point is to know roughly where a stopped sweep
+        got to, and a write per certificate would put the marker's cost in the
+        same order as the work it is describing.
+        """
+        self._write_sweep_marker(
+            {'started_at': started_at, 'total': total, 'examined': examined,
+             'finished': False})
+
+    def _mark_sweep_finished(self, summary: dict, duration: float) -> None:
+        completed_at = time.time()
+        self._write_sweep_marker({
+            'started_at': completed_at - duration,
+            'completed_at': completed_at,
+            'total': summary.get('examined', 0),
+            'examined': summary.get('examined', 0),
+            'duration_seconds': round(duration, 2),
+            'finished': True,
+        })
+        self._safe_metric(lambda c: c.record_renewal_sweep(
+            summary.get('examined', 0), duration, completed_at))
+
+    def _write_sweep_marker(self, record: dict) -> None:
+        """Never raises. A telemetry file that cannot be written must not stop
+        certificates from renewing — which is the one thing this is for."""
+        marker = self._sweep_marker_path()
+        try:
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            self._atomic_json_write(marker, record)
+        except Exception as e:
+            logger.debug("Could not write the renewal sweep marker: %s", e)
+
+    @staticmethod
+    def _safe_metric(emit) -> None:
+        try:
+            from .metrics import metrics_collector
+            emit(metrics_collector)
+        except Exception:  # pragma: no cover - defensive
+            logger.debug("Could not record a renewal sweep metric")
 
     def create_certificate_legacy(self, domain, email, cloudflare_token):
         """Legacy function for backward compatibility"""

--- a/modules/core/metrics.py
+++ b/modules/core/metrics.py
@@ -172,6 +172,38 @@ certificate_renewal_duration = Histogram(
     buckets=[30, 60, 120, 300, 600, 1200, 3600]
 )
 
+# The nightly renewal sweep, as a graph rather than as an inference.
+#
+# The sweep counted what it did and logged the counts, but nothing recorded how
+# long it took and nothing was exported — so an instance whose sweep was taking
+# longer every night, and would eventually stop finishing between runs, looked
+# exactly like one that was fine. These four series make "past capacity" visible
+# before it becomes "certificates stopped renewing".
+#
+# Gauges, not counters: the question is always about the LAST sweep. A counter
+# would answer "how much work since the process started", which nobody asks.
+renewal_sweep_duration = Gauge(
+    'certmate_renewal_sweep_duration_seconds',
+    'How long the last renewal sweep took'
+)
+
+renewal_sweep_examined = Gauge(
+    'certmate_renewal_sweep_certificates_examined',
+    'How many certificates the last renewal sweep looked at'
+)
+
+renewal_sweep_completed_at = Gauge(
+    'certmate_renewal_sweep_completed_timestamp_seconds',
+    'Unix time the last renewal sweep finished. Stops moving when the sweep '
+    'stops finishing, which is the signal a duration alone cannot give'
+)
+
+renewal_sweep_unfinished = Gauge(
+    'certmate_renewal_sweep_unfinished',
+    '1 when a sweep started and did not reach the end (the process died, or '
+    'it was still running when the next one began), else 0'
+)
+
 # ACME/Let's Encrypt metrics
 acme_errors_total = Counter(
     'certmate_acme_errors_total',
@@ -475,6 +507,18 @@ class CertMateMetricsCollector:
             status=status
         ).inc()
     
+    def record_renewal_sweep(self, examined: int, duration: float,
+                             completed_at: float):
+        """Record the shape of a renewal sweep that finished."""
+        renewal_sweep_examined.set(examined)
+        renewal_sweep_duration.set(duration)
+        renewal_sweep_completed_at.set(completed_at)
+        renewal_sweep_unfinished.set(0)
+
+    def record_renewal_sweep_unfinished(self):
+        """A previous sweep started and never reached the end."""
+        renewal_sweep_unfinished.set(1)
+
     def record_certificate_creation_time(self, dns_provider: str, duration: float):
         """Record certificate creation duration."""
         certificate_creation_duration.labels(dns_provider=dns_provider).observe(duration)

--- a/tests/test_check_renewals_summary.py
+++ b/tests/test_check_renewals_summary.py
@@ -48,7 +48,9 @@ def test_summary_counts_every_kind_of_entry(tmp_path):
 
     summary = mgr.check_renewals()
 
-    assert summary == {
+    counts = {k: v for k, v in summary.items()
+              if k not in ('duration_seconds', 'examined')}
+    assert counts == {
         'checked': 2,           # good.com + fresh.com
         'renewed': 1,           # good.com
         'failed': 0,
@@ -56,6 +58,13 @@ def test_summary_counts_every_kind_of_entry(tmp_path):
         'skipped_invalid': 3,   # empty, dict-without-domain, int
         'skipped_not_due': 0,   # certbot didn't report any "not yet due" no-op
     }
+    # The sweep also reports its own shape now — how long it took and how many
+    # entries it looked at — so an instance that is slowly outgrowing its
+    # schedule is visible before it stops finishing. Excluded above rather than
+    # pinned here: this test is about the counting, and those two are covered
+    # by tests/test_the_renewal_sweep_says_what_it_did.py.
+    assert summary['duration_seconds'] >= 0
+    assert summary['examined'] == 6   # 2 checked + 1 disabled + 3 invalid
     mgr.renew_certificate.assert_called_once_with('good.com')
 
 

--- a/tests/test_the_renewal_sweep_says_what_it_did.py
+++ b/tests/test_the_renewal_sweep_says_what_it_did.py
@@ -1,0 +1,259 @@
+"""An instance past its capacity has to say so before certificates stop.
+
+The nightly sweep counted what it did and logged the counts. That was the whole
+of its self-knowledge: no duration, nothing exported, and no way to tell
+"finished, nothing was due" from "died half way through". So an instance whose
+sweep takes longer every night — and will eventually stop finishing between
+runs — looked exactly like one that was fine, right up until certificates
+stopped renewing.
+
+Two artefacts, and neither needs a capacity number to be chosen in advance:
+
+* a marker file recording that a sweep is in progress and roughly how far it
+  has got, so the NEXT sweep can report that the previous one never finished
+  and where it stopped — the failing process is by definition not around to
+  report itself;
+* four gauges, so the same thing is a graph:
+  `certmate_renewal_sweep_duration_seconds`, `..._certificates_examined`,
+  `..._completed_timestamp_seconds` and `..._unfinished`. The timestamp is the
+  one a duration cannot replace: it stops moving when the sweep stops
+  finishing.
+
+What this deliberately does not do is *resume* from the stopping point.
+Renewal is idempotent and ordered by settings.json, so a rerun re-examines
+cheap not-due entries rather than losing work; reordering the sweep would be a
+behaviour change for a problem nobody has reported. Recording where it stopped
+is what makes that decision possible later, with evidence.
+"""
+import json
+import logging
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.certificates import CertificateManager
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def manager(tmp_path):
+    settings = MagicMock()
+    settings.load_settings.return_value = {'auto_renew': True, 'domains': []}
+    settings.migrate_domains_format.side_effect = lambda s: s
+    mgr = CertificateManager(tmp_path / 'certificates', settings,
+                             dns_manager=None)
+    return mgr
+
+
+def _with_domains(manager, names):
+    stored = {'auto_renew': True,
+              'domains': [{'domain': n, 'auto_renew': True} for n in names]}
+    manager.settings_manager.load_settings.return_value = stored
+    manager.settings_manager.migrate_domains_format.side_effect = lambda s: s
+    manager.get_certificate_info = MagicMock(
+        return_value={'needs_renewal': False, 'dns_provider': 'cloudflare'})
+
+
+def _marker(manager):
+    path = manager._sweep_marker_path()
+    return json.loads(path.read_text()) if path.exists() else None
+
+
+# --- the sweep reports its own shape ------------------------------------
+
+def test_the_summary_carries_the_duration_and_the_count(manager):
+    _with_domains(manager, [f'd{i}.example.com' for i in range(5)])
+    summary = manager.check_renewals()
+
+    assert summary['examined'] == 5
+    assert 'duration_seconds' in summary
+    assert summary['duration_seconds'] >= 0
+
+
+def test_completion_is_logged_with_the_duration(manager, caplog):
+    _with_domains(manager, ['a.example.com'])
+    with caplog.at_level(logging.INFO):
+        manager.check_renewals()
+
+    assert any('Renewal check complete in' in r.getMessage()
+               for r in caplog.records), (
+        'the completion line does not say how long the sweep took, which is '
+        'the number that grows before anything breaks'
+    )
+
+
+def test_the_start_says_how_much_work_there_is(manager, caplog):
+    """CONTROL for the pair: a duration is only readable next to a count."""
+    _with_domains(manager, [f'd{i}.example.com' for i in range(3)])
+    with caplog.at_level(logging.INFO):
+        manager.check_renewals()
+
+    assert any('3 certificate' in r.getMessage() for r in caplog.records)
+
+
+def test_the_metrics_are_recorded_on_completion(manager, monkeypatch):
+    recorded = {}
+    monkeypatch.setattr(
+        'modules.core.metrics.metrics_collector.record_renewal_sweep',
+        lambda examined, duration, completed_at: recorded.update(
+            examined=examined, duration=duration, completed_at=completed_at))
+
+    _with_domains(manager, ['a.example.com', 'b.example.com'])
+    manager.check_renewals()
+
+    assert recorded['examined'] == 2
+    assert recorded['duration'] >= 0
+    assert recorded['completed_at'] > time.time() - 60
+
+
+# --- a sweep that never finished ----------------------------------------
+
+def test_an_unfinished_sweep_is_reported_by_the_next_one(manager, caplog):
+    """The failing process cannot report itself. The marker is how the next
+    sweep finds out."""
+    marker = manager._sweep_marker_path()
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(json.dumps({
+        'started_at': time.time() - 3600, 'total': 400, 'examined': 130,
+        'finished': False}))
+
+    _with_domains(manager, ['a.example.com'])
+    with caplog.at_level(logging.WARNING):
+        manager.check_renewals()
+
+    warnings = [r.getMessage() for r in caplog.records
+                if r.levelno >= logging.WARNING]
+    assert any('did not finish' in m for m in warnings), (
+        'a sweep that died half way through left no signal for the next one'
+    )
+    said = next(m for m in warnings if 'did not finish' in m)
+    assert '130' in said and '400' in said, (
+        f'the warning does not say how far it got: {said}'
+    )
+    assert 'duration_seconds' in said, (
+        'the warning does not name the metric to watch'
+    )
+
+
+def test_a_finished_sweep_is_not_reported_as_unfinished(manager, caplog):
+    """CONTROL: a warning after every successful night is a warning nobody
+    reads, and it would fire on every single run."""
+    _with_domains(manager, ['a.example.com'])
+    manager.check_renewals()
+
+    with caplog.at_level(logging.WARNING):
+        manager.check_renewals()
+
+    assert not [r for r in caplog.records
+                if 'did not finish' in r.getMessage()]
+
+
+def test_the_unfinished_gauge_is_set_and_then_cleared(manager, monkeypatch):
+    flags = []
+    monkeypatch.setattr(
+        'modules.core.metrics.metrics_collector.record_renewal_sweep_unfinished',
+        lambda: flags.append('unfinished'))
+    monkeypatch.setattr(
+        'modules.core.metrics.metrics_collector.record_renewal_sweep',
+        lambda examined, duration, completed_at: flags.append('finished'))
+
+    marker = manager._sweep_marker_path()
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(json.dumps({'started_at': time.time() - 60,
+                                  'total': 10, 'examined': 4,
+                                  'finished': False}))
+    _with_domains(manager, ['a.example.com'])
+    manager.check_renewals()
+
+    assert flags == ['unfinished', 'finished'], (
+        'the unfinished flag must be raised by the next sweep and cleared '
+        'when that sweep completes'
+    )
+
+
+def test_the_marker_records_progress_part_way_through(manager):
+    """What makes "where it stopped" answerable at all."""
+    seen = []
+    _with_domains(manager, [f'd{i}.example.com' for i in range(25)])
+    real = manager.get_certificate_info
+
+    def spy(domain, **kw):
+        seen.append(_marker(manager))
+        return real(domain, **kw)
+
+    manager.get_certificate_info = spy
+    manager.check_renewals()
+
+    part_way = [m for m in seen if m and not m['finished'] and m['examined']]
+    assert part_way, (
+        'the marker never recorded progress, so a sweep that died would only '
+        'be known to have started'
+    )
+    assert max(m['examined'] for m in part_way) >= 20
+    assert all(m['total'] == 25 for m in part_way)
+
+
+def test_the_marker_is_left_finished_after_a_clean_run(manager):
+    _with_domains(manager, ['a.example.com'])
+    manager.check_renewals()
+
+    marker = _marker(manager)
+    assert marker['finished'] is True
+    assert marker['examined'] == 1
+    assert marker['duration_seconds'] >= 0
+
+
+# --- telemetry must never be the reason a renewal stops -----------------
+
+def test_a_marker_that_cannot_be_written_does_not_stop_the_sweep(manager,
+                                                                 monkeypatch):
+    """A read-only data volume is a real deployment, and telemetry must never
+    be the reason certificates stop renewing — which is the one thing this
+    whole mechanism exists to warn about."""
+    monkeypatch.setattr(
+        CertificateManager, '_atomic_json_write',
+        staticmethod(lambda path, data: (_ for _ in ()).throw(
+            OSError('read-only file system'))))
+    _with_domains(manager, ['a.example.com'])
+
+    summary = manager.check_renewals()
+
+    assert summary['checked'] == 1, 'a failed marker write aborted the sweep'
+    assert _marker(manager) is None, 'the marker was written after all'
+
+
+def test_a_corrupt_marker_is_ignored_rather_than_believed(manager, caplog):
+    marker = manager._sweep_marker_path()
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text('{not json')
+
+    _with_domains(manager, ['a.example.com'])
+    with caplog.at_level(logging.WARNING):
+        summary = manager.check_renewals()
+
+    assert summary['checked'] == 1
+    assert not [r for r in caplog.records
+                if 'did not finish' in r.getMessage()], (
+        'an unreadable marker was read as evidence of a failed sweep'
+    )
+
+
+def test_a_failing_metric_does_not_stop_the_sweep(manager, monkeypatch):
+    monkeypatch.setattr(
+        'modules.core.metrics.metrics_collector.record_renewal_sweep',
+        lambda *a, **kw: (_ for _ in ()).throw(RuntimeError('collector gone')))
+    _with_domains(manager, ['a.example.com'])
+
+    assert manager.check_renewals()['checked'] == 1
+
+
+def test_the_globally_disabled_path_is_untouched(manager):
+    """CONTROL: with auto_renew off the sweep returns early and must not
+    leave a marker claiming a sweep ran."""
+    manager.settings_manager.load_settings.return_value = {'auto_renew': False}
+    summary = manager.check_renewals()
+
+    assert summary.get('auto_renew_disabled') is True
+    assert _marker(manager) is None


### PR DESCRIPTION
## The gap

The nightly sweep counted what it did and logged the counts. That was the whole
of its self-knowledge: **no duration, nothing exported, and no way to tell
"finished, nothing was due" from "died half way through"**.

So an instance whose sweep takes longer every night — and will eventually stop
finishing between runs — looked exactly like one that was fine, right up until
certificates stopped renewing.

## Two artefacts, neither needing a capacity number chosen in advance

**A marker file** (`data/renewal_sweep.json`) records that a sweep is in
progress and roughly how far it has got — updated every **tenth** certificate,
not every one: the point is to know where a stopped sweep got to, and a write
per certificate would cost the same order as the work it describes.

The **next** sweep reads it and reports what happened, because the process that
failed to finish is by definition not around to report itself:

```
The previous renewal sweep did not finish. It started 60 minutes ago and had
examined 130 of 400 certificate(s). Either the process was stopped mid-sweep,
or the sweep is taking longer than the interval between runs — which ends with
certificates not being renewed. certmate_renewal_sweep_duration_seconds is the
number to watch.
```

**Four gauges** make the same thing a graph:

| metric | what it answers |
|---|---|
| `certmate_renewal_sweep_duration_seconds` | is it getting slower? |
| `certmate_renewal_sweep_certificates_examined` | slower because there is more, or slower per certificate? |
| `certmate_renewal_sweep_completed_timestamp_seconds` | **is it still finishing at all?** |
| `certmate_renewal_sweep_unfinished` | did one start and never end? |

Gauges rather than counters: the question is always about the *last* sweep. The
completion timestamp is the one a duration cannot replace — it stops moving
when the sweep stops finishing, which is the actual symptom.

The summary and completion log now carry the duration and the number examined,
and the opening line says how much work there is, because a duration is only
readable next to a count.

## What this deliberately does not do

**Resume from the stopping point.** Renewal is idempotent and ordered by
`settings.json`, so a rerun re-examines cheap not-due entries rather than
losing work; reordering the sweep to resume would be a behaviour change for a
problem nobody has reported. Recording where it stopped is what makes that
decision possible later, with evidence rather than a guess.

## Telemetry never breaks renewal

The one thing this mechanism exists to warn about must not be caused by it.
Three tests, each a real deployment:

- an **unwritable marker** — a read-only data volume;
- a **corrupt marker** — must be ignored, not believed (it must not be read as
  evidence of a failed sweep);
- a **failing collector**.

In each case the sweep still completes and still renews.

## One existing test adapted

`test_check_renewals_summary` asserted the summary dict equalled an exact
literal. Its subject is the counting, which it still pins exactly; the two new
reporting fields are excluded there and covered in the new file.

## Checks run locally

- 13 new tests; `pytest -m "not ui"` — **4291 passed, 59 skipped**
- Verified by mutation: removing the unfinished-sweep report fails 2 tests
- `flake8` with CI's selector set, `C901` at the real max — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
