### PR TITLE
docs: the Quick Start stops offering configuration nothing reads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,14 @@ API_BEARER_TOKEN=your_secure_api_token_here
 # Alternatively, set SECRET_KEY_FILE to a path containing the key.
 SECRET_KEY=your_secret_key_here
 
+# Optional: backups that can actually restore this instance.
+# Without a passphrase, automatic backups are written with their secrets masked
+# and are refused by the restore path — they are configuration snapshots, not
+# restore points. With one, every automatic backup is complete and encrypted at
+# rest (PBKDF2-SHA256 -> Fernet). Set it before you need it, and keep a copy of
+# an archive off this host.
+# CERTMATE_BACKUP_PASSPHRASE=a_long_random_passphrase
+
 # Optional: how long a login session lasts, in hours (default 8).
 # Governs both the server-side session record and the browser cookie, so a
 # shorter value really does log people out sooner. Values below 1 are clamped

--- a/README.md
+++ b/README.md
@@ -337,30 +337,21 @@ Edit `.env` file with your credentials:
 # you to paste this same token once to create the initial admin.
 API_BEARER_TOKEN=your_super_secure_api_token_here_change_this
 
-# DNS Provider Configuration (choose one or multiple)
-
-# Option 1: Cloudflare (Recommended for beginners)
+# DNS Provider Configuration
+#
+# Cloudflare is the only provider configured from the environment: this token
+# bootstraps the default Cloudflare account on first run. Route53, Azure,
+# Google Cloud DNS, PowerDNS and the other 25+ providers are configured in the
+# web UI (Settings -> DNS Providers) or through the API — CertMate reads no
+# environment variable for any of them, so setting AWS_ACCESS_KEY_ID or
+# AZURE_CLIENT_ID here does nothing at all.
 CLOUDFLARE_TOKEN=your_cloudflare_api_token_here
 
-# Option 2: AWS Route53
-# AWS_ACCESS_KEY_ID=your_aws_access_key
-# AWS_SECRET_ACCESS_KEY=your_aws_secret_key
-# AWS_DEFAULT_REGION=us-east-1
-
-# Option 3: Azure DNS
-# AZURE_SUBSCRIPTION_ID=your_azure_subscription_id
-# AZURE_RESOURCE_GROUP=your_resource_group
-# AZURE_TENANT_ID=your_tenant_id
-# AZURE_CLIENT_ID=your_client_id
-# AZURE_CLIENT_SECRET=your_client_secret
-
-# Option 4: Google Cloud DNS
-# GOOGLE_PROJECT_ID=your_gcp_project_id
-# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
-
-# Option 5: PowerDNS
-# POWERDNS_API_URL=https://your-powerdns-server:8081
-# POWERDNS_API_KEY=your_powerdns_api_key
+# Backups. Without a passphrase, automatic backups are written with their
+# secrets masked and CANNOT restore this instance — they are configuration
+# snapshots. With one, every automatic backup is complete and encrypted at
+# rest. Set it before you need it; see Backup and Recovery below.
+# CERTMATE_BACKUP_PASSPHRASE=a_long_random_passphrase
 
 # Optional: Application Settings
 SECRET_KEY=your_flask_secret_key_here

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,23 @@ services:
       - PORT=${PORT:-8000}                      # Internal listen port; also update ports: mapping if changed
       - GUNICORN_TIMEOUT=${GUNICORN_TIMEOUT:-300}  # Worker timeout; increase for slow DNS providers
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL:-}    # Overrides the email set via the web UI when set
+      # Without this, automatic backups are masked and CANNOT restore the
+      # instance; with it they are complete and encrypted at rest. Empty by
+      # default because a passphrase this file invented would be the same on
+      # every installation that never changed it.
+      - CERTMATE_BACKUP_PASSPHRASE=${CERTMATE_BACKUP_PASSPHRASE:-}
+    # Bind mounts, so these four directories keep the HOST's ownership and
+    # shadow the permissions the image sets. Docker creates them root-owned if
+    # they do not exist, and CertMate runs as a non-root user, so on a fresh
+    # clone prepare them once before `up`:
+    #
+    #   mkdir -p ./{certificates,data,logs,backups}
+    #   chgrp -R 0 ./{certificates,data,logs,backups}
+    #   chmod -R g+rwX ./{certificates,data,logs,backups}
+    #
+    # (Named volumes need none of this — see docs/docker.md. The app refuses to
+    # start rather than half-work when a directory is not writable, and names
+    # the directory and the fix in the error.)
     volumes:
       - ./certificates:/app/certificates:rw
       - ./logs:/app/logs:rw

--- a/tests/test_env_example_is_honest.py
+++ b/tests/test_env_example_is_honest.py
@@ -72,6 +72,11 @@ def _readers(name, blobs):
         rf"""\$\{{{name}[}}:]""",
         rf"""\${name}\b""",
         rf"""^\s*(ENV|ARG)\s+{name}\b""",
+        # The name held in a constant and read through it, which is how
+        # file_operations reads CERTMATE_BACKUP_PASSPHRASE. Requires the
+        # assignment form, so prose mentioning the variable does not count as
+        # reading it.
+        rf"""^\s*[A-Z][A-Z0-9_]*\s*=\s*['"]{name}['"]""",
     ]
     hits = []
     for path, blob in blobs.items():
