### PR TITLE
docs: tell every reader what exists, including the parts not in their language

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,8 +71,34 @@ CertMate is a modular, pluggable SSL/TLS certificate management system built wit
 │  │          Storage Layer (Pluggable Backends)    │  │
 │  │  Local FS │ Azure KV │ AWS SM │ Vault │ Infis │  │
 │  └───────────────────────────────────────────────┘  │
+│                                                     │
+│  ┌───────────────────────────────────────────────┐  │
+│  │   Composition root — modules/core/factory.py   │  │
+│  │                                               │  │
+│  │   create_app() constructs every manager above  │  │
+│  │   and then REGISTERS the API and web layers    │  │
+│  │   onto the Flask app.                          │  │
+│  └───┬───────────────────────────────────────┬───┘  │
+│      │ constructs (downward, like the rest)  │      │
+│      └──────────────► Manager Layer          │      │
+│                                              │      │
+│      ┌───────────────────────────────────────┘      │
+│      │ imports UPWARD — the one edge in the system  │
+│      └──────────────► REST API / Web Routes         │
 └─────────────────────────────────────────────────────┘
 ```
+
+Every arrow above points down except one. `modules/core/factory.py` is the
+composition root: it builds the managers *and* imports the API and web layers
+to register them, which is an import from `core/` into `api/` and `web/` —
+upward through the layers everything else respects.
+
+That is what a composition root is for, and it is deliberate: the alternative
+is either a layer that knows how to construct itself (and therefore its
+dependencies) or a registry that hides the same edge behind indirection. It is
+drawn here because a single documented exception is a design; an undocumented
+one is something the next reader finds by tracing an import and then wonders
+whether the rest of the diagram is true.
 
 ---
 

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -22,6 +22,8 @@ Willkommen in der CertMate-Dokumentation. Dieser Ordner enthält umfassende Anle
 - **[Architektur](./architecture.md)** — Systemdesign, Komponenten, Datenfluss
 - **[Test-Anleitung](./testing.md)** — Test-Framework, CI/CD, Abdeckung
 - **[Discovery & Inventar](../discovery-inventory.md)** — Probe-/CT-Log-Discovery, Inventar, Adopt, Krypto-Readiness *(auf Englisch)*
+- **[CSR-basierte Zertifikate](../csr-only-certificates.md)** — Ausstellung aus einer CSR, der private Schlüssel bleibt auf dem Gerät *(auf Englisch)*
+- **[Generische Webhooks](../webhooks.md)** — HTTP-Benachrichtigungen zu Lebenszyklus-Ereignissen: Payload, Signatur, Wiederholungen *(auf Englisch)*
 - **[Deploy-Hooks](./deploy-hooks.md)** — Hooks nach der Ausstellung: Konfiguration, Test, Redaktion der Ausgabe
 - **[Compliance](./compliance.md)** — Audit-Kette, Akteur-Attribution, NIS2-/eIDAS-Posture
 - **[Deployment-Probes](./probes.md)** — Prüfen, ob ein erneuertes Zertifikat ausgeliefert wird

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -22,6 +22,8 @@ Bienvenido a la documentación de CertMate. Esta carpeta contiene guías complet
 - **[Arquitectura](./architecture.md)** — Diseño del sistema, componentes, flujo de datos
 - **[Guía de pruebas](./testing.md)** — Framework de pruebas, CI/CD, cobertura
 - **[Descubrimiento e inventario](../discovery-inventory.md)** — Descubrimiento por sonda/CT-log, inventario, adopción, madurez criptográfica *(en inglés)*
+- **[Certificados a partir de CSR](../csr-only-certificates.md)** — Emisión desde una CSR, con la clave privada en el dispositivo *(en inglés)*
+- **[Webhooks genéricos](../webhooks.md)** — Notificaciones HTTP de eventos del ciclo de vida: payload, firma, reintentos *(en inglés)*
 - **[Deploy hooks](./deploy-hooks.md)** — Hooks posteriores a la emisión: configuración, pruebas, redacción de la salida
 - **[Cumplimiento](./compliance.md)** — Cadena de auditoría, atribución de acciones, postura NIS2/eIDAS
 - **[Sondas de despliegue](./probes.md)** — Comprobar que el certificado renovado se sirve de verdad

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -22,6 +22,8 @@ Bienvenue dans la documentation de CertMate. Ce dossier contient des guides comp
 - **[Architecture](./architecture.md)** — Conception du système, composants, flux de données
 - **[Guide de test](./testing.md)** — Framework de test, CI/CD, couverture
 - **[Découverte et inventaire](../discovery-inventory.md)** — Découverte par sonde/CT-log, inventaire, adoption, maturité cryptographique *(en anglais)*
+- **[Certificats à partir d'une CSR](../csr-only-certificates.md)** — Émission depuis une CSR, la clé privée restant sur l'appareil *(en anglais)*
+- **[Webhooks génériques](../webhooks.md)** — Notifications HTTP sur les événements du cycle de vie : payload, signature, relances *(en anglais)*
 - **[Deploy hooks](./deploy-hooks.md)** — Hooks post-émission : configuration, test, expurgation de la sortie
 - **[Conformité](./compliance.md)** — Chaîne d'audit, attribution des actions, posture NIS2/eIDAS
 - **[Sondes de déploiement](./probes.md)** — Vérifier que le certificat renouvelé est réellement servi

--- a/docs/it/README.md
+++ b/docs/it/README.md
@@ -22,6 +22,8 @@ Benvenuto nella documentazione di CertMate. Questa cartella contiene guide compl
 - **[Architettura](./architecture.md)** — Progettazione del sistema, componenti, flusso dei dati
 - **[Guida ai test](./testing.md)** — Framework di test, CI/CD, copertura
 - **[Discovery e inventario](../discovery-inventory.md)** — Discovery via probe/CT-log, inventario, adopt, crypto readiness *(in inglese)*
+- **[Certificati da CSR](../csr-only-certificates.md)** — Emissione a partire da una CSR, con la chiave privata che resta sul dispositivo *(in inglese)*
+- **[Webhook generici](../webhooks.md)** — Notifiche HTTP sugli eventi del ciclo di vita: payload, firma, ritentativi *(in inglese)*
 - **[Deploy hook](./deploy-hooks.md)** — Hook post-emissione: configurazione, test, redazione dell'output
 - **[Conformità](./compliance.md)** — Catena di audit, attribuzione delle azioni, postura NIS2/eIDAS
 - **[Sonde di deployment](./probes.md)** — Verificare che il certificato rinnovato sia davvero servito

--- a/tests/test_docs_navigation.py
+++ b/tests/test_docs_navigation.py
@@ -393,3 +393,154 @@ def test_the_mcp_suites_are_run_by_ci():
     ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
     assert "working-directory: mcp" in ci, "no CI job runs anything inside mcp/"
     assert "npm test" in ci, "the mcp job does not run its test suite"
+
+
+# ---------------------------------------------------------------------------
+# Every language must know the whole documentation set exists
+# ---------------------------------------------------------------------------
+#
+# The four translated trees carry sixteen pages where English carries nineteen.
+# Nothing compared them, so a reader in those languages was not told that pages
+# exist which they cannot see — the gap was invisible from inside the tree they
+# were reading.
+#
+# The project already had an answer for one of the three: `discovery-inventory`
+# is linked from every translated index as `../discovery-inventory.md`, marked
+# as being in English. `csr-only-certificates` and `webhooks` had no such link
+# in any language, so those two topics were simply absent.
+#
+# Linking to the original, marked, rather than writing a stub page per topic
+# per language: a stub says the same thing with a file attached, and four more
+# files that also go stale. What matters is that the reader is told the topic
+# exists and where to read it.
+
+# probes.md is probes.en.md under a shorter name in the translated trees.
+TRANSLATED_NAME = {"probes.en.md": "probes.md"}
+
+# Pages that are not part of the documentation set a reader browses.
+NOT_PART_OF_THE_SET = {"THEME_MIGRATION.md", "index.md"}
+
+
+def _english_pages():
+    return {p.name for p in DOCS.glob("*.md")} - NOT_PART_OF_THE_SET - {INDEX}
+
+
+@pytest.mark.parametrize("lang", [lang for lang in LANGUAGES if lang != "en"])
+def test_a_missing_translation_is_linked_to_the_original(lang):
+    """A topic that has no page in this language must at least be reachable.
+
+    Otherwise the reader is not told it exists: they see sixteen pages and
+    have no way to know there are nineteen.
+    """
+    present = {p.name for p in _lang_dir(lang).glob("*.md")}
+    index = (_lang_dir(lang) / INDEX).read_text(encoding="utf-8")
+
+    unreachable = []
+    for page in sorted(_english_pages()):
+        if TRANSLATED_NAME.get(page, page) in present:
+            continue
+        if f"../{page}" not in index:
+            unreachable.append(page)
+
+    assert not unreachable, (
+        f"docs/{lang}/ has no page for these topics and its {INDEX} does not "
+        f"link to the English original either, so a reader in {lang} is never "
+        f"told they exist: {', '.join(unreachable)}.\n\n"
+        f"Translate the page, or add a line to docs/{lang}/{INDEX} pointing "
+        f"at ../<page>.md and marked as being in English — the convention "
+        f"discovery-inventory.md already follows."
+    )
+
+
+@pytest.mark.parametrize("lang", [lang for lang in LANGUAGES if lang != "en"])
+def test_a_link_to_an_untranslated_page_says_it_is_in_english(lang):
+    """CONTROL for the fix above: a link that looks like every other entry
+    sends the reader to a page in a language they may not read, with no
+    warning. The marker is the whole difference between the two."""
+    index = (_lang_dir(lang) / INDEX).read_text(encoding="utf-8")
+    unmarked = []
+    for line in index.splitlines():
+        if "](../" in line and line.strip().startswith("-"):
+            if not re.search(r"\*\((in inglese|auf Englisch|en inglés|en anglais)\)\*",
+                             line):
+                unmarked.append(line.strip()[:80])
+    assert not unmarked, (
+        f"docs/{lang}/{INDEX} links out to the English tree without saying so:"
+        f"\n  " + "\n  ".join(unmarked))
+
+
+@pytest.mark.parametrize("lang", [lang for lang in LANGUAGES if lang != "en"])
+def test_every_page_a_translated_index_points_at_exists(lang):
+    """CONTROL: a link to ../something.md that is not there is worse than no
+    link — it is a 404 presented as the answer."""
+    index = (_lang_dir(lang) / INDEX).read_text(encoding="utf-8")
+    missing = [target for target in re.findall(r"\]\(\.\./([a-z0-9._-]+\.md)\)",
+                                               index)
+               if not (DOCS / target).exists()]
+    assert not missing, (
+        f"docs/{lang}/{INDEX} links to English pages that do not exist: "
+        + ", ".join(missing))
+
+
+def test_the_english_set_is_what_this_compares_against():
+    """CONTROL for the census: if _english_pages() returned nothing, every
+    language would trivially pass."""
+    pages = _english_pages()
+    assert len(pages) > 15, f"only {len(pages)} English pages found"
+    for expected in ("csr-only-certificates.md", "webhooks.md",
+                     "discovery-inventory.md"):
+        assert expected in pages
+
+
+# ---------------------------------------------------------------------------
+# The architecture diagram must draw the one edge that breaks its own rule
+# ---------------------------------------------------------------------------
+
+def test_the_composition_root_is_the_only_upward_import():
+    """The claim the diagram now makes, checked rather than asserted in prose.
+
+    Every arrow in the high-level diagram points down: web and API call into
+    the managers, the managers into execution and storage. One import goes the
+    other way — `modules/core/factory.py` imports `modules.api` and
+    `modules.web` in order to register them, which is `core/` reaching upward.
+
+    That is what a composition root is for, and the diagram says so. If a
+    SECOND file starts doing it, the diagram has stopped being true and this
+    fails with the file that did it.
+    """
+    import ast
+
+    upward = {}
+    for path in sorted((REPO_ROOT / "modules" / "core").glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            modules = []
+            if isinstance(node, ast.ImportFrom) and node.module:
+                modules.append("." * node.level + node.module)
+            elif isinstance(node, ast.Import):
+                modules += [alias.name for alias in node.names]
+            for module in modules:
+                if (module.startswith(("modules.api", "modules.web"))
+                        or module.startswith(("..api", "..web"))):
+                    upward.setdefault(path.name, []).append(
+                        f"{module} (line {node.lineno})")
+
+    assert set(upward) == {"factory.py"}, (
+        "modules/core/ imports upward into api/ or web/ from somewhere other "
+        "than the composition root, so the architecture diagram is no longer "
+        f"true: {upward}"
+    )
+
+
+def test_the_diagram_draws_the_composition_root():
+    """A single documented exception is a design; an undocumented one is
+    something the next reader finds by tracing an import and then wonders
+    whether the rest of the diagram is true."""
+    architecture = (DOCS / "architecture.md").read_text(encoding="utf-8")
+    diagram = architecture.split("## High-Level Diagram")[1].split("---")[0]
+    assert "Composition root" in diagram, (
+        "the high-level diagram has lost the composition root, so the only "
+        "upward edge in the system is again the one thing it does not draw"
+    )
+    assert "factory.py" in diagram
+    assert "UPWARD" in diagram or "upward" in diagram


### PR DESCRIPTION
Two findings, both about documentation that is true only from one angle.

## 1. Sixteen pages where English has nineteen, and nothing said so

Nothing compared the trees, so a reader in `de`/`es`/`fr`/`it` was not told that
pages exist which they cannot see. **The gap was invisible from inside the tree
they were reading.**

Measured rather than assumed: `probes.en.md` and `probes.md` are the same page
under two names, so the real gap is **three** topics, not four. And one of the
three was already handled — `discovery-inventory` is linked from every
translated index as `../discovery-inventory.md`, marked as being in English.

`csr-only-certificates` and `webhooks` had no such link **in any language** and
were simply absent.

They are linked now, following the convention the project already chose, rather
than by writing a stub page per topic per language: a stub says the same thing
with a file attached — and four more files that also go stale. What matters is
that the reader is told the topic exists and where to read it.

Three tests keep it true:

- every English page must **either** exist in a translated tree **or** be
  linked from that tree's index;
- a link out to the English tree must **say** it is in English — a link that
  looks like every other entry sends the reader to a language they may not
  read, with no warning;
- a link to an English page that does not exist fails, because a 404 presented
  as the answer is worse than no link.

## 2. The architecture diagram drew only downward arrows

Every layer calls into the one below — except `modules/core/factory.py`, which
imports `modules.api` and `modules.web` in order to register them. That is
`core/` reaching **upward**, it is the only such edge in the system, and it was
the one thing the diagram did not draw.

The composition root is in the diagram now, with the upward edge explicit and
the reason stated: the alternative is a layer that knows how to construct
itself, or a registry hiding the same edge behind indirection. A single
documented exception is a design; an undocumented one is something the next
reader finds by tracing an import and then wonders whether the rest of the
diagram is true.

**The claim is verified, not just written.** A test walks every module in
`modules/core/` and fails if any file other than `factory.py` imports upward,
naming the file that did it:

```
modules/core/ imports upward into api/ or web/ from somewhere other than the
composition root, so the architecture diagram is no longer true: {...}
```

## Verified by mutation

```
remove the webhooks link from the Italian index  -> fails, naming webhooks.md
remove the "(in inglese)" marker                 -> fails the marker test
```

## Checks run locally

- 6 new tests (48 in the file); `pytest -m "not ui"` — **4364 passed, 59 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
