### PR TITLE
security: the event stream goes through the same gate as everything else

### DIFF
--- a/modules/core/auth.py
+++ b/modules/core/auth.py
@@ -1456,6 +1456,64 @@ class AuthManager:
         decorated_function._certmate_protection = 'require_auth'
         return decorated_function
 
+    def require_session_role(self, min_role):
+        """Like :meth:`require_role`, but the cookie session is the only
+        accepted credential.
+
+        For surfaces a browser reaches that cannot carry an Authorization
+        header — Server-Sent Events is the whole set today. `EventSource`
+        offers no way to add one, so a bearer token cannot reach these routes
+        no matter how the caller is configured.
+
+        That was already the behaviour, written inline in the route as
+        `if not auth_manager.is_setup_mode(): ...check the cookie...`. Three
+        things were wrong with expressing it there and not here. The route was
+        invisible to any scan of what is protected, so it sat in the public
+        allowlist with "checked inline" as its reason. The check drifted from
+        the decorators' — it never consulted a role, so a `viewer`-only session
+        and an `admin` one were the same to it. And a second such surface would
+        have copied it.
+
+        Setup mode is honoured exactly as the other decorators honour it: with
+        no operator credential configured at all, every caller is admin, and
+        the live stream is no different from the dashboard it feeds.
+        """
+        def decorator(f):
+            @wraps(f)
+            def decorated_function(*args, **kwargs):
+                if self.is_setup_mode():
+                    request.current_user = {'username': 'setup_user',
+                                            'role': 'admin'}
+                    return f(*args, **kwargs)
+
+                session_id = request.cookies.get('certmate_session')
+                user = (self.validate_session(session_id)
+                        if session_id else None)
+                if not user:
+                    # No redirect, even for a browser: an EventSource cannot
+                    # follow one usefully, and a 302 to the login page would
+                    # arrive as an opaque stream error. 401 lets the client
+                    # decide to reconnect after logging in.
+                    return {'error': 'Unauthenticated',
+                            'code': 'SESSION_REQUIRED'}, 401
+
+                if (ROLE_HIERARCHY.get(user.get('role'), -1)
+                        < ROLE_HIERARCHY.get(min_role, 999)):
+                    self._log_rbac_denial(user=user, required_role=min_role,
+                                          endpoint=request.path)
+                    return {'error': f'{min_role} privileges required',
+                            'code': 'INSUFFICIENT_ROLE'}, 403
+
+                request.current_user = user
+                return f(*args, **kwargs)
+
+            decorated_function._certmate_protection = (
+                f'require_session_role:{min_role}')
+            return decorated_function
+
+        decorator._certmate_protection = f'require_session_role:{min_role}'
+        return decorator
+
     def require_role(self, min_role):
         """Decorator factory requiring a minimum role level.
 

--- a/modules/web/misc_routes.py
+++ b/modules/web/misc_routes.py
@@ -348,22 +348,23 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
         return jsonify(body), (200 if ready else 503)
 
     @app.route('/api/events/stream')
+    @auth_manager.require_session_role('viewer')
     def events_stream():
         """SSE: stream certificate lifecycle events to authenticated browsers.
 
