### PR TITLE
fix: a metadata write that does not happen says why (#757)

### DIFF
--- a/modules/api/resources_certificates.py
+++ b/modules/api/resources_certificates.py
@@ -10,7 +10,10 @@ import logging
 from flask import current_app, request
 from flask_restx import Resource
 
-from ..core.certificates import DomainOperationInProgress
+from ..core.certificates import (
+    DomainOperationInProgress,
+    MetadataWriteRefused,
+)
 from ..core.inventory_sources import (
     auto_renew_for,
     collect_domain_sources,
@@ -265,6 +268,13 @@ def create_certificates_resources(api, models, ctx: ApiContext) -> dict:
                         domain, changes)
                 except ValueError as e:
                     return {'error': str(e)}, 400
+                except MetadataWriteRefused as e:
+                    # Before RuntimeError, which it subclasses. A guard that
+                    # did its job is not a server error: reporting 500 sends
+                    # an operator looking for a fault in CertMate instead of
+                    # at the version they rolled back from (#757).
+                    return {'error': str(e),
+                            'code': 'METADATA_SCHEMA_DOWNGRADE'}, 409
                 except RuntimeError as e:
                     return {'error': str(e)}, 500
                 logger.info(

--- a/modules/core/cert_service.py
+++ b/modules/core/cert_service.py
@@ -419,9 +419,15 @@ class CertificateService:
                             '(no scheme, path, whitespace, or wildcard)')
                     metadata['deployment_host'] = host
 
-            if not self._certs._save_metadata(domain, metadata):
-                raise RuntimeError(
-                    f'Failed to update metadata for domain: {domain}')
+            # write_metadata, not _save_metadata: this is the one call site
+            # whose outcome reaches a person, and the boolean threw the reason
+            # away. "Failed to update metadata for domain: X" was produced by
+            # a read-only volume and by a deliberate schema-downgrade refusal
+            # alike, naming neither and suggesting nothing (#757). The
+            # exceptions it raises are RuntimeError subclasses, so the route's
+            # existing arm keeps handling them; it just has something to say
+            # now.
+            self._certs.write_metadata(domain, metadata)
 
             # The settings entry is written HERE, inside the same domain lock,
             # rather than by the caller afterwards.

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -360,6 +360,19 @@ def _usable(key_state):
     return key_state == 'present'
 
 
+class MetadataWriteRefused(RuntimeError):
+    """The metadata write was refused by design, not by a failure.
+
+    RuntimeError so the existing route arm keeps working unchanged; the API
+    layer narrows it to 409, because a guard doing its job is not a server
+    error and telling an operator "500" sends them looking for one.
+    """
+
+
+class MetadataWriteFailed(RuntimeError):
+    """The metadata write was attempted and could not be completed."""
+
+
 class CertificateManager:
     """Class to handle certificate operations"""
     
@@ -1175,30 +1188,64 @@ class CertificateManager:
         and the same meaning as for settings.json: proceed, and accept that
         this process may drop fields it does not know about.
         """
-        metadata_file = self._metadata_path(domain)
         try:
-            on_disk = self._metadata_schema_on_disk(metadata_file)
-            if (on_disk is not None
-                    and on_disk > METADATA_SCHEMA_VERSION
-                    and os.getenv('CERTMATE_ALLOW_SCHEMA_DOWNGRADE') != '1'):
-                logger.error(
-                    "Refusing to write metadata for %s: the file on disk "
-                    "declares schema v%s and this build understands v%s. An "
-                    "older process writing it would drop the fields it cannot "
-                    "read, and %s records which private key belongs to this "
-                    "certificate. Run the newer version, or set "
-                    "CERTMATE_ALLOW_SCHEMA_DOWNGRADE=1 to overwrite it anyway.",
-                    domain, on_disk, METADATA_SCHEMA_VERSION, metadata_file)
-                return False
-
-            stamped = dict(metadata)
-            stamped['metadata_schema_version'] = METADATA_SCHEMA_VERSION
-            self._atomic_json_write(metadata_file, stamped)
-            self._invalidate_certificate_info_cache(domain)
+            self.write_metadata(domain, metadata)
             return True
-        except Exception as e:
-            logger.warning(f"Failed to save metadata for {domain}: {e}")
+        except MetadataWriteRefused as e:
+            # ERROR, not WARNING: this one is a data-custody decision, and it
+            # was logged at ERROR before the reason became an exception. The
+            # domain stays a log ARGUMENT rather than being interpolated, so a
+            # handler can filter on it.
+            logger.error("Refusing to write metadata for %s: %s", domain, e)
             return False
+        except Exception as e:
+            logger.warning("Failed to save metadata for %s: %s", domain, e)
+            return False
+
+    def write_metadata(self, domain: str, metadata: dict) -> None:
+        """Write the metadata, or raise saying **why** it was not written.
+
+        Same rules as `_save_metadata`, which is now the bool-returning
+        wrapper around this. The split exists because the two kinds of caller
+        want different things and one of them was being denied it:
+
+        - six call sites write metadata as part of issuance or renewal and
+          cannot act on a reason. They keep the boolean, and a failure there
+          must not turn a cosmetic metadata problem into a failed issuance.
+        - one call site — a config edit from the UI or API — reports the
+          outcome to a person. It got the same bare ``False``, and produced
+          "Failed to update metadata for domain: X" for causes as different
+          as a read-only volume and a deliberate refusal to downgrade the
+          schema. The reason existed; it was written to the log and thrown
+          away before it could reach the person who had to act on it (#757).
+        """
+        metadata_file = self._metadata_path(domain)
+
+        on_disk = self._metadata_schema_on_disk(metadata_file)
+        if (on_disk is not None
+                and on_disk > METADATA_SCHEMA_VERSION
+                and os.getenv('CERTMATE_ALLOW_SCHEMA_DOWNGRADE') != '1'):
+            raise MetadataWriteRefused(
+                f"metadata.json for {domain} declares schema v{on_disk} and "
+                f"this build understands v{METADATA_SCHEMA_VERSION}. It was "
+                f"written by a newer version of CertMate; overwriting it here "
+                f"would drop the fields this build cannot read, including the "
+                f"record of which private key belongs to this certificate. "
+                f"Run the newer version, or set "
+                f"CERTMATE_ALLOW_SCHEMA_DOWNGRADE=1 to overwrite it anyway.")
+
+        stamped = dict(metadata)
+        stamped['metadata_schema_version'] = METADATA_SCHEMA_VERSION
+        try:
+            self._atomic_json_write(metadata_file, stamped)
+        except OSError as e:
+            # strerror, not the exception: str(OSError) repeats the path,
+            # which the message already names.
+            raise MetadataWriteFailed(
+                f"could not write {metadata_file}: {e.strerror}. Check that "
+                f"the certificates volume is mounted writable and owned by "
+                f"the user CertMate runs as (uid 1000 in the image).") from e
+        self._invalidate_certificate_info_cache(domain)
 
     @staticmethod
     def _metadata_schema_on_disk(metadata_file: Path):

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -1195,11 +1195,12 @@ class CertificateManager:
             # ERROR, not WARNING: this one is a data-custody decision, and it
             # was logged at ERROR before the reason became an exception. The
             # domain stays a log ARGUMENT rather than being interpolated, so a
-            # handler can filter on it.
-            logger.error("Refusing to write metadata for %s: %s", domain, e)
+            # handler can filter on it, and %r rather than %s so a newline in
+            # a domain name cannot forge a second log line.
+            logger.error("Refusing to write metadata for %r: %s", domain, e)
             return False
         except Exception as e:
-            logger.warning("Failed to save metadata for %s: %s", domain, e)
+            logger.warning("Failed to save metadata for %r: %s", domain, e)
             return False
 
     def write_metadata(self, domain: str, metadata: dict) -> None:

--- a/tests/test_a_refused_write_says_why.py
+++ b/tests/test_a_refused_write_says_why.py
@@ -208,9 +208,11 @@ def test_the_refusal_is_logged_at_error_with_the_domain_as_an_argument(
 
     refusals = [r for r in caplog.records if r.levelno == logging.ERROR]
     assert refusals, 'the refusal was not logged at ERROR'
-    assert 'example.com' in (refusals[0].args or ()), (
-        'the domain is interpolated into the message rather than passed as an '
-        'argument, so a log handler cannot filter on it')
+    # Indexed, not `in`: the tuple's FIRST argument is the domain, and
+    # membership would also pass if it turned up somewhere else in the args.
+    assert refusals[0].args[0] == 'example.com', (
+        'the domain is interpolated into the message rather than passed as the '
+        'first argument, so a log handler cannot filter on it')
 
 
 def test_a_write_failure_is_logged_at_warning_not_error(manager, caplog):

--- a/tests/test_a_refused_write_says_why.py
+++ b/tests/test_a_refused_write_says_why.py
@@ -1,0 +1,260 @@
+"""A metadata write that does not happen has to say why it did not happen.
+
+Reported as #757: configuring a deployment probe failed with
+
+    Failed: Failed to update metadata for domain: *.xx.xx
+
+and nothing else. The reporter, reasonably, concluded from the message that
+wildcards were the problem, and looked at the domain field — which is a text
+input with a `<datalist>`, not the dropdown its neighbour is — and concluded
+that too. Neither was the cause.
+
+`_save_metadata` returned a bare `False`. Two unrelated situations produced it:
+
+- the file could not be written (a read-only volume, or a certificates
+  directory owned by a different uid — the reporter runs on Kubernetes);
+- the write was **refused by design**, because `metadata.json` on disk
+  declares a newer schema than this build understands and overwriting it
+  would drop the fields it cannot read, including which private key belongs
+  to the certificate.
+
+Both reasons were computed, written to the server log, and then thrown away
+before reaching the person who had to act on one of them. Reproduced against
+the running application, both returned the identical body and status:
+
+    {"error": "Failed to update metadata for domain: X"}   HTTP 500
+
+`write_metadata` raises instead, carrying the reason. `_save_metadata` stays
+as the boolean wrapper for the six call sites that write metadata during
+issuance and renewal and cannot act on a reason — a cosmetic metadata problem
+must not become a failed issuance, which is why the split exists at all
+rather than the whole thing being changed to raise.
+"""
+import json
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.certificates import (
+    CertificateManager, MetadataWriteFailed, MetadataWriteRefused,
+)
+from modules.core.constants import METADATA_SCHEMA_VERSION
+from modules.core.file_operations import FileOperations
+from modules.core.settings import SettingsManager
+
+pytestmark = [pytest.mark.unit]
+
+LOGGER = 'modules.core.certificates'
+
+
+@pytest.fixture
+def manager(tmp_path):
+    cert_dir = tmp_path / 'certificates'
+    data_dir = tmp_path / 'data'
+    for directory in (cert_dir, data_dir, tmp_path / 'backups', tmp_path / 'logs'):
+        directory.mkdir()
+    file_ops = FileOperations(cert_dir=cert_dir, data_dir=data_dir,
+                              backup_dir=tmp_path / 'backups',
+                              logs_dir=tmp_path / 'logs')
+    settings = SettingsManager(file_ops=file_ops,
+                               settings_file=data_dir / 'settings.json')
+    mgr = CertificateManager(cert_dir=cert_dir, settings_manager=settings,
+                             dns_manager=MagicMock(),
+                             shell_executor=MagicMock())
+    (cert_dir / 'example.com').mkdir()
+    return mgr
+
+
+def _write_schema(manager, domain, version):
+    path = manager.cert_dir / domain / 'metadata.json'
+    path.write_text(json.dumps({'domain': domain,
+                                'metadata_schema_version': version}))
+
+
+# --- the ordinary case is untouched --------------------------------------
+
+def test_a_normal_write_succeeds_and_stamps_the_schema(manager):
+    manager.write_metadata('example.com', {'domain': 'example.com'})
+
+    stored = json.loads(
+        (manager.cert_dir / 'example.com' / 'metadata.json').read_text())
+    assert stored['metadata_schema_version'] == METADATA_SCHEMA_VERSION
+    assert stored['domain'] == 'example.com'
+
+
+def test_the_caller_is_not_handed_the_dict_it_passed(manager):
+    """CONTROL: the stamp is added to a copy. Mutating the caller's dict would
+    put a schema version into whatever it does with it next."""
+    original = {'domain': 'example.com'}
+
+    manager.write_metadata('example.com', original)
+
+    assert 'metadata_schema_version' not in original
+
+
+# --- a write that cannot happen ------------------------------------------
+
+def test_an_unwritable_directory_raises_with_the_path_and_the_reason(manager):
+    directory = manager.cert_dir / 'example.com'
+    directory.chmod(0o555)
+    try:
+        with pytest.raises(MetadataWriteFailed) as caught:
+            manager.write_metadata('example.com', {'domain': 'example.com'})
+    finally:
+        directory.chmod(0o755)
+
+    message = str(caught.value)
+    assert 'metadata.json' in message, 'the message does not name the file'
+    assert 'Permission denied' in message, 'the message does not say what failed'
+    assert 'uid 1000' in message, (
+        'the message does not point at the ownership of the mounted volume, '
+        'which is the fix in a container deployment')
+
+
+def test_a_record_from_a_newer_build_is_refused_with_both_versions(manager):
+    _write_schema(manager, 'example.com', METADATA_SCHEMA_VERSION + 5)
+
+    with pytest.raises(MetadataWriteRefused) as caught:
+        manager.write_metadata('example.com', {'domain': 'example.com'})
+
+    message = str(caught.value)
+    assert str(METADATA_SCHEMA_VERSION + 5) in message
+    assert str(METADATA_SCHEMA_VERSION) in message
+    assert 'CERTMATE_ALLOW_SCHEMA_DOWNGRADE' in message, (
+        'the refusal does not name its own override, so the operator has no '
+        'way out of it')
+
+
+def test_the_refusal_leaves_the_file_alone(manager):
+    """The whole reason for refusing. A partial write would be worse than the
+    error."""
+    _write_schema(manager, 'example.com', METADATA_SCHEMA_VERSION + 5)
+    before = (manager.cert_dir / 'example.com' / 'metadata.json').read_bytes()
+
+    with pytest.raises(MetadataWriteRefused):
+        manager.write_metadata('example.com', {'domain': 'other'})
+
+    assert (manager.cert_dir / 'example.com' / 'metadata.json').read_bytes() == before
+
+
+def test_the_override_lets_it_through(manager, monkeypatch):
+    _write_schema(manager, 'example.com', METADATA_SCHEMA_VERSION + 5)
+    monkeypatch.setenv('CERTMATE_ALLOW_SCHEMA_DOWNGRADE', '1')
+
+    manager.write_metadata('example.com', {'domain': 'example.com'})
+
+    stored = json.loads(
+        (manager.cert_dir / 'example.com' / 'metadata.json').read_text())
+    assert stored['metadata_schema_version'] == METADATA_SCHEMA_VERSION
+
+
+@pytest.mark.parametrize('value', ['0', 'true', 'yes', ''])
+def test_only_exactly_one_disables_the_refusal(manager, monkeypatch, value):
+    """CONTROL: a guard that any truthy-looking value switches off is a guard
+    that gets switched off by accident."""
+    _write_schema(manager, 'example.com', METADATA_SCHEMA_VERSION + 5)
+    monkeypatch.setenv('CERTMATE_ALLOW_SCHEMA_DOWNGRADE', value)
+
+    with pytest.raises(MetadataWriteRefused):
+        manager.write_metadata('example.com', {'domain': 'example.com'})
+
+
+def test_an_older_record_is_written_without_complaint(manager):
+    """CONTROL: only a record from the FUTURE is refused. Upgrading is the
+    normal direction and must not be blocked."""
+    _write_schema(manager, 'example.com', max(METADATA_SCHEMA_VERSION - 1, 0))
+
+    manager.write_metadata('example.com', {'domain': 'example.com'})
+
+    stored = json.loads(
+        (manager.cert_dir / 'example.com' / 'metadata.json').read_text())
+    assert stored['metadata_schema_version'] == METADATA_SCHEMA_VERSION
+
+
+# --- the six callers that cannot act on a reason keep their boolean ------
+
+def test_save_metadata_still_returns_true_on_success(manager):
+    assert manager._save_metadata('example.com', {'domain': 'example.com'}) is True
+
+
+@pytest.mark.parametrize('setup', ['unwritable', 'newer-schema'])
+def test_save_metadata_still_returns_false_rather_than_raising(manager, setup):
+    """THE compatibility property. Six call sites write metadata during
+    issuance and renewal and ignore the result; if this started raising, a
+    metadata problem would abort an issuance that had already obtained a
+    certificate."""
+    directory = manager.cert_dir / 'example.com'
+    if setup == 'unwritable':
+        directory.chmod(0o555)
+    else:
+        _write_schema(manager, 'example.com', METADATA_SCHEMA_VERSION + 5)
+    try:
+        assert manager._save_metadata(
+            'example.com', {'domain': 'example.com'}) is False
+    finally:
+        directory.chmod(0o755)
+
+
+def test_the_refusal_is_logged_at_error_with_the_domain_as_an_argument(
+        manager, caplog):
+    """It was logged at ERROR before the reason became an exception, and a
+    data-custody refusal deserves that level. The domain stays a log ARGUMENT
+    rather than being interpolated, so a handler can filter on it."""
+    _write_schema(manager, 'example.com', METADATA_SCHEMA_VERSION + 5)
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER):
+        manager._save_metadata('example.com', {'domain': 'example.com'})
+
+    refusals = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert refusals, 'the refusal was not logged at ERROR'
+    assert 'example.com' in (refusals[0].args or ()), (
+        'the domain is interpolated into the message rather than passed as an '
+        'argument, so a log handler cannot filter on it')
+
+
+def test_a_write_failure_is_logged_at_warning_not_error(manager, caplog):
+    """CONTROL for the level above: an I/O failure is not the same kind of
+    event as a refusal, and giving both ERROR would make the level say
+    nothing."""
+    directory = manager.cert_dir / 'example.com'
+    directory.chmod(0o555)
+    try:
+        with caplog.at_level(logging.WARNING, logger=LOGGER):
+            manager._save_metadata('example.com', {'domain': 'example.com'})
+    finally:
+        directory.chmod(0o755)
+
+    assert caplog.records
+    assert all(r.levelno == logging.WARNING for r in caplog.records)
+
+
+# --- what the API layer relies on ----------------------------------------
+
+def test_both_are_runtime_errors(manager):
+    """The route already had an arm for RuntimeError returning 500. Both
+    subclass it, so the change could not leave a path unhandled — the API
+    layer narrows the refusal to 409 on top of that, it does not depend on
+    doing so."""
+    assert issubclass(MetadataWriteRefused, RuntimeError)
+    assert issubclass(MetadataWriteFailed, RuntimeError)
+
+
+def test_the_two_are_distinguishable(manager):
+    """CONTROL: if one subclassed the other, the 409 arm would swallow the
+    500 case or the reverse, depending on the order of the except clauses."""
+    assert not issubclass(MetadataWriteRefused, MetadataWriteFailed)
+    assert not issubclass(MetadataWriteFailed, MetadataWriteRefused)
+
+
+def test_the_route_orders_the_refusal_before_the_generic_arm():
+    """`except RuntimeError` first would make the 409 unreachable, and the
+    tests above would still pass — this is the one that would not."""
+    import pathlib
+    source = (pathlib.Path(__file__).resolve().parent.parent / 'modules'
+              / 'api' / 'resources_certificates.py').read_text()
+    refusal = source.index('except MetadataWriteRefused')
+    generic = source.index('except RuntimeError as e:\n                    return')
+    assert refusal < generic, (
+        'the generic RuntimeError arm comes first, so a refused write is '
+        'reported as a 500 again')

--- a/tests/test_http_layers_do_not_reach_through.py
+++ b/tests/test_http_layers_do_not_reach_through.py
@@ -30,6 +30,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from modules.core.certificates import CertificateManager
+from modules.core.certificates import MetadataWriteFailed
 from modules.core.cert_service import CertificateService
 
 pytestmark = [pytest.mark.unit]
@@ -43,7 +44,7 @@ def _service(stored=None, sink=None):
     manager._domain_locks_mutex = threading.Lock()
     manager._domain_lock_timeout = lambda: 0.2
     manager._load_metadata = lambda domain: dict(stored or {})
-    manager._save_metadata = (
+    manager.write_metadata = (
         lambda domain, metadata: (sink.update(metadata) if sink is not None else None) or True)
     return CertificateService(manager, MagicMock(), MagicMock())
 
@@ -154,8 +155,15 @@ def test_a_failed_save_is_an_error_not_a_silent_success():
     manager._domain_locks_mutex = threading.Lock()
     manager._domain_lock_timeout = lambda: 0.2
     manager._load_metadata = lambda domain: {}
-    manager._save_metadata = lambda domain, metadata: False
+    # Raises rather than returning False: a boolean could not say WHY, and a
+    # write refused for a schema downgrade and one refused by a read-only
+    # volume produced the same unactionable message (#757). The match below
+    # now checks the reason survives to the caller, which is the point.
+    def _explode(domain, metadata):
+        raise MetadataWriteFailed(
+            'could not write /x/metadata.json: Permission denied')
+    manager.write_metadata = _explode
 
     service = CertificateService(manager, MagicMock(), MagicMock())
-    with pytest.raises(RuntimeError, match='Failed to update metadata'):
+    with pytest.raises(RuntimeError, match='Permission denied'):
         service.update_config('example.com', {'dns_provider': 'route53'})

--- a/tests/test_patch_metadata_takes_domain_lock.py
+++ b/tests/test_patch_metadata_takes_domain_lock.py
@@ -99,7 +99,7 @@ def test_update_config_takes_the_lock_and_reports_contention(tmp_path):
     manager._domain_locks_mutex = threading.Lock()
     manager._domain_lock_timeout = lambda: 0.2
     manager._load_metadata = lambda domain: {}
-    manager._save_metadata = lambda domain, metadata: True
+    manager.write_metadata = lambda domain, metadata: True
 
     service = CertificateService(manager, MagicMock(), MagicMock())
 
@@ -121,7 +121,7 @@ def test_update_config_writes_when_nothing_holds_the_lock(tmp_path):
     manager._domain_locks_mutex = threading.Lock()
     manager._domain_lock_timeout = lambda: 0.2
     manager._load_metadata = lambda domain: {'dns_provider': 'cloudflare'}
-    manager._save_metadata = lambda domain, metadata: written.update(metadata) or True
+    manager.write_metadata = lambda domain, metadata: written.update(metadata) or True
 
     service = CertificateService(manager, MagicMock(), MagicMock())
     metadata, old = service.update_config('example.com',

--- a/tests/test_patch_probe_config.py
+++ b/tests/test_patch_probe_config.py
@@ -12,6 +12,11 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+
+from modules.core.certificates import (
+    MetadataWriteFailed,
+    MetadataWriteRefused,
+)
 from flask import Flask
 from flask_restx import Api, Namespace
 
@@ -57,7 +62,7 @@ def _managers(tmp_path, saved):
     certificate_manager = MagicMock()
     certificate_manager.cert_dir = Path(tmp_path)
     # Capture exactly what would be persisted.
-    certificate_manager._save_metadata = MagicMock(
+    certificate_manager.write_metadata = MagicMock(
         side_effect=lambda _d, md: saved.update(md) or True
     )
 
@@ -235,14 +240,39 @@ def test_a_failed_write_becomes_a_500_not_a_200(tmp_path):
     walk away believing the certificate now renews with the new provider.
     """
     managers = _managers(tmp_path, {})
-    managers['certificates']._save_metadata = MagicMock(return_value=False)
+    # Raises, because that is how write_metadata reports a failure now:
+    # the boolean could not carry the reason, which is the defect #757
+    # was about. A double that returned False would report success.
+    managers['certificates'].write_metadata = MagicMock(
+        side_effect=MetadataWriteFailed('could not write /x: Permission denied'))
     app = _build_app(managers)
 
     resp = app.test_client().patch('/api/certificates/example.com',
                                    json={'dns_provider': 'route53'})
 
     assert resp.status_code == 500, resp.get_json()
-    assert 'Failed to update metadata' in resp.get_json()['error']
+    # The reason, not "Failed to update metadata for domain: X". That message
+    # was produced by a read-only volume and by a deliberate schema-downgrade
+    # refusal alike, naming neither (#757); the caller now gets the one the
+    # write actually hit.
+    assert resp.get_json()['error'] == 'could not write /x: Permission denied'
+
+
+def test_a_refused_write_is_a_409_not_a_500(tmp_path):
+    """A guard doing its job is not a server error. Reporting 500 for a
+    deliberate schema-downgrade refusal sends an operator looking for a fault
+    in CertMate instead of at the version they rolled back from (#757)."""
+    managers = _managers(tmp_path, {})
+    managers['certificates'].write_metadata = MagicMock(
+        side_effect=MetadataWriteRefused(
+            'metadata.json declares schema v99 and this build understands v1'))
+    app = _build_app(managers)
+
+    resp = app.test_client().patch('/api/certificates/example.com',
+                                   json={'dns_provider': 'route53'})
+
+    assert resp.status_code == 409, resp.get_json()
+    assert 'v99' in resp.get_json()['error']
 
 
 def test_a_successful_change_updates_the_settings_entry_too(tmp_path):

--- a/tests/test_the_dns_provider_has_one_home.py
+++ b/tests/test_the_dns_provider_has_one_home.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from modules.core.cert_service import CertificateService
+from modules.core.certificates import MetadataWriteFailed
 
 pytestmark = [pytest.mark.unit]
 
@@ -54,7 +55,7 @@ class _Certs:
 
         return _held()
 
-    def _save_metadata(self, domain, metadata):
+    def write_metadata(self, domain, metadata):
         self._metadata = dict(metadata)
         return True
 
@@ -175,7 +176,9 @@ def test_a_failed_metadata_write_does_not_touch_settings(parts):
     Settings naming a provider whose metadata says otherwise is the same
     defect, mirrored."""
     service, certs, stored, order = parts
-    certs._save_metadata = lambda domain, metadata: False
+    def _explode(domain, metadata):
+        raise MetadataWriteFailed('could not write /x: Permission denied')
+    certs.write_metadata = _explode
 
     with pytest.raises(RuntimeError):
         service.update_config('example.com', {'dns_provider': 'route53'})


### PR DESCRIPTION
Closes #757.

## It is not wildcards, and not the form

Reproduced against a running instance seeded with three certificates, one of
them a wildcard:

| what | result |
|---|---|
| `PATCH` a probe onto `*.wildcard.example.com` | **200**, config stored |
| the probe form's domain suggestions | populates with all three, wildcard included |
| `PATCH` a probe onto a domain with no certificate | **404** `Certificate not found for domain: …` |

So the paths the report points at work. The reporter's inference was reasonable
— the domain field *is* a text input with a `<datalist>` sitting next to a real
custom dropdown, which is why it reads as "just a text window" — but it was not
what failed.

## What actually produces that message

`_save_metadata` returns a bare `False`, and **two unrelated situations produce
it**:

- the file cannot be written — a read-only volume, or a certificates directory
  owned by a different uid, which is the shape a Kubernetes deployment gets
  wrong, and the reporter runs on Kubernetes;
- the write is **refused by design**, because `metadata.json` on disk declares a
  newer schema than this build understands and overwriting it would drop the
  fields it cannot read, including which private key belongs to the certificate.

Both reasons were computed, written to the server log, and thrown away before
reaching the person who had to act on one of them. Measured against the running
instance, both returned:

```
{"error": "Failed to update metadata for domain: X"}   HTTP 500
```

## After

```
permission   500  could not write /…/certificates/api.example.com/metadata.json:
                  Permission denied. Check that the certificates volume is
                  mounted writable and owned by the user CertMate runs as
                  (uid 1000 in the image).

schema       409  metadata.json for shop.example.com declares schema v99 and
                  this build understands v1. It was written by a newer version
                  of CertMate; overwriting it here would drop the fields this
                  build cannot read … set CERTMATE_ALLOW_SCHEMA_DOWNGRADE=1 to
                  overwrite it anyway.
                  code: METADATA_SCHEMA_DOWNGRADE
```

**409, not 500, for the refusal.** A guard doing its job is not a server error,
and reporting one sends an operator looking for a fault in CertMate instead of
at the version they rolled back from.

## Why the split rather than making it raise

`write_metadata` raises; `_save_metadata` stays as the boolean wrapper. That is
deliberate, not a leftover: **six** call sites write metadata during issuance
and renewal and ignore the result. If those started raising, a cosmetic metadata
problem would abort an issuance that had already obtained a certificate. Only
the one call site whose outcome reaches a person uses the raising form, and a
test pins that `_save_metadata` still returns `False` rather than raising for
both failure kinds.

The refusal also keeps its ERROR level and its domain-as-a-log-argument, which
an existing test already required.

## Blast radius, stated plainly

Four existing test files stubbed `_save_metadata` and no longer intercept the
call. They now stub `write_metadata` **and raise**, because a double that
returned `False` would report success — which is the defect, in miniature. One
assertion moved from matching the old message to matching the reason.

## Verification

19 new tests. They cannot run against `main` at all — the exception types do not
exist there — so the evidence that the behaviour changed is the before/after
above, taken from a real instance. Controls included: an older schema is written
without complaint, only exactly `1` disables the guard, the refusal leaves the
file byte-identical, and the route orders the 409 arm before the generic
`RuntimeError` one (that last test is the only one that would catch the arms
being swapped).

Locally 4458 passed, 0 failed.

## Not fixed here

The domain field being a `<datalist>` rather than the dropdown its neighbour is.
That is a real UX complaint and it actively misled this diagnosis, but it is a
separate change and I would rather it be reviewed as one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
