### PR TITLE
api: a contract version that moves when the contract does

### DIFF
--- a/README.md
+++ b/README.md
@@ -1494,6 +1494,40 @@ main "$@"
  loop: "{{ services_to_restart | default([]) }}"
 ```
 
+### API contract version
+
+Two versions appear in API responses and they answer different questions.
+
+| | what it is | when it moves |
+|---|---|---|
+| `version` (in `/health`, in the Swagger document) | the **release** number | every release |
+| `api_contract_version` (in `/health`), `X-CertMate-API-Version` (on **every** response) | the **interface** | only when this surface changes |
+
+A client deciding whether it still works should read the second. The first moves
+on every patch whether or not anything a caller depends on moved with it.
+
+- **minor** bump — the surface grew in a way you can ignore: a new endpoint, a
+  new field on a response, a new optional request field;
+- **major** bump — something you may depend on went away or changed meaning: an
+  endpoint removed, a response field removed or retyped, a request field that
+  became required, a status code that changed for an existing condition.
+
+Deprecating something bumps **neither** — that is the point of deprecating
+rather than removing.
+
+### Deprecation
+
+An endpoint on its way out answers normally and says so in its headers, so a
+client can warn instead of failing:
+
+```
+Deprecation: @1757289600                      # RFC 9745 — when it became deprecated
+Sunset: Mon, 08 Mar 2027 00:00:00 GMT         # RFC 8594 — earliest it may stop answering
+Link: <https://…/docs/api.md#…>; rel="deprecation"
+```
+
+Nothing is deprecated today. The headers appear only on an endpoint that is.
+
 ### Request validation
 
 The API validates request bodies against the models published in

--- a/modules/api/deprecation.py
+++ b/modules/api/deprecation.py
@@ -1,0 +1,97 @@
+"""Marking an endpoint as going away, in a shape a client can act on.
+
+There was no deprecation mechanism at all: no `Deprecation` header, no `Sunset`
+header, no `deprecated` flag in the Swagger document, no per-endpoint marker.
+An endpoint or a field could therefore be removed abruptly — breaking whatever
+was calling it, with the first notice being a 404 — or kept forever because
+removing it was the only alternative.
+
+Both of those are choices nobody wants to make. The standard shape lets a
+client warn instead of fail, which is what makes removal possible later:
+
+* **RFC 8594** `Sunset: <HTTP-date>` — the earliest date the endpoint may stop
+  answering.
+* **RFC 9745** `Deprecation: @<unix seconds>` — when it *became* deprecated. An
+  `@`-prefixed integer rather than a date string; that is the spec, not a
+  shortcut.
+* `Link: <...>; rel="deprecation"` — where to read what to do instead.
+
+Nothing is deprecated today, and that is the honest state: this module is the
+mechanism, and `DEPRECATIONS` is empty. Shipping the mechanism before it is
+needed is the point — the alternative is inventing it under time pressure, in
+the release where something has to go, which is when it gets skipped.
+
+`tests/test_the_contract_says_when_it_changes.py` checks the shape against an
+example entry rather than against production data, so the mechanism stays
+tested while nothing uses it.
+"""
+import datetime
+import logging
+
+logger = logging.getLogger(__name__)
+
+# endpoint name -> what to tell a caller. Empty on purpose; see the module
+# docstring.
+#
+# Shape:
+#   'certificates_certificate_list': {
+#       'since': '2026-09-08',        # when it became deprecated
+#       'sunset': '2027-03-08',       # earliest it may stop answering
+#       'link': 'https://.../docs/api.md#certificates',
+#       'note': 'Use GET /api/v2/certificates.',
+#   }
+DEPRECATIONS = {}
+
+
+def _http_date(day):
+    """An RFC 1123 date at midnight UTC, which is what Sunset takes."""
+    parsed = datetime.datetime.strptime(day, '%Y-%m-%d').replace(
+        tzinfo=datetime.timezone.utc)
+    return parsed.strftime('%a, %d %b %Y %H:%M:%S GMT')
+
+
+def _unix_at(day):
+    parsed = datetime.datetime.strptime(day, '%Y-%m-%d').replace(
+        tzinfo=datetime.timezone.utc)
+    return int(parsed.timestamp())
+
+
+def deprecation_headers(entry):
+    """The headers announcing one deprecation, or {} for a malformed entry.
+
+    Never raises. A typo in a date must not turn a working endpoint into a
+    500: the endpoint still answers, and the announcement is what is lost.
+    """
+    if not isinstance(entry, dict) or not entry.get('since'):
+        return {}
+    headers = {}
+    try:
+        headers['Deprecation'] = f"@{_unix_at(entry['since'])}"
+        if entry.get('sunset'):
+            headers['Sunset'] = _http_date(entry['sunset'])
+    except (TypeError, ValueError) as e:
+        logger.error(
+            "Malformed deprecation entry (%s); the endpoint still answers but "
+            "callers are not being told it is going away: %s", entry, e)
+        return {}
+    if entry.get('link'):
+        headers['Link'] = f'<{entry["link"]}>; rel="deprecation"'
+    return headers
+
+
+def apply_deprecation_headers(app):
+    """Announce, on every response, that its endpoint is going away.
+
+    Applied at the app rather than per route: a decorator would have to be
+    remembered on the endpoint being deprecated, which is the one moment
+    nobody is thinking about the mechanism.
+    """
+    from flask import request
+
+    @app.after_request
+    def _announce(response):
+        entry = DEPRECATIONS.get(request.endpoint)
+        if entry:
+            for name, value in deprecation_headers(entry).items():
+                response.headers.setdefault(name, value)
+        return response

--- a/modules/core/constants.py
+++ b/modules/core/constants.py
@@ -87,6 +87,26 @@ SETTINGS_SCHEMA_VERSION = 1
 # CertificateManager._save_metadata.
 METADATA_SCHEMA_VERSION = 1
 
+# Shape of the HTTP interface, on the same terms as the two schema versions
+# above: bumped only when the surface changes, never with the product version.
+#
+# `certmate_version` and the Swagger document's `version` are both the RELEASE
+# number, which moves on every patch whether or not anything a caller depends
+# on moved with it — so neither can answer "will my client still work". A
+# client that pinned the release number would refuse a patch that changed
+# nothing; one that ignored it had nothing else to read.
+#
+# Bump the MINOR when the surface grows in a way a caller can ignore: a new
+# endpoint, a new field on a response, a new optional request field. Bump the
+# MAJOR when something a caller may depend on goes away or changes meaning: an
+# endpoint removed, a response field removed or retyped, a request field that
+# becomes required, a status code that changes for an existing condition.
+#
+# Deprecating something does NOT bump either — that is the point of deprecating
+# rather than removing. It is announced with the Deprecation and Sunset headers
+# (see modules/api/deprecation.py) and the removal is what bumps the major.
+API_CONTRACT_VERSION = '1.0'
+
 # Protocols the deployment probe can speak. A domain fact, not an API one: the
 # service validates against it and modules/api/tls_probe drives it (#672 — it
 # lived in the API layer, which core could not reach without importing api and

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -1085,8 +1085,20 @@ def setup_scheduler(container: AppContainer):
 
 def setup_api(container: AppContainer, app):
     from modules import __version__
+    # `version` here is the release, which is what an OpenAPI document
+    # conventionally carries and what a reader expects to see. It is NOT the
+    # contract version: that is API_CONTRACT_VERSION, sent on every response
+    # as X-CertMate-API-Version and reported by /health, because the release
+    # number moves on every patch whether or not the surface did.
+    from .constants import API_CONTRACT_VERSION
     api = Api(app, version=__version__, title='CertMate API',
-              description='SSL Certificate API', doc='/docs/', prefix='/api')
+              description=(
+                  'SSL Certificate API. The interface contract is version '
+                  f'{API_CONTRACT_VERSION}, reported on every response as '
+                  'X-CertMate-API-Version and by GET /health as '
+                  'api_contract_version; it changes only when this surface '
+                  'does, unlike the release number above.'),
+              doc='/docs/', prefix='/api')
 
     api.authorizations = {
         'Bearer': {'type': 'apiKey', 'in': 'header', 'name': 'Authorization', 'description': 'Bearer token'}
@@ -1351,6 +1363,35 @@ def warn_if_multiple_workers():
         "with --workers 1 and raise --threads instead.",
         workers=workers)
     return workers
+
+
+def setup_api_contract_headers(app):
+    """Tell every caller which interface they are talking to.
+
+    The only version a client could read was the release number — in the
+    Swagger document and in /health — and it moves on every patch whether or
+    not anything a caller depends on moved with it. A client that pinned it
+    would refuse a patch that changed nothing; one that ignored it had nothing
+    else to read.
+
+    `X-CertMate-API-Version` carries API_CONTRACT_VERSION, which moves only
+    when the surface does. Sent as a header rather than only as a field so a
+    client learns it from any response, including the error it is trying to
+    understand, without a second call.
+
+    Deprecation announcements ride along here for the same reason: see
+    modules/api/deprecation.py.
+    """
+    from .constants import API_CONTRACT_VERSION
+    from ..api.deprecation import apply_deprecation_headers
+
+    @app.after_request
+    def _api_version(response):
+        response.headers.setdefault('X-CertMate-API-Version',
+                                    API_CONTRACT_VERSION)
+        return response
+
+    apply_deprecation_headers(app)
 
 
 def setup_correlation_ids(app):
@@ -1619,6 +1660,7 @@ def create_app(test_config=None):
     setup_error_handlers(app)
     setup_security_headers(app)
     setup_correlation_ids(app)
+    setup_api_contract_headers(app)
     setup_rate_limiting(app, container)
     setup_slow_request_logging(app, container)
 

--- a/modules/web/misc_routes.py
+++ b/modules/web/misc_routes.py
@@ -299,9 +299,14 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
         # "unknown"; fall back to the canonical package version (same source
         # Swagger and the Prometheus build_info use).
         from modules import __version__
+        from modules.core.constants import API_CONTRACT_VERSION
         return jsonify({
             'status': overall,
             'version': app.config.get('VERSION') or __version__,
+            # The release number above moves on every patch. This one moves
+            # only when the interface does, so it is the field a client can
+            # actually decide compatibility on.
+            'api_contract_version': API_CONTRACT_VERSION,
             'checks': checks
         })
 

--- a/scripts/check_coverage_floors.py
+++ b/scripts/check_coverage_floors.py
@@ -35,6 +35,11 @@ from pathlib import Path
 FLOORS = {
     'modules/api/__init__.py': 100,
     'modules/api/client_certificates.py': 60,
+    # 100 because it is 33 statements of pure logic with no I/O and no Flask
+    # dependency beyond one after_request — there is no honest reason for any
+    # of it to be unreached, and the mechanism is meant to be trustworthy on
+    # the day it is first used, which is a day nobody will be testing it.
+    'modules/api/deprecation.py': 100,
     'modules/api/models.py': 100,
     'modules/api/path_validation.py': 80,
     'modules/api/resource_context.py': 100,

--- a/tests/test_the_contract_says_when_it_changes.py
+++ b/tests/test_the_contract_says_when_it_changes.py
@@ -1,0 +1,198 @@
+"""A client needs a version that moves when the interface does, and not before.
+
+The only version a caller could read was the release number — in the Swagger
+document and in `/health`. It moves on every patch whether or not anything a
+caller depends on moved with it, so it cannot answer *"will my client still
+work"*. A client that pinned it would refuse a patch that changed nothing; one
+that ignored it had nothing else to read.
+
+`API_CONTRACT_VERSION` is that other thing. It is sent on **every** response as
+`X-CertMate-API-Version` — a header rather than only a field, so a client learns
+it from any response including the error it is trying to understand, without a
+second call — and reported by `/health` as `api_contract_version` for anything
+that already polls there.
+
+The rule is written where the constant is: **minor** when the surface grows in
+a way a caller can ignore, **major** when something a caller may depend on goes
+away or changes meaning. Deprecating does neither — that is the point of
+deprecating rather than removing.
+
+Which is the second half. There was no deprecation mechanism at all: no
+`Deprecation` header, no `Sunset`, no marker. So an endpoint could be removed
+abruptly, with a 404 as the first notice, or kept forever because removing it
+was the only alternative.
+
+`DEPRECATIONS` is empty, and that is the honest state — nothing is deprecated
+today. The mechanism ships before it is needed on purpose: the alternative is
+inventing it under time pressure in the release where something has to go,
+which is the release where it gets skipped. These tests exercise it against an
+example entry so it stays tested while nothing uses it.
+"""
+import datetime
+import pathlib
+
+import pytest
+from flask import Flask
+
+from modules.api.deprecation import (
+    DEPRECATIONS, apply_deprecation_headers, deprecation_headers,
+)
+from modules.core.constants import API_CONTRACT_VERSION
+
+pytestmark = [pytest.mark.unit]
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+EXAMPLE = {
+    'since': '2026-09-08',
+    'sunset': '2027-03-08',
+    'link': 'https://example.invalid/docs/api.md#certificates',
+    'note': 'Use GET /api/v2/certificates.',
+}
+
+
+# --- the contract version ------------------------------------------------
+
+def test_it_is_not_the_release_number():
+    """The whole point. If these were the same value, the new one would move
+    on every patch and answer nothing the old one did not."""
+    from modules import __version__
+    assert API_CONTRACT_VERSION != __version__
+
+
+def test_it_looks_like_a_two_part_version():
+    major, _, minor = API_CONTRACT_VERSION.partition('.')
+    assert major.isdigit() and minor.isdigit(), (
+        f'{API_CONTRACT_VERSION!r} is not major.minor, so "bump the major" is '
+        f'not an instruction anyone can follow'
+    )
+
+
+def test_the_rule_for_bumping_it_is_written_down():
+    """A version with no stated rule is a number that drifts. The rule lives
+    beside the constant, where the next person to change the surface is."""
+    source = (REPO / 'modules' / 'core' / 'constants.py').read_text()
+    block = source.split('API_CONTRACT_VERSION')[0][-2000:]
+    for expected in ('MINOR', 'MAJOR', 'endpoint removed'):
+        assert expected in block, (
+            f'the constant does not say what a {expected} bump means'
+        )
+
+
+def test_every_response_carries_it(app_client):
+    response = app_client.get('/health')
+    assert response.headers['X-CertMate-API-Version'] == API_CONTRACT_VERSION
+
+
+def test_an_error_response_carries_it_too(app_client):
+    """The case a header buys over a field: a client trying to understand a
+    failure learns which interface produced it, without a second call."""
+    response = app_client.get('/no-such-route-at-all')
+    assert response.status_code == 404
+    assert response.headers['X-CertMate-API-Version'] == API_CONTRACT_VERSION
+
+
+def test_health_reports_it_as_a_field(app_client):
+    body = app_client.get('/health').get_json()
+    assert body['api_contract_version'] == API_CONTRACT_VERSION
+    assert body['version'] != body['api_contract_version'], (
+        'health reports the same number twice, so one of them is redundant'
+    )
+
+
+# --- deprecation ---------------------------------------------------------
+
+def test_nothing_is_deprecated_today():
+    """The honest state, asserted so that adding an entry is a deliberate act
+    that shows up in a diff next to this line."""
+    assert DEPRECATIONS == {}
+
+
+def test_the_headers_follow_the_specs():
+    headers = deprecation_headers(EXAMPLE)
+
+    # RFC 9745: an @-prefixed unix timestamp, not a date string.
+    assert headers['Deprecation'] == '@%d' % int(
+        datetime.datetime(2026, 9, 8, tzinfo=datetime.timezone.utc).timestamp())
+    # RFC 8594: an HTTP-date.
+    assert headers['Sunset'] == 'Mon, 08 Mar 2027 00:00:00 GMT'
+    assert headers['Link'] == (
+        '<https://example.invalid/docs/api.md#certificates>; '
+        'rel="deprecation"')
+
+
+def test_a_deprecation_without_a_sunset_still_announces_itself():
+    """Not every deprecation has a removal date yet, and saying "this is going
+    away" is worth more than saying nothing until the date is chosen."""
+    headers = deprecation_headers({'since': '2026-09-08'})
+    assert 'Deprecation' in headers
+    assert 'Sunset' not in headers
+
+
+@pytest.mark.parametrize('entry', [
+    {}, None, 'a string', {'sunset': '2027-03-08'},          # no `since`
+    {'since': 'not-a-date'},
+    {'since': '2026-09-08', 'sunset': 'whenever'},
+])
+def test_a_malformed_entry_produces_no_headers_rather_than_an_error(entry):
+    """CONTROL, and the one that matters: a typo in a date must not turn a
+    working endpoint into a 500. The endpoint still answers; what is lost is
+    the announcement."""
+    assert deprecation_headers(entry) == {}
+
+
+def test_a_deprecated_endpoint_announces_itself(monkeypatch):
+    app = Flask(__name__)
+
+    @app.route('/old')
+    def old_thing():
+        return {'ok': True}
+
+    monkeypatch.setitem(DEPRECATIONS, 'old_thing', EXAMPLE)
+    apply_deprecation_headers(app)
+
+    response = app.test_client().get('/old')
+    assert response.status_code == 200, 'deprecated is not gone'
+    assert response.headers['Deprecation'].startswith('@')
+    assert response.headers['Sunset']
+
+
+def test_an_endpoint_that_is_not_deprecated_says_nothing(monkeypatch):
+    """CONTROL: a Deprecation header on every response would train clients to
+    ignore it."""
+    app = Flask(__name__)
+
+    @app.route('/current')
+    def current_thing():
+        return {'ok': True}
+
+    monkeypatch.setitem(DEPRECATIONS, 'something_else', EXAMPLE)
+    apply_deprecation_headers(app)
+
+    response = app.test_client().get('/current')
+    assert 'Deprecation' not in response.headers
+    assert 'Sunset' not in response.headers
+
+
+# --- the app under test --------------------------------------------------
+
+@pytest.fixture(scope='module')
+def app_client():
+    import tempfile
+    root = pathlib.Path(tempfile.mkdtemp()) / 'certmate'
+    module_dir = root / 'modules' / 'core'
+    module_dir.mkdir(parents=True)
+    anchor = module_dir / 'factory.py'
+    anchor.write_text('# test path anchor\n')
+    for shared in ('templates', 'static'):
+        source = REPO / shared
+        if source.is_dir():
+            (root / shared).symlink_to(source)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setenv('TESTING', 'true')
+        patch.setenv('FLASK_ENV', 'testing')
+        patch.setattr('modules.core.factory.__file__', str(anchor))
+        from modules.core.factory import create_app
+        app, _ = create_app()
+    return app.test_client()


### PR DESCRIPTION
Two findings, both about an interface that could not describe its own evolution.

## 1. The only version was the release number

`version` — in the Swagger document and in `/health` — moves on **every patch**,
whether or not anything a caller depends on moved with it. So it cannot answer
*"will my client still work"*. A client that pinned it would refuse a patch that
changed nothing; one that ignored it had nothing else to read.

| | what it is | when it moves |
|---|---|---|
| `version` | the **release** | every release |
| `api_contract_version` / `X-CertMate-API-Version` | the **interface** | only when the surface changes |

Sent as a **header on every response**, not only as a field: a client learns it
from any response — including the error it is trying to understand — without a
second call. There is a test for exactly that, on a 404.

**The rule lives beside the constant**, because a version with no stated rule is
a number that drifts:

- **minor** — the surface grew in a way a caller can ignore;
- **major** — something a caller may depend on went away or changed meaning.

Deprecating bumps **neither**. Which is the other half.

## 2. There was no way to deprecate anything

No `Deprecation` header, no `Sunset`, no marker, no flag. So an endpoint could
be removed **abruptly** — a 404 as the first notice — or **kept forever**,
because removing it was the only alternative. Both are choices nobody wants to
make.

`modules/api/deprecation.py` is the standard shape:

```
Deprecation: @1757289600                    # RFC 9745, an @-prefixed unix time
Sunset: Mon, 08 Mar 2027 00:00:00 GMT       # RFC 8594, an HTTP-date
Link: <https://…/docs/api.md#…>; rel="deprecation"
```

Applied at the **app**, not per route: a decorator would have to be remembered
on the endpoint being deprecated, which is the one moment nobody is thinking
about the mechanism.

## `DEPRECATIONS` is empty, and a test says so

Nothing is deprecated today. Shipping the mechanism **before** it is needed is
the point: the alternative is inventing it under time pressure in the release
where something has to go — which is the release where it gets skipped.

The tests exercise it against an example entry so it stays tested while nothing
uses it, and `test_nothing_is_deprecated_today` asserts the emptiness, so adding
an entry is a deliberate act visible in a diff next to that line.

**A malformed entry produces no headers rather than an error.** A typo in a date
must not turn a working endpoint into a 500 — the endpoint still answers; what
is lost is the announcement. Six parametrised cases cover it.

## The coverage gate caught the new file

`test_every_http_module_has_a_floor` (#662) failed because
`modules/api/deprecation.py` had none. It has one now, at **100**: 33 statements
of pure logic with no I/O, meant to be trustworthy on the day it is first
used — a day nobody will be testing it.

## Checks run locally

- 17 new tests; `pytest -m "not ui"` — **4429 passed, 59 skipped**
- `flake8` with CI's selector set, `C901` at the real max — clean
- README documents both, with the bump rule and the header shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
