### PR TITLE
fix: the event bus says what it could not deliver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1595,6 +1595,7 @@ by the schema, with a message naming the accepted set — for example
 | `CERTMATE_ISSUANCE_WORKERS` | | `2`            | Threads serving asynchronous issuance jobs. Clamped to 1-16; each one can be running a certbot subprocess |
 | `CERTMATE_ISSUANCE_JOB_HISTORY` | | `200`      | How many finished issuance jobs stay queryable via `/api/certificates/jobs`. Clamped to 20-2000 |
 | `CERTMATE_EVENT_WORKERS` |    | `4`            | Threads dispatching event listeners (deploy hooks, cache invalidation). Clamped to 1-32. Nothing is dropped when they are busy; the backlog is logged instead |
+| `CERTMATE_EVENT_DRAIN_SECONDS` |    | `5`            | How long a shutdown waits for queued event dispatches to start before giving up on them. Clamped to 0-60. Whatever is left is logged with its event and domain, so a deploy hook that never ran after a renewal is named rather than lost |
 | `CERTMATE_PROBE_TIMEOUT_SECONDS` | | `5`       | Deployment-probe connection timeout. Clamped to 1-30 |
 | `CERTMATE_LAST_USED_PERSIST_SECONDS` | | `60`  | How often a session's "last used" timestamp is written to disk. `0` writes on every request, which is the original behaviour and one write per request |
 | `CERTMATE_SLOW_REQUEST_LOGGING` | | `true`       | Log a warning, with the thread's stack, for requests that outlive the threshold below. The stack is what makes a hung request diagnosable after the fact |

--- a/app.py
+++ b/app.py
@@ -95,4 +95,16 @@ if __name__ == '__main__':
                 # worth one line, because "stopped" printing and "stopped"
                 # happening were previously indistinguishable (#671).
                 print(f"⚠️  Background scheduler did not stop cleanly: {e}")
+        # After the scheduler, not before: stopping it first means no new
+        # renewal can queue a deploy while the bus is draining.
+        event_bus = (container.managers or {}).get('events')
+        if event_bus is not None:
+            try:
+                undelivered = event_bus.stop()
+                print("📨 Event bus drained"
+                      if not undelivered
+                      else f"⚠️  {undelivered} queued dispatch(es) never ran — "
+                           f"see the log for which certificates they were for")
+            except Exception as e:
+                print(f"⚠️  Event bus did not stop cleanly: {e}")
         sys.exit(0)

--- a/modules/core/events.py
+++ b/modules/core/events.py
@@ -36,6 +36,17 @@ DEFAULT_DISPATCH_WORKERS = 4
 # in the log rather than something an operator infers from latency.
 BACKLOG_WARN_AT = 50
 
+# How long stop() waits for the queue to empty before reporting what is left.
+# Small on purpose: this is spent on every shutdown, and the workers are daemon
+# threads precisely so a slow listener cannot hold the process open. Override
+# with CERTMATE_EVENT_DRAIN_SECONDS.
+DEFAULT_DRAIN_SECONDS = 5.0
+
+# How many of the undelivered items to name in the log line. All of them would
+# be unbounded; none of them leaves an operator with a number and no way to act
+# on it.
+UNDELIVERED_SAMPLE = 10
+
 
 class EventBus:
     """Simple in-process event bus with SSE streaming support."""
@@ -73,6 +84,10 @@ class EventBus:
         self._workers = []
         self._worker_count = self._resolve_worker_count(workers)
         self._backlog_warned = False
+        # Set by stop(). A publish after it is refused rather than queued: the
+        # process is going away, and accepting work nobody will run would put
+        # it in the undelivered report of a bus that had already reported.
+        self._stopping = False
 
     @staticmethod
     def _resolve_worker_count(workers) -> int:
@@ -122,6 +137,68 @@ class EventBus:
                     "Event listener failed for %s: %s", event, e, exc_info=True)
             finally:
                 self._work.task_done()
