### PR TITLE
test: the per-module coverage floors watch the core, not only the HTTP layer

### DIFF
--- a/scripts/check_coverage_floors.py
+++ b/scripts/check_coverage_floors.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Per-module coverage floors for the HTTP layer (#662).
+"""Per-module coverage floors for the HTTP layer and the core (#662).
 
 The gated suite already has a project-wide `--cov-fail-under`. One number
 cannot protect a layer: `modules/api/resources_ca.py` sat at 11% — 99 of its
@@ -78,9 +78,83 @@ FLOORS = {
     # so raising the floor would lock in a number nobody earned.
     'modules/web/settings_routes.py': 50,
     'modules/web/ui_routes.py': 60,
+
+    # modules/core/ — the layer this check did not watch.
+    #
+    # The floors above were added because one project-wide number could not
+    # protect a layer: resources_ca.py sat at 11% while the project figure
+    # stayed comfortably above its floor. The same argument applies with more
+    # force one directory over, and it was not being made: modules/core holds
+    # the issuance path, the storage backends, the settings store and the audit
+    # chain, and nothing but the project-wide 75% stood behind any of it.
+    #
+    # What that allowed, measured rather than argued: storage_backends.py has
+    # 1,202 statements of which 877 were covered. Losing every one of them —
+    # a module whose tests are deleted or stop importing, which is exactly the
+    # failure #651 describes — takes the project figure to 76.3%. Above the
+    # floor. Green build, one of the largest modules in the product dark.
+    #
+    # Values are the measured coverage rounded DOWN to a multiple of five, and
+    # down another five where that left less than a point of headroom, so
+    # ordinary churn does not trip the build while a real regression does. They
+    # come from the `unit` tier alone; the gated run also executes e2e and live
+    # tests, so the real numbers are at or above these. Raise them as they
+    # climb; never lower one to make a red build pass.
+    'modules/core/__init__.py': 95,
+    'modules/core/audit.py': 80,
+    'modules/core/audit_chain.py': 85,
+    'modules/core/audit_context.py': 90,
+    'modules/core/audit_prune.py': 80,
+    'modules/core/audit_signing.py': 85,
+    'modules/core/audit_sink.py': 80,
+    'modules/core/audit_verify.py': 75,
+    'modules/core/auth.py': 85,
+    'modules/core/ca_manager.py': 70,
+    'modules/core/cache.py': 60,
+    'modules/core/cert_adopt.py': 95,
+    'modules/core/cert_discovery.py': 95,
+    'modules/core/cert_inventory.py': 95,
+    'modules/core/cert_jobs.py': 90,
+    'modules/core/cert_probe.py': 80,
+    'modules/core/cert_service.py': 90,
+    'modules/core/certificates.py': 85,
+    'modules/core/client_certificates.py': 75,
+    'modules/core/constants.py': 80,
+    'modules/core/crypto_report.py': 95,
+    'modules/core/csr_handler.py': 80,
+    'modules/core/csr_issuance.py': 95,
+    'modules/core/ct_monitor.py': 90,
+    'modules/core/deploy_targets.py': 90,
+    'modules/core/deploy_window.py': 90,
+    'modules/core/deployer.py': 85,
+    'modules/core/digest.py': 85,
+    'modules/core/dns_alias_hook.py': 65,
+    'modules/core/dns_providers.py': 85,
+    'modules/core/dns_strategies.py': 80,
+    'modules/core/dns_zone_discovery.py': 95,
+    'modules/core/domain_paths.py': 85,
+    'modules/core/events.py': 80,
+    'modules/core/factory.py': 80,
+    'modules/core/file_operations.py': 80,
+    'modules/core/inventory_sources.py': 95,
+    'modules/core/inventory_view.py': 95,
+    'modules/core/issuance_readiness.py': 95,
+    'modules/core/metrics.py': 70,
+    'modules/core/notifier.py': 90,
+    'modules/core/ocsp_crl.py': 85,
+    'modules/core/oidc.py': 75,
+    'modules/core/private_ca.py': 80,
+    'modules/core/rate_limit.py': 70,
+    'modules/core/secret_refs.py': 95,
+    'modules/core/settings.py': 80,
+    'modules/core/shell.py': 75,
+    'modules/core/storage_backends.py': 70,
+    'modules/core/structured_logging.py': 70,
+    'modules/core/utils.py': 80,
+    'modules/core/zombie.py': 80,
 }
 
-WATCHED_PREFIXES = ('modules/api/', 'modules/web/')
+WATCHED_PREFIXES = ('modules/api/', 'modules/web/', 'modules/core/')
 
 
 def main(argv: list[str]) -> int:
@@ -123,7 +197,7 @@ def main(argv: list[str]) -> int:
 
     for name in sorted(set(measured) - set(FLOORS)):
         problems.append(
-            f"{name}: is in the HTTP layer with no coverage floor. Add one at "
+            f"{name}: is a watched module with no coverage floor. Add one at "
             f"{int(measured[name] // 5 * 5)}% (its current {measured[name]:.1f}%) "
             f"so it cannot rot unnoticed.")
 
@@ -134,7 +208,7 @@ def main(argv: list[str]) -> int:
         return 1
 
     lowest = min(measured.items(), key=lambda kv: kv[1])
-    print(f"Coverage floors met for {len(measured)} HTTP-layer modules "
+    print(f"Coverage floors met for {len(measured)} watched modules "
           f"(lowest: {lowest[0]} at {lowest[1]:.1f}%).")
     return 0
 

--- a/tests/test_coverage_floors_are_enforced.py
+++ b/tests/test_coverage_floors_are_enforced.py
@@ -30,11 +30,15 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 CHECKER = REPO_ROOT / 'scripts' / 'check_coverage_floors.py'
 
 
-def _floors():
+def _checker_namespace():
     namespace = {}
     exec(compile(CHECKER.read_text(encoding='utf-8'), str(CHECKER), 'exec'),
          namespace)
-    return namespace['FLOORS']
+    return namespace
+
+
+def _floors():
+    return _checker_namespace()['FLOORS']
 
 
 def _report(overrides=None, drop=None, extra=None):
@@ -115,19 +119,44 @@ def test_every_floor_names_a_file_that_exists(tmp_path):
     )
 
 
-def test_every_http_module_has_a_floor():
+def test_every_watched_module_has_a_floor():
     """The other direction, checked against the tree rather than a report, so a
     new module is caught even before anyone runs coverage."""
     floors = set(_floors())
     on_disk = {
         str(path.relative_to(REPO_ROOT))
-        for directory in ('modules/api', 'modules/web')
+        for directory in ('modules/api', 'modules/web', 'modules/core')
         for path in (REPO_ROOT / directory).glob('*.py')
     }
     assert not (on_disk - floors), (
-        f'these HTTP-layer modules have no coverage floor: '
+        f'these watched modules have no coverage floor: '
         f'{sorted(on_disk - floors)}'
     )
+
+
+def test_the_core_is_watched_too():
+    """THE regression this file gained after the audit.
+
+    The floors existed because one project-wide number cannot protect a layer,
+    and then watched only the HTTP layer — so the argument was not being made
+    for modules/core, which holds the issuance path, the storage backends, the
+    settings store and the audit chain. Measured at the time: storage_backends
+    could lose all 877 of its covered statements and the project figure would
+    land at 76.3%, above the 75% floor, with a green build.
+    """
+    assert 'modules/core/' in _checker_namespace()['WATCHED_PREFIXES']
+
+
+def test_the_core_floors_are_not_all_zero():
+    """CONTROL: adding the prefix with floors of 0 would satisfy the test above
+    while protecting nothing."""
+    core = {name: floor for name, floor in _floors().items()
+            if name.startswith('modules/core/')}
+
+    assert len(core) > 40, 'the core floors are not there'
+    assert min(core.values()) >= 50, (
+        f'these floors are too low to catch a module going dark: '
+        f'{sorted(k for k, v in core.items() if v < 50)}')
 
 
 def test_the_checker_is_wired_into_ci():


### PR DESCRIPTION
## What this is

The per-module floors were added because one project-wide number cannot protect a layer — `resources_ca.py` sat at 11% while the project figure stayed comfortably above its floor. That argument was applied to `modules/api` and `modules/web`, and stopped there. It was never made for `modules/core`, which holds the issuance path, the storage backends, the settings store and the audit chain.

**Measured, not argued.** `storage_backends.py` has 1,202 statements, 877 of them covered. If every one went uncovered — a module whose tests are deleted or stop importing, exactly the failure #651 describes — the project figure lands at **76.28%**, above the 75% floor. Green build, one of the largest modules in the product dark.

Checked both ways against a doctored coverage report with that module at 0%:

```
old checker: Coverage floors met for 29 HTTP-layer modules   → exit 0
new checker: modules/core/storage_backends.py: 0.0% is below its floor of 70%  → exit 1
```

## The change

- `WATCHED_PREFIXES` gains `modules/core/`, and all 52 core modules get a floor.
- Values are set the way the existing ones were: measured coverage rounded **down** to a multiple of five, and down another five where that left less than a point of headroom, so ordinary churn does not trip the build while a real regression does.
- They come from the `unit` tier alone, so the gated run — which also executes e2e and live tests — measures at or above them. That is the safe direction, and the file says so.
- Both anti-vacuity guards now cover the core: a floor whose module vanished is an error, and a watched module with no floor is an error. That second one is what stops a new core module from arriving unguarded, which is how `resources_ca` reached 11% in the first place.

## Verification

- `tests/test_coverage_floors_are_enforced.py` gains three: the core is watched, the core floors are not all zero (a control — adding the prefix with floors of 0 would satisfy the first while protecting nothing), and the existing every-module-has-a-floor test now covers `modules/core` too. All three fail against the parent commit.
- Full unit suite: **4515 passed, 31 skipped** in 128 s; the checker itself passes against a real report (81 watched modules, lowest `modules/web/settings_routes.py` at 50.8%).

Found by the 20-category audit of v2.30.0 (`CERTMA-TEST-01`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)