### PR TITLE
security: what counts as a secret cannot be decided by accident any more

### DIFF
--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -123,10 +123,16 @@ _SECRET_KEY_RE = re.compile(
     r'(token|secret|password|key|credential|hmac|authorization)',
     re.IGNORECASE,
 )
-# Keys whose name matches the secret regex but whose value is NOT a secret.
-# Mirrors _NON_SECRET_KEYS in modules/web/settings_routes.py: these carry
-# the global default key-options ('rsa', 2048, 'secp256r1'), not credentials,
-# so empty values must NOT be treated as "preserve".
+# Keys whose name matches the secret regex but whose value is NOT a secret:
+# they carry the global default key-options ('rsa', 2048, 'secp256r1'), not
+# credentials, so an empty value must NOT be treated as "preserve".
+#
+# This used to be mirrored by a _NON_SECRET_KEYS list in
+# modules/web/settings_routes.py, and the two could disagree — a value masked
+# on GET but unrecognised on POST is written back as the mask, destroying the
+# secret. The routes now call this module rather than keeping a second copy,
+# so there is one definition; the comment that still pointed at the old one
+# outlived it.
 _NON_SECRET_KEY_NAMES = frozenset({
     'default_key_type',
     'default_key_size',
@@ -187,6 +193,11 @@ _PROVIDER_SPECIFIC_SECRET_FIELDS = {
     # share-safe backup ZIP. Masked like any other secret; restored on a save.
     'webhooks': frozenset({'url'}),
 }
+# Every credential field of every DNS provider must be covered by the regex
+# above or declared here. tests/test_what_counts_as_a_secret_is_declared.py
+# walks _DNS_PROVIDER_CREDENTIALS and fails on one that is neither, so a new
+# provider whose credential happens to be named something the seven words miss
+# cannot be added without someone deciding which it is.
 
 # List keys whose items carry secrets keyed by the LIST name rather than the
 # container's provider context. webhooks[*] is the case: its items live under

--- a/tests/test_what_counts_as_a_secret_is_declared.py
+++ b/tests/test_what_counts_as_a_secret_is_declared.py
@@ -1,0 +1,174 @@
+"""A credential must not escape masking because of how it happens to be named.
+
+What counts as a secret is decided by a regular expression over the field's
+NAME — seven words — plus a declared list for the fields whose names the regex
+misses. A credential named something else is neither masked on `GET
+/api/web/settings` nor kept out of the share-safe backup, which is the archive
+explicitly meant to be shareable.
+
+**Measured before writing anything: today, nothing is missed.** All 29 DNS
+providers' credential fields are covered. The eleven that the regex does not
+match are identifiers and endpoints, and each is named below with the reason —
+including `custom-script.auth_hook`, which reads like a place to hide a token
+and is in fact a *script path* (`_validated_hook_path`), and
+`acme-dns.username`, which IS treated as a secret because there it is half of a
+generated credential rather than an account name a person chose.
+
+So the risk is entirely about the **next** provider. This file makes that
+condition impossible to introduce silently: a credential field that is neither
+matched nor declared fails, naming the provider and the field.
+
+The classification of "not a secret" lives here rather than in production code
+on purpose. It changes no behaviour — it is a review artefact, the record of a
+decision someone made, in the place where the next person is asked to make the
+same one.
+"""
+import pytest
+
+from modules.core.settings import (
+    _PROVIDER_SPECIFIC_SECRET_FIELDS, _SECRET_KEY_RE, _is_secret_key,
+    mask_secrets_in_settings,
+)
+from modules.core.utils import _DNS_PROVIDER_CREDENTIALS
+
+pytestmark = [pytest.mark.unit]
+
+
+# Credential-registry fields the regex does not match, and why each is not a
+# secret. A field here is a decision; a field in neither this nor
+# _PROVIDER_SPECIFIC_SECRET_FIELDS is an oversight.
+NOT_A_SECRET = {
+    ('acme-dns', 'api_url'): 'the acme-dns server endpoint',
+    ('azure', 'subscription_id'): 'an Azure subscription identifier',
+    ('azure', 'resource_group'): 'a resource group name',
+    ('azure', 'tenant_id'): 'an Azure tenant identifier',
+    ('azure', 'client_id'): 'the application id; client_secret is the secret',
+    ('custom-script', 'auth_hook'):
+        'a PATH to a script on disk, screened by _validated_hook_path — not '
+        'an inline command, so it cannot carry an embedded token',
+    ('edgedns', 'host'): 'the Akamai EdgeDNS API host',
+    ('google', 'project_id'): 'a GCP project identifier',
+    ('he-ddns', 'username'):
+        'the Hurricane Electric account name, which the operator knows and '
+        'which is not on its own a credential',
+    ('namecheap', 'username'): 'the Namecheap account name',
+    ('ovh', 'endpoint'): 'the OVH API region endpoint',
+    ('powerdns', 'api_url'): 'the PowerDNS API endpoint',
+    ('rfc2136', 'nameserver'): 'the address of the nameserver to update',
+    ('solidserver', 'host'): 'the SOLIDserver appliance address',
+    ('solidserver', 'username'): 'the SOLIDserver account name',
+    ('solidserver', 'dns_name'): 'the name of the DNS service on the appliance',
+}
+
+
+def _declared(provider, field):
+    return field in _PROVIDER_SPECIFIC_SECRET_FIELDS.get(provider,
+                                                         frozenset())
+
+
+# --- the census ----------------------------------------------------------
+
+def test_every_provider_credential_is_classified():
+    unclassified = []
+    for provider, fields in sorted(_DNS_PROVIDER_CREDENTIALS.items()):
+        for field in fields:
+            if _SECRET_KEY_RE.search(field) or _declared(provider, field):
+                continue
+            if (provider, field) in NOT_A_SECRET:
+                continue
+            unclassified.append(f'{provider}.{field}')
+
+    assert not unclassified, (
+        "these DNS provider credential fields are matched by neither the "
+        "secret-name regex nor _PROVIDER_SPECIFIC_SECRET_FIELDS, so they are "
+        "returned in cleartext by GET /api/web/settings and written into the "
+        "share-safe backup:\n  " + '\n  '.join(unclassified)
+        + "\n\nIf one IS a secret, add it to _PROVIDER_SPECIFIC_SECRET_FIELDS "
+          "in modules/core/settings.py. If it is not, add it to NOT_A_SECRET "
+          "here with the reason."
+    )
+
+
+def test_the_not_a_secret_list_does_not_outlive_its_fields():
+    """A stale entry is a standing exemption for a name that may come back
+    meaning something else."""
+    stale = sorted(
+        f'{provider}.{field}' for provider, field in NOT_A_SECRET
+        if field not in _DNS_PROVIDER_CREDENTIALS.get(provider, ()))
+    assert not stale, (
+        'NOT_A_SECRET names fields no provider declares any more: '
+        + ', '.join(stale))
+
+
+def test_every_exemption_says_why():
+    for (provider, field), reason in NOT_A_SECRET.items():
+        assert len(reason.strip()) > 15, (
+            f'{provider}.{field} is exempt with no usable reason: {reason!r}')
+
+
+def test_a_field_is_not_exempted_and_declared_at_once():
+    """CONTROL: the two lists must not disagree — a field in both would have
+    one of them saying something false about it."""
+    both = sorted(
+        f'{provider}.{field}' for provider, field in NOT_A_SECRET
+        if _declared(provider, field))
+    assert not both, (
+        'these are listed as not-a-secret AND declared as secret: '
+        + ', '.join(both))
+
+
+# --- controls on the census ---------------------------------------------
+
+def test_the_registry_has_the_providers_it_should():
+    """Without this, an empty registry makes every assertion above pass."""
+    assert len(_DNS_PROVIDER_CREDENTIALS) > 25
+    assert 'cloudflare' in _DNS_PROVIDER_CREDENTIALS
+
+
+def test_the_regex_still_recognises_an_obvious_credential():
+    """CONTROL: a regex that matched nothing would push every field into
+    NOT_A_SECRET; one that matched everything would hide a real gap."""
+    for name in ('api_token', 'client_secret', 'password', 'api_key',
+                 'hmac_key', 'credentials_json'):
+        assert _is_secret_key(name), f'{name} is no longer seen as a secret'
+    for name in ('domain', 'email', 'port', 'enabled'):
+        assert not _is_secret_key(name), f'{name} is now seen as a secret'
+
+
+def test_the_key_option_defaults_are_still_not_secrets():
+    """They match the regex on 'key' and are not credentials. Treating them
+    as secrets would make an empty value mean "preserve", so an operator
+    could never clear one."""
+    for name in ('default_key_type', 'default_key_size',
+                 'default_elliptic_curve'):
+        assert _is_secret_key(name) is False
+
+
+# --- and the masking actually happens -----------------------------------
+
+def test_a_declared_field_is_masked_even_though_its_name_is_innocent():
+    """The webhook URL: for Slack, Discord, ntfy and Gotify the incoming URL
+    embeds the bearer secret in its path, and 'url' matches no pattern."""
+    masked = mask_secrets_in_settings({
+        'notifications': {'channels': {'webhooks': [
+            {'name': 'ops', 'url': 'https://hooks.example.invalid/T/B/XXXX'}]}}
+    })
+    webhook = masked['notifications']['channels']['webhooks'][0]
+    assert webhook['url'] != 'https://hooks.example.invalid/T/B/XXXX'
+    assert webhook['name'] == 'ops', 'the label was masked too'
+
+
+def test_an_ordinary_credential_is_masked():
+    masked = mask_secrets_in_settings(
+        {'dns_providers': {'cloudflare': {'default': {'api_token': 'abc'}}}})
+    assert masked['dns_providers']['cloudflare']['default']['api_token'] \
+        != 'abc'
+
+
+def test_a_non_secret_is_left_readable():
+    """CONTROL: masking everything would make the settings page unusable and
+    would round-trip real values away on save."""
+    masked = mask_secrets_in_settings({'email': 'ops@example.com',
+                                       'auto_renew': True})
+    assert masked['email'] == 'ops@example.com'
+    assert masked['auto_renew'] is True


### PR DESCRIPTION
## The finding

What counts as a secret — for masking on read, and for preserve-on-save — is a
regex over the field's **name**: seven words, plus a declared list for the
fields whose names it misses. A credential named something else is neither
masked on `GET /api/web/settings` nor kept out of the **share-safe backup**,
which is the archive explicitly meant to be shareable.

## Measured before changing anything: today nothing is missed

All **29** DNS providers' credential fields are covered. Sixteen are not matched
by the regex, and every one is an identifier or an endpoint. Two are worth
naming:

- **`custom-script.auth_hook`** reads like a place to hide a token. It is a
  script **path**, screened by `_validated_hook_path` — not an inline command,
  so it cannot carry one.
- **`acme-dns.username`** *is* already declared a secret, because there it is
  half of a generated credential rather than an account name a person chose.
  `he-ddns` and `namecheap` usernames are not, for exactly that reason.

So the finding's risk is entirely about the **next** provider.

## Why not the refactor the finding proposed

Replacing the regex with a frozenset of secret paths has a failure mode: a
forgotten path **silently un-masks a live credential**. That is worse than the
over-broad matching it would replace — over-broad has a visible symptom (a
field you cannot clear), under-broad has none.

So instead, the dangerous condition is made impossible to introduce silently. A
credential field matched by neither the regex nor the declared list fails the
build, naming the provider and the field:

```
these DNS provider credential fields are matched by neither the secret-name
regex nor _PROVIDER_SPECIFIC_SECRET_FIELDS, so they are returned in cleartext
by GET /api/web/settings and written into the share-safe backup:
  newprovider.pat
```

The "not a secret" classification lives in the **test**, not in production
code, because it changes no behaviour. It is a review artefact — the record of
a decision someone made — in the place where the next person is asked to make
the same one, with the reason beside each entry.

## Controls

A census that measures nothing would let every field through, so: the registry
must hold more than 25 providers; the regex must still recognise `api_token`,
`client_secret`, `password`, `api_key`, and still *not* recognise `domain`,
`email`, `port`; and the masking is exercised end-to-end on the webhook URL —
the case where an innocent name (`url`) carries the bearer secret in its path.

## Two smaller things found on the way

The comment beside `_NON_SECRET_KEY_NAMES` said it mirrored a list in
`modules/web/settings_routes.py`. **That list is gone** — the routes call this
module now — so the comment was pointing the next reader at a file that would
not explain anything.

And the finding's own suggestion to *"collapse the two mirrored exception lists
into one"* had already happened.

## Checks run locally

- 10 new tests; `pytest -m "not ui"` — **4442 passed, 59 skipped**
- Verified by mutation: a provider whose credential is named `pat` fails the
  census by name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