+
+    def stop(self, timeout: Optional[float] = None) -> int:
+        """Stop accepting dispatches and give the queued ones a bounded chance
+        to start. Returns how many never did.
+
+        The workers are daemon threads, deliberately: joining them would let a
+        300-second deploy hook hold shutdown open until the container runtime
+        killed it anyway. The cost of that choice was that a container stopped
+        during or just after a renewal sweep discarded whatever was queued —
+        typically the deploy hook for a certificate that HAD been renewed, so
+        the service kept serving the old one while the dashboard showed a
+        success, and nothing anywhere recorded that it had happened.
+
+        This does not change the daemon decision. It bounds the loss and, more
+        importantly, names it: what could not be started in `timeout` seconds is
+        drained off the queue and logged with its event and its domain, so the
+        line an operator finds after a restart says which certificates to
+        redeploy by hand.
+
+        Waits for the queue to EMPTY, not for the workers to finish: an item
+        that has reached a worker is running, and waiting for a deploy hook is
+        the thing this must not do. Idempotent, and immediate when the queue is
+        already empty, which is the ordinary case.
+        """
+        if timeout is None:
+            timeout = self._drain_timeout()
+        self._stopping = True
+        deadline = time.monotonic() + max(0.0, timeout)
+        while self._work.qsize() and time.monotonic() < deadline:
+            time.sleep(0.02)
+
+        undelivered = []
+        while True:
+            try:
+                listener, event, data, _ = self._work.get_nowait()
+            except queue.Empty:
+                break
+            undelivered.append((event, (data or {}).get('domain')))
+            self._work.task_done()
+
+        if undelivered:
+            sample = ', '.join(
+                f"{event}({domain or 'no domain'})"
+                for event, domain in undelivered[:UNDELIVERED_SAMPLE])
+            logger.warning(
+                "Event bus stopped with %d dispatch(es) never started: %s%s. "
+                "These are listener invocations — deploy hooks and cache "
+                "invalidations — for events that DID happen, so the "
+                "certificate is renewed and its deploy did not run.",
+                len(undelivered), sample,
+                '' if len(undelivered) <= UNDELIVERED_SAMPLE else ', …')
+        else:
+            logger.info("Event bus stopped with an empty queue")
+        return len(undelivered)
+
+    @staticmethod
+    def _drain_timeout() -> float:
+        try:
+            return max(0.0, min(60.0, float(os.environ.get(
+                'CERTMATE_EVENT_DRAIN_SECONDS', DEFAULT_DRAIN_SECONDS))))
+        except (TypeError, ValueError):
+            return DEFAULT_DRAIN_SECONDS
 
     def add_listener(self, callback) -> None:
         """Register a callback invoked on every publish(). Signature: callback(event, data)."""
@@ -188,6 +265,13 @@ class EventBus:
         with self._lock:
             listeners = list(self._listeners)
         if not listeners:
+            return
+        if self._stopping:
+            # SSE subscribers above already got the message; what is refused
+            # here is queueing a listener invocation nobody will run.
+            logger.warning(
+                "Event bus is stopping: %s was not dispatched to %d listener(s)",
+                event, len(listeners))
             return
         self._ensure_workers()
 

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -1,3 +1,4 @@
+import atexit
 import os
 import secrets
 import sys
@@ -1671,8 +1672,29 @@ def create_app(test_config=None):
     reconcile_served_copies(container)
     check_issuance_readiness(container)
     warn_if_multiple_workers()
+    _drain_event_bus_at_exit(container)
 
     return app, container
+
+
+def _drain_event_bus_at_exit(container: AppContainer):
+    """Give the event bus a bounded drain when the process goes away.
+
+    There is no shutdown hook to hang this on: the image runs gunicorn from a
+    plain command line, so there is no gunicorn config file with on_exit, and
+    app.py's KeyboardInterrupt handler only covers `python app.py`. atexit is
+    what both paths have in common — it runs when a gunicorn worker exits on
+    SIGTERM, and it does not run on SIGKILL, which is the correct behaviour for
+    a drain that must never delay a kill.
+
+    Registered here rather than in EventBus.__init__ so that constructing a bus
+    — which most of the test suite does — does not leave a handler behind
+    holding a reference to it.
+    """
+    bus = container.managers.get('events') if container.managers else None
+    if bus is None:
+        return
+    atexit.register(bus.stop)
 
 
 def check_issuance_readiness(container: AppContainer):