-        SSE cannot send custom headers, so this only accepts the cookie session.
-        When local auth is enabled and the request has no valid session, this
-        returns a 401 JSON error and does not expose the event stream.
+        `require_session_role` rather than `require_role`: `EventSource` offers
+        no way to add an Authorization header, so a bearer token cannot reach
+        this route however the caller is configured. A bearer-only deployment
+        therefore has no live stream — and no web UI to feed it to either.
+
+        That was already the behaviour, written inline here. Expressing it as a
+        decorator gives it three things it did not have: the route becomes
+        visible to a scan of what is protected (it had to sit in the public
+        allowlist with "checked inline" as its reason), the check now consults
+        a role like every other one, and a second such surface will not copy
+        the logic.
         """
-        from flask import Response, stream_with_context, request as _req
-        # Once the instance is configured (local auth + user, OR an operator
-        # bearer token) require a valid session. SSE can't carry a bearer
-        # header, so a bearer-only deployment simply has no live stream — the
-        # web UI it feeds is locked for that deployment anyway.
-        if not auth_manager.is_setup_mode():
-            session_id = _req.cookies.get('certmate_session')
-            if not session_id or not auth_manager.validate_session(session_id):
-                return jsonify({'error': 'Unauthenticated'}), 401
+        from flask import Response, stream_with_context
         event_bus = managers.get('events')
         if event_bus is None:
             return jsonify({'error': 'Event bus not available'}), 503

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -290,7 +290,8 @@ def _passthrough(*_a, **_k):
 
 def _verify_app(managers):
     app = Flask(__name__)
-    auth_manager = SimpleNamespace(require_role=_passthrough)
+    auth_manager = SimpleNamespace(require_role=_passthrough,
+                                   require_session_role=_passthrough)
     register_misc_routes(app, managers, _passthrough, auth_manager)
     return app
 

--- a/tests/test_audit_checkpoint_crosscheck.py
+++ b/tests/test_audit_checkpoint_crosscheck.py
@@ -156,7 +156,9 @@ def _passthrough(*_a, **_k):
 def _verify_route(audit):
     app = Flask(__name__)
     register_misc_routes(app, {'audit': audit}, _passthrough,
-                         SimpleNamespace(require_role=_passthrough))
+                         SimpleNamespace(
+                             require_role=_passthrough,
+                             require_session_role=_passthrough))
     return app.test_client().get('/api/audit/verify')
 
 

--- a/tests/test_audit_export_slice_anchor.py
+++ b/tests/test_audit_export_slice_anchor.py
@@ -258,7 +258,9 @@ def test_export_endpoint_slice_verifies(audit, tmp_path):
 
     app = Flask(__name__)
     register_misc_routes(app, {"audit": audit}, _passthrough,
-                         SimpleNamespace(require_role=_passthrough))
+                         SimpleNamespace(
+                             require_role=_passthrough,
+                             require_session_role=_passthrough))
 
     response = app.test_client().get("/api/audit/export?from_seq=4")
 

--- a/tests/test_audit_notifications_and_acmedns_masking.py
+++ b/tests/test_audit_notifications_and_acmedns_masking.py
@@ -192,6 +192,8 @@ class TestNotificationsGetMaskedSmtpPassword:
                 return fn
             return deco
         auth_manager.require_role = MagicMock(side_effect=passthrough_role)
+        auth_manager.require_session_role = MagicMock(
+            side_effect=passthrough_role)
 
         managers = {
             'auth': auth_manager,

--- a/tests/test_audit_phase3.py
+++ b/tests/test_audit_phase3.py
@@ -233,7 +233,8 @@ def _passthrough(*_a, **_k):
 
 def _app(managers):
     app = Flask(__name__)
-    auth_manager = SimpleNamespace(require_role=_passthrough)
+    auth_manager = SimpleNamespace(require_role=_passthrough,
+                                   require_session_role=_passthrough)
     register_misc_routes(app, managers, _passthrough, auth_manager)
     return app
 

--- a/tests/test_certbot_is_a_startup_condition.py
+++ b/tests/test_certbot_is_a_startup_condition.py
@@ -191,6 +191,7 @@ def _app(managers):
     app.config['VERSION'] = 'test'
     auth = MagicMock()
     auth.require_role = lambda role: (lambda fn: fn)
+    auth.require_session_role = lambda role: (lambda fn: fn)
     auth.is_local_auth_enabled.return_value = False
     auth.has_any_users.return_value = False
     register_misc_routes(app, managers, require_web_auth=None,

--- a/tests/test_every_route_is_protected_or_listed.py
+++ b/tests/test_every_route_is_protected_or_listed.py
@@ -5,8 +5,10 @@ Route protection here is expressed three ways, and all three are legitimate:
 * the `require_role` / `require_auth` decorators, and `require_web_auth` for
   HTML pages;
 * an inline check inside the view — `/` reads the session cookie itself so the
-  context processor sees the user, and `/api/events/stream` does it because SSE
-  cannot carry a bearer header;
+  context processor sees the user. `/api/events/stream` used to be the second
+  such route; it now carries `require_session_role('viewer')`, which is that
+  same rule expressed once, so it appears in the protected set rather than in
+  the list below;
 * a redirect to a route that is itself checked — `/audit` redirects to
   `/activity`, `/certificates` to `/`.
 
@@ -79,10 +81,6 @@ PUBLIC_ROUTES = {
         '/login, so that the template context processor sees the user. The '
         'decorator would authenticate but not populate request.current_user '
         'in the same way.',
-    '/api/events/stream':
-        'SSE cannot send an Authorization header, so this validates the '
-        'session cookie inline and returns 401 when the instance is out of '
-        'setup mode.',
 
     # --- redirects to a route that is checked --------------------------
     '/audit':

--- a/tests/test_metrics_access_model.py
+++ b/tests/test_metrics_access_model.py
@@ -38,6 +38,7 @@ def _app_recording_declared_roles():
         return deco
 
     auth_manager.require_role = _recording_require_role
+    auth_manager.require_session_role = _recording_require_role
     auth_manager.is_local_auth_enabled.return_value = False
     auth_manager.has_any_users.return_value = False
 
@@ -88,6 +89,7 @@ def _metrics_list_declared_role():
         return deco
 
     auth_manager.require_role = _recording_require_role
+    auth_manager.require_session_role = _recording_require_role
 
     class _Managers(dict):
         """Supplies a stub for any manager the closure reaches for, so the

