### PR TITLE
data: a domain's DNS provider is written once, under one lock

### DIFF
--- a/modules/api/resources_certificates.py
+++ b/modules/api/resources_certificates.py
@@ -272,17 +272,12 @@ def create_certificates_resources(api, models, ctx: ApiContext) -> dict:
                     f"{old_provider} → {new_dns_provider or old_provider}"
                 )
 
-                # 2. Update domain entry in settings
-                def _update_domain_provider(s):
-                    for entry in s.get('domains', []):
-                        if isinstance(entry, dict) and entry.get('domain') == domain:
-                            if new_dns_provider:
-                                entry['dns_provider'] = new_dns_provider
-                            if new_account_id:
-                                entry['dns_account_id'] = new_account_id
-                            break
-
-                ctx.settings.update(_update_domain_provider, "dns_provider_change")
+                # The settings entry used to be written here, after
+                # update_config returned and therefore AFTER the domain lock
+                # was released. A renewal starting in that window read the old
+                # provider from settings while the metadata already said the
+                # new one. Both writes now happen inside the lock, in
+                # CertificateService.update_config.
 
                 response = {
                     'message': f'Certificate config updated for {domain}',

--- a/modules/core/cert_service.py
+++ b/modules/core/cert_service.py
@@ -423,7 +423,44 @@ class CertificateService:
                 raise RuntimeError(
                     f'Failed to update metadata for domain: {domain}')
 
+            # The settings entry is written HERE, inside the same domain lock,
+            # rather than by the caller afterwards.
+            #
+            # A domain's DNS provider is authoritative in two files: this
+            # certificate's metadata.json, which issuance reads, and the
+            # domain's entry in settings.json, which get_domain_dns_provider
+            # reads. They were updated by two separate writes with the lock
+            # released between them, and nothing reconciled them — so a
+            # renewal starting in that window read the OLD provider from
+            # settings while the metadata already said the new one, and
+            # neither file was wrong on its own.
+            #
+            # Lock ordering: this takes the settings lock while holding the
+            # domain lock. Checked before doing it — no settings mutate
+            # callback anywhere acquires a domain lock, so the reverse order
+            # does not exist and this cannot deadlock. Anything that adds one
+            # would have to take the domain lock first.
+            self._settings.update(
+                lambda s: self._write_domain_provider(s, domain, changes),
+                'dns_provider_change')
+
         return metadata, old_dns_provider
+
+    @staticmethod
+    def _write_domain_provider(settings, domain, changes):
+        """Mirror the DNS provider onto the domain's settings entry.
+
+        Only the keys the caller actually sent: an absent one means "leave
+        alone", the same rule the metadata write above follows, so a probe-only
+        edit does not touch the provider.
+        """
+        for entry in settings.get('domains', []):
+            if isinstance(entry, dict) and entry.get('domain') == domain:
+                if changes.get('dns_provider'):
+                    entry['dns_provider'] = changes['dns_provider']
+                if changes.get('account_id'):
+                    entry['dns_account_id'] = changes['account_id']
+                break
 
     def prepare_reissue(self, *, domain, san_domains=None, dns_provider=None,
                         account_id=None, ca_provider=None, challenge_type=None,

--- a/tests/test_the_dns_provider_has_one_home.py
+++ b/tests/test_the_dns_provider_has_one_home.py
@@ -1,0 +1,222 @@
+"""Two files hold a domain's DNS provider, and they must never disagree.
+
+`metadata.json` is what issuance reads. The domain's entry in `settings.json`
+is what `get_domain_dns_provider` reads. Both are authoritative, and they were
+updated by **two separate writes with the domain lock released between them**:
+`CertificateService.update_config` wrote the metadata under the lock and
+returned, and the route wrote the settings entry afterwards.
+
+Nothing reconciled them. A renewal starting in that window read the **old**
+provider from settings while the metadata already said the new one — and
+neither file was wrong on its own, which is what makes it hard to see.
+
+Both writes now happen inside the same `domain_lock` section, so the pair is
+atomic with respect to a renewal.
+
+**Lock ordering was checked before doing this**, because taking the settings
+lock while holding the domain lock creates one. No settings mutate callback
+anywhere in the codebase acquires a domain lock, so the reverse order does not
+exist and this cannot deadlock. Anything that adds one would have to take the
+domain lock first — which is why it is stated in the code and here.
+"""
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.cert_service import CertificateService
+
+pytestmark = [pytest.mark.unit]
+
+
+class _Certs:
+    """A certificate manager with a real per-domain lock and metadata in
+    memory, so the ordering of the two writes is observable."""
+
+    def __init__(self, metadata=None):
+        self.cert_dir = None
+        self._metadata = metadata or {}
+        self._lock = threading.RLock()
+        self.depth = 0
+
+    def domain_lock(self, domain):
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _held():
+            self._lock.acquire()
+            self.depth += 1
+            try:
+                yield
+            finally:
+                self.depth -= 1
+                self._lock.release()
+
+        return _held()
+
+    def _save_metadata(self, domain, metadata):
+        self._metadata = dict(metadata)
+        return True
+
+
+@pytest.fixture
+def parts():
+    certs = _Certs({'domain': 'example.com', 'dns_provider': 'cloudflare'})
+    stored = {'domains': [{'domain': 'example.com',
+                           'dns_provider': 'cloudflare',
+                           'dns_account_id': 'old'}]}
+    order = []
+
+    settings = MagicMock()
+
+    def _update(mutate, reason):
+        # Record whether the DOMAIN lock is held at the moment of the settings
+        # write. That is the property under test, and it is only observable
+        # from inside the callback.
+        order.append(('settings-write', reason, certs.depth))
+        mutate(stored)
+
+    settings.update.side_effect = _update
+    service = CertificateService(certs, settings, MagicMock(), MagicMock())
+    service.read_metadata = lambda domain: dict(certs._metadata)
+    return service, certs, stored, order
+
+
+# --- both writes happen, and both happen under the lock -----------------
+
+def test_both_stores_are_updated(parts):
+    service, certs, stored, _ = parts
+
+    service.update_config('example.com', {'dns_provider': 'route53'})
+
+    assert certs._metadata['dns_provider'] == 'route53'
+    assert stored['domains'][0]['dns_provider'] == 'route53', (
+        'the settings entry still names the old provider, so a renewal would '
+        'use it'
+    )
+
+
+def test_the_settings_write_happens_while_the_domain_lock_is_held(parts):
+    """The whole point, and the only assertion that actually pins it.
+
+    An earlier version of this test checked that the write happened and that
+    the lock was acquired and released — which is equally true of the broken
+    ordering it replaces. What matters is the domain lock being held AT THE
+    MOMENT of the settings write, because a renewal starting in a gap between
+    the two would read a provider the metadata had already replaced.
+    """
+    service, certs, _, order = parts
+
+    service.update_config('example.com', {'dns_provider': 'route53'})
+
+    assert order, 'the settings entry was never written'
+    _, _, depth_at_write = order[0]
+    assert depth_at_write == 1, (
+        'the settings entry was written with the domain lock NOT held, so a '
+        'renewal can interleave between the two writes'
+    )
+    assert certs.depth == 0, 'the domain lock was not released afterwards'
+
+
+def test_the_settings_write_carries_a_reason(parts):
+    service, _, _, order = parts
+    service.update_config('example.com', {'dns_provider': 'route53'})
+    assert order[0][1] == 'dns_provider_change'
+
+
+def test_the_account_id_is_mirrored_too(parts):
+    service, certs, stored, _ = parts
+    service.update_config('example.com',
+                          {'dns_provider': 'route53', 'account_id': 'prod'})
+    assert certs._metadata['account_id'] == 'prod'
+    assert stored['domains'][0]['dns_account_id'] == 'prod'
+
+
+# --- what must not be touched -------------------------------------------
+
+def test_a_probe_only_edit_leaves_the_provider_alone(parts):
+    """CONTROL: absent means "leave alone", the same rule the metadata write
+    follows. Mirroring an absent key as empty would wipe the provider on a
+    port change."""
+    service, certs, stored, _ = parts
+
+    service.update_config('example.com', {'deployment_port': 8443})
+
+    assert certs._metadata['deployment_port'] == 8443
+    assert stored['domains'][0]['dns_provider'] == 'cloudflare'
+    assert stored['domains'][0]['dns_account_id'] == 'old'
+
+
+def test_a_domain_with_no_settings_entry_is_not_invented(parts):
+    """A certificate can exist without a settings entry — an adopted one, for
+    instance. Creating a half-populated entry here would make it look managed
+    when it is not."""
+    service, _, stored, _ = parts
+    stored['domains'] = []
+
+    service.update_config('example.com', {'dns_provider': 'route53'})
+
+    assert stored['domains'] == []
+
+
+def test_a_malformed_domains_list_does_not_crash_the_edit(parts):
+    """settings.json is hand-editable. A string entry among the dicts must
+    not turn a config change into a 500."""
+    service, _, stored, _ = parts
+    stored['domains'] = ['example.com', {'domain': 'example.com'}]
+
+    service.update_config('example.com', {'dns_provider': 'route53'})
+
+    assert stored['domains'][1]['dns_provider'] == 'route53'
+
+
+def test_a_failed_metadata_write_does_not_touch_settings(parts):
+    """CONTROL: the two must not half-apply in the other direction either.
+    Settings naming a provider whose metadata says otherwise is the same
+    defect, mirrored."""
+    service, certs, stored, order = parts
+    certs._save_metadata = lambda domain, metadata: False
+
+    with pytest.raises(RuntimeError):
+        service.update_config('example.com', {'dns_provider': 'route53'})
+
+    assert stored['domains'][0]['dns_provider'] == 'cloudflare'
+    assert not order, 'settings were written after the metadata write failed'
+
+
+# --- the route no longer does half the job ------------------------------
+
+def test_the_route_no_longer_writes_settings_itself():
+    import pathlib
+    source = (pathlib.Path(__file__).resolve().parent.parent / 'modules'
+              / 'api' / 'resources_certificates.py').read_text()
+    assert 'dns_provider_change' not in source, (
+        'the route writes the settings entry again, outside the domain lock '
+        'that update_config holds'
+    )
+
+
+def test_no_settings_mutate_callback_takes_a_domain_lock():
+    """The precondition for holding the settings lock inside the domain lock.
+    If one ever did, the two orders would exist and could deadlock — so the
+    check that made this safe is kept rather than remembered."""
+    import ast
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parent.parent / 'modules'
+    offenders = []
+    for path in root.rglob('*.py'):
+        tree = ast.parse(path.read_text(encoding='utf-8'))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.Lambda)):
+                continue
+            name = getattr(node, 'name', '<lambda>')
+            body = ast.unparse(node)
+            if ('domain_lock' in body
+                    and name in ('_mutate', '_update_domain_provider',
+                                 '_apply', '_write_domain_provider')):
+                offenders.append(f'{path.name}:{node.lineno} {name}')
+
+    assert not offenders, (
+        'a settings mutate callback acquires a domain lock, so the two lock '
+        'orders now both exist: ' + ', '.join(offenders))


