### PR TITLE
docs: put the history in the past tense

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,25 @@ that has to be remembered is a version string that goes stale.
   is wrong. Much of the commentary in this codebase records a bug that was paid
   for once; that is the house style, and it is worth more than a comment
   restating the code.
+- **Put the history in the past tense.** That style has one failure mode: a
+  paragraph describing the defect a line exists to prevent, written in the
+  present, reads as a description of what the code does now. A reader skimming
+  for current behaviour comes away believing the bug is still there.
+
+  ```python
+  # WRONG — reads as the current behaviour
+  # The settings entry is written after the lock is released, so a renewal
+  # can interleave and read the old provider.
+
+  # RIGHT — the tense says which is which
+  # Both writes happen under one lock. Previously the settings entry was
+  # written after the lock was released, so a renewal could interleave and
+  # read the old provider.
+  ```
+
+  Present tense for what the code does; past tense, or a leading
+  `Previously:`, for what it used to do wrongly. Existing comments are not
+  being rewritten for this — it applies to the ones you add.
 - Add tests for new behaviour. For a bug fix, check that your test **fails
   against the old code** — a gate nobody has watched fail is not a gate.
 


### PR DESCRIPTION
## The problem with the house style

This codebase deliberately records, next to a line, the bug that line exists to
prevent. That is worth keeping — it is most of what makes the commentary here
worth reading.

It has one failure mode, and it is common enough to be worth naming: the
paragraph describing the defect is written in the **present tense**, so it reads
as a description of what the code does now. A reader skimming for current
behaviour comes away believing the bug is still there.

```python
# WRONG — reads as the current behaviour
# The settings entry is written after the lock is released, so a renewal
# can interleave and read the old provider.

# RIGHT — the tense says which is which
# Both writes happen under one lock. Previously the settings entry was
# written after the lock was released, so a renewal could interleave and
# read the old provider.
```

## What this adds

One bullet in `CONTRIBUTING.md` under Code style, next to the bullet that
establishes the style in the first place: present tense for what the code does,
past tense or a leading `Previously:` for what it used to do wrongly.

## What it deliberately does not do

Nothing is being rewritten. Retrofitting hundreds of comments would produce a
diff nobody can review, over a readability nit, and would touch the blame of
every file it edited. The convention applies to comments people add from here
on, which is where it costs nothing.

There is also no gate for it. "Is this paragraph about the present or the past"
is not a property a linter can decide, and a check that guessed would either
pass on everything or fail on prose that was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
