### PR TITLE
fix: the metrics /metrics exports are the ones the instance measures

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -495,8 +495,58 @@ class CertificateManager:
                 metrics_collector.record_acme_error(
                     type(error).__name__ if error else 'unknown',
                     domain, provider)
+                self._record_rate_limit_hit(error, provider, 'renewal')
         except Exception:  # pragma: no cover - defensive
             logger.debug("Failed to record renewal metrics for a domain")
+
+    def _record_creation_metrics(self, domain, dns_provider, success, duration,
+                                 error=None):
+        """Emit issuance outcome + duration to the Prometheus collector.
+
+        The renewal path has recorded its outcome since #417; the creation path
+        recorded nothing, so certmate_certificate_requests_total and the
+        creation duration histogram were exported empty at every scrape while
+        the renewal series next to them moved. An operator could not answer
+        'how many certificates did we issue this week, and how many attempts
+        failed' from /metrics at all, and a Let's Encrypt outage during a burst
+        of new issuance registered as zero ACME errors — because the only
+        record_acme_error call site was the renewal one.
+
+        Never raises: telemetry must not be the reason an issuance that already
+        obtained a certificate is reported as failed.
+        """
+        try:
+            from .metrics import metrics_collector
+            provider = dns_provider or 'unknown'
+            metrics_collector.record_certificate_request(
+                domain, provider, success)
+            metrics_collector.record_certificate_creation_time(
+                provider, duration)
+            if not success:
+                metrics_collector.record_acme_error(
+                    type(error).__name__ if error else 'unknown',
+                    domain, provider)
+                self._record_rate_limit_hit(error, provider, 'issuance')
+        except Exception:  # pragma: no cover - defensive
+            logger.debug("Failed to record issuance metrics for a domain")
+
+    @staticmethod
+    def _record_rate_limit_hit(error, provider, limit_type):
+        """Count a CA refusal that was a rate limit rather than a fault.
+
+        certmate_acme_rate_limit_hits_total is the one series an operator of
+        this software would alert on first, and it could never fire: the metric
+        was declared and no code path incremented it — monitoring/prometheus-alerts.yml
+        says so, and omits the alert for that reason. It is separated from the
+        generic ACME error counter because the two mean opposite things about
+        what to do next: an error is worth retrying, a rate limit is what
+        retrying causes.
+        """
+        from .utils import is_acme_rate_limit
+        if error is None or not is_acme_rate_limit(error):
+            return
+        from .metrics import metrics_collector
+        metrics_collector.record_rate_limit_hit(limit_type, provider)
 
     @staticmethod
     def _certificate_info_cache_ttl() -> int:
@@ -2806,6 +2856,7 @@ class CertificateManager:
 
             duration = time.time() - start_time
             logger.info(f"Certificate created successfully for {domain} in {duration:.2f} seconds")
+            self._record_creation_metrics(domain, dns_provider, True, duration)
             self._invalidate_certificate_info_cache(domain)
             self._write_pfx(domain)
 
@@ -2821,13 +2872,17 @@ class CertificateManager:
                 result['storage_warning'] = storage_warning
             return result
             
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as e:
             logger.error(f"Certificate creation timeout for {domain}")
+            self._record_creation_metrics(
+                domain, dns_provider, False, time.time() - start_time, error=e)
             raise RuntimeError("Certificate creation timed out")
-            
+
         except Exception as e:
             duration = time.time() - start_time
             logger.error(f"Certificate creation failed for {domain}: {str(e)} (duration: {duration:.2f}s)")
+            self._record_creation_metrics(
+                domain, dns_provider, False, duration, error=e)
             raise
         finally:
             domain_lock.release()

--- a/modules/core/metrics.py
+++ b/modules/core/metrics.py
@@ -224,11 +224,17 @@ dns_provider_accounts = Gauge(
     ['provider']
 )
 
