### PR TITLE
security: a credential can name where it lives instead of holding its value

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -104,6 +104,52 @@ Treat the admin role as highly privileged: grant it only to trusted operators,
 and prefer scoped, non-admin API keys for automation that only needs to create
 or download certificates.
 
+### Keeping credentials out of `settings.json`
+
+DNS provider API tokens and the OIDC client secret are stored in
+`settings.json` as cleartext JSON, in a file written `0600`. The permission is
+correct and is not the interesting part: that file is what gets backed up,
+copied between hosts, mounted into a container and attached to a bug report.
+
+Any of those fields can instead **name** where its value lives, the way
+`API_BEARER_TOKEN_FILE` already does for the bearer token. Beside a field, write
+`<field>_file` with a path or `<field>_env` with a variable name:
+
+```json
+{
+  "dns_providers": {
+    "cloudflare": {
+      "accounts": {
+        "prod": { "api_token_file": "/run/secrets/cloudflare_api_token" }
+      }
+    }
+  },
+  "oidc": { "client_secret_env": "CERTMATE_OIDC_CLIENT_SECRET" }
+}
+```
+
+The value is read at the moment it is used — to run certbot, or to build the
+OIDC client — and is never written back, so a settings save does not turn a
+reference into a stored secret. Listing accounts and rendering the settings page
+do not read it at all: an account counts as configured because the reference is
+present, not because the secret could be read.
+
+Details worth knowing before relying on it:
+
+- A reference **wins over** a value in the same field. Adding `api_token_file`
+  next to an existing `api_token` switches over immediately; the stale literal
+  is ignored rather than silently preferred.
+- `_file` wins over `_env` if both are present.
+- Trailing whitespace is stripped, because `docker secret` and
+  `kubectl create secret --from-file` both produce files ending in a newline.
+- A reference that resolves to nothing is **refused**, not treated as empty. A
+  missing mount fails issuance with a log line naming the field and the path,
+  rather than sending a blank token to the DNS provider.
+
+This does not encrypt anything and is not a substitute for protecting the data
+volume. What it does is let the highest-value secrets live wherever the
+deployment already keeps secrets, instead of in the file that travels.
+
 ## Known dependency constraint
 
 CertMate pins `cryptography==46.0.7` and `pyopenssl==26.0.0`. Every version

