### PR TITLE
obs: give every unit of work an id, including the ones that are not requests

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -31,6 +31,7 @@ from cryptography import x509
 from .shell import ShellExecutor
 from .dns_strategies import DNSStrategyFactory, HTTP01Strategy, acme_webroot_dir, check_certbot_plugin_installed
 from .constants import METADATA_SCHEMA_VERSION, CERTIFICATE_FILES, DEFAULT_RENEWAL_THRESHOLD_DAYS
+from .structured_logging import LogContext, new_correlation_id
 from .csr_issuance import (
     CSR_OUTPUT_DIRNAME, CSR_OUTPUT_FILES, CSRError, csr_domains,
     csr_fingerprint, read_csr, to_csr_command,
@@ -3261,7 +3262,24 @@ class CertificateManager:
         debug-level one), so a typo in settings.json could quietly exclude a
         domain from renewal forever; every skip and failure is now counted
         and logged.
+
+        The sweep runs under one correlation id, which every line it produces
+        carries — including the deploy hooks it triggers, because the event
+        bus hands the id across the thread boundary. Scheduled work had no
+        identifier at all, so a renewal and its deploy were two unrelated sets
+        of log lines and the only way to associate them was the clock, on a
+        run where dozens of certificates renew inside the same minute.
+
+        A wrapper rather than a `with` around the body: the body is long and
+        already deeply nested, and `with` guarantees the release on every exit
+        path — a leaked context would tag every later job on this scheduler
+        thread with a stale sweep id, which is worse than no id at all.
         """
+        with LogContext(request_id=new_correlation_id(),
+                        operation='renewal_sweep'):
+            return self._check_renewals()
+
+    def _check_renewals(self):
         settings = self.settings_manager.load_settings()
 
         if not settings.get('auto_renew', True):

--- a/modules/core/events.py
+++ b/modules/core/events.py
@@ -9,9 +9,20 @@ import os
 import queue
 import time
 import threading
+from contextlib import contextmanager
 from typing import Optional, Dict, Any
 
+from .structured_logging import current_correlation_id
+
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _nothing():
+    """A do-nothing context, for work published outside any correlated unit —
+    a manual publish from a shell, say. Entering LogContext(request_id=None)
+    would set the field to null and hide an id an outer context had set."""
+    yield
 
 
 # How many listener invocations run at once. A listener can be slow on
@@ -91,10 +102,18 @@ class EventBus:
             self._workers.append(worker)
 
     def _dispatch_forever(self) -> None:
+        from .structured_logging import LogContext
         while True:
-            listener, event, data = self._work.get()
+            listener, event, data, correlation_id = self._work.get()
             try:
-                listener(event, data)
+                # contextvars do NOT cross a thread boundary — a worker starts
+                # with an empty context, not a copy of the publisher's — so
+                # the id is carried in the queued item and re-entered here.
+                # Without this a renewal and the deploy it triggered are two
+                # unrelated sets of log lines.
+                with LogContext(request_id=correlation_id) if correlation_id \
+                        else _nothing():
+                    listener(event, data)
             except Exception as e:
                 # A listener that raises must not take the worker with it, or
                 # the pool bleeds capacity one bad event at a time until
@@ -173,8 +192,9 @@ class EventBus:
         self._ensure_workers()
 
         payload = message.get('data', {})
+        correlation_id = current_correlation_id()
         for listener in listeners:
-            self._work.put((listener, event, payload))
+            self._work.put((listener, event, payload, correlation_id))
 
         backlog = self._work.qsize()
         if backlog >= BACKLOG_WARN_AT and not self._backlog_warned:

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -1274,6 +1274,67 @@ def setup_error_handlers(app):
         }), 500
 
 
+def setup_correlation_ids(app):
+    """Give every request an id, and put it in every log line it produces.
+
+    The structured logger has always had a `request_id` field and a LogContext
+    to fill it. Nothing ever set either: the field was read off `g.request_id`,
+    which no code assigned, and the slow-request watchdog took the raw
+    `X-Request-Id` header — so on the overwhelmingly common case of a caller
+    that sends no such header, every log line carried `request_id: null` and
+    two lines from the same request could not be told from two lines from
+    different ones.
+
+    Three decisions here, none of them obvious:
+
+    * a caller-supplied id is honoured, because the point of the header is to
+      let a caller stitch its logs to ours — but only if it is an opaque token
+      (see clean_correlation_id). An id reaches a log line and a response
+      header, so an unbounded or newline-carrying one would let a caller write
+      its own log entries and split the header. A rejected id is REPLACED by a
+      generated one rather than sanitised: an id the caller did not send and
+      cannot match is worse than an honest new one.
+    * the id is echoed back in `X-Request-Id`, so a caller that sent nothing
+      can still quote it in a bug report.
+    * `g.request_id` is set as well as the log context, because
+      `get_request_context()` already reads it and the slow-request watchdog
+      reports it.
+    """
+    from .structured_logging import (
+        LogContext, clean_correlation_id, new_correlation_id,
+    )
+
+    @app.before_request
+    def _bind_correlation_id():
+        from flask import g, request
+        supplied = clean_correlation_id(request.headers.get('X-Request-Id'))
+        g.request_id = supplied or new_correlation_id()
+        # Entered here and exited in teardown rather than wrapping the view:
+        # the id must be on the log lines of before_request handlers, error
+        # handlers and after_request handlers too, which a decorator around
+        # the view would miss.
+        g._log_context = LogContext(request_id=g.request_id)
+        g._log_context.__enter__()
+
+    @app.after_request
+    def _echo_correlation_id(response):
+        from flask import g
+        request_id = getattr(g, 'request_id', None)
+        if request_id and 'X-Request-Id' not in response.headers:
+            response.headers['X-Request-Id'] = request_id
+        return response
+
+    @app.teardown_request
+    def _release_correlation_id(_exc):
+        from flask import g
+        context = getattr(g, '_log_context', None)
+        if context is not None:
+            try:
+                context.__exit__(None, None, None)
+            except Exception:  # pragma: no cover - defensive
+                logger.debug("Could not release the request log context")
+
+
 def setup_security_headers(app):
     @app.after_request
     def add_security_headers(response):
@@ -1456,6 +1517,7 @@ def create_app(test_config=None):
     setup_csrf_protection(app)
     setup_error_handlers(app)
     setup_security_headers(app)
+    setup_correlation_ids(app)
     setup_rate_limiting(app, container)
     setup_slow_request_logging(app, container)
 

--- a/modules/core/structured_logging.py
+++ b/modules/core/structured_logging.py
@@ -315,6 +315,50 @@ class LogContext:
         _log_context.set(current)
 
 
+# A correlation id is written into logs and echoed back in a response header,
+# and on the request path it can come from the caller. Bound in length and
+# restricted to characters that cannot break a log line or a header: an id is
+# an opaque token, and anything that is not one is not worth carrying.
+_SAFE_CORRELATION_ID = re.compile(r'^[A-Za-z0-9._:-]{1,64}$')
+
+
+def new_correlation_id() -> str:
+    """A fresh id for one unit of work.
+
+    Short on purpose: it exists to be grepped out of a log and pasted into
+    another query, not to be globally unique across the internet. Sixteen hex
+    characters is 64 bits, which is far past collision for the number of
+    operations one CertMate instance performs in the time anyone would look
+    at a log.
+    """
+    import uuid
+    return uuid.uuid4().hex[:16]
+
+
+def clean_correlation_id(value) -> Optional[str]:
+    """A caller-supplied id, if it is safe to carry; otherwise None.
+
+    The value reaches a log line and a response header. An unbounded or
+    newline-carrying one would let a caller write its own log entries and
+    split the header — so a rejected id is replaced by a generated one rather
+    than sanitised into something the caller did not send and cannot match.
+    """
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value if _SAFE_CORRELATION_ID.match(value) else None
+
+
+def current_correlation_id() -> Optional[str]:
+    """The id of the work being done on this thread, if any.
+
+    Reads the same contextvar LogContext writes, so anything that wants to
+    HAND the id to another thread — the event bus does — asks here rather than
+    threading a parameter through every call in between.
+    """
+    return _log_context.get().get('request_id')
+
+
 def set_context(**kwargs):
     """Set context fields for current scope"""
     current = _log_context.get().copy()

--- a/tests/test_work_carries_a_correlation_id.py
+++ b/tests/test_work_carries_a_correlation_id.py
@@ -1,0 +1,289 @@
+"""Two log lines from the same operation must be identifiable as such.
+
+The structured logger has always had a `request_id` field and a `LogContext`
+to fill it. Nothing ever set either. The field was read off `g.request_id`,
+which no code assigned, and the slow-request watchdog took the raw
+`X-Request-Id` header — so on the overwhelmingly common case of a caller that
+sends no such header, every line carried `request_id: null`, and two lines from
+one request were indistinguishable from two lines from different ones.
+
+Background work had nothing at all. A renewal and the deploy hook it triggered
+were two unrelated sets of lines, associable only by the clock — on a nightly
+sweep where dozens of certificates renew within the same minute.
+
+Three seams, and the third is the one that is easy to get wrong:
+
+* **requests** get an id in `before_request`, honoured from the caller's header
+  when it is an opaque token and generated otherwise, and echoed back so a
+  caller who sent nothing can still quote it;
+* **the renewal sweep** mints one for itself;
+* **listener threads** get it from the queued item, because *contextvars do not
+  cross a thread boundary*. A worker starts with an empty context, not a copy
+  of the publisher's, so passing it implicitly is not an option — and a test
+  that only checked the publisher's side would pass while the deploy hook
+  logged nothing.
+"""
+import threading
+import time
+
+import pytest
+from flask import Flask, g
+
+from modules.core.events import EventBus
+from modules.core.factory import setup_correlation_ids
+from modules.core.structured_logging import (
+    LogContext, clean_correlation_id, current_correlation_id,
+    new_correlation_id,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def app():
+    application = Flask(__name__)
+    setup_correlation_ids(application)
+
+    @application.route('/thing')
+    def thing():
+        return {'seen': current_correlation_id(), 'g': g.request_id}
+
+    return application
+
+
+def _eventually(predicate, timeout=5):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+# --- the id itself -------------------------------------------------------
+
+def test_a_generated_id_is_short_and_unique():
+    ids = {new_correlation_id() for _ in range(1000)}
+    assert len(ids) == 1000
+    assert all(len(i) == 16 for i in ids), (
+        'an id is meant to be grepped out of a log and pasted into a query'
+    )
+
+
+@pytest.mark.parametrize('supplied', [
+    'abc-123', 'trace:0af7651916cd43dd', 'A' * 64, 'x.y_z-1',
+])
+def test_an_opaque_token_from_the_caller_is_honoured(supplied):
+    """The point of the header is letting a caller stitch its logs to ours."""
+    assert clean_correlation_id(supplied) == supplied
+
+
+@pytest.mark.parametrize('hostile', [
+    'evil\nINFO impersonated log line',
+    'evil\r\nX-Injected: yes',
+    'A' * 65,
+    'has spaces',
+    'semi;colon',
+    '',
+    '   ',
+    None,
+    42,
+])
+def test_anything_that_is_not_an_opaque_token_is_refused(hostile):
+    """The id reaches a log line AND a response header. An unbounded or
+    newline-carrying one would let a caller write its own log entries and
+    split the header."""
+    assert clean_correlation_id(hostile) is None
+
+
+# --- requests ------------------------------------------------------------
+
+def test_a_request_without_a_header_still_gets_an_id(app):
+    body = app.test_client().get('/thing').get_json()
+    assert body['seen'], 'the request produced no correlation id at all'
+    assert body['seen'] == body['g'], (
+        'the log context and g.request_id disagree, so the watchdog and the '
+        'log lines would report different ids for one request'
+    )
+
+
+def test_the_id_is_echoed_back(app):
+    response = app.test_client().get('/thing')
+    assert response.headers['X-Request-Id'] == response.get_json()['seen'], (
+        'a caller who sent no header cannot quote the id in a bug report'
+    )
+
+
+def test_a_supplied_id_is_used(app):
+    response = app.test_client().get(
+        '/thing', headers={'X-Request-Id': 'caller-abc'})
+    assert response.get_json()['seen'] == 'caller-abc'
+    assert response.headers['X-Request-Id'] == 'caller-abc'
+
+
+@pytest.mark.parametrize('hostile', ['A' * 200, 'has spaces', 'a;b'])
+def test_a_hostile_id_is_replaced_rather_than_sanitised(app, hostile):
+    """Sanitising would produce an id the caller did not send and cannot
+    match — worse than an honest new one.
+
+    A newline is not among these: werkzeug refuses to put one in a header at
+    all, on the way in as well as on the way out, so the case cannot be
+    reached through the HTTP layer. `clean_correlation_id` still refuses it —
+    the header is not the only thing that ever reaches that function — and
+    that is asserted directly above.
+    """
+    response = app.test_client().get(
+        '/thing', headers={'X-Request-Id': hostile})
+
+    seen = response.get_json()['seen']
+    assert seen != hostile, 'the hostile value was carried through'
+    assert len(seen) == 16, 'the replacement is not a freshly generated id'
+    assert response.headers['X-Request-Id'] == seen
+
+
+def test_two_requests_get_different_ids(app):
+    client = app.test_client()
+    first = client.get('/thing').get_json()['seen']
+    second = client.get('/thing').get_json()['seen']
+    assert first != second
+
+
+def test_the_context_does_not_leak_past_the_request(app):
+    """CONTROL: contextvars persist per thread, and the test client runs on
+    this one. A context never exited would tag everything that follows with a
+    stale request's id."""
+    app.test_client().get('/thing')
+    assert current_correlation_id() is None, (
+        'the request log context was never released'
+    )
+
+
+def test_a_view_that_raises_still_releases_the_context(app):
+    """CONTROL: an unhandled exception is exactly when a context manager
+    entered by hand gets skipped, and it is also when the id matters most."""
+    @app.route('/boom')
+    def boom():
+        raise RuntimeError('kaboom')
+
+    response = app.test_client().get('/boom')
+
+    assert response.status_code == 500
+    assert current_correlation_id() is None, (
+        'a view that raised left its log context bound to this thread'
+    )
+
+
+# --- across the thread boundary -----------------------------------------
+
+def test_a_listener_thread_sees_the_publisher_s_id():
+    """The seam that cannot work by accident: a worker thread starts with an
+    EMPTY context, not a copy of the publisher's."""
+    seen = []
+    bus = EventBus(workers=1)
+    bus.add_listener(lambda event, data: seen.append(current_correlation_id()))
+
+    with LogContext(request_id='sweep-1234'):
+        bus.publish('certificate_renewed', {'domain': 'x.example.com'})
+
+    assert _eventually(lambda: len(seen) == 1)
+    assert seen[0] == 'sweep-1234', (
+        'the deploy hook logged under a different id than the renewal that '
+        'triggered it, which is the whole defect'
+    )
+
+
+def test_a_publish_outside_any_context_carries_no_id():
+    """CONTROL: inventing an id here would be worse than none — it would look
+    like a correlated unit of work that nothing else belongs to."""
+    seen = []
+    bus = EventBus(workers=1)
+    bus.add_listener(lambda event, data: seen.append(current_correlation_id()))
+
+    bus.publish('certificate_renewed', {'domain': 'x.example.com'})
+
+    assert _eventually(lambda: len(seen) == 1)
+    assert seen[0] is None
+
+
+def test_the_id_does_not_leak_between_two_dispatches():
+    """One worker handles both; the second must not inherit the first's id."""
+    seen = []
+    bus = EventBus(workers=1)
+    bus.add_listener(lambda event, data: seen.append(current_correlation_id()))
+
+    with LogContext(request_id='first-one'):
+        bus.publish('certificate_created', {'domain': 'a.example.com'})
+    assert _eventually(lambda: len(seen) == 1)
+
+    bus.publish('certificate_created', {'domain': 'b.example.com'})
+    assert _eventually(lambda: len(seen) == 2)
+    assert seen == ['first-one', None]
+
+
+def test_concurrent_publishers_do_not_share_an_id():
+    """Two requests renewing different domains at once must stay apart."""
+    seen = {}
+    bus = EventBus(workers=4)
+    bus.add_listener(
+        lambda event, data: seen.__setitem__(data['domain'],
+                                             current_correlation_id()))
+
+    def publish(name):
+        with LogContext(request_id=f'req-{name}'):
+            bus.publish('certificate_created', {'domain': name})
+
+    threads = [threading.Thread(target=publish, args=(f'd{i}.example.com',))
+               for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert _eventually(lambda: len(seen) == 8)
+    assert seen == {f'd{i}.example.com': f'req-d{i}.example.com'
+                    for i in range(8)}
+
+
+# --- the renewal sweep ---------------------------------------------------
+
+def test_the_sweep_runs_under_an_id_and_releases_it(tmp_path):
+    from unittest.mock import MagicMock
+    from modules.core.certificates import CertificateManager
+
+    settings = MagicMock()
+    settings.load_settings.return_value = {
+        'auto_renew': True,
+        'domains': [{'domain': 'a.example.com', 'auto_renew': True}]}
+    settings.migrate_domains_format.side_effect = lambda s: s
+    manager = CertificateManager(tmp_path / 'certificates', settings,
+                                 dns_manager=None)
+
+    seen = []
+    manager.get_certificate_info = MagicMock(
+        side_effect=lambda domain, **kw: seen.append(current_correlation_id())
+        or {'needs_renewal': False})
+
+    manager.check_renewals()
+
+    assert seen and seen[0], 'the sweep ran without a correlation id'
+    assert current_correlation_id() is None, (
+        'the sweep context leaked, so every later job on this scheduler '
+        'thread would carry a stale sweep id'
+    )
+
+
+def test_the_sweep_releases_its_id_even_when_it_blows_up(tmp_path):
+    """CONTROL: the release is in a finally for this reason."""
+    from unittest.mock import MagicMock
+    from modules.core.certificates import CertificateManager
+
+    settings = MagicMock()
+    settings.load_settings.return_value = {'auto_renew': True, 'domains': []}
+    settings.migrate_domains_format.side_effect = (
+        lambda s: (_ for _ in ()).throw(RuntimeError('settings exploded')))
+    manager = CertificateManager(tmp_path / 'certificates', settings,
+                                 dns_manager=None)
+
+    with pytest.raises(RuntimeError):
+        manager.check_renewals()
+    assert current_correlation_id() is None


### PR DESCRIPTION
## The field existed. Nothing ever set it.

The structured logger has always had a `request_id` field and a `LogContext` to fill it. `get_request_context()` read it off `g.request_id` — which no code assigned — and the slow-request watchdog took the raw `X-Request-Id` header. So for any caller that sends no such header (nearly all of them) **every log line carried `request_id: null`**, and two lines from one request were indistinguishable from two lines from different ones.

Background work had nothing at all. A renewal and the deploy hook it triggered were two unrelated sets of lines, associable only by the clock — on a nightly sweep where dozens of certificates renew inside the same minute.

## Three seams

**Requests.** An id in `before_request`, honoured from the callers header when it is an opaque token and generated otherwise, echoed back in `X-Request-Id` so a caller who sent nothing can still quote it. Entered in `before_request` and released in `teardown_request` rather than around the view, so error handlers and after-request handlers log under it too — and so a view that raises does not leave it bound to the thread.

**The renewal sweep** mints one for itself, released in a `finally`: a leaked context would tag every later job on that scheduler thread with a stale sweep id, which is worse than no id at all.

**Listener threads** get it from the queued item. This is the seam that cannot work by accident:

> contextvars do **not** cross a thread boundary — a worker starts with an *empty* context, not a copy of the publishers.

A change that only set the id on the publishers side would pass every test that looked there while the deploy hook still logged nothing.

## Why a supplied id is replaced, not sanitised

The value reaches a log line **and** a response header. An unbounded or newline-carrying one would let a caller write its own log entries and split the header. Sanitising it would produce an id the caller did not send and cannot match — worse than an honest new one.

## Controls

- a publish **outside** any context carries no id, rather than inventing one that would look like a correlated unit of work nothing else belongs to;
- one worker handling two dispatches must not let the second inherit the firsts id;
- eight concurrent publishers keep eight distinct ids;
- the request context is released after a normal request **and** after one that raised.

## Verified by mutation

```
drop the id from the queued item        -> 3 tests fail
do not generate one without a header    -> 6 tests fail
```

## Two tests were written wrong first, and say so

werkzeug refuses to put a newline in a header at all — on the way in as well as out — so that case cannot be reached through HTTP; the refusal is asserted directly on `clean_correlation_id` instead. And Flask returns 500 rather than propagating, so the raising-view control asserts the *release*, not the exception.

## Checks run locally

- 29 new tests; `pytest -m "not ui"` — **4329 passed, 59 skipped**
- `flake8` with CIs selector set; the C901 ratchet at 115 still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)