### PR TITLE
perf: the private key is not re-validated on every certificate read

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -387,6 +387,12 @@ class CertificateManager:
         # Per-domain locks to prevent concurrent create/renew on the same domain
         self._domain_locks: dict[str, threading.Lock] = {}
         self._domain_locks_mutex = threading.Lock()
+        # domain -> (key digest, cert digest, answer) for private_key_state.
+        # One entry per domain, like _domain_locks above and bounded the same
+        # way: by how many certificates this instance manages. See
+        # private_key_state for why the answer is worth remembering at all.
+        self._key_state_cache: dict[str, tuple[bytes, bytes, str]] = {}
+        self._key_state_mutex = threading.Lock()
         # Optional audit logger, injected by the factory so unattended renewals
         # produce an attributed (actor.kind='scheduler') audit record. None in
         # standalone/unit contexts, where emission is simply skipped.
@@ -1807,6 +1813,23 @@ class CertificateManager:
         question: cert.pem from one issuance beside privkey.pem from another
         cannot complete a handshake either, and comparing public numbers
         catches it for RSA and EC alike without needing to know the key type.
+
+        **The answer is remembered per (key bytes, certificate bytes).** This
+        is called once per domain by every listing, by every Prometheus
+        collection and by every renewal sweep, and the comparison is dominated
+        by loading the private key, which OpenSSL validates as it parses.
+        Measured on one machine: 51.6 ms for RSA-2048, 275 ms for RSA-4096,
+        0.020 ms for EC P-256 — and CertMate's default key shape is RSA-2048,
+        so on the common installation this single call was ~99% of the cost of
+        reading a certificate's information. It is pure with respect to the two
+        files' contents, so hashing both (tens of microseconds) and reusing the
+        answer is exact rather than approximate: any change to either file —
+        renewal, re-key, a restored backup, a torn publish — changes a digest
+        and the comparison runs again. Time is not part of the key, because
+        nothing about this answer expires.
+
+        The warning below therefore fires once per distinct file pair rather
+        than once per read, which is the same information at 1/N the volume.
         """
         key_file = self.cert_dir / domain / 'privkey.pem'
         if not key_file.exists():
@@ -1821,11 +1844,42 @@ class CertificateManager:
             return 'present'
 
         try:
+            key_bytes = key_file.read_bytes()
+        except OSError as e:
+            # Same answer as an unparseable key, and for the same reason: a key
+            # this process cannot read is not one it can serve with.
+            logger.warning(
+                "Could not read the private key for %s: %s",
+                str(domain).replace(chr(10), ' ').replace(chr(13), ' '), e)
+            return 'mismatched'
+
+        key_digest = hashlib.sha256(key_bytes).digest()
+        cert_digest = hashlib.sha256(cert_content).digest()
+        with self._key_state_mutex:
+            remembered = self._key_state_cache.get(domain)
+        if remembered is not None and remembered[:2] == (key_digest, cert_digest):
+            return remembered[2]
+
+        state = self._compare_key_to_certificate(domain, key_bytes, cert_content)
+        with self._key_state_mutex:
+            self._key_state_cache[domain] = (key_digest, cert_digest, state)
+        return state
+
+    @staticmethod
+    def _compare_key_to_certificate(domain, key_bytes, cert_content):
+        """Does this private key belong to this certificate? The expensive half.
+
+        Split out of `private_key_state` so the cheap decisions (no key file at
+        all, no certificate to compare against) and the cache lookup stay
+        readable above, and so a test can count how often the parsing actually
+        happens.
+        """
+        try:
             from cryptography.hazmat.primitives import serialization
             from cryptography import x509
 
             private_key = serialization.load_pem_private_key(
-                key_file.read_bytes(), password=None)
+                key_bytes, password=None)
             certificate = x509.load_pem_x509_certificate(cert_content)
         except Exception as e:
             # An unreadable or encrypted key is not a usable one. Say so

--- a/tests/test_the_key_check_is_not_repeated_per_read.py
+++ b/tests/test_the_key_check_is_not_repeated_per_read.py
@@ -1,0 +1,293 @@
+"""Reading a certificate should not re-validate a private key that has not changed.
+
+`private_key_state` answers "is there a usable private key beside this
+certificate", and it answers it by loading the key — which OpenSSL validates as
+it parses. That is not a cheap parse. Measured on one machine at the commit
+this file was written against:
+
+    load_pem_private_key   RSA-2048    51.6 ms
+    load_pem_private_key   RSA-4096   275.5 ms
+    load_pem_private_key   EC P-256     0.020 ms
+
+    get_certificate_info, real RSA-2048 key beside the certificate   58.7 ms
+    get_certificate_info, key present but unparseable                 0.19 ms
+
+CertMate's default key shape is `rsa`/2048 (see `settings.py`), so on the
+common installation ~99% of the cost of reading one certificate's information
+was re-answering a question whose inputs had not moved. It is called once per
+domain by the dashboard listing, by every Prometheus collection (serially, on
+the request thread) and by every renewal sweep.
+
+The answer is a pure function of two files' contents, so it is remembered per
+`(sha256(privkey.pem), sha256(cert.pem))`. Hashing both costs tens of
+microseconds against tens of milliseconds, and — unlike an mtime or a TTL — it
+is exact: any change to either file produces a different digest and the
+comparison runs again. That matters here more than it usually would, because
+the three ways these files change are renewal, re-keying, and a torn publish
+leaving a new certificate beside the previous key, and the last one is the
+condition this check exists to catch.
+
+What is asserted below is the number of parses, not the elapsed time: a
+wall-clock ceiling measures the runner, and the reliable response to a flaky
+one is to raise it until it never fires. The timing is printed instead
+(`pytest -s`), in the same spirit as tests/test_three_operations_have_a_number.py.
+"""
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
+
+from modules.core.certificates import CertificateManager
+from modules.core.file_operations import FileOperations
+from modules.core.settings import SettingsManager
+
+pytestmark = [pytest.mark.unit]
+
+
+def _key(kind='ec'):
+    if kind == 'rsa':
+        return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return ec.generate_private_key(ec.SECP256R1())
+
+
+def _pem_pair(key, common_name='perf.example.com', days_left=60):
+    """A self-signed certificate for *key*, and the key, both PEM."""
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    now = datetime.now(timezone.utc)
+    cert = (x509.CertificateBuilder()
+            .subject_name(name).issuer_name(name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - timedelta(days=30))
+            .not_valid_after(now + timedelta(days=days_left))
+            .add_extension(x509.SubjectAlternativeName(
+                [x509.DNSName(common_name)]), critical=False)
+            .sign(key, hashes.SHA256()))
+    return (cert.public_bytes(serialization.Encoding.PEM),
+            key.private_bytes(serialization.Encoding.PEM,
+                              serialization.PrivateFormat.TraditionalOpenSSL,
+                              serialization.NoEncryption()))
+
+
+@pytest.fixture
+def manager(tmp_path):
+    cert_dir = tmp_path / 'certificates'
+    data_dir = tmp_path / 'data'
+    for directory in (cert_dir, data_dir, tmp_path / 'backups', tmp_path / 'logs'):
+        directory.mkdir()
+    file_ops = FileOperations(cert_dir=cert_dir, data_dir=data_dir,
+                              backup_dir=tmp_path / 'backups',
+                              logs_dir=tmp_path / 'logs')
+    settings = SettingsManager(file_ops=file_ops,
+                               settings_file=data_dir / 'settings.json')
+    return CertificateManager(cert_dir=cert_dir, settings_manager=settings,
+                              dns_manager=None, shell_executor=None)
+
+
+def _plant(manager, domain, cert_pem, key_pem=None):
+    directory = manager.cert_dir / domain
+    directory.mkdir(exist_ok=True)
+    (directory / 'cert.pem').write_bytes(cert_pem)
+    if key_pem is not None:
+        (directory / 'privkey.pem').write_bytes(key_pem)
+    return directory
+
+
+@pytest.fixture
+def parses(monkeypatch):
+    """Count how often a private key is actually parsed.
+
+    Patched on the cryptography module rather than on CertMate's own helper:
+    the property under test is 'the expensive operation does not happen twice',
+    and hanging the count on our own seam would keep passing if that seam were
+    refactored away.
+    """
+    calls = []
+    real = serialization.load_pem_private_key
+
+    def counting(*args, **kwargs):
+        calls.append(1)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(serialization, 'load_pem_private_key', counting)
+    return calls
+
+
+# --- THE regression ------------------------------------------------------
+
+def test_the_key_is_parsed_once_across_repeated_reads(manager, parses):
+    key = _key()
+    cert_pem, key_pem = _pem_pair(key)
+    _plant(manager, 'perf.example.com', cert_pem, key_pem)
+
+    answers = {manager.private_key_state('perf.example.com', cert_pem)
+               for _ in range(10)}
+
+    assert answers == {'present'}
+    assert len(parses) == 1, (
+        f'{len(parses)} private-key parses for 10 reads of the same unchanged '
+        f'files — the answer is being recomputed per read again')
+
+
+# --- the answer itself is unchanged --------------------------------------
+
+def test_a_matching_key_is_present(manager):
+    key = _key()
+    cert_pem, key_pem = _pem_pair(key)
+    _plant(manager, 'a.example.com', cert_pem, key_pem)
+
+    assert manager.private_key_state('a.example.com', cert_pem) == 'present'
+
+
+def test_a_key_from_another_issuance_is_mismatched(manager):
+    cert_pem, _ = _pem_pair(_key())
+    _, other_key_pem = _pem_pair(_key())
+    _plant(manager, 'b.example.com', cert_pem, other_key_pem)
+
+    assert manager.private_key_state('b.example.com', cert_pem) == 'mismatched'
+
+
+def test_no_key_at_all_is_missing(manager):
+    cert_pem, _ = _pem_pair(_key())
+    _plant(manager, 'c.example.com', cert_pem)
+
+    assert manager.private_key_state('c.example.com', cert_pem) == 'missing'
+
+
+def test_a_csr_only_certificate_is_external(manager):
+    """The key was never ours to hold, so its absence is the feature (#599)."""
+    cert_pem, _ = _pem_pair(_key())
+    _plant(manager, 'd.example.com', cert_pem)
+
+    assert manager.private_key_state(
+        'd.example.com', cert_pem,
+        {'key_management': 'external'}) == 'external'
+
+
+def test_no_certificate_to_compare_against_is_present(manager):
+    """The cheap path: a key file exists and there is nothing to compare it
+    with, so nothing is parsed and nothing is remembered."""
+    cert_pem, key_pem = _pem_pair(_key())
+    _plant(manager, 'e.example.com', cert_pem, key_pem)
+
+    assert manager.private_key_state('e.example.com') == 'present'
+
+
+# --- the cache cannot answer for files that moved ------------------------
+
+def test_a_rekeyed_certificate_is_compared_again(manager, parses):
+    key = _key()
+    cert_pem, key_pem = _pem_pair(key)
+    directory = _plant(manager, 'f.example.com', cert_pem, key_pem)
+    assert manager.private_key_state('f.example.com', cert_pem) == 'present'
+
+    _, foreign_key_pem = _pem_pair(_key())
+    (directory / 'privkey.pem').write_bytes(foreign_key_pem)
+
+    assert manager.private_key_state('f.example.com', cert_pem) == 'mismatched'
+    assert len(parses) == 2, 'the replaced key was answered from the cache'
+
+
+def test_a_renewed_certificate_is_compared_again(manager, parses):
+    """THE case this check exists for. A promote that tore leaves a NEW
+    cert.pem beside the PREVIOUS privkey.pem; if the certificate side were not
+    part of the key, the cached 'present' from before the renewal would hide
+    exactly that."""
+    key = _key()
+    cert_pem, key_pem = _pem_pair(key)
+    _plant(manager, 'g.example.com', cert_pem, key_pem)
+    assert manager.private_key_state('g.example.com', cert_pem) == 'present'
+
+    renewed_pem, _ = _pem_pair(_key())  # new generation, and a new key with it
+
+    assert manager.private_key_state('g.example.com', renewed_pem) == 'mismatched'
+    assert len(parses) == 2, 'the new certificate was answered from the cache'
+
+
+def test_identical_bytes_rewritten_still_hit(manager, parses):
+    """The key is the content, not the timestamp. Republishing the same bytes
+    — which `reconcile_served_copies` can do — must not cost another parse."""
+    key = _key()
+    cert_pem, key_pem = _pem_pair(key)
+    directory = _plant(manager, 'h.example.com', cert_pem, key_pem)
+    assert manager.private_key_state('h.example.com', cert_pem) == 'present'
+
+    time.sleep(0.01)
+    (directory / 'privkey.pem').write_bytes(key_pem)
+
+    assert manager.private_key_state('h.example.com', cert_pem) == 'present'
+    assert len(parses) == 1
+
+
+# --- controls ------------------------------------------------------------
+
+def test_two_domains_do_not_share_an_answer(manager, parses):
+    """CONTROL. A cache keyed carelessly would let one domain's verdict answer
+    for another, which for this particular answer means reporting a keyless
+    certificate as healthy."""
+    key = _key()
+    cert_pem, key_pem = _pem_pair(key)
+    _plant(manager, 'i.example.com', cert_pem, key_pem)
+    _, foreign_key_pem = _pem_pair(_key())
+    _plant(manager, 'j.example.com', cert_pem, foreign_key_pem)
+
+    assert manager.private_key_state('i.example.com', cert_pem) == 'present'
+    assert manager.private_key_state('j.example.com', cert_pem) == 'mismatched'
+    assert len(parses) == 2
+
+
+def test_an_unparseable_key_is_never_remembered_as_present(manager):
+    """CONTROL. The failure arm returns 'mismatched' and that is what must be
+    remembered — a cache that stored the optimistic answer on the error path
+    would report a certificate whose key cannot be loaded as servable."""
+    cert_pem, _ = _pem_pair(_key())
+    _plant(manager, 'k.example.com', cert_pem, b'-----BEGIN PRIVATE KEY-----\nnope\n')
+
+    assert manager.private_key_state('k.example.com', cert_pem) == 'mismatched'
+    assert manager.private_key_state('k.example.com', cert_pem) == 'mismatched'
+
+
+def test_the_expensive_half_is_still_reachable_on_its_own(manager, parses):
+    """CONTROL for the split: the comparison must still be the thing that
+    decides, so a test that stubs the cache away gets the real answer."""
+    key = _key()
+    cert_pem, key_pem = _pem_pair(key)
+
+    assert manager._compare_key_to_certificate(
+        'l.example.com', key_pem, cert_pem) == 'present'
+    assert len(parses) == 1
+
+
+# --- what it is worth, measured rather than asserted ---------------------
+
+@pytest.mark.parametrize('kind', ['rsa', 'ec'])
+def test_report_the_cost_of_a_repeated_read(manager, kind):
+    """Not a ceiling — a number to compare against. Printed with `-s`.
+
+    Measured while writing this (Apple silicon, warm page cache):
+
+        rsa  first read 45.14 ms, repeat 0.03 ms
+        ec   first read  0.08 ms, repeat 0.02 ms
+
+    The RSA row is the default installation.
+    """
+    domain = f'cost-{kind}.example.com'
+    cert_pem, key_pem = _pem_pair(_key(kind), common_name=domain)
+    _plant(manager, domain, cert_pem, key_pem)
+
+    started = time.perf_counter()
+    first = manager.private_key_state(domain, cert_pem)
+    cold = time.perf_counter() - started
+
+    started = time.perf_counter()
+    for _ in range(20):
+        manager.private_key_state(domain, cert_pem)
+    warm = (time.perf_counter() - started) / 20
+
+    print(f'\n{kind}: first read {cold * 1000:.2f} ms, '
+          f'repeat {warm * 1000:.2f} ms')
+    assert first == 'present'

--- a/tests/test_three_operations_have_a_number.py
+++ b/tests/test_three_operations_have_a_number.py
@@ -31,7 +31,7 @@ from unittest.mock import MagicMock
 import pytest
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.x509.oid import NameOID
 
 from modules.core.certificates import CertificateManager
@@ -45,14 +45,23 @@ pytestmark = [pytest.mark.unit]
 DOMAIN_COUNT = 120
 
 
-def _certificate(days_left):
+def _certificate(days_left, key_kind='rsa'):
     """One self-signed certificate and its key.
 
-    The key matters: since #608 a certificate with no private key is reported as
-    needing attention regardless of expiry, so a sweep over key-less certs would
-    measure the renewal path rather than the skip path.
+    The key matters twice over. Since #608 a certificate with no private key is
+    reported as needing attention regardless of expiry, so a sweep over key-less
+    certs would measure the renewal path rather than the skip path. And the KIND
+    of key decides most of the per-domain cost: reading a certificate's
+    information compares the key against the certificate, and loading a private
+    key is where OpenSSL validates it — measured on one machine, 51.6 ms for
+    RSA-2048 against 0.020 ms for EC P-256.
+
+    This file used to generate EC keys only. CertMate's default key shape is
+    `rsa`/2048, so the per-domain figure it recorded described an estate almost
+    nobody runs; both are measured now, and the RSA row is the default one.
     """
-    key = ec.generate_private_key(ec.SECP256R1())
+    key = (rsa.generate_private_key(public_exponent=65537, key_size=2048)
+           if key_kind == 'rsa' else ec.generate_private_key(ec.SECP256R1()))
     name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'example.com')])
     now = datetime.now(timezone.utc)
     cert = (x509.CertificateBuilder()
@@ -85,14 +94,16 @@ class _CountingSettings(SettingsManager):
         return super().load_settings(*args, **kwargs)
 
 
-@pytest.fixture(scope='module')
-def populated(tmp_path_factory):
+@pytest.fixture(scope='module', params=['rsa', 'ec'])
+def populated(request, tmp_path_factory):
     """One instance with DOMAIN_COUNT complete certificates on disk.
 
     Module-scoped: generating the keys is the slow part and it is setup, not
-    the thing being measured.
+    the thing being measured. Parametrised over the two key shapes CertMate
+    issues, because the counts asserted below are the same for both and the
+    timings are not — see `_certificate`.
     """
-    root = tmp_path_factory.mktemp('perf')
+    root = tmp_path_factory.mktemp(f'perf-{request.param}')
     cert_dir = root / 'certificates'
     data_dir = root / 'data'
     for directory in (cert_dir, data_dir, root / 'backups', root / 'logs'):
@@ -107,7 +118,7 @@ def populated(tmp_path_factory):
     # One key pair reused across domains: the certificates differ only in what
     # they are named, and generating 120 distinct keys would double the setup
     # for a property that does not depend on them being distinct.
-    cert_pem, key_pem = _certificate(days_left=60)
+    cert_pem, key_pem = _certificate(days_left=60, key_kind=request.param)
     domains = [f'perf-{index}.example.com' for index in range(DOMAIN_COUNT)]
     for domain in domains:
         directory = cert_dir / domain
@@ -120,21 +131,29 @@ def populated(tmp_path_factory):
     manager = CertificateManager(cert_dir=cert_dir, settings_manager=settings,
                                  dns_manager=MagicMock(),
                                  shell_executor=MagicMock())
-    return manager, settings, domains
+    return manager, settings, domains, request.param
 
 
 # --- 1. the listing at a stated domain count -----------------------------
 
 def test_a_listing_loads_settings_once_not_once_per_domain(populated):
-    """Measured at 120 domains, four runs on an M-series laptop: **0 settings
-    loads**, 30-36 ms total, 0.25-0.30 ms per domain.
+    """Measured at 120 domains on an M-series laptop: **0 settings loads**,
+    and the wall clock depends on the key shape and on whether the key states
+    are already known:
 
-    This is the property the listing route's own comment describes: workers
-    have no Flask request context, so the request-scoped settings cache does
-    not apply to them, and a per-domain load means reading settings.json off
-    disk once per domain — 120 reads for one page.
+        rsa  cold 5631 ms (46.93 ms/domain)  repeat 9 ms (0.08 ms/domain)
+        ec   cold   13 ms ( 0.11 ms/domain)  repeat 8 ms (0.06 ms/domain)
+
+    The RSA row is the default installation, and the gap between its two
+    columns is `private_key_state` remembering an answer whose inputs have not
+    changed rather than re-validating the key on every read.
+
+    This test is the settings-load property: workers have no Flask request
+    context, so the request-scoped settings cache does not apply to them, and a
+    per-domain load means reading settings.json off disk once per domain — 120
+    reads for one page.
     """
-    manager, settings, domains = populated
+    manager, settings, domains, key_kind = populated
     loaded = settings.load_settings()
     settings.loads = 0
 
@@ -143,8 +162,15 @@ def test_a_listing_loads_settings_once_not_once_per_domain(populated):
              for domain in domains]
     elapsed = time.perf_counter() - started
 
-    print(f'\nlisting {len(domains)} domains: {elapsed * 1000:.0f} ms total, '
-          f'{elapsed / len(domains) * 1000:.2f} ms/domain, '
+    started = time.perf_counter()
+    for domain in domains:
+        manager.get_certificate_info(domain, settings=loaded)
+    repeat = time.perf_counter() - started
+
+    print(f'\nlisting {len(domains)} {key_kind} domains: '
+          f'cold {elapsed * 1000:.0f} ms ({elapsed / len(domains) * 1000:.2f} '
+          f'ms/domain), repeat {repeat * 1000:.0f} ms '
+          f'({repeat / len(domains) * 1000:.2f} ms/domain), '
           f'{settings.loads} settings loads')
 
     assert all(info and info['exists'] for info in infos)
@@ -156,7 +182,7 @@ def test_a_listing_loads_settings_once_not_once_per_domain(populated):
 def test_the_listing_reads_each_certificate_once(populated):
     """CONTROL for the count above: a listing that loaded no settings because
     it also did no work would pass it. Every domain has to come back parsed."""
-    manager, settings, domains = populated
+    manager, settings, domains, key_kind = populated
     loaded = settings.load_settings()
 
     infos = [manager.get_certificate_info(domain, settings=loaded)
@@ -204,7 +230,7 @@ def test_a_remote_backed_listing_costs_one_round_trip_per_domain(populated):
     cache actually removes them on the next load, which is what makes a
     remote-backed dashboard usable at all.
     """
-    manager, settings, domains = populated
+    manager, settings, domains, key_kind = populated
     cert_pem = (manager.cert_dir / domains[0] / 'cert.pem').read_bytes()
     backend = _CountingBackend(cert_pem, {'dns_provider': 'cloudflare'})
     manager.storage_manager = backend
@@ -242,16 +268,21 @@ def test_a_remote_backed_listing_costs_one_round_trip_per_domain(populated):
 # --- 3. the renewal sweep ------------------------------------------------
 
 def test_a_sweep_loads_settings_a_fixed_number_of_times(populated):
-    """Measured at 120 certificates, none due, four runs: **1 settings load**
-    for the whole sweep, 24-67 ms. One, not 120 — the count does not move with
-    the number of certificates, which is the whole property.
+    """Measured at 120 certificates, none due: **1 settings load** for the
+    whole sweep, 13-20 ms. One, not 120 — the count does not move with the
+    number of certificates, which is the whole property.
+
+    The wall clock here is not comparable to a cold listing: this runs after
+    the listing test in the same module, against the same manager, so every
+    key state is already known. A sweep on a freshly started process pays the
+    per-domain cost of the listing's cold column once.
 
     The sweep is the one caller that visits every domain in a background
     thread, outside any request context, so nothing else is holding a cached
     settings dict for it. A per-domain load here is 120 disk reads on a timer,
     every sweep, forever.
     """
-    manager, settings, domains = populated
+    manager, settings, domains, key_kind = populated
     def _register(stored):
         stored['domains'] = [{'domain': domain, 'dns_provider': 'cloudflare'}
                              for domain in domains]
@@ -279,5 +310,5 @@ def test_the_sweep_renewed_nothing(populated):
     """CONTROL: the count above is the cost of the SKIP path. A sweep that
     tried to renew would shell out to certbot, and the number would be
     measuring a MagicMock rather than the loop."""
-    manager, _, _ = populated
+    manager, _, _, _ = populated
     manager.shell_executor.run.assert_not_called()


### PR DESCRIPTION
## What this is

`private_key_state` answers "is there a usable private key beside this certificate" by loading the key — and loading a private key is where OpenSSL validates it. Measured at `5194d874` on one machine:

| operation | measured |
|---|---|
| `load_pem_private_key`, RSA-2048 | **51.6 ms** |
| `load_pem_private_key`, RSA-4096 | 275.5 ms |
| `load_pem_private_key`, EC P-256 | 0.020 ms |
| `get_certificate_info`, real RSA-2048 key beside the certificate | **58.7 ms** |
| `get_certificate_info`, key present but unparseable | 0.19 ms |

CertMate's default key shape is `rsa`/2048, so on the common installation roughly 99% of the cost of reading one certificate's information was re-answering a question whose two input files had not moved. It runs once per domain in the dashboard listing, in every Prometheus collection (serially, on the request thread) and in every renewal sweep.

## The change

The answer is remembered per `(sha256(privkey.pem), sha256(cert.pem))`. Hashing both costs tens of microseconds against tens of milliseconds, and unlike an mtime or a TTL it is exact: any change to either file produces a different digest and the comparison runs again.

The certificate side has to be part of the key, and is: the condition this check exists for is a torn publish leaving a **new** certificate beside the **previous** private key, and a cache keyed on the key file alone would have hidden exactly that. There is a test for it.

Also split out `_compare_key_to_certificate` so the cheap decisions (no key file, nothing to compare against) and the lookup stay readable, and so a test can count how often the expensive half happens.

## Measured after, in the project's own benchmark at 120 domains

```
listing 120 rsa domains: cold 5631 ms (46.93 ms/domain), repeat 9 ms (0.08 ms/domain)
listing 120 ec  domains: cold   13 ms ( 0.11 ms/domain), repeat 8 ms (0.06 ms/domain)
```

That benchmark could not see any of this before: `tests/test_three_operations_have_a_number.py` generated **EC** keys, the one shape where loading a key is free, so its recorded 0.25–0.30 ms per domain described an estate almost nobody runs. It is parametrised over both shapes now and the RSA row is the default one. The counts it asserts (settings loads per listing, backend round-trips per domain, settings loads per sweep) are key-shape independent and unchanged.

## Verification

- `tests/test_the_key_check_is_not_repeated_per_read.py` — 14 tests. The regression asserts a **count** (one parse for ten reads), not a wall-clock ceiling. Checked against the old code: 3 fail, 11 pass — the 11 are the ones asserting that every answer (`present` / `missing` / `mismatched` / `external`) is unchanged.
- Controls included: two domains do not share an answer; an unparseable key is never remembered as `present`; identical bytes rewritten still hit (the key is content, not timestamp); a re-keyed or renewed certificate is compared again.
- Full unit suite: **4477 passed, 31 skipped**, in 131.6 s — 12 s faster than before this change despite the added RSA benchmark.
- `flake8 --select=E9,F63,F7,F82,F811,F632,E711,E712,E713,E714`: clean. `bandit --severity-level medium`: clean.

Found by the 20-category audit of v2.30.0 (`CERTMA-PERF-02` and `CERTMA-PERF-01`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)