--- a/tests/test_metrics_endpoint_context.py
+++ b/tests/test_metrics_endpoint_context.py
@@ -24,7 +24,8 @@ def _passthrough(*_a, **_k):
 
 def _app(managers):
     app = Flask(__name__)
-    auth_manager = SimpleNamespace(require_role=_passthrough)
+    auth_manager = SimpleNamespace(require_role=_passthrough,
+                                   require_session_role=_passthrough)
     register_misc_routes(app, managers, _passthrough, auth_manager)
     return app
 

--- a/tests/test_minor_queue_lot1_telemetry_and_status_codes.py
+++ b/tests/test_minor_queue_lot1_telemetry_and_status_codes.py
@@ -78,6 +78,8 @@ def client_cert_app():
         return deco
     auth_manager = MagicMock()
     auth_manager.require_role = MagicMock(side_effect=require_role_factory)
+    auth_manager.require_session_role = MagicMock(
+        side_effect=require_role_factory)
     cert_manager = MagicMock()
     cert_manager.get_certificate_metadata.return_value = None          # unknown id
     cert_manager.get_certificate_file.return_value = None              # no such file
@@ -148,7 +150,10 @@ def _metrics_body(tmp_path, domain, cert_info):
     from modules.core import metrics as metrics_module
     metrics_module.metrics_collector.last_collection = 0
     app = Flask(__name__)
-    register_misc_routes(app, managers, passthrough, SimpleNamespace(require_role=passthrough))
+    register_misc_routes(
+        app, managers, passthrough,
+        SimpleNamespace(require_role=passthrough,
+                        require_session_role=passthrough))
     body = app.test_client().get('/metrics').get_data(as_text=True)
     metrics_module.metrics_collector.last_collection = 0   # leave it fresh for the next test
     return body

--- a/tests/test_notifications_config_route.py
+++ b/tests/test_notifications_config_route.py
@@ -82,6 +82,8 @@ def route_client(tmp_path):
 
     auth_manager = MagicMock()
     auth_manager.require_role = MagicMock(side_effect=_passthrough_role)