-dns_provider_api_calls = Counter(
-    'certmate_dns_provider_api_calls_total',
-    'Total DNS provider API calls',
-    ['provider', 'operation', 'status']
-)
+# There is no certmate_dns_provider_api_calls_total, and there deliberately is
+# not one. It existed here, declared and never incremented, and it cannot be
+# incremented from where the calls happen: CertMate does not talk to a DNS
+# provider's API in this process. certbot does, in its own subprocess, and the
+# one path where CertMate itself does — the DNS-alias manual hook — is a
+# separate short-lived Python process that certbot spawns, so a counter it
+# increments dies with it and never reaches this registry. Recording it would
+# need a multiprocess collector, which is a larger decision than the metric is
+# worth. Removed rather than left exported, because a series that is always
+# zero reads as "no calls are failing".
+
 
 # System health metrics
 application_uptime = Gauge(
@@ -540,15 +546,6 @@ class CertMateMetricsCollector:
         acme_rate_limit_hits.labels(
             limit_type=limit_type,
             dns_provider=dns_provider
-        ).inc()
-    
-    def record_dns_api_call(self, provider: str, operation: str, success: bool):
-        """Record a DNS provider API call."""
-        status = 'success' if success else 'failure'
-        dns_provider_api_calls.labels(
-            provider=provider,
-            operation=operation,
-            status=status
         ).inc()
     
     def record_background_job(self, job_type: str, duration: float):

--- a/modules/core/utils.py
+++ b/modules/core/utils.py
@@ -7,6 +7,7 @@ depend on the Flask application context or global configuration variables.
 """
 import dataclasses
 import json
+import logging
 import os
 import re
 import secrets
@@ -17,6 +18,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
+
+# stdlib only, like every other import in this file: the module deliberately
+# has no intra-package imports, which is what lets everything else import it
+# without thinking about order.
+logger = logging.getLogger(__name__)
 
 
 def utc_now() -> datetime:
@@ -401,6 +407,42 @@ _CERTBOT_CONFIG_PATH_RE = re.compile(
 _CERTBOT_STDERR_MAX_BYTES = 4096
 
 
+# What a CA says when it refuses because a limit was reached, rather than
+# because anything about the request was wrong. Kept as data, and in one place,
+# because two callers ask the same question for different purposes: the API
+# turns it into a message and a code, and the metrics layer turns it into
+# certmate_acme_rate_limit_hits_total. A second copy of these markers would
+# drift, and the failure mode of the drift is silent — an alert that never
+# fires while the operator is being rate limited.
+#
+# The strings are Boulder's (Let's Encrypt) and the wording other ACME CAs
+# copied from it. Matched case-insensitively against certbot's stderr.
+# Deliberately NOT a bare 'rate limit': a DNS provider's API says that too, and
+# counting a Cloudflare throttle as an ACME rate limit would put the wrong
+# number in front of the operator at the worst moment. The ACME error type is
+# in certbot's output for every one of these, so the first marker is the
+# reliable one and the rest are the human-readable text people search for.
+_ACME_RATE_LIMIT_MARKERS = (
+    'ratelimited',                    # urn:ietf:params:acme:error:rateLimited
+    'too many certificates',
+    'too many failed authorizations',
+    'too many currently pending authorizations',
+    'too many new orders',
+    'too many registrations',
+)
+
+
+def is_acme_rate_limit(reason) -> bool:
+    """Did the CA refuse this because a rate limit was reached?
+
+    Worth distinguishing from every other issuance failure because it is the
+    one an operator cannot fix by retrying — retrying is what causes it — and
+    because the remedy (wait, or use a different account) is unlike any other.
+    """
+    return any(marker in str(reason or '').lower()
+               for marker in _ACME_RATE_LIMIT_MARKERS)
+
+
 def classify_renewal_error(reason: str) -> tuple:
     """Map a renewal failure reason to a (user_message, code) pair.
 
@@ -430,6 +472,15 @@ def classify_renewal_error(reason: str) -> tuple:
             "The DNS provider account this certificate uses is no longer "
             "configured. Re-add it in Settings → DNS, then retry the renewal.",
             'DNS_ACCOUNT_NOT_CONFIGURED',
+        )
+    if is_acme_rate_limit(low):
+        return (
+            "The certificate authority refused this because a rate limit was "
+            "reached, not because anything is wrong with the request. Retrying "
+            "makes it worse: wait for the window to pass, or issue from a "
+            "different ACME account. The server log carries the CA's own text, "
+            "which names the limit and when it resets.",
+            'ACME_RATE_LIMITED',
         )
     return ('Certificate renewal failed', 'RENEWAL_FAILED')
 
