### PR TITLE
api: a certificate request states its own limit, instead of the backup's

### DIFF
--- a/modules/core/cert_service.py
+++ b/modules/core/cert_service.py
@@ -24,6 +24,21 @@ from .utils import validate_domain, validate_key_options
 
 logger = logging.getLogger(__name__)
 
+# Per-request bounds, because the global MAX_CONTENT_LENGTH is 50 MB and
+# exists for the backup upload. Without these, the ceiling on a certificate
+# request was "however many names fit in fifty megabytes" and "however large a
+# PEM fits in fifty megabytes" — neither of which is a limit anyone chose, and
+# neither of which any endpoint stated.
+#
+# 100 is Let's Encrypt's cap on names per certificate, so a request naming more
+# cannot be satisfied by the CA regardless of what CertMate does with it.
+MAX_SAN_DOMAINS = 100
+
+# A PEM CSR for a 4096-bit key carrying a hundred names is a few kilobytes.
+# 64 KB is generous by more than an order of magnitude and still refuses long
+# before anything reaches the parser.
+MAX_CSR_BYTES = 64 * 1024
+
 
 # Kept as a local alias: this module's call sites read better with the short
 # name, but the implementation now lives once, in the logging module.
@@ -175,6 +190,19 @@ class CertificateService:
             domain_alias = normalized_alias
         if san_domains and not isinstance(san_domains, list):
             raise ValueError('Invalid san_domains format')
+        if san_domains and len(san_domains) > MAX_SAN_DOMAINS:
+            # The global 50 MB body limit exists for the backup upload, and
+            # applied to this endpoint too — so the ceiling on a certificate
+            # request was "however many names fit in fifty megabytes", which
+            # is not a limit anyone chose. Let's Encrypt caps a certificate at
+            # 100 names, so a request naming more cannot be satisfied by the
+            # CA regardless; refusing it here says so, instead of building a
+            # certbot command line with thousands of -d flags and letting the
+            # CA reject it after the DNS challenges have been set up.
+            raise ValueError(
+                f'Too many san_domains: {len(san_domains)}. A certificate can '
+                f'carry at most {MAX_SAN_DOMAINS} names, including the primary '
+                f'domain.')
 
         # A CSR is signed over its own subject and SANs, and carries its own
         # public key. A request that also names SANs or a key shape is asking
@@ -182,6 +210,17 @@ class CertificateService:
         # silently ignored — the certificate would come back different from
         # what the caller asked for, with nothing to say why (#599).
         if csr_pem is not None:
+            if not isinstance(csr_pem, (str, bytes)):
+                raise ValueError('Invalid CSR: expected PEM text')
+            if len(csr_pem) > MAX_CSR_BYTES:
+                # Same reasoning as the SAN bound above: without this, the
+                # limit on a CSR was the global body limit. A PEM CSR for a
+                # 4096-bit key with a hundred names is a few kilobytes; the
+                # bound is generous by two orders of magnitude and still says
+                # no long before anything reaches the parser.
+                raise ValueError(
+                    f'CSR too large: {len(csr_pem)} bytes. A certificate '
+                    f'request PEM is at most {MAX_CSR_BYTES} bytes.')
             if san_domains:
                 raise ValueError(
                     'san_domains cannot be combined with a CSR: the '

--- a/tests/test_a_request_states_its_own_limit.py
+++ b/tests/test_a_request_states_its_own_limit.py
@@ -1,0 +1,149 @@
+"""A certificate request's ceiling should not be the backup upload's ceiling.
+
+One `MAX_CONTENT_LENGTH` of 50 MB applied to every endpoint. It exists for the
+backup upload, which needs it. Applied to certificate creation it meant the
+limit on `san_domains` was *"however many names fit in fifty megabytes"* and
+the limit on `csr` was *"however large a PEM fits in fifty megabytes"* —
+neither of which is a limit anyone chose, and neither of which any endpoint
+stated.
+
+The bounds here are not arbitrary:
+
+* **100 names** is Let's Encrypt's own cap per certificate. A request naming
+  more cannot be satisfied by the CA regardless of what CertMate does with it,
+  so refusing it at the boundary says so — instead of building a certbot
+  command line with thousands of `-d` flags and letting the CA reject it after
+  the DNS challenges have been set up, which costs an ACME order and a set of
+  DNS writes to learn nothing.
+* **64 KB** for a CSR is generous by more than an order of magnitude: a PEM
+  request for a 4096-bit key carrying a hundred names is a few kilobytes. It
+  refuses long before anything reaches the parser.
+
+The global limit is deliberately left alone. Lowering it would break the backup
+upload, which is the one endpoint that genuinely receives megabytes.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.cert_service import (
+    MAX_CSR_BYTES, MAX_SAN_DOMAINS, CertificateService,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def service():
+    settings = MagicMock()
+    settings.load_settings.return_value = {
+        'email': 'ops@example.com',
+        'dns_provider': 'cloudflare',
+        'dns_providers': {'cloudflare': {'default': {'api_token': 'x'}}},
+    }
+    auth = MagicMock()
+    auth.user_can_access_domain.return_value = True
+    return CertificateService(MagicMock(), settings, auth, MagicMock())
+
+
+def _create(service, **kwargs):
+    return service.prepare_create(domain='example.com', **kwargs)
+
+
+# --- how many names ------------------------------------------------------
+
+def test_a_request_at_the_limit_is_accepted(service):
+    """CONTROL: the bound must be reachable. An off-by-one here would refuse
+    a certificate Let's Encrypt would happily issue."""
+    names = [f'n{i}.example.com' for i in range(MAX_SAN_DOMAINS)]
+    _create(service, san_domains=names)          # no raise
+
+
+def test_a_request_past_the_limit_is_refused_with_the_number(service):
+    names = [f'n{i}.example.com' for i in range(MAX_SAN_DOMAINS + 1)]
+    with pytest.raises(ValueError) as caught:
+        _create(service, san_domains=names)
+
+    message = str(caught.value)
+    assert str(MAX_SAN_DOMAINS) in message, (
+        f'the refusal does not say what the limit is: {message}'
+    )
+    assert str(len(names)) in message, (
+        f'the refusal does not say what was sent: {message}'
+    )
+
+
+def test_an_absurd_request_is_refused_rather_than_built_into_a_command(service):
+    """The case the global 50 MB limit permitted: a request that would have
+    become a certbot command line with thousands of -d flags."""
+    with pytest.raises(ValueError):
+        _create(service, san_domains=[f'n{i}.example.com'
+                                      for i in range(20_000)])
+
+
+def test_no_sans_at_all_is_still_fine(service):
+    _create(service)
+    _create(service, san_domains=[])
+
+
+def test_the_shape_check_still_runs(service):
+    """CONTROL: the new length bound must not shadow the type check that was
+    already there — `san_domains` as a string has a length too."""
+    with pytest.raises(ValueError, match='Invalid san_domains format'):
+        _create(service, san_domains='not-a-list.example.com')
+
+
+# --- how large a CSR -----------------------------------------------------
+
+def test_an_oversized_csr_is_refused_before_it_reaches_the_parser(service):
+    with pytest.raises(ValueError) as caught:
+        _create(service, csr_pem='-' * (MAX_CSR_BYTES + 1))
+
+    message = str(caught.value)
+    assert 'CSR too large' in message
+    assert str(MAX_CSR_BYTES) in message, (
+        f'the refusal does not say what the limit is: {message}'
+    )
+
+
+def test_a_csr_of_a_plausible_size_reaches_the_parser(service):
+    """CONTROL: the bound must not refuse a real CSR. This one is nonsense,
+    so it fails at the PARSER — which is the proof it got that far."""
+    with pytest.raises(ValueError, match='Invalid CSR'):
+        _create(service, csr_pem='-----BEGIN CERTIFICATE REQUEST-----\nx\n'
+                                 '-----END CERTIFICATE REQUEST-----\n')
+
+
+def test_a_csr_that_is_not_text_is_refused_as_such(service):
+    """A dict or a list has no meaningful length, and `len()` on one would
+    pass the size check and then confuse the parser's error."""
+    with pytest.raises(ValueError, match='expected PEM text'):
+        _create(service, csr_pem={'pem': 'nope'})
+
+
+def test_bytes_are_accepted_as_a_csr(service):
+    """CONTROL: the type check must not refuse the other legitimate shape.
+    Nonsense bytes, so this reaches the parser and fails there."""
+    with pytest.raises(ValueError, match='Invalid CSR'):
+        _create(service, csr_pem=b'-----BEGIN CERTIFICATE REQUEST-----\n')
+
+
+# --- what must not change ------------------------------------------------
+
+def test_the_global_body_limit_is_left_alone():
+    """The backup upload is the one endpoint that genuinely receives
+    megabytes. Lowering the global limit to fix the certificate endpoints
+    would break it."""
+    import pathlib
+    source = (pathlib.Path(__file__).resolve().parent.parent / 'modules'
+              / 'core' / 'factory.py').read_text()
+    assert "app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024" in source, (
+        'the global body limit changed; the backup upload needs it'
+    )
+
+
+def test_the_limits_are_named_constants_not_literals():
+    """So an operator reading the refusal can find where the number is
+    decided, and so the tests and the code cannot disagree about it."""
+    assert MAX_SAN_DOMAINS == 100
+    assert MAX_CSR_BYTES == 64 * 1024


### PR DESCRIPTION
## The finding

One `MAX_CONTENT_LENGTH` of **50 MB** applied to every endpoint. It exists for the backup upload, which needs it. Applied to certificate creation it meant:

- the ceiling on `san_domains` was *"however many names fit in fifty megabytes"*;
- the ceiling on `csr` was *"however large a PEM fits in fifty megabytes"*.

Neither is a limit anyone chose, and neither was stated by any endpoint.

## Both bounds are derived, not picked

**100 names** is Lets Encrypts own cap per certificate. A request naming more cannot be satisfied by the CA regardless of what CertMate does with it — so refusing it at the boundary says so, instead of building a certbot command line with thousands of `-d` flags and letting the CA reject it **after** the DNS challenges have been set up. That costs an ACME order and a set of DNS writes to learn nothing.

**64 KB** for a CSR is generous by more than an order of magnitude: a PEM request for a 4096-bit key carrying a hundred names is a few kilobytes. It refuses long before anything reaches the parser.

Both refusals name the limit **and** what was sent — a 400 that says only "too large" leaves the caller guessing at the number.

## The type check is part of the same change

`len()` on a dict succeeds. Without the type check a non-text CSR would pass the size bound and then produce a parser error describing the wrong problem.

## The global limit is deliberately unchanged

There is a test saying so. Lowering it to fix these two endpoints would break the backup upload — the one endpoint that genuinely receives megabytes.

## Verified by mutation

Removing both bounds fails **4 of the 11** tests.

The controls matter as much as the assertions: a request **at** the limit is accepted (an off-by-one would refuse a certificate the CA would happily issue), a plausible CSR still reaches the parser, `bytes` is still a valid CSR shape, and the existing `san_domains` **type** check is not shadowed by the new **length** check — a string has a length too.

## Checks run locally

- 11 new tests; `pytest -m "not ui"` — **4385 passed, 59 skipped**
- `flake8` with CIs selector set, `C901` at the real max — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)