### PR TITLE
fix: the renewal sweep names the certificates it cannot renew (#759)

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -30,7 +30,9 @@ from pathlib import Path
 from cryptography import x509
 from .shell import ShellExecutor
 from .dns_strategies import DNSStrategyFactory, HTTP01Strategy, acme_webroot_dir, check_certbot_plugin_installed
-from .constants import METADATA_SCHEMA_VERSION, CERTIFICATE_FILES, DEFAULT_RENEWAL_THRESHOLD_DAYS
+from .constants import (METADATA_SCHEMA_VERSION, CERTIFICATE_FILES,
+                        DEFAULT_RENEWAL_THRESHOLD_DAYS,
+                        iter_cert_domain_dirs)
 from .structured_logging import LogContext, new_correlation_id
 from .csr_issuance import (
     CSR_OUTPUT_DIRNAME, CSR_OUTPUT_FILES, CSRError, csr_domains,
@@ -3304,9 +3306,15 @@ class CertificateManager:
 
         if not settings.get('auto_renew', True):
             logger.info("Automatic renewal is globally disabled; skipping renewal check")
+            # `unmanaged` present but zero: the key is part of the summary
+            # shape, and a caller that reads it must not have to know which
+            # early return produced the dict. Nothing is reported here because
+            # renewal was switched off deliberately — naming certificates the
+            # sweep "did not consider" when it considered none would be noise.
             return {'checked': 0, 'renewed': 0, 'failed': 0,
                     'skipped_disabled': 0, 'skipped_invalid': 0,
-                    'skipped_not_due': 0, 'auto_renew_disabled': True}
+                    'skipped_not_due': 0, 'unmanaged': 0,
+                    'auto_renew_disabled': True}
 
         # Migrate settings format if needed
         settings = self.settings_manager.migrate_domains_format(settings)
@@ -3316,7 +3324,12 @@ class CertificateManager:
 
         summary = {'checked': 0, 'renewed': 0, 'failed': 0,
                    'skipped_disabled': 0, 'skipped_invalid': 0,
-                   'skipped_not_due': 0}
+                   'skipped_not_due': 0, 'unmanaged': 0}
+        # Every domain this sweep took a decision about, so the reconciliation
+        # below can name the certificates it never reached. Collected rather
+        # than re-derived from `domains`, because a malformed entry is skipped
+        # here and must not read as "seen".
+        considered = set()
         started = time.time()
         self._report_unfinished_sweep()
         self._mark_sweep_started(len(domains))
@@ -3343,6 +3356,8 @@ class CertificateManager:
                     logger.warning(f"Skipping domain entry with no domain name: {domain_entry!r}")
                     summary['skipped_invalid'] += 1
                     continue
+
+                considered.add(domain)
 
                 # Per-certificate opt-out: skip when auto_renew is explicitly
                 # disabled on this domain entry. The global auto_renew flag is
@@ -3421,6 +3436,28 @@ class CertificateManager:
                 summary['skipped_invalid'],
                 'y' if summary['skipped_invalid'] == 1 else 'ies',
             )