@@ -154,3 +159,63 @@ def test_no_documented_variable_contradicts_the_template():
             f"{name} is read by {_readers(name, blobs)} but is not offered in "
             f".env.example, so nobody copying the template will set it."
         )
+
+
+# --- the same question, asked of the README -------------------------------
+#
+# `.env.template` was deleted for promising ten provider variables that never
+# existed. The README's Quick Start kept its own copy of four of them, in the
+# block headed "Edit `.env` file with your credentials" — so an operator
+# following the most-read file in the repository still filled in
+# AWS_ACCESS_KEY_ID, AZURE_CLIENT_ID, GOOGLE_PROJECT_ID or POWERDNS_API_KEY and
+# reached a UI that showed the provider unconfigured. Every other DNS provider
+# is configured in the web UI or through the API; only CLOUDFLARE_TOKEN
+# bootstraps an account from the environment.
+
+README = REPO_ROOT / "README.md"
+
+
+def _readme_env_block():
+    """The fenced block the Quick Start tells operators to put in `.env`.
+
+    Located by the heading rather than by position: a block that moves should
+    keep being checked, and a heading that is renamed should fail loudly here
+    rather than silently stop checking anything.
+    """
+    text = README.read_text(encoding="utf-8")
+    start = text.index("### 2. Configure Environment")
+    end = text.index("### 3.", start)
+    section = text[start:end]
+    fences = re.findall(r"```[a-z]*\n(.*?)```", section, re.S)
+    assert fences, (
+        "the Quick Start's Configure Environment section has no fenced block; "
+        "this check is no longer looking at anything"
+    )
+    return "\n".join(fences)
+
+
+def _readme_declared():
+    return [
+        (match.group(1), line.strip())
+        for line in _readme_env_block().splitlines()
+        if (match := re.match(r"^\s*#?\s*([A-Z][A-Z0-9_]*)=", line))
+    ]
+
+
+def test_the_quick_start_block_declares_something():
+    assert len(_readme_declared()) >= 3, (
+        "the README's .env block parses to almost nothing, so the check below "
+        "would pass over a file it is not reading"
+    )
+
+
+@pytest.mark.parametrize("name,line", _readme_declared(),
+                         ids=[d[0] for d in _readme_declared()])
+def test_every_variable_the_quick_start_offers_is_read_by_something(name, line):
+    blobs = _blobs()
+    assert _readers(name, blobs), (
+        f"README Quick Start offers `{line}`, which nothing in the application "
+        f"reads. Setting it does nothing, and for a DNS provider it does worse "
+        f"than nothing: the operator believes the provider is configured. "
+        f"Every provider except Cloudflare is configured in the UI or the API."
+    )


### PR DESCRIPTION
## What this is

`.env.template` was deleted because it promised ten commented variables configuring Route53, Azure, Google Cloud DNS and PowerDNS from the environment — none of which has ever existed. **The README's Quick Start kept its own copy of the same fiction**, in the block headed *"Edit `.env` file with your credentials"*: the more-read of the two files, and the one the installation path starts from.

Setting them does nothing, and for a DNS provider it does worse than nothing: the operator believes the provider is configured, reaches a UI that says it is not, and has no reason to suspect the file they were told to edit. For Route53 it is worse still — `Route53Strategy.prepare_environment` **writes** `AWS_ACCESS_KEY_ID` into certbot's environment from the settings store, with an empty string when nothing is configured, so a value placed in `.env` is overwritten rather than merely ignored.

`CLOUDFLARE_TOKEN` stays — it genuinely bootstraps the default account on first run. The block now says where everything else is configured.

## Two more things an operator meets before the first run

- **`CERTMATE_BACKUP_PASSPHRASE`** is now offered in `.env.example` and in the compose file. It decides whether an automatic backup can restore the instance at all; the README's own recovery procedure says to *"restore the most recent backup that can actually restore"*; and it appeared in neither of the two files an operator edits.
- **The compose file's four bind mounts** carry the preparation `docs/docker.md` documents. Docker creates missing host directories root-owned, the container runs as a non-root user, and on a fresh clone that is a boot-time refusal — clear, and avoidable by saying so where the mounts are declared.

## Verification

The guard that caught the `.env.template` case now asks the same question of the README: every variable the Quick Start offers must be read by something. Run against the parent commit it reports all twelve —

```
AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION,
AZURE_SUBSCRIPTION_ID, AZURE_RESOURCE_GROUP, AZURE_TENANT_ID,
AZURE_CLIENT_ID, AZURE_CLIENT_SECRET,
GOOGLE_PROJECT_ID, GOOGLE_APPLICATION_CREDENTIALS,
POWERDNS_API_URL, POWERDNS_API_KEY
```

— and passes on this one. It locates the block by its heading rather than by position, and asserts the block parses to something first, so a renamed heading fails loudly instead of silently checking nothing.

The reader-detection also learned the indirection this codebase uses: a name held in a constant and read through it (`BACKUP_PASSPHRASE_ENV = 'CERTMATE_BACKUP_PASSPHRASE'`), matched in the assignment form only, so prose mentioning a variable still does not count as reading it.

Full unit suite: **4523 passed, 31 skipped**. The compose file still parses.

Found by the 20-category audit of v2.30.0 (`CERTMA-DOC-01`, `CERTMA-OPS-01`, `CERTMA-OPS-02`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)