### PR TITLE
ops: a backup that cannot restore is not a restore point

### DIFF
--- a/README.md
+++ b/README.md
@@ -2414,18 +2414,32 @@ All notification channels support per-event filtering (created, renewed, expirin
 
 ### Downgrades & Recovery
 
-Downgrading to a version older than the one that wrote `settings.json` is not supported and may result in a broken configuration or loss of accounts. If you see a `DOWNGRADE DETECTED` message in the logs after rolling back, **restore the latest unified backup before using the UI**:
+Downgrading to a version older than the one that wrote `settings.json` is not supported and may result in a broken configuration or loss of accounts. If you see a `DOWNGRADE DETECTED` message in the logs after rolling back, **restore the most recent backup that can actually restore**.
+
+> **Not every backup is a restore point.** Unless `CERTMATE_BACKUP_PASSPHRASE`
+> was set when the backup was taken, automatic backups are written with secrets
+> masked and **cannot restore this instance** — they are configuration
+> snapshots. On an instance that has never had a passphrase set, the newest
+> archive is almost certainly one of those, so picking "the latest" by
+> timestamp picks one that will be refused. Ask the API which ones qualify: it
+> reports `can_restore` per archive, and `restore_blocked_reason` when it is
+> false.
 
 ```bash
-# List available backups inside the container
-docker exec certmate ls -lt /app/backups/unified/
+# Which backups can actually restore, newest first
+curl -s -H "Authorization: Bearer $API_TOKEN" http://localhost:8000/api/backups \
+  | jq -r '.unified[] | "\(.filename)  can_restore=\(.can_restore)  \(.restore_blocked_reason // "")"'
 
-# Restore the most recent one
+# Restore the newest one whose can_restore is true
 curl -H "Authorization: Bearer $API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"filename": "backup_YYYYMMDD_HHMMSS.zip", "create_backup_before_restore": true}' \
   http://localhost:8000/api/backups/restore/unified
 ```
+
+If nothing reports `can_restore: true`, this instance has no restore point.
+Set `CERTMATE_BACKUP_PASSPHRASE`, take a backup immediately, and keep a copy
+off this node — see [Backup and Recovery](#backup-and-recovery).
 
 If you have lost the admin password and cannot log in, use the emergency reset script (requires container shell access):
 

--- a/charts/certmate/README.md
+++ b/charts/certmate/README.md
@@ -41,6 +41,38 @@ settings store, the certificate inventory and the tamper-evident audit chain
 all live on disk. Disabling persistence without supplying
 `persistence.existingClaim` fails at template time.
 
+### Where the backups live
+
+By default `/app/backups` is a subPath of the same claim as the certificates,
+the settings store and the audit chain — the things the backups exist to
+recover. **One volume loss therefore destroys the data and its restore points
+together.** That is the default because a second claim is a real cost for a
+small install, and because where backups belong is a fact about your
+infrastructure rather than about CertMate.
+
+Two ways out, in increasing order of how much they actually protect you:
+
+```bash
+# 1. Its own claim. Survives losing the pod and the data volume's contents;
+#    a claim on the same storage class still shares a failure domain.
+helm upgrade certmate ... --set persistence.backups.separateClaim=true
+
+# 2. A claim on different storage that you manage.
+helm upgrade certmate ... \
+  --set persistence.backups.separateClaim=true \
+  --set persistence.backups.existingClaim=nfs-certmate-backups
+
+# 3. Off the cluster entirely: a CronJob copying /app/backups/unified out.
+#    The image and command are yours; the backup volume is mounted read-only
+#    so a misconfigured copy cannot damage what it is preserving.
+#    See persistence.backups.offsite in values.yaml for a worked rclone example.
+```
+
+**None of this makes a backup restorable.** Unless `CERTMATE_BACKUP_PASSPHRASE`
+is set, automatic backups are written with secrets masked and cannot restore
+the instance — copying those off-site preserves exactly that. Set the
+passphrase first; the API reports `can_restore` per archive.
+
 **The volume outlives the release.** The PVC carries
 `helm.sh/resource-policy: keep`, so `helm uninstall` leaves your certificates
 alone. Removing them is a deliberate `kubectl delete pvc`.
@@ -95,8 +127,11 @@ or run a controller that does it for you, such as
 | key | default | note |
 |---|---|---|
 | `image.tag` | chart `appVersion` | pin a digest for production |
-| `persistence.size` | `2Gi` | certificates, inventory, audit chain, backups |
+| `persistence.size` | `2Gi` | certificates, inventory, audit chain, and backups unless moved (below) |
 | `persistence.existingClaim` | `""` | bring your own volume |
+| `persistence.backups.separateClaim` | `false` | give `/app/backups` its own claim |
+| `persistence.backups.existingClaim` | `""` | a backup volume you manage — the one that actually leaves the failure domain |
+| `persistence.backups.offsite.enabled` | `false` | CronJob copying the archives somewhere else; you choose the image and command |
 | `env.behindProxy` | `true` | correct when traffic arrives via Ingress |
 | `env.gunicornTimeout` | `300` | raise for slow DNS providers |
 | `ingress.enabled` | `false` | |

--- a/charts/certmate/templates/_helpers.tpl
+++ b/charts/certmate/templates/_helpers.tpl
@@ -52,6 +52,23 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+The claim holding /app/backups. The main claim unless persistence.backups
+.separateClaim is on, in which case backups get a volume of their own so a
+loss of the primary does not take the restore points with it.
+*/}}
+{{- define "certmate.backupPvcName" -}}
+{{- if .Values.persistence.backups.separateClaim }}
+{{- if .Values.persistence.backups.existingClaim }}
+{{- .Values.persistence.backups.existingClaim }}
+{{- else }}
+{{- printf "%s-backups" (include "certmate.fullname" .) }}
+{{- end }}
+{{- else }}
+{{- include "certmate.pvcName" . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Refuse to render a configuration the application cannot survive.
 
 CertMate runs APScheduler inside the web process and gunicorn with a single

--- a/charts/certmate/templates/deployment.yaml
+++ b/charts/certmate/templates/deployment.yaml
@@ -102,13 +102,26 @@ spec:
             - name: data
               mountPath: /app/logs
               subPath: logs
+            {{- if .Values.persistence.backups.separateClaim }}
+            # Backups on their own claim, so losing the primary volume does
+            # not take the restore points with it. No subPath: the claim
+            # exists for this and nothing else.
+            - name: backups
+              mountPath: /app/backups
+            {{- else }}
             - name: data
               mountPath: /app/backups
               subPath: backups
+            {{- end }}
       volumes:
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "certmate.pvcName" . }}
+        {{- if .Values.persistence.backups.separateClaim }}
+        - name: backups
+          persistentVolumeClaim:
+            claimName: {{ include "certmate.backupPvcName" . }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/certmate/templates/offsite-backup-cronjob.yaml
+++ b/charts/certmate/templates/offsite-backup-cronjob.yaml
@@ -1,0 +1,69 @@
+{{- if and .Values.persistence.enabled .Values.persistence.backups.offsite.enabled }}
+{{/*
+Copy the restore points somewhere the cluster's storage failure does not reach.
+
+The README has always said "keep a copy off the host". This turns that
+instruction into something an operator can apply rather than design — but it
+deliberately stops short of choosing a destination: `image` and `command` are
+yours, because where your backups belong is a fact about your infrastructure,
+not about CertMate.
+
+Two things it does decide, because getting them wrong is easy:
+
+* the backup volume is mounted READ-ONLY, so a misconfigured copy command can
+  never damage what it is copying;
+* it runs as the same non-root user as the application, so it can read files
+  the application wrote.
+
+A copy is not a restore point on its own. Unless CERTMATE_BACKUP_PASSPHRASE was
+set when the archive was written, it is a share-safe snapshot with the secrets
+masked and cannot restore the instance — copying it off-site preserves exactly
+that. See the README's Backup and Recovery section.
+*/}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "certmate.fullname" . }}-offsite-backup
+  labels: {{- include "certmate.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.persistence.backups.offsite.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels: {{- include "certmate.selectorLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: {{ .Values.persistence.backups.offsite.restartPolicy }}
+          {{- with .Values.podSecurityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: offsite-backup
+              image: {{ .Values.persistence.backups.offsite.image | quote }}
+              {{- with .Values.persistence.backups.offsite.command }}
+              args: {{- toYaml . | nindent 16 }}
+              {{- end }}
+              {{- with .Values.persistence.backups.offsite.env }}
+              env: {{- toYaml . | nindent 16 }}
+              {{- end }}
+              {{- with .Values.persistence.backups.offsite.resources }}
+              resources: {{- toYaml . | nindent 16 }}
+              {{- end }}
+              volumeMounts:
+                # Read-only: a copy job must never be able to damage the
+                # archives it exists to preserve.
+                - name: backups
+                  mountPath: /app/backups
+                  readOnly: true
+                  {{- if not .Values.persistence.backups.separateClaim }}
+                  subPath: backups
+                  {{- end }}
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: {{ include "certmate.backupPvcName" . }}
+                readOnly: true
+{{- end }}

--- a/charts/certmate/templates/pvc.yaml
+++ b/charts/certmate/templates/pvc.yaml
@@ -21,3 +21,28 @@ spec:
   storageClassName: {{ .Values.persistence.storageClass }}
   {{- end }}
 {{- end }}
+{{- if and .Values.persistence.enabled .Values.persistence.backups.separateClaim (not .Values.persistence.backups.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "certmate.backupPvcName" . }}
+  labels: {{- include "certmate.labels" . | nindent 4 }}
+  annotations:
+    # The restore points. Kept when the release goes away for the same reason
+    # as the data volume, and more so: this is what is left if the other one
+    # is gone.
+    helm.sh/resource-policy: keep
+    {{- with .Values.persistence.backups.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.backups.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.backups.size }}
+  {{- if .Values.persistence.backups.storageClass }}
+  storageClassName: {{ .Values.persistence.backups.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/certmate/values.yaml
+++ b/charts/certmate/values.yaml
@@ -37,16 +37,65 @@ ingress:
   tls: []
 
 persistence:
-  # Certificates, the settings/inventory/audit store, logs and backups all
-  # live on one volume under separate subPaths. One ReadWriteOnce claim is
-  # both simpler and more honest than four: the app is single-instance, so
-  # there is nothing to share.
+  # Certificates, the settings/inventory/audit store and logs live on one
+  # volume under separate subPaths. One ReadWriteOnce claim is both simpler
+  # and more honest than three: the app is single-instance, so there is
+  # nothing to share.
   enabled: true
   existingClaim: ""
   storageClass: ""
   accessMode: ReadWriteOnce
   size: 2Gi
   annotations: {}
+
+  # Backups, by default, live on that same volume — which means one volume
+  # loss destroys the data AND the copies that exist to recover it. That is
+  # the default because a second claim is a real cost for a small install,
+  # and because putting backups somewhere else is a decision about YOUR
+  # infrastructure that this chart cannot make.
+  #
+  # Enable this to give /app/backups its own claim, so the primary volume's
+  # failure does not reach the restore points. A separate claim on the same
+  # storage class still shares a failure domain: point `existingClaim` at a
+  # volume on different storage, or use the CronJob below, if the threat you
+  # care about is losing the storage rather than losing the pod.
+  #
+  # Neither of these is off-site. The archive worth keeping is the one made
+  # with CERTMATE_BACKUP_PASSPHRASE set — without it, automatic backups are
+  # written with secrets masked and cannot restore the instance at all. See
+  # the README's Backup and Recovery section before relying on any of this.
+  backups:
+    separateClaim: false
+    existingClaim: ""
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    annotations: {}
+
+    # A CronJob that copies /app/backups/unified somewhere the cluster's
+    # storage failure does not reach. Off by default and deliberately not
+    # opinionated about the destination: `image` and `command` are yours.
+    #
+    # The example below is what most people want — rclone to object storage,
+    # with the remote's credentials in a Secret you create. It reads the
+    # backup volume ReadOnlyMany, so it cannot corrupt what it is copying.
+    offsite:
+      enabled: false
+      schedule: "17 3 * * *"
+      image: rclone/rclone:1.71.2
+      # Everything after `--` is passed to the image's entrypoint.
+      command: []
+      #  - copy
+      #  - /app/backups/unified
+      #  - remote:certmate-backups
+      env: []
+      #  - name: RCLONE_CONFIG_REMOTE_TYPE
+      #    value: s3
+      #  - name: RCLONE_CONFIG_REMOTE_ACCESS_KEY_ID
+      #    valueFrom:
+      #      secretKeyRef: {name: certmate-offsite, key: access-key}
+      restartPolicy: OnFailure
+      resources: {}
 
 # Values that belong in a Secret. Leave them empty and CertMate generates what
 # it can on first boot; set them for reproducible deployments.

--- a/tests/test_helm_chart.py
+++ b/tests/test_helm_chart.py
@@ -150,3 +150,94 @@ class TestSecretWiring:
             "the secretRef is optional again — a non-existent Secret would let "
             "the pod start without its credentials"
         )
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm is not installed")
+class TestBackupPlacement:
+    """Backups must be able to live somewhere the primary volume's failure
+    does not reach.
+
+    The chart put `/app/backups` on the same claim as the certificates, the
+    settings store and the audit chain — the things the backups exist to
+    recover — so one volume loss destroyed the data and its restore points
+    together. That stays the default, because a second claim is a real cost
+    for a small install and because where backups belong is a fact about the
+    operator's infrastructure, not about CertMate. What changed is that it is
+    now a decision with an off switch rather than the only shape available.
+    """
+
+    def _template(self, *args):
+        return subprocess.run(
+            ["helm", "template", "t", str(CHART), *args],
+            capture_output=True, text=True,
+        )
+
+    def test_the_default_is_unchanged(self):
+        """Existing installs must render exactly as before: one claim, and
+        backups on it under a subPath."""
+        out = self._template().stdout
+        assert out.count("kind: PersistentVolumeClaim") == 1
+        assert "kind: CronJob" not in out
+        backups = out.split("mountPath: /app/backups")[1][:80]
+        assert "subPath: backups" in backups, (
+            "the default no longer puts backups on the shared volume under a "
+            "subPath, which silently relocates every existing install's "
+            "restore points"
+        )
+
+    def test_a_separate_claim_moves_the_backups_off_the_data_volume(self):
+        res = self._template("--set", "persistence.backups.separateClaim=true")
+        assert res.returncode == 0, res.stderr
+        assert res.stdout.count("kind: PersistentVolumeClaim") == 2
+        mount = res.stdout.split("mountPath: /app/backups")[1][:80]
+        assert "subPath" not in mount, (
+            "backups are on their own claim but still mounted under a "
+            "subPath, so they would land in a subdirectory of an empty volume"
+        )
+        assert "t-certmate-backups" in res.stdout
+
+    def test_an_existing_backup_claim_is_used_without_creating_one(self):
+        """The case that actually gets backups out of the failure domain:
+        a claim the operator made on different storage."""
+        res = self._template(
+            "--set", "persistence.backups.separateClaim=true",
+            "--set", "persistence.backups.existingClaim=nfs-backups")
+        assert res.returncode == 0, res.stderr
+        assert "claimName: nfs-backups" in res.stdout
+        assert res.stdout.count("kind: PersistentVolumeClaim") == 1
+
+    def test_the_backup_claim_survives_an_uninstall(self):
+        """It is what is left when the other volume is gone, so deleting it
+        with the release would defeat the whole point."""
+        res = self._template("--set", "persistence.backups.separateClaim=true")
+        pvcs = [doc for doc in res.stdout.split("---")
+                if "kind: PersistentVolumeClaim" in doc]
+        assert len(pvcs) == 2
+        assert all("helm.sh/resource-policy: keep" in doc for doc in pvcs)
+
+    def test_the_offsite_job_reads_the_backups_read_only(self):
+        """A copy job must never be able to damage the archives it exists to
+        preserve."""
+        res = self._template(
+            "--set", "persistence.backups.offsite.enabled=true",
+            "--set", "persistence.backups.offsite.command={copy,/app/backups,r:x}")
+        assert res.returncode == 0, res.stderr
+        assert "kind: CronJob" in res.stdout
+        job = res.stdout.split("kind: CronJob")[1]
+        assert "readOnly: true" in job
+
+    def test_the_offsite_job_follows_the_backup_claim(self):
+        """With a separate claim it must mount that one, and without the
+        subPath the shared layout needs."""
+        res = self._template(
+            "--set", "persistence.backups.separateClaim=true",
+            "--set", "persistence.backups.offsite.enabled=true",
+            "--set", "persistence.backups.offsite.command={copy,/app/backups,r:x}")
+        job = res.stdout.split("kind: CronJob")[1]
+        assert "t-certmate-backups" in job
+        assert "subPath" not in job
+
+    def test_no_offsite_job_without_being_asked_for(self):
+        """CONTROL: a CronJob nobody configured would run an image nobody
+        chose, on a schedule nobody set."""
+        assert "kind: CronJob" not in self._template().stdout


### PR DESCRIPTION
Two findings about the same thing: the gap between what the recovery
instructions say and what an operator following them would actually get.

## 1. The runbook told you to restore a backup that will be refused

The Downgrades & Recovery section said *"restore the latest unified backup"*
and showed `ls -lt` to pick it.

Unless `CERTMATE_BACKUP_PASSPHRASE` was set **when the backup was taken**,
automatic backups are written with secrets masked and **cannot restore the
instance** — they are configuration snapshots. So on an install that never set
a passphrase, the newest archive is almost certainly one the restore path will
refuse, and the runbook walked the operator straight into it during the one
procedure where they are already having a bad day.

The listing has reported `can_restore` per archive since #655. Only the runbook
did not point at it:

```bash
# Which backups can actually restore, newest first
curl -s -H "Authorization: Bearer $API_TOKEN" http://localhost:8000/api/backups \
  | jq -r '.unified[] | "\(.filename)  can_restore=\(.can_restore)  \(.restore_blocked_reason // "")"'
```

…plus the sentence that has to be there: **if nothing reports
`can_restore: true`, this instance has no restore point.**

## 2. The chart kept the backups on the volume they exist to recover

`/app/backups` was a subPath of the same claim as the certificates, the
settings store and the audit chain. One volume loss destroyed the data **and**
its restore points together.

**That stays the default**, deliberately: a second claim is a real cost for a
small install, and where backups belong is a fact about the operator's
infrastructure, not about CertMate. What changed is that it is now a decision
with an off switch rather than the only shape available — in three steps of
increasing protection:

| | what it survives |
|---|---|
| `persistence.backups.separateClaim` | losing the pod and the data volume's contents. A claim on the same storage class is still one failure domain. |
| `persistence.backups.existingClaim` | losing that storage — a claim you made somewhere else |
| `persistence.backups.offsite` | losing the cluster |

The CronJob deliberately does **not** choose a destination — image and command
are yours — but it decides two things that are easy to get wrong: the backup
volume is mounted **read-only**, so a misconfigured copy command can never
damage the archives it exists to preserve; and it runs under the same pod
security context as the app, so it can read what the app wrote. `values.yaml`
carries a worked rclone example.

## The default render is asserted unchanged

Silently relocating an existing install's restore points would be a worse
outcome than the one being fixed, so there is a test that the default still
produces **one** claim, **no** CronJob, and `/app/backups` mounted under
`subPath: backups` exactly as before.

Both claims carry `helm.sh/resource-policy: keep` — the backup volume more so
than the other, since it is what is left when the other one is gone.

## None of this makes a backup restorable

Copying a masked archive off-site preserves exactly a masked archive. The chart
README says so where an operator will read it, next to the switch.

## Checks run locally

- 7 new chart tests (22 in the file); `pytest -m "not ui"` — **4299 passed, 59 skipped**
- `helm lint` clean; all three configurations rendered and inspected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