+        # A certificate in CertMate's own store that no settings entry names is
+        # invisible to this loop, which iterates settings and nothing else. It
+        # is NOT invisible to the rest of the application: `digest.py` takes
+        # the union of settings and the certificate directories, and
+        # `get_certificate_info` reads the disk — so the dashboard shows it,
+        # the digest reports it expiring, and the sweep that is supposed to
+        # renew it never mentions it. That disagreement is what made #759 look
+        # like a threshold bug: the log had no line for the domain at all,
+        # because the sweep never reached it.
+        #
+        # It is reported, not adopted. Renewing a certificate the operator
+        # never registered would issue against a CA for a domain CertMate was
+        # not asked to manage, and the sweep is not the place to make that
+        # decision. Saying so out loud is.
+        for orphan in self._certificates_absent_from_settings(considered):
+            summary['unmanaged'] += 1
+            logger.warning(
+                "Certificate %r exists on disk but no settings entry names it, "
+                "so this renewal sweep did not consider it and it will not "
+                "renew. Re-register it with the 'Add Domain' flow or "
+                "POST /api/settings.", orphan)
+
         duration = time.time() - started
         summary['duration_seconds'] = round(duration, 2)
         summary['examined'] = (
@@ -3429,13 +3466,29 @@ class CertificateManager:
         self._mark_sweep_finished(summary, duration)
         logger.info(
             "Renewal check complete in %.1fs: %d checked, %d renewed, "
-            "%d failed, %d disabled, %d invalid, %d not-due",
+            "%d failed, %d disabled, %d invalid, %d not-due, %d unmanaged",
             duration,
             summary['checked'], summary['renewed'], summary['failed'],
             summary['skipped_disabled'], summary['skipped_invalid'],
-            summary['skipped_not_due'],
+            summary['skipped_not_due'], summary['unmanaged'],
         )
         return summary
+
+    def _certificates_absent_from_settings(self, considered):
+        """Certificate directories no settings entry named, sorted.
+
+        Read-only and failure-tolerant: an unreadable certificate directory
+        must not turn a completed renewal sweep into a failed one. Losing the
+        warning is bad; losing the sweep that renews everything else is worse.
+        """
+        try:
+            on_disk = {path.name for path in iter_cert_domain_dirs(self.cert_dir)}
+        except OSError as e:
+            logger.warning(
+                "Could not enumerate certificate directories to check for "
+                "unmanaged certificates: %s", e)
+            return []
+        return sorted(on_disk - set(considered))
 
     # ------------------------------------------------------------------
     # Renewal sweep progress

--- a/tests/test_check_renewals_summary.py
+++ b/tests/test_check_renewals_summary.py
@@ -57,6 +57,11 @@ def test_summary_counts_every_kind_of_entry(tmp_path):
         'skipped_disabled': 1,  # disabled.com
         'skipped_invalid': 3,   # empty, dict-without-domain, int
         'skipped_not_due': 0,   # certbot didn't report any "not yet due" no-op
+        # Zero because this instance has no certificate directories at all —
+        # every domain here is a settings entry with nothing on disk behind it.
+        # A certificate present on disk that no entry names is counted here and
+        # named in the log (#759); it used to be skipped in silence.
+        'unmanaged': 0,
     }
     # The sweep also reports its own shape now — how long it took and how many
     # entries it looked at — so an instance that is slowly outgrowing its