--- a/tests/test_the_bus_says_what_it_could_not_deliver.py
+++ b/tests/test_the_bus_says_what_it_could_not_deliver.py
@@ -1,0 +1,206 @@
+"""What the event bus could not dispatch is drained, counted and named.
+
+The dispatch workers are daemon threads on purpose: joining them would let a
+300-second deploy hook hold shutdown open until the container runtime killed it
+anyway, and that trade is written into the bus. The cost of it was invisible.
+A container stopped during or just after a renewal sweep discarded whatever was
+still queued — typically the deploy hook for a certificate that HAD been
+renewed — so the service kept serving the old certificate, the dashboard showed
+a success, `deploy_hook_failed` never fired (the hook had not failed, it had
+never started), and nothing anywhere recorded it. The bus had no stop, drain,
+close or join at all.
+
+`stop()` does not change the daemon decision. It bounds the loss and names it:
+queued work gets a deadline to start, and what is left is taken off the queue
+and logged with its event and its domain, so an operator reading the log after
+a restart knows which certificates to redeploy by hand.
+
+The property that matters is the count and the naming, not the timing, so that
+is what these assert.
+"""
+import logging
+import threading
+import time
+
+import pytest
+
+from modules.core.events import EventBus
+
+pytestmark = [pytest.mark.unit]
+
+LOGGER = 'modules.core.events'
+
+
+def _blocking_listener(started, release):
+    """A listener that occupies its worker until released."""
+    def listener(event, data):
+        started.set()
+        release.wait(timeout=5)
+    return listener
+
+
+# --- the count -----------------------------------------------------------
+
+def test_what_never_started_is_counted(caplog):
+    """THE regression. One worker, one listener held open, five events: the
+    four that never reached a worker are reported rather than discarded."""
+    bus = EventBus(workers=1)
+    started, release = threading.Event(), threading.Event()
+    bus.add_listener(_blocking_listener(started, release))
+    try:
+        for index in range(5):
+            bus.publish('certificate_renewed', {'domain': f'd{index}.example.com'})
+        assert started.wait(timeout=5), 'the worker never picked anything up'
+
+        undelivered = bus.stop(timeout=0.05)
+    finally:
+        release.set()
+
+    assert undelivered == 4, (
+        f'{undelivered} reported undelivered; four never reached a worker')
+
+
+def test_an_empty_queue_reports_nothing_and_returns_immediately():
+    """The ordinary case: nothing queued, so stop() costs nothing and says so.
+    A drain that slept its full timeout on every shutdown would be the reason
+    somebody deletes it."""
+    bus = EventBus(workers=1)
+    bus.add_listener(lambda event, data: None)
+
+    started = time.monotonic()
+    assert bus.stop(timeout=5) == 0
+    assert time.monotonic() - started < 1.0
+
+
+def test_work_that_starts_within_the_deadline_is_not_reported(caplog):
+    """CONTROL: a bus that reported everything queued, delivered or not, would
+    turn every clean shutdown into a false alarm."""
+    bus = EventBus(workers=2)
+    seen = []
+    bus.add_listener(lambda event, data: seen.append(data.get('domain')))
+
+    for index in range(4):
+        bus.publish('certificate_renewed', {'domain': f'ok{index}.example.com'})
+
+    assert bus.stop(timeout=5) == 0
+    assert len(seen) == 4
+
+
+# --- the naming ----------------------------------------------------------
+
+def test_the_undelivered_are_named_with_their_domain(caplog):
+    bus = EventBus(workers=1)
+    started, release = threading.Event(), threading.Event()
+    bus.add_listener(_blocking_listener(started, release))
+    try:
+        bus.publish('certificate_renewed', {'domain': 'first.example.com'})
+        assert started.wait(timeout=5)
+        bus.publish('certificate_renewed', {'domain': 'lost.example.com'})
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER):
+            bus.stop(timeout=0.05)
+    finally:
+        release.set()
+
+    message = '\n'.join(record.getMessage() for record in caplog.records)
+    assert 'lost.example.com' in message, (
+        'the log names a count but not which certificate, which is the half '
+        'an operator can act on')
+    assert 'certificate_renewed' in message
+
+
+def test_a_payload_without_a_domain_is_still_named(caplog):
+    """CONTROL: not every event carries a domain, and a KeyError in the
+    shutdown reporter would lose the very report it exists to make."""
+    bus = EventBus(workers=1)
+    started, release = threading.Event(), threading.Event()
+    bus.add_listener(_blocking_listener(started, release))
+    try:
+        bus.publish('certificate_renewed', {'domain': 'first.example.com'})
+        assert started.wait(timeout=5)
+        bus.publish('backup_completed', None)
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER):
+            assert bus.stop(timeout=0.05) == 1
+    finally:
+        release.set()
+
+    assert 'backup_completed' in '\n'.join(r.getMessage() for r in caplog.records)
+
+
+# --- after stopping ------------------------------------------------------
+
+def test_publishing_after_stop_is_refused_rather_than_queued(caplog):
+    """Accepting work after the report would put it in a report that has
+    already been made — which is how a shutdown loses something quietly for a
+    second time."""
+    bus = EventBus(workers=1)
+    dispatched = []
+    bus.add_listener(lambda event, data: dispatched.append(event))
+    bus.stop(timeout=0)
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        bus.publish('certificate_renewed', {'domain': 'late.example.com'})
+
+    assert bus.pending_dispatches() == 0
+    assert 'stopping' in '\n'.join(r.getMessage() for r in caplog.records).lower()
+
+
+def test_sse_subscribers_still_receive_after_stop():
+    """CONTROL for the refusal above: it is the LISTENER dispatch that is
+    refused. A browser holding an SSE stream open during shutdown should still
+    see the last event rather than have it silently dropped."""
+    bus = EventBus(workers=1)
+    subscriber = bus.subscribe()
+    bus.add_listener(lambda event, data: None)
+    bus.stop(timeout=0)
+
+    bus.publish('certificate_renewed', {'domain': 'sse.example.com'})
+
+    message = subscriber.get_nowait()
+    assert message['event'] == 'certificate_renewed'
+
+
+def test_stop_is_idempotent():
+    bus = EventBus(workers=1)
+    bus.add_listener(lambda event, data: None)
+
+    assert bus.stop(timeout=0) == 0
+    assert bus.stop(timeout=0) == 0
+
+
+# --- the wiring ----------------------------------------------------------
+
+def test_the_drain_deadline_is_configurable(monkeypatch):
+    monkeypatch.setenv('CERTMATE_EVENT_DRAIN_SECONDS', '12')
+    assert EventBus._drain_timeout() == 12.0
+
+
+@pytest.mark.parametrize('value', ['not-a-number', '', '-3', '900'])
+def test_a_broken_deadline_is_clamped_not_obeyed(monkeypatch, value):
+    """A typo must not make shutdown hang for fifteen minutes, and must not
+    make the drain zero either — both would be silent."""
+    monkeypatch.setenv('CERTMATE_EVENT_DRAIN_SECONDS', value)
+
+    timeout = EventBus._drain_timeout()
+
+    assert 0.0 <= timeout <= 60.0
+
+
+def test_the_application_registers_the_drain_at_exit():
+    """The property, not the mechanism: something must call stop() when the
+    process goes away. There is no gunicorn config file to hang an on_exit
+    hook on, and app.py's KeyboardInterrupt path only covers `python app.py`,
+    so atexit is what both deployment shapes have in common.
+    """
+    import inspect
+
+    from modules.core import factory
+
+    source = inspect.getsource(factory._drain_event_bus_at_exit)
+    assert 'atexit.register' in source
+    assert '.stop' in source
+
+    entrypoint = inspect.getsource(factory.create_app)
+    assert '_drain_event_bus_at_exit(container)' in entrypoint, (
+        'the drain is defined but nothing calls it during app creation')