### PR DESCRIPTION
## Two files, both authoritative, written without a lock between them

`metadata.json` is what **issuance** reads. The domain's entry in
`settings.json` is what **`get_domain_dns_provider`** reads.

They were updated by two separate writes with the domain lock **released**
between them: `CertificateService.update_config` wrote the metadata under the
lock and returned, and the route wrote the settings entry afterwards.

Nothing reconciled them. A renewal starting in that window read the **old**
provider from settings while the metadata already said the new one — and
neither file was wrong on its own, which is what makes it hard to see.

Both writes now happen inside the same `domain_lock` section. The route stops
doing half the job; `update_config` owns the pair.

## Lock ordering was checked, not assumed

Taking the settings lock while holding the domain lock **creates an ordering**.
No settings mutate callback anywhere in `modules/` acquires a domain lock, so
the reverse order does not exist and this cannot deadlock.

That check is a **test**, not a memory:
`test_no_settings_mutate_callback_takes_a_domain_lock` walks every module and
fails, naming the file, if one ever appears.

## The mirror follows the metadata write's own rule

Absent means "leave alone", so:

- a **probe-only** edit does not touch the provider — mirroring an absent key
  as empty would wipe it on a port change;
- a certificate with **no settings entry** (an adopted one) does not gain a
  half-populated one that makes it look managed;
- a **hand-edited** `domains` list with a stray string among the dicts does not
  turn a config change into a 500;
- a **failed metadata write** leaves settings untouched — the pair must not
  half-apply in that direction either.

## The test that pins this was written wrong first

It checked that the write happened and that the lock was acquired and
released — **equally true of the broken version it replaces**.

It now records whether the domain lock is *held at the moment of the settings
write*, which is the only observation that distinguishes the two. The mutation
confirms it — after a **first mutation attempt that silently failed to apply**
and therefore measured nothing, which is why the second one verifies the file
actually changed before drawing a conclusion.

## Checks run locally

- 10 new tests; `pytest -m "not ui"` — **4433 passed, 59 skipped**
- Verified by mutation: moving the settings write back outside the lock fails
  the ordering test
- `flake8` with CI's selector set, `C901` at the real max — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