@@ -821,6 +872,32 @@ def validate_dns_provider_account(provider: str, account_id: str, account_config
 # CACHE SYSTEM CLASS
 # =============================================
 
+def _record_cache_outcome(hit: bool) -> None:
+    """Tell the metrics collector about one cache lookup. Never raises.
+
+    Imported here rather than at module scope on purpose: utils.py has no
+    intra-package imports at all, which is what lets every other module import
+    it without thinking about order — and modules.core.metrics imports from
+    modules.core.constants, so a top-level import here would put this file into
+    a graph it deliberately stays out of. One local import is cheaper than
+    making it a node in that graph (the same trade `validate_dns_provider_account`
+    makes for secret_refs).
+    """
+    try:
+        from .metrics import metrics_collector
+        if hit:
+            metrics_collector.record_cache_hit()
+        else:
+            metrics_collector.record_cache_miss()
+    except Exception as e:  # pragma: no cover - telemetry is never the failure
+        # DEBUG, and said rather than swallowed: this runs on every lookup, so
+        # a louder level would drown the log the moment it started failing —
+        # but a broad catch whose body is `pass` is the shape that turns a real
+        # failure into a wrong value with nothing attached (#671).
+        logger.debug("Failed to record a cache %s: %s",
+                     'hit' if hit else 'miss', e)
+
+
 @dataclasses.dataclass
 class _CacheEntry:
     """Internal dataclass to represent a single, structured cache entry."""
@@ -842,12 +919,24 @@ class DeploymentStatusCache:
         self._lock = threading.Lock()
 
     def get(self, domain: str) -> Optional[Any]:
-        """Get a cached result for a domain, returning None if expired or not found."""
+        """Get a cached result for a domain, returning None if expired or not found.
+
+        The hit and the miss are counted here because here is where they
+        happen. certmate_cache_hits_total and certmate_cache_misses_total were
+        declared and exported from the first release and nothing ever
+        incremented either, so the hit rate an operator would use to decide
+        whether the cache TTL is doing anything was permanently 0/0.
+
+        Counting outside the lock: the counter is the collector's own concern
+        and must not extend the window during which nothing else can read the
+        cache. `_record_cache_outcome` never raises.
+        """
         with self._lock:
             entry = self._cache.get(domain)
-            if entry and time.time() <= entry.expires_at:
-                return entry.result
-        return None
+            hit = bool(entry and time.time() <= entry.expires_at)
+            result = entry.result if hit else None
+        _record_cache_outcome(hit)
+        return result
 
     def set(self, domain: str, result: Any, ttl: Optional[int] = None) -> None:
         """Cache a result for a domain with a specific or default TTL."""

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -44,22 +44,45 @@ populates** — the certificate inventory gauges, refreshed on every scrape:
 > (settings, cert dir, cache). That wiring ships alongside this bundle; without
 > it the endpoint emits only `application_uptime`.
 
-### Not yet included (needs instrumentation)
+### What is recorded, and the one thing that is not
 
-These metrics are **defined but never recorded at runtime**, so any panel or
-alert on them would read "No data" / never fire. They are deliberately left
-out until the code is instrumented, at which point the operations row and the
-renewal/ACME alerts can be added back:
+Everything the dashboard and the alerts use is recorded at runtime. That was
+not always true — this section used to list eight metrics that were defined and
+never incremented, which is worse than a missing metric: a panel built on one
+shows a flat line, and an alert on one never fires, so both read as "nothing is
+going wrong".
 
-- Operations counters/histograms — `certmate_certificate_requests_total`,
-  `certmate_certificate_renewals_total`, the `*_duration_seconds` histograms,
-  `certmate_acme_errors_total`, `certmate_acme_rate_limit_hits_total`,
-  `certmate_dns_provider_api_calls_total`, `certmate_cache_hits_total` /
-  `_misses_total`: no `record_*` caller exists yet.
-- `certmate_certificates_by_status{status="renewal_failed"}`: the status is
-  never assigned, so it is constant 0.
-- `certmate_certificate_last_renewal_timestamp` /
-  `_next_renewal_timestamp`: derived from the renewal threshold, not real
-  events — would mislead.
-- `certmate_background_job_last_run_timestamp` / `_duration_seconds`:
-  reserved; no caller records background-job runs.
+Recorded on the operations side:
+
+- `certmate_certificate_renewals_total` and
+  `certmate_certificate_renewal_duration_seconds` — by the renewal sweep, on
+  both the success and the failure path.
+- `certmate_certificate_requests_total` and
+  `certmate_certificate_creation_duration_seconds` — by the issuance path,
+  on success, on failure and on the certbot timeout.
+- `certmate_acme_errors_total` — on any failed issuance or renewal, labelled
+  with the exception type.
+- `certmate_acme_rate_limit_hits_total` — when the CA's refusal is a rate
+  limit rather than a fault, which is a different thing to do about it.
+- `certmate_cache_hits_total` / `_misses_total` — at the deployment-status
+  cache lookup itself.
+- `certmate_background_job_last_run_timestamp` / `_duration_seconds` — by the
+  background-job wrapper, on both paths, which is what makes "the sweep has
+  not run in N days" a writable alert.
+- `certmate_renewal_sweep_*` — duration, certificates examined, completion
+  time, and whether the last sweep finished.
+- `certmate_certificate_last_renewal_timestamp` / `_next_renewal_timestamp` —
+  from the real event in the certificate's metadata, not derived from the
+  expiry date.
+
+Still not populated, and left out of the dashboard for that reason:
+
+- `certmate_certificates_by_status{status="renewal_failed"}`: the collector
+  assigns `valid`, `expiring_soon`, `expired` and `missing`, and nothing
+  assigns this one, so it is constant 0.
+
+There is no `certmate_dns_provider_api_calls_total`. It was defined and never
+recorded, and it cannot be recorded from where those calls happen: certbot
+talks to the DNS provider in its own subprocess, and CertMate's own DNS-alias
+hook is a separate short-lived process whose counters die with it. It was
+removed rather than left exported.

--- a/monitoring/prometheus-alerts.yml
+++ b/monitoring/prometheus-alerts.yml
@@ -48,9 +48,48 @@ groups:
           summary: "{{ $value }} certificate(s) have expired"
           description: "CertMate reports expired certificates. Automatic renewal has failed for at least one domain."
 
-# NOTE: alerts on renewal/issuance outcomes, ACME errors and rate-limit hits
-# are intentionally omitted: those metrics (certmate_certificate_renewals_total,
-# certmate_acme_errors_total, certmate_acme_rate_limit_hits_total, and the
-# renewal_failed status) are defined by CertMate but not yet recorded at
-# runtime, so an alert on them could never fire. Add them back together with
-# the record_* instrumentation.
+  # These four were omitted for years with a note saying why: the metrics were
+  # defined and never recorded, so an alert on them could never fire. They are
+  # recorded now — renewals and ACME errors since the renewal sweep started
+  # reporting its outcome, issuance and rate-limit hits since the creation path
+  # did the same — so the alerts come back with them.
+  #
+  # `increase(...)` rather than a raw counter: what matters is that failures
+  # are happening NOW, not that any ever happened since the process started.
+  - name: certmate-issuance
+    rules:
+      - alert: CertMateRenewalsFailing
+        expr: sum(increase(certmate_certificate_renewals_total{status="failure"}[6h])) > 0
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $value | printf \"%.0f\" }} certificate renewal(s) failed in the last 6h"
+          description: "A renewal that keeps failing ends in an expired certificate on a schedule nobody is watching. Check the sweep's log lines for the domain and the CA's error."
+
+      - alert: CertMateIssuanceFailing
+        expr: sum(increase(certmate_certificate_requests_total{status="failure"}[1h])) > 3
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $value | printf \"%.0f\" }} certificate issuance attempts failed in the last hour"
+          description: "Repeated issuance failures usually mean a DNS provider credential, a propagation timeout, or a CA problem — and each attempt costs the CA's failed-authorization budget."
+
+      - alert: CertMateACMERateLimited
+        expr: sum(increase(certmate_acme_rate_limit_hits_total[24h])) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "The certificate authority is rate limiting this instance"
+          description: "{{ $value | printf \"%.0f\" }} rate-limit refusal(s) in 24h. Retrying is what causes this: stop issuing for the affected names until the window passes, or use a different ACME account. Let's Encrypt's duplicate-certificate window is 168h."
+
+      - alert: CertMateACMEErrors
+        expr: sum by (error_type) (increase(certmate_acme_errors_total[1h])) > 5
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $value | printf \"%.0f\" }} ACME errors of type {{ $labels.error_type }} in the last hour"
+          description: "Sustained ACME errors of one kind point at a configuration problem rather than at a transient CA fault."

--- a/tests/test_every_declared_metric_is_recorded.py
+++ b/tests/test_every_declared_metric_is_recorded.py
@@ -1,0 +1,263 @@
+"""A metric that is exported and never incremented is worse than one that is missing.
+
+Six recorder methods on the collector had no caller anywhere in the
+application, so five series were exported at every scrape and were permanently
+empty:
+
+    certmate_certificate_requests_total
+    certmate_certificate_creation_duration_seconds
+    certmate_acme_rate_limit_hits_total
+    certmate_cache_hits_total
+    certmate_cache_misses_total
+
+A missing metric is a gap somebody notices while building a dashboard. A dead
+one is a flat line and an alert that never fires, which reads as "nothing is
+going wrong" — and `monitoring/prometheus-alerts.yml` had a note omitting four
+alerts for exactly that reason.
+
+Two of them mattered operationally. Certificate CREATION incremented nothing at
+all while renewal incremented three things, so 'how many did we issue this
+week, and how many attempts failed' could not be answered from /metrics. And
+`certmate_acme_rate_limit_hits_total` is the first series an operator of ACME
+software would alert on.
+
+The seventh recorder, `record_dns_api_call`, was deleted with its metric
+instead: CertMate does not talk to a DNS provider's API in this process —
+certbot does, in its own subprocess, and the DNS-alias hook is a separate
+short-lived process whose counters never reach this registry.
+
+These tests read the collector's own registry rather than mocking it, so they
+fail if the wiring is removed AND if a metric is renamed out from under it.
+"""
+import pytest
+
+from modules.core import metrics as metrics_module
+from modules.core.certificates import CertificateManager
+from modules.core.utils import DeploymentStatusCache, is_acme_rate_limit
+
+pytestmark = [pytest.mark.unit]
+
+prometheus = pytest.importorskip(
+    'prometheus_client', reason='metrics are a no-op without the client library')
+
+
+def _value(metric, **labels):
+    """The current value of one labelled child, or 0.0 if it has none yet."""
+    total = 0.0
+    for sample_family in metric.collect():
+        for sample in sample_family.samples:
+            if not sample.name.endswith(('_total', '_count', '_sum')):
+                continue
+            if all(sample.labels.get(key) == value
+                   for key, value in labels.items()):
+                if sample.name.endswith('_sum'):
+                    continue
+                total += sample.value
+    return total
+
+
+@pytest.fixture
+def manager(tmp_path):
+    """A manager with nothing wired but the metrics path under test."""
+    return CertificateManager.__new__(CertificateManager)
+
+
+# --- issuance: the half that recorded nothing ----------------------------
+
+def test_a_successful_issuance_counts_a_request_and_its_duration(manager):
+    before = _value(metrics_module.certificate_requests_total,
+                    domain='m1.example.com', status='success')
+    before_duration = _value(metrics_module.certificate_creation_duration,
+                             dns_provider='cloudflare')
+
+    manager._record_creation_metrics('m1.example.com', 'cloudflare', True, 12.5)
+
+    assert _value(metrics_module.certificate_requests_total,
+                  domain='m1.example.com', status='success') == before + 1
+    assert _value(metrics_module.certificate_creation_duration,
+                  dns_provider='cloudflare') == before_duration + 1
+
+
+def test_a_failed_issuance_counts_a_failure_and_an_acme_error(manager):
+    before = _value(metrics_module.certificate_requests_total,
+                    domain='m2.example.com', status='failure')
+    before_errors = _value(metrics_module.acme_errors_total,
+                           domain='m2.example.com', error_type='RuntimeError')
+
+    manager._record_creation_metrics('m2.example.com', 'route53', False, 3.0,
+                                     error=RuntimeError('certbot said no'))
+
+    assert _value(metrics_module.certificate_requests_total,
+                  domain='m2.example.com', status='failure') == before + 1
+    assert _value(metrics_module.acme_errors_total,
+                  domain='m2.example.com',
+                  error_type='RuntimeError') == before_errors + 1
+
+
+def test_an_unknown_provider_is_labelled_rather_than_dropped(manager):
+    """A failure early enough that the provider was never resolved still has
+    to be counted — that is exactly when issuance is broken."""
+    before = _value(metrics_module.certificate_requests_total,
+                    dns_provider='unknown', status='failure')
+
+    manager._record_creation_metrics('m3.example.com', None, False, 0.2,
+                                     error=ValueError('no provider'))
+
+    assert _value(metrics_module.certificate_requests_total,
+                  dns_provider='unknown', status='failure') == before + 1
+
+
+def test_recording_never_raises(manager):
+    """CONTROL. Telemetry must not be the reason an issuance that already
+    obtained a certificate is reported as failed."""
+    class Hostile:
+        def __str__(self):
+            raise RuntimeError('even the error is broken')
+
+    manager._record_creation_metrics('m4.example.com', 'cloudflare', False,
+                                     1.0, error=Hostile())
+
+
+# --- the rate limit, which is not just another ACME error ----------------
+
+def test_a_rate_limited_refusal_is_counted_separately(manager):
+    before = _value(metrics_module.acme_rate_limit_hits,
+                    limit_type='issuance', dns_provider='cloudflare')
+
+    manager._record_creation_metrics(
+        'm5.example.com', 'cloudflare', False, 4.0,
+        error=RuntimeError(
+            'urn:ietf:params:acme:error:rateLimited :: too many certificates '
+            '(5) already issued for this exact set of domains'))
+
+    assert _value(metrics_module.acme_rate_limit_hits,
+                  limit_type='issuance',
+                  dns_provider='cloudflare') == before + 1
+
+
+def test_a_rate_limited_renewal_is_counted_under_renewal(manager):
+    before = _value(metrics_module.acme_rate_limit_hits,
+                    limit_type='renewal', dns_provider='azure')
+
+    manager._record_renewal_metrics(
+        'm6.example.com', {'dns_provider': 'azure'}, False, 9.0,
+        error=RuntimeError('Error creating new order :: too many failed '
+                           'authorizations recently'))
+
+    assert _value(metrics_module.acme_rate_limit_hits,
+                  limit_type='renewal', dns_provider='azure') == before + 1
+
+
+def test_an_ordinary_failure_is_not_counted_as_a_rate_limit(manager):
+    """CONTROL. If everything counted as a rate limit, the alert built on this
+    series would fire on every DNS misconfiguration and be turned off."""
+    before = _value(metrics_module.acme_rate_limit_hits,
+                    limit_type='issuance', dns_provider='cloudflare')
+
+    manager._record_creation_metrics(
+        'm7.example.com', 'cloudflare', False, 2.0,
+        error=RuntimeError('DNS problem: NXDOMAIN looking up TXT'))
+
+    assert _value(metrics_module.acme_rate_limit_hits,
+                  limit_type='issuance',
+                  dns_provider='cloudflare') == before
+
+
+@pytest.mark.parametrize('reason, expected', [
+    ('urn:ietf:params:acme:error:rateLimited', True),
+    ('too many certificates (5) already issued', True),
+    ('too many failed authorizations recently', True),
+    ('too many currently pending authorizations', True),
+    ('Error creating new order :: too many new orders recently', True),
+    ('DNS problem: NXDOMAIN looking up TXT', False),
+    ('parsefail: renewal configuration is broken', False),
+    # A DNS provider throttling us is not the CA rate limiting us, and
+    # conflating them puts the wrong number in front of the operator.
+    ('Cloudflare API error 971: rate limit exceeded', False),
+    ('', False),
+    (None, False),
+])
+def test_what_counts_as_a_ca_rate_limit(reason, expected):
+    assert is_acme_rate_limit(reason) is expected
+
+
+def test_the_api_gives_a_rate_limit_its_own_code():
+    """The same question, asked by the other caller: an operator reading the
+    API response gets a code that says retrying is the wrong move."""
+    from modules.core.utils import classify_renewal_error
+
+    message, code = classify_renewal_error(
+        'too many certificates already issued for this exact set of domains')
+
+    assert code == 'ACME_RATE_LIMITED'
+    assert 'wait' in message.lower()
+
+
+# --- the cache, counted where the lookup happens -------------------------
+
+def test_a_cache_hit_and_a_cache_miss_are_both_counted():
+    cache = DeploymentStatusCache(default_ttl=300)
+    before_hits = _value(metrics_module.cache_hits_total)
+    before_misses = _value(metrics_module.cache_misses_total)
+
+    assert cache.get('nothing.example.com') is None
+    cache.set('something.example.com', {'deployed': True})
+    assert cache.get('something.example.com') == {'deployed': True}
+
+    assert _value(metrics_module.cache_misses_total) == before_misses + 1
+    assert _value(metrics_module.cache_hits_total) == before_hits + 1
+
+
+def test_an_expired_entry_is_a_miss_not_a_hit():
+    """CONTROL. Counting an expired entry as a hit would make the hit rate say
+    the cache is working while every lookup goes to disk."""
+    cache = DeploymentStatusCache(default_ttl=300)
+    before_hits = _value(metrics_module.cache_hits_total)
+    before_misses = _value(metrics_module.cache_misses_total)
+
+    cache.set('stale.example.com', {'deployed': True}, ttl=-1)
+    assert cache.get('stale.example.com') is None
+
+    assert _value(metrics_module.cache_hits_total) == before_hits
+    assert _value(metrics_module.cache_misses_total) == before_misses + 1
+
+
+# --- what the module exports -------------------------------------------
+
+def test_the_metric_that_cannot_be_recorded_is_not_exported():
+    """It lived in this module, declared and never incremented, and the only
+    place it could be incremented from is a subprocess whose registry never
+    reaches this one. Removed rather than exported empty."""
+    assert not hasattr(metrics_module, 'dns_provider_api_calls')
+    assert not hasattr(metrics_module.metrics_collector, 'record_dns_api_call')
+
+
+def test_every_recorder_has_a_caller_in_the_application():
+    """THE regression, as a property rather than a list.
+
+    Every `record_*` method on the collector must be called from somewhere that
+    is not metrics.py itself. This is what would have caught the original
+    defect, and it fails the day someone adds a metric and forgets to wire it.
+    """
+    import inspect
+    import pathlib
+    import re
+
+    collector = type(metrics_module.metrics_collector)
+    recorders = [name for name, _ in inspect.getmembers(collector, inspect.isfunction)
+                 if name.startswith('record_')]
+    assert recorders, 'no recorders found — this test is not looking at anything'
+
+    root = pathlib.Path(__file__).resolve().parent.parent
+    application = '\n'.join(
+        path.read_text(encoding='utf-8')
+        for path in sorted(root.glob('modules/**/*.py'))
+        if path.name != 'metrics.py')
+
+    unwired = [name for name in recorders
+               if not re.search(rf'\.{name}\s*\(', application)]
+    assert not unwired, (
+        'these metrics are declared and exported but nothing in the '
+        f'application increments them: {unwired}. Wire them where the outcome '
+        'is known, or delete them — a series that is always zero reads as '
+        '"nothing is going wrong".')


### PR DESCRIPTION
## What this is

Six recorder methods on the metrics collector had **no caller anywhere in the application**, so five series were exported at every scrape and were permanently empty:

| metric | recorder | state before |
|---|---|---|
| `certmate_certificate_requests_total` | `record_certificate_request` | never incremented |
| `certmate_certificate_creation_duration_seconds` | `record_certificate_creation_time` | never observed |
| `certmate_acme_rate_limit_hits_total` | `record_rate_limit_hit` | never incremented |
| `certmate_cache_hits_total` | `record_cache_hit` | never incremented |
| `certmate_cache_misses_total` | `record_cache_miss` | never incremented |
| `certmate_dns_provider_api_calls_total` | `record_dns_api_call` | never incremented |

A missing metric is a gap somebody notices while building a dashboard. A dead one is a flat line and an alert that never fires, which reads as *nothing is going wrong* — `monitoring/prometheus-alerts.yml` already carried a note omitting four alerts for exactly this reason.

Two of them mattered operationally. Certificate **creation** recorded nothing while **renewal** recorded three things, so `how many certificates did we issue this week, and how many attempts failed` could not be answered from `/metrics` at all — and since the only `record_acme_error` call site was the renewal one, a CA outage during a burst of new issuance registered as zero ACME errors. And a rate-limit hit is the first thing anyone running ACME software alerts on.

## The change

- **Issuance records its outcome** on all three exits (success, certbot timeout, failure), mirroring `_record_renewal_metrics`. A failure before the provider is resolved is labelled `unknown` rather than dropped — that is exactly when issuance is broken.
- **A rate limit is counted apart from an ACME error**, because the two mean opposite things about what to do next: an error is worth retrying, a rate limit is what retrying causes. One predicate (`is_acme_rate_limit`) serves both callers, so the API also gets a distinct `ACME_RATE_LIMITED` code with a message that says to wait. Deliberately not matching a bare `rate limit`: a DNS provider says that too, and counting a Cloudflare throttle as a CA rate limit puts the wrong number in front of the operator at the worst moment.
- **Cache hits and misses are counted at the lookup**, so the hit rate that would justify the TTL is no longer 0/0. An expired entry counts as a miss (there is a control test).
- **`certmate_dns_provider_api_calls_total` is removed**, with its recorder and with the reason written where it was. It cannot be recorded from where those calls happen: certbot talks to the DNS provider in its own subprocess, and CertMate's own DNS-alias hook is a separate short-lived process whose counters never reach this registry. Exporting it empty was the worse of the two options.
- **The four omitted alerts come back** — renewals failing, issuance failing, rate limited, sustained ACME errors — on `increase(...)` rather than raw counters, and `monitoring/README.md` now lists what *is* recorded instead of what is not (that section had gone stale: it still listed renewals, ACME errors and background jobs as unrecorded).

## Verification

- `tests/test_every_declared_metric_is_recorded.py` — 22 tests reading the collector's **own registry** rather than a mock, so they fail if the wiring is removed *and* if a metric is renamed out from under them.
- Its last test is the general property rather than a list: **every `record_*` method must have a caller outside `metrics.py`**. Run against the parent commit, that property reports exactly the six unwired recorders: `['record_certificate_request', 'record_certificate_creation_time', 'record_rate_limit_hit', 'record_dns_api_call', 'record_cache_hit', 'record_cache_miss']`.
- Controls: an ordinary DNS failure is *not* counted as a rate limit; an expired cache entry is a miss, not a hit; recording never raises even when the error object itself throws on `str()`.
- The repo's own `test_no_silent_swallows` caught my first draft of the telemetry helper (`except Exception: pass`) — it now logs at DEBUG, and `utils.py` gained the module logger it turned out never to have had.
- Full unit suite: **4499 passed, 31 skipped** in 128 s. `flake8` (gated selection) and `bandit --severity-level medium`: clean.

Found by the 20-category audit of v2.30.0 (`CERTMA-OBS-01`, `CERTMA-OBS-02`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)