--- a/tests/test_the_bus_says_what_it_could_not_deliver.py
+++ b/tests/test_the_bus_says_what_it_could_not_deliver.py
@@ -88,6 +88,21 @@ def test_work_that_starts_within_the_deadline_is_not_reported(caplog):
 
 # --- the naming ----------------------------------------------------------
 
+def _reported_names(caplog):
+    """The undelivered items the warning named, as exact elements.
+
+    Read out of the log record's ARGUMENTS rather than out of the rendered
+    string: `'something' in message` is both weaker than it looks — it passes
+    when the name turns up anywhere at all, including inside another name —
+    and the shape this repository has already agreed to stop writing.
+    """
+    for record in caplog.records:
+        if record.levelno == logging.WARNING and record.args:
+            sample = record.args[1]
+            return set(str(sample).split(', '))
+    return set()
+
+
 def test_the_undelivered_are_named_with_their_domain(caplog):
     bus = EventBus(workers=1)
     started, release = threading.Event(), threading.Event()
@@ -102,11 +117,9 @@ def test_the_undelivered_are_named_with_their_domain(caplog):
     finally:
         release.set()
 
-    message = '\n'.join(record.getMessage() for record in caplog.records)
-    assert 'lost.example.com' in message, (
+    assert _reported_names(caplog) == {'certificate_renewed(lost.example.com)'}, (
         'the log names a count but not which certificate, which is the half '
         'an operator can act on')
-    assert 'certificate_renewed' in message
 
 
 def test_a_payload_without_a_domain_is_still_named(caplog):
@@ -125,7 +138,7 @@ def test_a_payload_without_a_domain_is_still_named(caplog):
     finally:
         release.set()
 
-    assert 'backup_completed' in '\n'.join(r.getMessage() for r in caplog.records)
+    assert _reported_names(caplog) == {'backup_completed(no domain)'}
 
 
 # --- after stopping ------------------------------------------------------
@@ -143,7 +156,11 @@ def test_publishing_after_stop_is_refused_rather_than_queued(caplog):
         bus.publish('certificate_renewed', {'domain': 'late.example.com'})
 
     assert bus.pending_dispatches() == 0
-    assert 'stopping' in '\n'.join(r.getMessage() for r in caplog.records).lower()
+    assert not dispatched
+    refusals = [record for record in caplog.records
+                if record.msg.startswith('Event bus is stopping')]
+    assert len(refusals) == 1, 'the refusal was not reported'
+    assert refusals[0].args == ('certificate_renewed', 1)
 
 
 def test_sse_subscribers_still_receive_after_stop():


### PR DESCRIPTION
## What this is

The event bus had no `stop`, `drain`, `close` or `join` — nothing at all. Its dispatch workers are daemon threads **on purpose**, and the reasoning is written into the class: joining them would let a 300-second deploy hook hold shutdown open until the container runtime killed it anyway. What was never written down is what that trade cost.

A container stopped during or just after a renewal sweep discards whatever is still queued. That queue holds listener invocations — and the listener that matters is `DeployManager.on_certificate_event`. So the certificate **was** renewed and published, the deploy hook that installs it never ran, `deploy_hook_failed` never fired (the hook did not fail — it never started), the dashboard shows a success, and the service keeps serving the old certificate. Nothing anywhere records that it happened.

## The change

`stop(timeout)` does not change the daemon decision. It bounds the loss and names it:

- queued dispatches get a bounded deadline to reach a worker;
- whatever is left is drained off the queue and logged **with its event and its domain**, so the line an operator finds after a restart says which certificates to redeploy by hand;
- it waits for the **queue** to empty, not for the workers to finish — an item that has reached a worker is running, and waiting for a deploy hook is the one thing this must not do;
- a publish after `stop()` is refused rather than queued, because accepting work after the report would put it in a report that has already been made. SSE subscribers still receive — it is the *listener dispatch* that is refused, and a browser holding a stream open during shutdown should still see the last event.

Wired in the two places that exist: `atexit` (runs when a gunicorn worker exits on SIGTERM, does **not** run on SIGKILL — exactly right for a drain that must never delay a kill) and `app.py`'s `KeyboardInterrupt` handler, after the scheduler stops so no new renewal can queue a deploy mid-drain. The registration lives in the factory rather than in `EventBus.__init__`, so constructing a bus — which most of the suite does — leaves no handler behind holding a reference to it.

## Verification

- `tests/test_the_bus_says_what_it_could_not_deliver.py` — 14 tests. THE regression: one worker held open, five events, `stop(0.05)` reports the four that never reached a worker. All 14 fail against the parent commit (there is no `stop` to call).
- Controls: work that *does* start within the deadline is not reported (a bus that reported everything queued would make every clean shutdown a false alarm); an empty queue returns immediately rather than sleeping its full timeout; a payload with no domain is still named rather than raising in the reporter; SSE delivery survives the refusal; `stop` is idempotent.
- The deadline is `CERTMATE_EVENT_DRAIN_SECONDS`, default 5, clamped 0–60 — a typo must not hang shutdown for fifteen minutes, and must not silently make the drain zero either.
- The last test asserts the *property* rather than the mechanism: something must call `stop()` when the process goes away, and `create_app` must call the thing that registers it.
- Full unit suite: **4513 passed, 31 skipped** in 120 s. `flake8` (gated selection) clean.

Two of the repository's own gates shaped this change: `test_no_silent_swallows` refused an `except Exception: pass` in the previous PR's telemetry helper, and `test_every_env_var_is_documented` refused this one until `CERTMATE_EVENT_DRAIN_SECONDS` was in the README's environment table.

Found by the 20-category audit of v2.30.0 (`CERTMA-CONC-01`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)