--- a/tests/test_the_sweep_names_what_it_cannot_renew.py
+++ b/tests/test_the_sweep_names_what_it_cannot_renew.py
@@ -1,0 +1,294 @@
+"""A certificate the renewal sweep cannot see must not be passed over in silence.
+
+Reported as #759: a certificate issued from a private CA with a 31-day lifespan
+and a 30-day threshold never auto-renewed, and — the detail that matters — the
+log carried **nothing at all** for that domain. Not a failure, not a skip.
+
+The threshold arithmetic was not the cause. Reproduced against the real code,
+a registered certificate with those numbers is picked up from day zero
+(`days_left` 30, `30 <= 30`), and `ca_provider` never enters the decision.
+
+The cause is that `check_renewals` iterates `settings['domains']` and nothing
+else, while the rest of the application answers "which certificates exist"
+differently:
+
+- `digest.py` takes the **union** of `settings['domains']` and the certificate
+  directories, so the digest reports the certificate as expiring;
+- `get_certificate_info` reads the disk, so the dashboard shows it, with
+  `needs_renewal: true`.
+
+A certificate present on disk and absent from settings is therefore visible
+everywhere except in the one component whose job is to renew it — and that
+component said nothing, which is why the report reads as a threshold bug.
+
+The sweep now names every such certificate and counts it in `unmanaged`. It
+does **not** adopt it: renewing a certificate the operator never registered
+would issue against a CA for a domain CertMate was not asked to manage, and a
+background sweep is not where that decision belongs.
+"""
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from modules.core.certificates import CertificateManager
+from modules.core.file_operations import FileOperations
+from modules.core.settings import SettingsManager
+
+pytestmark = [pytest.mark.unit]
+
+LOGGER = 'modules.core.certificates'
+
+
+def _leaf(domain, lifespan_days, issued_days_ago):
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, domain)])
+    issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'Private CA')])
+    issued = datetime.now(timezone.utc) - timedelta(days=issued_days_ago)
+    cert = (x509.CertificateBuilder()
+            .subject_name(subject).issuer_name(issuer)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(issued)
+            .not_valid_after(issued + timedelta(days=lifespan_days))
+            .sign(key, hashes.SHA256()))
+    return (cert.public_bytes(serialization.Encoding.PEM),
+            key.private_bytes(serialization.Encoding.PEM,
+                              serialization.PrivateFormat.PKCS8,
+                              serialization.NoEncryption()))
+
+
+@pytest.fixture
+def instance(tmp_path):
+    """A CertificateManager over a real directory, with a factory for putting
+    certificates on disk and, separately, into settings — because the whole
+    subject of this file is the two coming apart."""
+    cert_dir = tmp_path / 'certificates'
+    data_dir = tmp_path / 'data'
+    for directory in (cert_dir, data_dir, tmp_path / 'backups', tmp_path / 'logs'):
+        directory.mkdir()
+
+    file_ops = FileOperations(cert_dir=cert_dir, data_dir=data_dir,
+                              backup_dir=tmp_path / 'backups',
+                              logs_dir=tmp_path / 'logs')
+    settings = SettingsManager(file_ops=file_ops,
+                               settings_file=data_dir / 'settings.json')
+    manager = CertificateManager(cert_dir=cert_dir, settings_manager=settings,
+                                 dns_manager=MagicMock(),
+                                 shell_executor=MagicMock())
+
+    def put_on_disk(domain, *, lifespan=31, issued_days_ago=25,
+                    ca_provider='private_ca'):
+        directory = cert_dir / domain
+        directory.mkdir()
+        cert_pem, key_pem = _leaf(domain, lifespan, issued_days_ago)
+        for name in ('cert.pem', 'fullchain.pem', 'chain.pem'):
+            (directory / name).write_bytes(cert_pem)
+        (directory / 'privkey.pem').write_bytes(key_pem)
+        (directory / 'metadata.json').write_text(json.dumps(
+            {'domain': domain, 'ca_provider': ca_provider,
+             'dns_provider': 'cloudflare'}))
+
+    def register(*entries, threshold=30, auto_renew=True):
+        def _seed(stored):
+            stored['domains'] = list(entries)
+            stored['auto_renew'] = auto_renew
+            stored['renewal_threshold_days'] = threshold
+        settings.update(_seed, reason='test')
+
+    manager.put_on_disk = put_on_disk
+    manager.register = register
+    return manager
+
+
+# --- the reported symptom, and that it is not the threshold --------------
+
+def test_a_registered_private_ca_cert_is_picked_up_from_day_zero(instance):
+    """The control that redirects the diagnosis. 31-day lifespan, 30-day
+    threshold: `days_left` is 30 on the day it is issued and `30 <= 30`, so a
+    REGISTERED certificate renews immediately. The reported numbers do not
+    produce the reported symptom."""
+    instance.put_on_disk('registered.example.com', issued_days_ago=0)
+    instance.register({'domain': 'registered.example.com',
+                       'dns_provider': 'cloudflare'})
+
+    info = instance.get_certificate_info(
+        'registered.example.com',
+        settings=instance.settings_manager.load_settings(), use_cache=False)
+
+    assert info['days_left'] == 30
+    assert info['needs_renewal'] is True
+
+
+def test_an_unregistered_certificate_is_never_checked(instance):
+    """The actual mechanism. The certificate exists, needs renewal, and the
+    sweep visits nothing."""
+    instance.put_on_disk('orphan.example.com')
+    instance.register()  # nothing registered
+
+    info = instance.get_certificate_info(
+        'orphan.example.com',
+        settings=instance.settings_manager.load_settings(), use_cache=False)
+    summary = instance.check_renewals()
+
+    assert info['exists'] is True and info['needs_renewal'] is True, (
+        'the fixture no longer reproduces the report')
+    assert summary['checked'] == 0
+    assert summary['renewed'] == 0 and summary['failed'] == 0
+
+
+def test_the_sweep_now_names_it(instance, caplog):
+    """THE fix. Previously this ran to completion emitting one line — "Checking
+    0 certificate(s)" — and the operator, reading the log for their domain,
+    found nothing and concluded renewal had been attempted and lost."""
+    instance.put_on_disk('orphan.example.com')
+    instance.register()
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        summary = instance.check_renewals()
+
+    assert summary['unmanaged'] == 1
+    message = '\n'.join(record.getMessage() for record in caplog.records)
+    assert 'orphan.example.com' in message, (
+        'the sweep counted an unmanaged certificate without saying which')
+    assert 'Add Domain' in message, (
+        'the warning does not say what to do about it')
+
+
+def test_a_registered_certificate_is_not_reported_as_unmanaged(instance):
+    """CONTROL. Without this, a reconciliation that named every certificate on
+    every run would pass the test above and be useless."""
+    instance.put_on_disk('managed.example.com')
+    instance.register({'domain': 'managed.example.com',
+                       'dns_provider': 'cloudflare'})
+
+    summary = instance.check_renewals()
+
+    assert summary['unmanaged'] == 0
+
+
+def test_only_the_unregistered_one_is_named_among_several(instance, caplog):
+    """The insidious shape, and the one the pre-existing startup warning misses:
+    it only fires when `domains` is EMPTY, so an instance with nine registered
+    certificates and one orphan was told nothing at all."""
+    for name in ('a.example.com', 'b.example.com'):
+        instance.put_on_disk(name)
+    instance.put_on_disk('orphan.example.com')
+    instance.register({'domain': 'a.example.com'}, {'domain': 'b.example.com'})
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        summary = instance.check_renewals()
+
+    assert summary['unmanaged'] == 1
+    # Only the lines the reconciliation emits. a/b appear elsewhere in this
+    # log because they are genuinely due and the stub executor fails them,
+    # which is the fixture, not the subject.
+    named = [record.getMessage() for record in caplog.records
+             if 'exists on disk but no settings entry' in record.getMessage()]
+    assert len(named) == 1
+    assert 'orphan.example.com' in named[0]
+    assert 'a.example.com' not in named[0] and 'b.example.com' not in named[0]
+
+
+def test_a_certificate_switched_off_on_purpose_is_not_called_unmanaged(instance):
+    """`auto_renew: false` is the supported way to stop a certificate renewing.
+    Reporting it as unmanaged would turn a deliberate choice into a warning on
+    every sweep, and a warning that fires on a correct configuration is one
+    people learn to skip."""
+    instance.put_on_disk('paused.example.com')
+    instance.register({'domain': 'paused.example.com', 'auto_renew': False})
+
+    summary = instance.check_renewals()
+
+    assert summary['skipped_disabled'] == 1
+    assert summary['unmanaged'] == 0
+
+
+def test_a_hand_edited_entry_that_is_dropped_at_load_is_now_recovered(instance,
+                                                                       caplog):
+    """A settings entry the load path cannot read is removed before the sweep
+    ever sees it — measured, for both shapes: a dict with no `domain` key and a
+    bare number both come back as `domains: []` from `load_settings`.
+
+    That makes the sweep's own `skipped_invalid` branch unreachable through
+    normal loading, and it means a typo in a hand-edited settings.json used to
+    remove a certificate from renewal with nothing said anywhere. The
+    reconciliation catches exactly this: the entry is gone, so the certificate
+    is unmanaged, so it gets named.
+    """
+    import json as _json
+    instance.put_on_disk('orphan.example.com')
+    instance.register({'domain': 'orphan.example.com'})
+
+    path = instance.settings_manager.settings_file
+    stored = _json.loads(path.read_text())
+    stored['domains'] = [{'dns_provider': 'cloudflare'}]  # typo: no `domain`
+    path.write_text(_json.dumps(stored))
+
+    assert instance.settings_manager.load_settings()['domains'] == [], (
+        'the load path now keeps malformed entries, so this test is measuring '
+        'something else')
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        summary = instance.check_renewals()
+
+    assert summary['unmanaged'] == 1
+    assert 'orphan.example.com' in '\n'.join(
+        record.getMessage() for record in caplog.records)
+
+
+# --- the reconciliation must not become a way to lose the sweep ----------
+
+def test_an_unreadable_certificate_directory_does_not_fail_the_sweep(
+        instance, monkeypatch, caplog):
+    """CONTROL. Losing the warning is bad; losing the sweep that renews
+    everything else is worse. The reconciliation runs after the work, and its
+    failure must not discard it."""
+    instance.put_on_disk('managed.example.com')
+    instance.register({'domain': 'managed.example.com'})
+
+    def _explode(_):
+        raise OSError('permission denied')
+
+    monkeypatch.setattr('modules.core.certificates.iter_cert_domain_dirs',
+                        _explode)
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        summary = instance.check_renewals()
+
+    assert summary['checked'] == 1, 'the sweep lost its work to the check'
+    assert summary['unmanaged'] == 0
+    assert 'permission denied' in '\n'.join(
+        record.getMessage() for record in caplog.records)
+
+
+def test_globally_disabled_renewal_still_returns_the_key(instance):
+    """The early return is a different dict literal. A caller reading
+    `summary['unmanaged']` must not have to know which one produced it."""
+    instance.put_on_disk('orphan.example.com')
+    instance.register(auto_renew=False)
+
+    summary = instance.check_renewals()
+
+    assert summary['auto_renew_disabled'] is True
+    assert summary['unmanaged'] == 0
+
+
+def test_the_completion_line_reports_the_count(instance, caplog):
+    """The number belongs in the one line an operator greps for."""
+    instance.put_on_disk('orphan.example.com')
+    instance.register()
+
+    with caplog.at_level(logging.INFO, logger=LOGGER):
+        instance.check_renewals()
+
+    completion = [record.getMessage() for record in caplog.records
+                  if 'Renewal check complete' in record.getMessage()]
+    assert completion, 'the sweep no longer logs a completion line'
+    assert '1 unmanaged' in completion[0]