+    auth_manager.require_session_role = MagicMock(
+        side_effect=_passthrough_role)
 
     managers = {
         "auth": auth_manager,

--- a/tests/test_rate_limits_config.py
+++ b/tests/test_rate_limits_config.py
@@ -101,6 +101,8 @@ def route_client(tmp_path):
 
     auth_manager = MagicMock()
     auth_manager.require_role = MagicMock(side_effect=_passthrough_role)
+    auth_manager.require_session_role = MagicMock(
+        side_effect=_passthrough_role)
 
     managers = {"auth": auth_manager, "settings": settings_manager, "audit": MagicMock()}
 

--- a/tests/test_scheduler_status_health.py
+++ b/tests/test_scheduler_status_health.py
@@ -43,6 +43,7 @@ def _build_app(managers: dict) -> Flask:
         return deco
 
     auth_manager.require_role = _passthrough
+    auth_manager.require_session_role = _passthrough
     auth_manager.is_local_auth_enabled.return_value = False
     auth_manager.has_any_users.return_value = False
 

--- a/tests/test_the_event_stream_goes_through_the_same_gate.py
+++ b/tests/test_the_event_stream_goes_through_the_same_gate.py
@@ -1,0 +1,175 @@
+"""The event stream's access rule belongs with the other access rules.
+
+`/api/events/stream` decided who could read it with an inline
+`if not auth_manager.is_setup_mode(): ...check the cookie...`. The *behaviour*
+was right — `EventSource` offers no way to add an Authorization header, so a
+bearer token cannot reach this route however the caller is configured, and only
+the cookie session can serve.
+
+Three things were wrong with expressing that in the route rather than as a
+decorator:
+
+* **The route was invisible.** Nothing enumerating protection could see it, so
+  it sat in the public allowlist (#761) with "checked inline" as its reason —
+  a protected route recorded as an exception.
+* **The check had drifted.** It never consulted a role, so a `viewer`-only
+  session and an `admin` one were the same to it, while every other route in
+  the system distinguishes them.
+* **A second such surface would have copied it.** SSE is the whole set today;
+  it is not obviously the whole set forever.
+
+`require_session_role('viewer')` is that rule expressed once. Setup mode is
+honoured exactly as the other decorators honour it: with no operator credential
+configured at all, every caller is admin, and the live stream is no different
+from the dashboard it feeds.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from modules.core.auth import AuthManager
+
+pytestmark = [pytest.mark.unit]
+
+
+def _auth(*, setup_mode, session_user=None):
+    auth = AuthManager.__new__(AuthManager)
+    auth.settings_manager = MagicMock()
+    auth.is_setup_mode = lambda: setup_mode
+    auth.validate_session = lambda sid: session_user if sid else None
+    auth._log_rbac_denial = MagicMock()
+    return auth
+
+
+def _app(auth, min_role='viewer'):
+    app = Flask(__name__)
+
+    @app.route('/stream')
+    @auth.require_session_role(min_role)
+    def stream():
+        from flask import request
+        return {'ok': True, 'user': request.current_user.get('username')}
+
+    return app
+
+
+# --- the cookie is the only credential -----------------------------------
+
+def test_a_valid_session_is_let_through():
+    auth = _auth(setup_mode=False,
+                 session_user={'username': 'ada', 'role': 'operator'})
+    client = _app(auth).test_client()
+    client.set_cookie('certmate_session', 'abc')
+
+    response = client.get('/stream')
+    assert response.status_code == 200
+    assert response.get_json()['user'] == 'ada'
+
+
+def test_no_cookie_is_a_401_not_a_redirect():
+    """An EventSource cannot follow a redirect usefully — a 302 to the login
+    page arrives as an opaque stream error. 401 lets the client decide to
+    reconnect after logging in."""
+    auth = _auth(setup_mode=False)
+    response = _app(auth).test_client().get('/stream')
+
+    assert response.status_code == 401
+    assert response.get_json()['code'] == 'SESSION_REQUIRED'
+
+
+def test_an_invalid_session_is_refused():
+    auth = _auth(setup_mode=False, session_user=None)
+    client = _app(auth).test_client()
+    client.set_cookie('certmate_session', 'stale')
+    assert client.get('/stream').status_code == 401
+
+
+def test_a_bearer_token_does_not_open_it():
+    """CONTROL, and the reason this decorator exists rather than require_role:
+    a browser cannot send this header on an EventSource, so accepting it here
+    would be a credential path only a non-browser could use — on a surface
+    that exists for the browser."""
+    auth = _auth(setup_mode=False)
+    auth.authenticate_api_token = MagicMock(
+        return_value={'username': 'api', 'role': 'admin'})
+
+    response = _app(auth).test_client().get(
+        '/stream', headers={'Authorization': 'Bearer whatever'})
+    assert response.status_code == 401
+
+
+# --- roles, which the inline check never looked at ----------------------
+
+def test_a_role_below_the_requirement_is_refused():
+    auth = _auth(setup_mode=False,
+                 session_user={'username': 'bob', 'role': 'viewer'})
+    client = _app(auth, min_role='admin').test_client()
+    client.set_cookie('certmate_session', 'abc')
+
+    response = client.get('/stream')
+    assert response.status_code == 403
+    assert response.get_json()['code'] == 'INSUFFICIENT_ROLE'
+
+
+def test_a_role_denial_is_audited():
+    """The same treatment require_role gives it: privilege enumeration must
+    leave a trace rather than vanishing behind a silent 403."""
+    auth = _auth(setup_mode=False,
+                 session_user={'username': 'bob', 'role': 'viewer'})
+    client = _app(auth, min_role='admin').test_client()
+    client.set_cookie('certmate_session', 'abc')
+    client.get('/stream')
+
+    assert auth._log_rbac_denial.called
+
+
+def test_a_higher_role_satisfies_a_lower_requirement():
+    auth = _auth(setup_mode=False,
+                 session_user={'username': 'root', 'role': 'admin'})
+    client = _app(auth, min_role='viewer').test_client()
+    client.set_cookie('certmate_session', 'abc')
+    assert client.get('/stream').status_code == 200
+
+
+# --- setup mode ----------------------------------------------------------
+
+def test_setup_mode_lets_everyone_in_as_it_does_everywhere_else():
+    """With no operator credential configured at all, every caller is admin.
+    The live stream must not be stricter than the dashboard it feeds — that
+    would break the onboarding it exists to show."""
+    auth = _auth(setup_mode=True)
+    response = _app(auth).test_client().get('/stream')
+
+    assert response.status_code == 200
+    assert response.get_json()['user'] == 'setup_user'
+
+
+# --- the census sees it now ---------------------------------------------
+
+def test_the_decorator_marks_what_it_protects():
+    auth = _auth(setup_mode=False)
+
+    def view():
+        pass
+
+    factory = auth.require_session_role('viewer')
+    assert factory._certmate_protection == 'require_session_role:viewer'
+    assert factory(view)._certmate_protection == 'require_session_role:viewer'
+
+
+def test_the_stream_is_no_longer_listed_as_a_public_route():
+    """The point of the change: a protected route was recorded as an
+    exception, which is the one thing an allowlist must not contain."""
+    import tests.test_every_route_is_protected_or_listed as census
+    assert '/api/events/stream' not in census.PUBLIC_ROUTES
+
+
+def test_the_route_actually_carries_the_decorator():
+    import pathlib
+    source = (pathlib.Path(__file__).resolve().parent.parent / 'modules'
+              / 'web' / 'misc_routes.py').read_text()
+    stream = source.split("@app.route('/api/events/stream')")[1][:200]
+    assert "require_session_role('viewer')" in stream, (
+        'the event stream went back to deciding access inline'
+    )

--- a/tests/test_webhook_payload_template.py
+++ b/tests/test_webhook_payload_template.py
@@ -260,6 +260,8 @@ def _app(notifier):
     app.secret_key = 't'
     auth_manager = MagicMock()
     auth_manager.require_role = MagicMock(side_effect=lambda *a, **k: (lambda f: f))
+    auth_manager.require_session_role = MagicMock(
+        side_effect=lambda *a, **k: (lambda f: f))
     settings_manager = MagicMock()
     managers = {'notifier': notifier, 'settings': settings_manager, 'audit': None}
     register_misc_routes(app, managers, lambda f: f, auth_manager)


### PR DESCRIPTION
## The behaviour was right. Where it was written was not.

`/api/events/stream` decided who could read it with an inline check:

```python
if not auth_manager.is_setup_mode():
    session_id = _req.cookies.get('certmate_session')
    if not session_id or not auth_manager.validate_session(session_id):
        return jsonify({'error': 'Unauthenticated'}), 401
```

`EventSource` offers no way to add an `Authorization` header, so a bearer token
cannot reach this route however the caller is configured — only the cookie
session can serve it. That part is correct and unchanged.

## Three things were wrong with expressing it there

**The route was invisible.** Nothing enumerating protection could see it, so
#761's census had to record it in the **public** allowlist with *"checked
inline"* as its reason — a protected route listed as an exception, which is the
one thing an allowlist must not contain.

**The check had drifted.** It never consulted a role, so a `viewer`-only
session and an `admin` one were the same to it, while every other route in the
system distinguishes them. It did not audit a denial either.

**A second such surface would have copied it.** SSE is the whole set today. It
is not obviously the whole set forever.

## `require_session_role(min_role)`

The same rule, expressed once, next to `require_role` and `require_auth` and
marked for the census like them.

It returns **401, not a redirect**, even for a browser: an `EventSource` cannot
follow a redirect usefully, and a 302 to the login page arrives as an opaque
stream error. 401 lets the client decide to reconnect after logging in.

Setup mode is honoured exactly as the other decorators honour it — with no
operator credential configured at all every caller is admin, and the live
stream must not be stricter than the dashboard it feeds.

`/api/events/stream` is now **out of `PUBLIC_ROUTES`** and in the protected set,
which is the point.

## Thirteen test doubles were incomplete

They build an `AuthManager` stand-in stubbing `require_role`, so they did not
have the new method and Flask asked a `MagicMock` for its `__name__`.

Completed rather than worked around: an incomplete model of the class under
test is the defect, not the decorator. Each edit is one line, and the shape is
identical in all thirteen.

*(Worth noting for later: a `SimpleNamespace(require_role=…)` silently misses
any decorator added afterwards. That is a fragility in the doubles, not in this
change, and it is what made a one-line addition land as 37 failures.)*

## Checks run locally

- 11 new tests; `pytest -m "not ui"` — **4395 passed, 59 skipped**
- `pytest -m ui` against the real container — **57 passed**, because the
  browser is what this route exists for
- `flake8` with CI's selector set, `C901` at the real max — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
