### PR TITLE
build: the image ships the two scripts it runs, not the fourteen in the directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,15 @@ jobs:
           # passed explicitly: it is what this build was meant to carry, and
           # guessing it is the difference between a missing plugin and an
           # optional one.
+          #
+          # Copied in rather than shipped: the image carries the two scripts
+          # the running process executes, and this is a gate, not a runtime
+          # component. Into /app/scripts, not /tmp, because the script resolves
+          # its requirements file relative to its own parent's parent — from
+          # /tmp it would look for /requirements.txt and refuse. `docker cp`
+          # fails loudly under `set -e` if the file is not where this expects
+          # it, so the check cannot silently stop running.
+          docker cp scripts/check_providers.py "$cid":/app/scripts/check_providers.py
           if ! docker exec "$cid" python /app/scripts/check_providers.py "$req"; then
             echo "::error::$req built an image whose providers cannot all reach certbot"
             docker rm -f "$cid" >/dev/null 2>&1 || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -184,13 +184,24 @@ ENV PATH="/opt/venv/bin:$PATH"
 #
 # What is here is what the running process actually touches:
 #   app.py, modules/, templates/, static/  the application
-#   scripts/                               solidserver_hook.py is executed by
+#   two files from scripts/                solidserver_hook.py is executed by
 #                                          the SolidServer DNS strategy
-#                                          (modules/core/dns_strategies.py)
+#                                          (modules/core/dns_strategies.py);
+#                                          reset_admin_password.py is the
+#                                          documented in-container recovery
+#                                          (README, and the login page points
+#                                          at it by name)
 #   requirements*.txt                      two error paths tell the operator to
 #                                          install one of these into a running
 #                                          container to add a DNS or storage
 #                                          backend
+#
+# scripts/ is copied BY NAME, not as a directory. It was `COPY scripts/`, which
+# put the other twelve files in the image: release.sh with the whole release
+# procedure, regenerate_lockfiles.sh, five check_*.py gates, the theme codemod,
+# the walkthrough recorder. All build-time, none read by the running process —
+# which is the same defect the allowlist above was written to fix, surviving one
+# directory further down because the allowlist named a directory.
 #
 # tests/test_image_ships_only_what_it_runs.py checks this against the built
 # image rather than against this comment.
@@ -199,7 +210,7 @@ COPY requirements*.txt requirements*.lock ./
 COPY modules/ ./modules/
 COPY templates/ ./templates/
 COPY static/ ./static/
-COPY scripts/ ./scripts/
+COPY scripts/solidserver_hook.py scripts/reset_admin_password.py ./scripts/
 
 # Create the runtime-writable directories and make them arbitrary-UID ready.
 #

--- a/tests/test_image_ships_only_what_it_runs.py
+++ b/tests/test_image_ships_only_what_it_runs.py
@@ -51,10 +51,23 @@ EXPECTED = {
     'modules',           # the application
     'templates',         # rendered by it
     'static',            # served by it
-    'scripts',           # solidserver_hook.py is executed by the SolidServer
-                         # DNS strategy (modules/core/dns_strategies.py)
+    'scripts',           # two files; see EXPECTED_SCRIPTS
     # Runtime-writable trees the Dockerfile creates, not copies.
     'backups', 'certificates', 'data', 'logs',
+}
+
+# The allowlist above names directories, and that is one level too coarse for
+# this one: `COPY scripts/` put all fourteen files in the image, of which the
+# runtime reads two. The other twelve are build- and release-time — release.sh
+# carries the entire release procedure, regenerate_lockfiles.sh, five check_*
+# gates, the theme codemod, the walkthrough recorder — which is the same defect
+# the allowlist was written to fix, surviving one directory further down.
+EXPECTED_SCRIPTS = {
+    # Executed by the SolidServer DNS strategy as a certbot manual hook.
+    'solidserver_hook.py',
+    # The documented in-container recovery: the README gives the docker exec
+    # line and the login page names the file.
+    'reset_admin_password.py',
 }
 
 # Two error paths tell the operator to install one of these into a running
@@ -161,3 +174,32 @@ def test_the_dockerfile_does_not_copy_the_whole_tree():
         if stripped.startswith('COPY') and '--from=' not in stripped:
             assert stripped.split()[1] != '.', (
                 'the runtime stage copies the whole tree again: ' + stripped)
+
+
+@pytest.fixture(scope='module')
+def scripts_dir(docker_container):
+    """What `/app/scripts` holds in the image under test."""
+    from tests.conftest import IMAGE_NAME
+    result = subprocess.run(
+        ['docker', 'run', '--rm', '--entrypoint', 'sh', IMAGE_NAME,
+         '-c', 'ls -A /app/scripts'],
+        capture_output=True, text=True, timeout=120)
+    assert result.returncode == 0, result.stderr
+    return set(result.stdout.split())
+
+
+def test_the_runtime_scripts_are_present(scripts_dir):
+    """CONTROL first: an empty directory would satisfy the check below while
+    breaking SolidServer issuance and the password reset."""
+    assert EXPECTED_SCRIPTS <= scripts_dir, (
+        f'missing from the image: {sorted(EXPECTED_SCRIPTS - scripts_dir)}')
+
+
+def test_no_build_time_script_ships(scripts_dir):
+    """The other direction, one level deeper than the /app check above."""
+    unexpected = sorted(scripts_dir - EXPECTED_SCRIPTS)
+    assert not unexpected, (
+        'these are in /app/scripts and nothing in the runtime reads them:\n  '
+        + '\n  '.join(unexpected)
+        + '\n\nThey are build- or release-time. Copy the runtime ones by name '
+          'rather than copying the directory.')


### PR DESCRIPTION
## What this is

The runtime stage copies an allowlist rather than the build context, and the comment above it explains why: *a denylist ships whatever nobody remembered to add to it*. The allowlist names **directories**, and for `scripts/` that is one level too coarse — `COPY scripts/` put all fourteen files in the published image, of which the running process reads two.

The other twelve are build- and release-time:

```
release.sh  regenerate_lockfiles.sh  lockfile.py
check_advisories.py  check_resolved_advisories.py  check_coverage_floors.py
check_providers.py  check_wiki.py
theme_codemod.py  theme_baseline.py  record_walkthrough.py  ui_paths_changed.py
```

None is read by the running process — the same defect the allowlist was written to fix, surviving one directory further down.

## The two that stay

- `solidserver_hook.py` — executed by the SolidServer DNS strategy as a certbot manual hook (`modules/core/dns_strategies.py` resolves `scripts/solidserver_hook.py`).
- `reset_admin_password.py` — the documented in-container recovery: the README gives the `docker exec` line, and the login page names the file to the operator.

## Verified in the image, not in the Dockerfile

Built from this branch:

```
$ docker run --rm --entrypoint sh certmate:scripts-check -c 'ls -A /app/scripts'
reset_admin_password.py
solidserver_hook.py

$ curl -sf localhost:8899/health
{"api_contract_version":"2.0","checks":{"cert_dir":"ok","certbot":"ok","certbot_version":"certbot 2.10.0",...
```

Both scripts compile inside the image, and the container boots and answers `/health`.

`tests/test_image_ships_only_what_it_runs.py` now asserts `/app/scripts` in both directions, the same way it already asserts `/app`: a **control** that the two runtime scripts are present — an empty directory would pass a one-directional check while breaking SolidServer issuance and the password reset — and that nothing else is. Those tests are in the `e2e` tier, which the gated CI job runs (the last run executed 4678 tests including the image ones), so this is enforced rather than documented.

Found by the 20-category audit of v2.30.0 (`the-allowlist-stops-one-directory-short`, Build & Packaging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)