--- a/docs/de/docker.md
+++ b/docs/de/docker.md
@@ -108,6 +108,17 @@ docker run -d --name certmate \
 
 Siehe den [Installationsleitfaden](./installation.md#environment-variables) für die vollständige Liste.
 
+### DNS-Token aus `settings.json` heraushalten
+
+Über die Oberfläche konfigurierte DNS-Provider-Token liegen in `settings.json`
+— genau der Datei, die gesichert, kopiert und eingebunden wird. Jedes
+Zugangsdatenfeld kann stattdessen **angeben**, wo sein Wert liegt:
+`api_token_file` mit einem Pfad oder `api_token_env` mit einem Variablennamen,
+so wie es `API_BEARER_TOKEN_FILE` bereits tut. Der Wert wird gelesen, wenn
+certbot läuft, und nie zurückgeschrieben. Für das OIDC-`client_secret` gilt
+dasselbe. Siehe
+[SECURITY.md](https://github.com/fabriziosalmi/certmate/blob/main/SECURITY.md#keeping-credentials-out-of-settingsjson).
+
 ---
 
 ## Docker Compose

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -112,6 +112,16 @@ docker run -d --name certmate \
 
 See the [Installation Guide](./installation.md#environment-variables) for the complete list.
 
+### Keeping DNS tokens out of `settings.json`
+
+DNS provider tokens configured through the UI are stored in `settings.json`,
+which is the file that gets backed up, copied and mounted. Any credential field
+can instead **name** where its value lives — `api_token_file` with a path, or
+`api_token_env` with a variable name — the same way `API_BEARER_TOKEN_FILE`
+works. The value is read when certbot runs and is never written back. The OIDC
+`client_secret` accepts the same pair. See
+[SECURITY.md](https://github.com/fabriziosalmi/certmate/blob/main/SECURITY.md#keeping-credentials-out-of-settingsjson).
+
 ---
 
 ## Docker Compose

--- a/docs/es/docker.md
+++ b/docs/es/docker.md
@@ -108,6 +108,17 @@ docker run -d --name certmate \
 
 Consulta la [Guía de instalación](./installation.md#environment-variables) para ver la lista completa.
 
+### Mantener los tokens DNS fuera de `settings.json`
+
+Los tokens de los proveedores DNS configurados desde la interfaz se guardan en
+`settings.json`, que es el archivo que se respalda, se copia y se monta. En su
+lugar, cualquier campo de credencial puede **indicar** dónde vive su valor:
+`api_token_file` con una ruta, o `api_token_env` con el nombre de una variable,
+igual que ya hace `API_BEARER_TOKEN_FILE`. El valor se lee cuando se ejecuta
+certbot y nunca se vuelve a escribir. El `client_secret` de OIDC acepta el mismo
+par. Consulta
+[SECURITY.md](https://github.com/fabriziosalmi/certmate/blob/main/SECURITY.md#keeping-credentials-out-of-settingsjson).
+
 ---
 
 ## Docker Compose

--- a/docs/fr/docker.md
+++ b/docs/fr/docker.md
@@ -106,6 +106,17 @@ docker run -d --name certmate \
 
 Voir le [Guide d'installation](./installation.md#variables-denvironnement) pour la liste complète.
 
+### Garder les jetons DNS hors de `settings.json`
+
+Les jetons des fournisseurs DNS configurés depuis l'interface sont stockés dans
+`settings.json`, c'est-à-dire le fichier qui est sauvegardé, copié et monté.
+Chaque champ d'identifiant peut à la place **indiquer** où se trouve sa valeur :
+`api_token_file` avec un chemin, ou `api_token_env` avec un nom de variable,
+comme le fait déjà `API_BEARER_TOKEN_FILE`. La valeur est lue au moment où
+certbot s'exécute et n'est jamais réécrite. Le `client_secret` OIDC accepte la
+même paire. Voir
+[SECURITY.md](https://github.com/fabriziosalmi/certmate/blob/main/SECURITY.md#keeping-credentials-out-of-settingsjson).
+
 ---
 
 ## Docker Compose

--- a/docs/it/docker.md
+++ b/docs/it/docker.md
@@ -108,6 +108,17 @@ docker run -d --name certmate \
 
 Consulta la [Guida all'installazione](./installation.md#environment-variables) per l'elenco completo.
 
+### Tenere i token DNS fuori da `settings.json`
+
+I token dei provider DNS configurati dall'interfaccia finiscono in
+`settings.json`, che è il file che viene copiato, montato e incluso nei backup.
+Ogni campo credenziale può invece **indicare** dove sta il valore —
+`api_token_file` con un percorso, oppure `api_token_env` con il nome di una
+variabile — come già fa `API_BEARER_TOKEN_FILE`. Il valore viene letto quando
+certbot viene eseguito e non viene mai riscritto. Lo stesso vale per il
+`client_secret` OIDC. Vedi
+[SECURITY.md](https://github.com/fabriziosalmi/certmate/blob/main/SECURITY.md#keeping-credentials-out-of-settingsjson).
+
 ---
 
 ## Docker Compose

--- a/modules/core/dns_providers.py
+++ b/modules/core/dns_providers.py
@@ -5,6 +5,7 @@ Handles DNS provider configuration, account management, and provider-specific op
 
 import logging
 
+from .secret_refs import SecretReferenceError, has_value, resolve
 from .utils import _DNS_PROVIDER_CREDENTIALS
 
 logger = logging.getLogger(__name__)
@@ -66,6 +67,14 @@ class DNSManager:
         already there. Now checks the provider's OWN required fields
         (_DNS_PROVIDER_CREDENTIALS); for a provider not in that registry, any
         non-empty value counts, so an unknown provider is not silently rejected.
+
+        A field counts as present when it holds a value OR names one — see
+        secret_refs: `api_token_file` and `api_token_env` configure an account
+        just as `api_token` does. The reference is NOT followed here. This
+        question is asked to render a settings page, and reading every secret
+        off disk to decide whether to draw a green tick would both put
+        credentials in memory for a page view and make the page fail on a host
+        where the secret simply is not mounted.
         """
         if not isinstance(acc_config, dict):
             return False
@@ -75,19 +84,46 @@ class DNSManager:
             # enforces (it reports each missing field). A partial account that
             # passed here would resolve, then fail at certbot with a less
             # specific error; consistency keeps "configured" meaning one thing.
-            return all(acc_config.get(field) for field in required)
+            return all(has_value(acc_config, field) for field in required)
         # Unknown provider: treat any non-empty value as "configured" rather
         # than rejecting it (the old allowlist would have).
         return any(v for v in acc_config.values())
 
-    def get_dns_provider_account_config(self, provider, account_id=None, settings=None):
-        """Get DNS provider account configuration
-        
+    def get_dns_provider_account_config(self, provider, account_id=None,
+                                        settings=None):
+        """The account's configuration, with any referenced secret resolved.
+
+        Thin wrapper over the lookup below, so that resolution happens once for
+        every caller instead of at each of the seven call sites. Everything
+        that issues a certificate arrives here; everything that only lists
+        accounts does not, which is what keeps a resolved secret out of the
+        API responses and out of anything that writes settings back.
+        """
+        config, used_account_id = self._locate_account_config(
+            provider, account_id=account_id, settings=settings)
+        if config is None:
+            return None, None
+        try:
+            return resolve(config), used_account_id
+        except SecretReferenceError as exc:
+            # Named precisely, because the alternative is an issuance failure
+            # at the DNS provider that blames the credential rather than the
+            # mount. Never the value: this line goes to the log.
+            logger.error(
+                "DNS provider '%s' account '%s': field '%s' names %r, which %s",
+                provider, used_account_id, exc.field, exc.reference, exc.reason)
+            return None, None
+
+    def _locate_account_config(self, provider, account_id=None, settings=None):
+        """Find the stored account configuration, exactly as written.
+
+        Returns what is in settings, references unresolved — see the wrapper.
+
         Args:
             provider: DNS provider name (e.g., 'cloudflare')
             account_id: Specific account ID (optional, uses default if not provided)
             settings: Settings dict (optional, loads current if not provided)
-            
+
         Returns:
             tuple: (account_config_dict, used_account_id)
         """
@@ -407,7 +443,11 @@ class DNSManager:
 
             required = _DNS_PROVIDER_CREDENTIALS.get(provider, [])
             config = config if isinstance(config, dict) else {}
-            missing = [field for field in required if not config.get(field)]
+            # has_value, so a field supplied as `<field>_file` / `<field>_env`
+            # passes. The reference is not followed: this is a shape check, and
+            # it is reached from a button in the UI.
+            missing = [field for field in required
+                       if not has_value(config, field)]
             if missing:
                 return False, (
                     f"Missing required credential field(s) for {provider}: "
@@ -457,7 +497,11 @@ class DNSManager:
             outcome = {'ok': False}
 
             def _mutate(settings):
-                _, existing_account_id = self.get_dns_provider_account_config(
+                # The lookup, not the resolving wrapper: this only needs to
+                # know the account exists. Choosing a default should not read a
+                # secret off disk, and must not fail because the secret is
+                # mounted somewhere this process cannot see it.
+                _, existing_account_id = self._locate_account_config(
                     provider, account_id, settings
                 )
                 if not existing_account_id:

--- a/modules/core/dns_providers.py
+++ b/modules/core/dns_providers.py
@@ -109,9 +109,16 @@ class DNSManager:
             # Named precisely, because the alternative is an issuance failure
             # at the DNS provider that blames the credential rather than the
             # mount. Never the value: this line goes to the log.
+            #
+            # %r on every interpolated value, not %s. The provider name comes
+            # from the request and the account id and path come from
+            # settings.json, so a newline in any of them would forge a log
+            # line; repr escapes it. It also makes an account id with a space
+            # in it readable, which %s did not.
             logger.error(
-                "DNS provider '%s' account '%s': field '%s' names %r, which %s",
-                provider, used_account_id, exc.field, exc.reference, exc.reason)
+                'DNS provider %r account %r: field %r names %r, which %s',
+                provider, used_account_id, exc.field, exc.reference,
+                exc.reason)
             return None, None
 
     def _locate_account_config(self, provider, account_id=None, settings=None):

--- a/modules/core/oidc.py
+++ b/modules/core/oidc.py
@@ -34,6 +34,7 @@ from urllib.parse import urlparse, urlencode
 from flask import session as flask_session
 
 from .auth import validate_username
+from .secret_refs import SecretReferenceError, resolve_field
 from .settings import _strip_masked_values
 from .utils import utc_now
 
@@ -277,13 +278,37 @@ class OIDCManager:
         """
         import hashlib
 
-        secret = cfg.get('client_secret') or ''
+        # OIDCManager, not self: _client_fingerprint is a staticmethod.
+        secret = OIDCManager._client_secret(cfg)
         return (
             cfg.get('issuer_url'),
             cfg.get('client_id'),
             hashlib.sha256(secret.encode()).hexdigest(),
             tuple(cfg.get('scopes') or ()),
         )
+
+    @staticmethod
+    def _client_secret(cfg: dict) -> str:
+        """The client secret, following ``client_secret_file`` / ``_env``.
+
+        Resolved HERE and not in ``_load_config`` on purpose. ``update_config``
+        loads the config, merges a partial payload onto it and writes the
+        result back; if loading resolved the reference, the first settings save
+        after a config edit would persist the secret into ``settings.json`` —
+        the exact file this mechanism exists to keep it out of.
+
+        An unresolvable reference returns '' rather than raising, and the
+        caller then fails the way a blank secret already fails. Raising here
+        would turn a missing mount into a 500 on the login page for every
+        user, including the local admin who needs to get in and fix it.
+        """
+        try:
+            return resolve_field(cfg, 'client_secret') or ''
+        except SecretReferenceError as exc:
+            logger.error(
+                "OIDC client_secret names %r, which %s — SSO will be refused "
+                "until it resolves", exc.reference, exc.reason)
+            return ''
 
     def _build_oauth_client(self, app):
         """Return a cached Authlib client bound to ``app``.
@@ -312,7 +337,7 @@ class OIDCManager:
         oauth.register(
             name='certmate_oidc',
             client_id=cfg['client_id'],
-            client_secret=cfg['client_secret'] or None,
+            client_secret=self._client_secret(cfg) or None,
             server_metadata_url=f"{issuer}/.well-known/openid-configuration",
             client_kwargs={
                 'scope': ' '.join(cfg['scopes']),

--- a/modules/core/secret_refs.py
+++ b/modules/core/secret_refs.py
@@ -1,0 +1,161 @@
+"""Let a credential name where it lives instead of holding its value.
+
+Every DNS provider API token and the OIDC client secret rest in
+`settings.json` as cleartext JSON. The file is written 0600, which is the
+right permission and is not the point: that file is what gets backed up,
+copied between hosts, mounted into a container and handed to whoever is
+debugging a renewal. A deployment that already keeps its secrets in a Docker
+or Kubernetes secret had no way to keep them out of it.
+
+`API_BEARER_TOKEN_FILE` already solved this shape for one secret. This is the
+same idea generalised to the settings file: any field may be supplied
+indirectly, by naming a file or an environment variable beside it.
+
+    "cloudflare": {"accounts": {"prod": {"api_token_file": "/run/secrets/cf"}}}
+    "cloudflare": {"accounts": {"prod": {"api_token_env": "CF_API_TOKEN"}}}
+
+This does not encrypt anything and does not claim to. What it does is move the
+highest-value secrets out of the file that travels, using a mechanism the
+project already documents.
+
+Three decisions worth stating, because each is a failure mode if reversed:
+
+**A reference beats a literal.** A deployment moving to secrets sets
+`api_token_file` and leaves the old `api_token` behind. Having the stale
+literal win would keep issuing with the credential they thought they had
+replaced, and nothing would say so. Order is `_file`, then `_env`, then the
+literal.
+
+**Trailing whitespace is stripped.** `docker secret` and `kubectl create
+secret --from-file` both produce files ending in a newline. A token with a
+trailing `\\n` reaches the DNS API as a wrong token, and what comes back is an
+authentication error that names nothing useful.
+
+**An unresolvable reference is never silently empty.** A missing file or an
+unset variable raises rather than resolving to `''`, because an empty
+credential produces a certbot failure that reads like a provider outage.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+
+# Only these two suffixes are references. Checked against the credential
+# registry by a test, so a provider field that one day genuinely ends in
+# `_file` is a failing test rather than a field silently read as a pointer.
+FILE_SUFFIX = '_file'
+ENV_SUFFIX = '_env'
+
+
+class SecretReferenceError(Exception):
+    """A field named a file or a variable that did not yield a value.
+
+    Carries the field and the reference — never the value, and never a value
+    read partially — because this is logged and the log is not the place for a
+    credential.
+    """
+
+    def __init__(self, field: str, reference: str, reason: str):
+        self.field = field
+        self.reference = reference
+        self.reason = reason
+        super().__init__(f'{field}: {reference} {reason}')
+
+
+def _read_file(field: str, path: str) -> str:
+    """*field* is threaded through so the error names it. It was not, once,
+    and the log line read `field ''` — which is the one thing the operator
+    needed, since the whole point of that message is to say which credential
+    the missing mount belongs to."""
+    try:
+        text = pathlib.Path(path).read_text(encoding='utf-8')
+    except OSError as exc:
+        # strerror, not the exception: str(OSError) includes the filename,
+        # which is already in the message, and nothing else useful.
+        raise SecretReferenceError(
+            field, path, f'could not be read ({exc.strerror})')
+    return text
+
+
+def resolve_field(config: dict, field: str) -> str | None:
+    """The value for *field*, following a reference if one is present.
+
+    Returns None when the field is absent altogether, which is different from
+    a reference that could not be resolved — that raises.
+    """
+    file_key = field + FILE_SUFFIX
+    env_key = field + ENV_SUFFIX
+
+    reference = config.get(file_key)
+    if isinstance(reference, str) and reference.strip():
+        value = _read_file(field, reference.strip()).strip()
+        if not value:
+            raise SecretReferenceError(field, reference.strip(), 'is empty')
+        return value
+
+    reference = config.get(env_key)
+    if isinstance(reference, str) and reference.strip():
+        value = (os.environ.get(reference.strip()) or '').strip()
+        if not value:
+            raise SecretReferenceError(
+                field, reference.strip(), 'is unset or empty in the environment')
+        return value
+
+    literal = config.get(field)
+    return literal if literal is not None else None
+
+
+def referenced_fields(config: dict) -> set[str]:
+    """The fields this config supplies by reference rather than by value."""
+    if not isinstance(config, dict):
+        return set()
+    fields = set()
+    for key, value in config.items():
+        if not isinstance(value, str) or not value.strip():
+            continue
+        for suffix in (FILE_SUFFIX, ENV_SUFFIX):
+            if key.endswith(suffix) and len(key) > len(suffix):
+                fields.add(key[:-len(suffix)])
+    return fields
+
+
+def has_value(config: dict, field: str) -> bool:
+    """True when *field* is supplied, by value or by reference.
+
+    Deliberately does NOT resolve. This answers "is this account configured",
+    which is asked to render a settings page — reading every secret off disk to
+    decide whether to draw a green tick would put credentials in memory for a
+    page view, and would make the page fail when a secret is merely not mounted
+    on the host that happens to be rendering it.
+    """
+    if not isinstance(config, dict):
+        return False
+    literal = config.get(field)
+    # `str(...).strip()`, matching what validate_dns_provider_account did
+    # before this replaced it: a whitespace-only token is not a token, and
+    # letting one count as configured would move the failure to certbot.
+    if isinstance(literal, str):
+        if literal.strip():
+            return True
+    elif literal:
+        return True
+    return field in referenced_fields(config)
+
+
+def resolve(config: dict) -> dict:
+    """A copy of *config* with every referenced field resolved to its value.
+
+    The reference keys are left in place: strategies read the fields they know
+    by name, so an extra `api_token_file` key is inert, and removing it would
+    make the returned dict no longer round-trip against what was stored.
+
+    Raises SecretReferenceError if any reference cannot be resolved. Resolving
+    the rest and leaving one field empty would produce a failure at the DNS
+    provider that names the credential rather than the mount.
+    """
+    if not isinstance(config, dict):
+        return config
+    resolved = dict(config)
+    for field in sorted(referenced_fields(config)):
+        resolved[field] = resolve_field(config, field)
+    return resolved

--- a/modules/core/utils.py
+++ b/modules/core/utils.py
@@ -792,9 +792,23 @@ def validate_dns_provider_account(provider: str, account_id: str, account_config
         if not isinstance(account_config, dict):
             return False, f"Account configuration must be a dictionary, but got {type(account_config).__name__}."
         
+        # A field is satisfied by a value OR by a reference to one
+        # (`api_token_file`, `api_token_env` — see modules/core/secret_refs).
+        # Without this, an account that keeps its token in a Docker secret
+        # could not be SAVED: the save path rejected it as missing the very
+        # field it supplies, and the feature would exist only for configs
+        # edited into settings.json by hand.
+        #
+        # Imported here rather than at module scope: utils.py has no
+        # intra-package imports at all, which is what lets every other module
+        # import it without thinking about order. One local import is cheaper
+        # than making it a node in that graph.
+        from .secret_refs import has_value
+
         required_fields = _DNS_PROVIDER_CREDENTIALS[provider]
-        missing_fields = [f for f in required_fields if not str(account_config.get(f) or '').strip()]
-            
+        missing_fields = [f for f in required_fields
+                          if not has_value(account_config, f)]
+
         if missing_fields:
             return False, f"Missing or empty required fields: {', '.join(sorted(missing_fields))}."
         

--- a/tests/test_a_credential_can_name_where_it_lives.py
+++ b/tests/test_a_credential_can_name_where_it_lives.py
@@ -1,0 +1,403 @@
+"""A DNS token or the OIDC secret can live outside settings.json.
+
+Every DNS provider API token and the OIDC client secret rested in
+`settings.json` as cleartext JSON. 0600 is the right permission and is not the
+point: that file is what gets backed up, copied between hosts, mounted into a
+container and attached to a bug report. A deployment already keeping its
+secrets in a Docker or Kubernetes secret had no way to keep them out of it.
+
+`API_BEARER_TOKEN_FILE` already solved this for one secret. `secret_refs`
+generalises it: any field may be supplied as `<field>_file` or `<field>_env`
+instead of as a value.
+
+Two properties carry the whole feature, and both have controls here:
+
+**The resolved value must never be written back.** Resolving where the config
+is *loaded* rather than where it is *used* would mean the next settings save
+persists the secret into the file the mechanism exists to keep it out of —
+silently, and permanently. `test_editing_the_oidc_config_does_not_persist_the
+_resolved_secret` and its DNS counterpart fail on exactly that.
+
+**A reference must never resolve to nothing.** An empty credential produces a
+certbot or IdP failure that reads like a provider outage. A missing file or an
+unset variable is refused, and the log names the reference — never the value.
+"""
+import logging
+
+import pytest
+
+from modules.core.dns_providers import DNSManager
+from modules.core.secret_refs import (
+    SecretReferenceError, has_value, referenced_fields, resolve, resolve_field,
+)
+from modules.core.utils import (
+    _DNS_PROVIDER_CREDENTIALS, validate_dns_provider_account,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+# --- resolution ----------------------------------------------------------
+
+def test_a_field_can_name_a_file(tmp_path):
+    secret = tmp_path / 'cf_token'
+    secret.write_text('the-real-token')
+
+    config = {'api_token_file': str(secret)}
+
+    assert resolve(config)['api_token'] == 'the-real-token'
+
+
+def test_a_field_can_name_an_environment_variable(monkeypatch):
+    monkeypatch.setenv('CF_API_TOKEN', 'from-the-environment')
+
+    assert resolve({'api_token_env': 'CF_API_TOKEN'})['api_token'] == (
+        'from-the-environment')
+
+
+def test_the_trailing_newline_a_secret_manager_adds_is_stripped(tmp_path):
+    """`docker secret` and `kubectl create secret --from-file` both leave a
+    trailing newline. A token with one reaches the DNS API as a wrong token,
+    and the authentication error that comes back names nothing useful."""
+    secret = tmp_path / 'cf_token'
+    secret.write_text('the-real-token\n')
+
+    assert resolve({'api_token_file': str(secret)})['api_token'] == (
+        'the-real-token')
+
+
+def test_a_reference_beats_a_stale_literal(tmp_path):
+    """The migration case. Someone adds `api_token_file` and leaves the old
+    `api_token` in place; if the literal won, issuance would keep using the
+    credential they believe they replaced and nothing would say so."""
+    secret = tmp_path / 'cf_token'
+    secret.write_text('the-new-token')
+
+    resolved = resolve({'api_token': 'the-old-token',
+                        'api_token_file': str(secret)})
+
+    assert resolved['api_token'] == 'the-new-token'
+
+
+def test_a_file_beats_an_environment_variable(tmp_path, monkeypatch):
+    """Both set is a configuration a person can arrive at; the order is stated
+    rather than whichever the dict happened to yield."""
+    secret = tmp_path / 'cf_token'
+    secret.write_text('from-the-file')
+    monkeypatch.setenv('CF_API_TOKEN', 'from-the-environment')
+
+    resolved = resolve({'api_token_file': str(secret),
+                        'api_token_env': 'CF_API_TOKEN'})
+
+    assert resolved['api_token'] == 'from-the-file'
+
+
+def test_a_config_with_no_references_is_returned_unchanged():
+    config = {'api_token': 'literal', 'name': 'prod'}
+    assert resolve(config) == config
+
+
+def test_the_original_is_not_mutated(tmp_path):
+    """resolve() returns a copy. If it edited in place, the caller's dict —
+    which for the DNS path is a slice of the loaded settings — would carry the
+    secret into whatever writes settings next."""
+    secret = tmp_path / 'cf_token'
+    secret.write_text('the-real-token')
+    config = {'api_token_file': str(secret)}
+
+    resolve(config)
+
+    assert 'api_token' not in config
+
+
+# --- what must NOT resolve to nothing ------------------------------------
+
+def test_a_missing_file_is_refused(tmp_path):
+    with pytest.raises(SecretReferenceError) as caught:
+        resolve({'api_token_file': str(tmp_path / 'not-mounted')})
+    assert 'could not be read' in str(caught.value)
+
+
+def test_an_empty_file_is_refused(tmp_path):
+    """A mounted-but-empty secret is the shape a half-finished deployment has.
+    Resolving it to '' would issue with a blank token."""
+    secret = tmp_path / 'cf_token'
+    secret.write_text('   \n')
+
+    with pytest.raises(SecretReferenceError) as caught:
+        resolve({'api_token_file': str(secret)})
+    assert 'is empty' in str(caught.value)
+
+
+def test_an_unset_environment_variable_is_refused(monkeypatch):
+    monkeypatch.delenv('CF_API_TOKEN', raising=False)
+
+    with pytest.raises(SecretReferenceError) as caught:
+        resolve({'api_token_env': 'CF_API_TOKEN'})
+    assert 'unset' in str(caught.value)
+
+
+def test_the_error_never_carries_the_value(tmp_path):
+    """CONTROL: this exception is logged. A message that interpolated the
+    secret would put it in the log for every failed resolution."""
+    secret = tmp_path / 'cf_token'
+    secret.write_text('SUPER-SECRET-TOKEN')
+
+    error = SecretReferenceError('api_token', str(secret), 'is empty')
+
+    assert 'SUPER-SECRET-TOKEN' not in str(error)
+    assert error.field == 'api_token'
+
+
+@pytest.mark.parametrize('config', [
+    {'api_token_file': ''}, {'api_token_file': '   '},
+    {'api_token_env': ''}, {'api_token_file': None},
+    {'api_token_file': 12}, {'_file': '/x'},
+])
+def test_a_blank_or_malformed_reference_is_not_a_reference(config):
+    """It falls through to the literal — which is absent — rather than raising.
+    An empty string in a settings field is what an untouched UI input leaves
+    behind, and it must not stop the account from loading."""
+    assert referenced_fields(config) == set()
+    assert resolve(config) == config
+
+
+def test_an_absent_field_is_none_not_an_error():
+    assert resolve_field({'other': 'x'}, 'api_token') is None
+
+
+@pytest.mark.parametrize('config', ['a string', None, 42, ['a', 'list']])
+def test_a_config_that_is_not_a_dict_does_not_raise(config):
+    """settings.json is hand-editable, and a provider entry written as a string
+    reaches all three of these. Raising would turn a typo in a config file into
+    a 500 on the settings page rather than an account that reads as
+    unconfigured."""
+    assert referenced_fields(config) == set()
+    assert has_value(config, 'api_token') is False
+    assert resolve(config) == config
+
+
+def test_a_non_string_literal_still_counts_as_configured():
+    """`rfc2136` stores a port; `custom-script` a boolean flag. The whitespace
+    rule applies to strings only — a truthy non-string is a value."""
+    assert has_value({'port': 53}, 'port')
+    assert not has_value({'port': 0}, 'port')
+
+
+# --- "is this configured" must not read secrets --------------------------
+
+def test_a_referenced_field_counts_as_configured(tmp_path):
+    """Without this, a file-backed account renders as unconfigured in the UI
+    and `get_available_providers` reports the provider as unset."""
+    assert has_value({'api_token_file': '/run/secrets/cf'}, 'api_token')
+    assert has_value({'api_token_env': 'CF_API_TOKEN'}, 'api_token')
+
+
+def test_asking_whether_it_is_configured_does_not_read_the_file(tmp_path):
+    """The reference names a path that does not exist. If has_value followed
+    it, rendering the settings page would raise on any host where the secret
+    is not mounted — and would read every credential to draw a green tick."""
+    assert has_value({'api_token_file': str(tmp_path / 'absent')}, 'api_token')
+
+
+def test_a_whitespace_only_literal_is_still_not_configured():
+    """REGRESSION CONTROL. The check this replaced did `str(...).strip()`; a
+    plain truthiness test would count '   ' as a token and move the failure to
+    certbot."""
+    assert not has_value({'api_token': '   '}, 'api_token')
+    assert not has_value({'api_token': ''}, 'api_token')
+    assert not has_value({}, 'api_token')
+
+
+def test_no_credential_field_could_be_mistaken_for_a_reference():
+    """The suffix rule is only safe while no real field ends in `_file` or
+    `_env`. If one is ever added, this fails instead of that field being
+    silently read as a pointer to another one."""
+    offenders = sorted(
+        field
+        for fields in _DNS_PROVIDER_CREDENTIALS.values()
+        for field in fields
+        if field.endswith('_file') or field.endswith('_env')
+    )
+    assert not offenders, (
+        f'{offenders} would be read as a reference to another field rather '
+        f'than as itself')
+
+
+# --- the DNS path end to end ---------------------------------------------
+
+class _Settings:
+    def __init__(self, data):
+        self.data = data
+        self.saved = []
+
+    def load_settings(self):
+        import copy
+        return copy.deepcopy(self.data)
+
+    def migrate_dns_providers_to_multi_account(self, settings):
+        return settings
+
+    def save_settings(self, settings):
+        self.saved.append(settings)
+        return True
+
+
+@pytest.fixture
+def file_backed(tmp_path):
+    secret = tmp_path / 'cf_token'
+    secret.write_text('the-real-token\n')
+    settings = _Settings({'dns_providers': {'cloudflare': {'accounts': {
+        'prod': {'api_token_file': str(secret), 'name': 'Production'}}}}})
+    return DNSManager(settings), settings, secret
+
+
+def test_issuance_gets_the_resolved_token(file_backed):
+    manager, _, _ = file_backed
+
+    config, account_id = manager.get_dns_provider_account_config('cloudflare')
+
+    assert account_id == 'prod'
+    assert config['api_token'] == 'the-real-token'
+
+
+def test_the_account_shows_as_configured(file_backed):
+    manager, _, _ = file_backed
+
+    accounts = manager.list_dns_provider_accounts('cloudflare')
+
+    assert [a['configured'] for a in accounts] == [True]
+
+
+def test_listing_accounts_does_not_return_the_secret(file_backed):
+    """CONTROL: the listing feeds API responses. Resolving there would put the
+    token in a response that previously only carried names."""
+    manager, _, _ = file_backed
+
+    listed = manager.list_accounts()
+
+    assert 'the-real-token' not in repr(listed)
+
+
+def test_an_unreadable_reference_does_not_look_like_a_missing_account(
+        file_backed, caplog):
+    """The account resolves to (None, None) — the existing contract — but the
+    log has to name the mount, or the operator debugs a credential that is
+    correct."""
+    manager, settings, secret = file_backed
+    secret.unlink()
+
+    logger = logging.getLogger('modules.core.dns_providers')
+    with caplog.at_level(logging.ERROR, logger=logger.name):
+        config, account_id = manager.get_dns_provider_account_config(
+            'cloudflare')
+
+    assert (config, account_id) == (None, None)
+    message = '\n'.join(r.getMessage() for r in caplog.records)
+    assert 'api_token' in message
+    assert str(secret) in message
+    assert 'prod' in message
+
+
+def test_a_saved_config_still_holds_the_reference_not_the_value(file_backed):
+    """THE control for this feature. If anything resolved on the load path,
+    the settings dict the manager hands around would carry the token, and the
+    next save would write it into settings.json permanently."""
+    manager, settings, _ = file_backed
+
+    manager.get_dns_provider_account_config('cloudflare')
+
+    stored = settings.data['dns_providers']['cloudflare']['accounts']['prod']
+    assert 'api_token' not in stored
+    assert 'the-real-token' not in repr(settings.data)
+
+
+def test_a_literal_account_still_works(tmp_path):
+    """CONTROL: the overwhelmingly common configuration must be untouched."""
+    settings = _Settings({'dns_providers': {'cloudflare': {'accounts': {
+        'prod': {'api_token': 'plain-old-token'}}}}})
+
+    config, account_id = DNSManager(
+        settings).get_dns_provider_account_config('cloudflare')
+
+    assert config['api_token'] == 'plain-old-token'
+    assert account_id == 'prod'
+
+
+# --- the save path accepts it --------------------------------------------
+
+def test_a_file_backed_account_can_be_saved():
+    """Without this the feature exists only for settings.json edited by hand:
+    the validator rejected the account as missing the field it supplies."""
+    ok, message = validate_dns_provider_account(
+        'cloudflare', 'prod', {'api_token_file': '/run/secrets/cf'})
+    assert ok, message
+
+
+def test_an_account_with_neither_is_still_rejected():
+    """CONTROL: the validator must not have become a rubber stamp."""
+    ok, message = validate_dns_provider_account('cloudflare', 'prod', {})
+    assert not ok
+    assert 'api_token' in message
+
+
+def test_a_partially_referenced_account_is_still_rejected():
+    """route53 needs two fields. Supplying one by reference does not excuse
+    the other."""
+    ok, message = validate_dns_provider_account(
+        'route53', 'prod', {'access_key_id_file': '/run/secrets/id'})
+    assert not ok
+    assert 'secret_access_key' in message
+
+
+def test_the_test_provider_button_accepts_a_reference():
+    manager = DNSManager(_Settings({}))
+    ok, _ = manager.test_provider(
+        'cloudflare', {'api_token_env': 'CF_API_TOKEN'})
+    assert ok
+
+
+# --- OIDC ----------------------------------------------------------------
+
+def test_the_oidc_secret_can_name_a_file(tmp_path):
+    from modules.core.oidc import OIDCManager
+
+    secret = tmp_path / 'oidc'
+    secret.write_text('the-client-secret\n')
+
+    assert OIDCManager._client_secret(
+        {'client_secret_file': str(secret)}) == 'the-client-secret'
+
+
+def test_an_unresolvable_oidc_secret_is_blank_rather_than_a_500(
+        tmp_path, caplog):
+    """Raising here would take down the login page for everyone, including the
+    local admin who is the only person able to fix the mount."""
+    from modules.core.oidc import OIDCManager
+
+    with caplog.at_level(logging.ERROR, logger='modules.core.oidc'):
+        value = OIDCManager._client_secret(
+            {'client_secret_file': str(tmp_path / 'absent')})
+
+    assert value == ''
+    assert 'client_secret' in '\n'.join(
+        r.getMessage() for r in caplog.records)
+
+
+def test_editing_the_oidc_config_does_not_persist_the_resolved_secret(
+        tmp_path):
+    """THE control on the OIDC side. `update_config` loads the config, merges
+    the payload onto it and writes the result back — so resolving on the load
+    path would write the secret into settings.json the first time anyone
+    toggled a checkbox in the SSO settings page."""
+    from modules.core.oidc import _normalize_oidc_config
+
+    secret = tmp_path / 'oidc'
+    secret.write_text('the-client-secret')
+
+    loaded = _normalize_oidc_config({'client_secret_file': str(secret),
+                                     'issuer_url': 'https://idp.invalid',
+                                     'client_id': 'certmate'})
+
+    assert loaded['client_secret'] == ''
+    assert 'the-client-secret' not in repr(loaded)


### PR DESCRIPTION
## The situation

DNS provider API tokens and the OIDC client secret rest in `settings.json` as
cleartext JSON. `0600` is the right permission and is not the point: that file
is the one that gets backed up, copied between hosts, mounted into a container
and attached to a bug report. A deployment already keeping its secrets in a
Docker or Kubernetes secret had no way to keep them out of it.

`API_BEARER_TOKEN_FILE` already solved this shape for one secret. This
generalises it to the settings file.

## What you can write now

```json
{
  "dns_providers": {
    "cloudflare": {
      "accounts": {
        "prod": { "api_token_file": "/run/secrets/cloudflare_api_token" }
      }
    }
  },
  "oidc": { "client_secret_env": "CERTMATE_OIDC_CLIENT_SECRET" }
}
```

Beside any field, `<field>_file` names a path and `<field>_env` names a
variable. Nothing is encrypted and nothing claims to be — the secrets simply
stop living in the file that travels.

## The seam is the whole design

Resolution happens where the value is **used**, never where the config is
loaded.

- `get_dns_provider_account_config` resolves; `list_dns_provider_accounts` and
  `list_accounts` do not, which keeps a resolved secret out of API responses.
- On the OIDC side it resolves in `_client_secret`, **not** in `_load_config` —
  because `update_config` loads the config, merges a payload onto it and writes
  the result back. Resolving on the load path would persist the secret into
  `settings.json` the first time anyone toggled a checkbox on the SSO settings
  page, silently and permanently.

Both have a test that fails on exactly that:
`test_a_saved_config_still_holds_the_reference_not_the_value` and
`test_editing_the_oidc_config_does_not_persist_the_resolved_secret`.

## Three behaviours, each a failure mode if reversed

| Decision | What the other choice does |
|---|---|
| A reference beats a literal | Someone adds `api_token_file` and leaves the old `api_token`; the stale credential keeps being used and nothing says so |
| Trailing whitespace is stripped | `docker secret` and `kubectl create secret --from-file` both end in a newline; the DNS API returns an auth error that names nothing useful |
| An unresolvable reference is refused | An empty token produces a certbot failure that reads like a provider outage |

The refusal log names the field and the path — never the value. A test asserts
the exception cannot carry the secret, because that exception gets logged.

## "Is this configured" does not read secrets

It is asked to render a settings page. Following references there would put
every credential in memory for a page view, and would make the page fail on a
host where a secret simply is not mounted. An account counts as configured
because the reference is *present*.

## Three call sites had to learn the same rule

Without these the feature would have existed only for `settings.json` edited by
hand:

- `validate_dns_provider_account` — the **save path rejected** a file-backed
  account as missing the very field it supplies.
- `test_provider` — the UI's Test button.
- `_account_has_credentials` — a file-backed account rendered as unconfigured.

## The suffix rule is pinned, not assumed

It is only safe while no real credential field ends in `_file` or `_env`. None
of the 31 fields across the 29 providers does, and
`test_no_credential_field_could_be_mistaken_for_a_reference` fails if one is
added — rather than that field being silently read as a pointer to another one.

## What was found while building it

The first version lost the field name on a read error, so the operator log read
``field ''`` — the one thing that message exists to say.
`test_an_unreadable_reference_does_not_look_like_a_missing_account` caught it.

## Verification

40 new tests. Locally: **4400 passed, 0 failed** across the suite excluding the
seven container-building files — this machine is running 39 unrelated
containers and CertMate's test containers do not become healthy inside the
60-second budget, so those are left to CI, which has healthy Docker.

Documented in SECURITY.md and in `docs/docker.md` across all five locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