--- a/tests/test_the_sweep_names_what_it_cannot_renew.py
+++ b/tests/test_the_sweep_names_what_it_cannot_renew.py
@@ -28,6 +28,7 @@ background sweep is not where that decision belongs.
 """
 import json
 import logging
+import re
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
@@ -44,6 +45,21 @@ from modules.core.settings import SettingsManager
 pytestmark = [pytest.mark.unit]
 
 LOGGER = 'modules.core.certificates'
+
+
+MARKER = 'exists on disk but no settings entry'
+
+
+def _reported(caplog):
+    """The certificate names the reconciliation warned about, exactly.
+
+    A set of parsed names rather than `'domain' in message`: the substring
+    form passes when the name appears anywhere in the log, including in an
+    unrelated renewal-failure line, so it asserts less than it looks like it
+    does. CodeQL flags it too, and it is right to.
+    """
+    return {re.search(r"Certificate '([^']+)'", record.getMessage()).group(1)
+            for record in caplog.records if MARKER in record.getMessage()}
 
 
 def _leaf(domain, lifespan_days, issued_days_ago):
@@ -154,10 +170,11 @@ def test_the_sweep_now_names_it(instance, caplog):
         summary = instance.check_renewals()
 
     assert summary['unmanaged'] == 1
-    message = '\n'.join(record.getMessage() for record in caplog.records)
-    assert 'orphan.example.com' in message, (
+    assert _reported(caplog) == {'orphan.example.com'}, (
         'the sweep counted an unmanaged certificate without saying which')
-    assert 'Add Domain' in message, (
+    remedy = [record.getMessage() for record in caplog.records
+              if MARKER in record.getMessage()][0]
+    assert 'Add Domain' in remedy, (
         'the warning does not say what to do about it')
 
 
@@ -185,15 +202,12 @@ def test_only_the_unregistered_one_is_named_among_several(instance, caplog):
     with caplog.at_level(logging.WARNING, logger=LOGGER):
         summary = instance.check_renewals()
 
+    # Exactly the orphan, and nothing else. a/b appear elsewhere in this log
+    # because they are genuinely due and the stub executor fails them, which
+    # is the fixture and not the subject — so the comparison is against the
+    # parsed set, not against the whole log.
     assert summary['unmanaged'] == 1
-    # Only the lines the reconciliation emits. a/b appear elsewhere in this
-    # log because they are genuinely due and the stub executor fails them,
-    # which is the fixture, not the subject.
-    named = [record.getMessage() for record in caplog.records
-             if 'exists on disk but no settings entry' in record.getMessage()]
-    assert len(named) == 1
-    assert 'orphan.example.com' in named[0]
-    assert 'a.example.com' not in named[0] and 'b.example.com' not in named[0]
+    assert _reported(caplog) == {'orphan.example.com'}
 
 
 def test_a_certificate_switched_off_on_purpose_is_not_called_unmanaged(instance):
@@ -239,8 +253,7 @@ def test_a_hand_edited_entry_that_is_dropped_at_load_is_now_recovered(instance,
         summary = instance.check_renewals()
 
     assert summary['unmanaged'] == 1
-    assert 'orphan.example.com' in '\n'.join(
-        record.getMessage() for record in caplog.records)
+    assert _reported(caplog) == {'orphan.example.com'}
 
 
 # --- the reconciliation must not become a way to lose the sweep ----------
@@ -264,8 +277,8 @@ def test_an_unreadable_certificate_directory_does_not_fail_the_sweep(
 
     assert summary['checked'] == 1, 'the sweep lost its work to the check'
     assert summary['unmanaged'] == 0
-    assert 'permission denied' in '\n'.join(
-        record.getMessage() for record in caplog.records)
+    assert any('permission denied' in record.getMessage()
+               for record in caplog.records)
 
 
 def test_globally_disabled_renewal_still_returns_the_key(instance):


### PR DESCRIPTION
Closes #759.

## The threshold is not the cause

The report suspects the 31-day lifespan against the 30-day threshold, or the
private CA. Reproduced against the real code at eight points across the
certificate's life, a **registered** certificate with exactly those numbers is
picked up from day zero — and `ca_provider` never enters the decision:

```
 giorno  days_left  needs_renewal  esito dello sweep
      0         30           True  checked=1 tentato_rinnovo=1
      1         29           True  checked=1 tentato_rinnovo=1
     25          5           True  checked=1 tentato_rinnovo=1
```

`days_left` is 30 on the day it is issued and the comparison is `<=`, so it
renews immediately.

## What actually happened

The detail that matters is in the report, not the title: **the log carried
nothing at all for that domain.** Not a failure, not a skip, not a "not yet
due". Reproducing that:

```
CERTIFICATO SUL DISCO MA NON IN settings['domains']
  il cert esiste:        True, days_left=5
  needs_renewal:         True   <- dice SI
  lo sweep lo visita:    checked=0
  rinnovi tentati:       0
  righe di log sul dominio: NESSUNA
  righe di log dello sweep: ['Checking 0 certificate(s) for renewal']
```

Exact match, including "manual renewal works" — the manual path is addressed by
domain and never consults the list.

## The two views disagree

`check_renewals` iterates `settings['domains']` and nothing else. The rest of
the application does not:

| Component | Which certificates it considers |
|---|---|
| `digest.py` | **union** of `settings['domains']` and the certificate directories |
| `get_certificate_info` | reads the disk |
| `check_renewals` | `settings['domains']` only |

So the certificate shows on the dashboard with `needs_renewal: true`, the digest
reports it expiring — and the one component whose job is to renew it never
mentions it. That silence is why the report reads as a threshold bug: there was
no other evidence to read.

## The change

The sweep reconciles what it considered against the certificate directories.
Each one no settings entry named gets a warning naming it and the remedy, plus a
new `unmanaged` count carried in the completion line:

```
Certificate 'orphan.example.com' exists on disk but no settings entry names it,
so this renewal sweep did not consider it and it will not renew. Re-register it
with the 'Add Domain' flow or POST /api/settings.
```

**It reports; it does not adopt.** Renewing a certificate the operator never
registered would issue against a CA for a domain CertMate was not asked to
manage — a half-restored backup would start requesting certificates — and a
background sweep is not where that decision belongs. Happy to add self-healing
adoption as a follow-up if you want it; it is a policy call, not a bug fix.

## Deliberately not done

- **The `settings.py` warning stays as it is.** It only fires when `domains` is
  entirely empty, which is exactly why an instance with nine registered
  certificates and one orphan was told nothing. Broadening it would put a
  `scandir` on every `load_settings()` call; the sweep now emits a better
  message once per run instead.
- **No new Prometheus gauge.** `record_renewal_sweep` is part of the `/metrics`
  surface and widening it belongs in its own change.

## Found while writing the tests

`load_settings` **strips** a domains entry it cannot read a domain out of — both
a dict with no `domain` key and a bare number come back as `domains: []`. That
makes the sweep's own `skipped_invalid` branch unreachable through normal
loading, and it means a typo in a hand-edited `settings.json` used to remove a
certificate from renewal with nothing said anywhere. The reconciliation catches
that case too, and a test records it.

## Verification

10 new tests; **8 fail against the code they replace**, and the 2 that pass are
the diagnosis (they describe behaviour that was already there). Controls
included: a registered certificate is not reported, an `auto_renew: false`
certificate is not reported (a warning that fires on a correct configuration is
one people learn to skip), and an unreadable certificate directory does not cost
the sweep its work.

Locally 4434 passed, 0 failed across the suite excluding the seven
container-building files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
