### PR TITLE
fix: two answers that outlived the thing that invalidated them

### DIFF
--- a/README.md
+++ b/README.md
@@ -1587,6 +1587,7 @@ by the schema, with a message naming the accepted set — for example
 | `CERTMATE_ISSUANCE_JOB_HISTORY` | | `200`      | How many finished issuance jobs stay queryable via `/api/certificates/jobs`. Clamped to 20-2000 |
 | `CERTMATE_EVENT_WORKERS` |    | `4`            | Threads dispatching event listeners (deploy hooks, cache invalidation). Clamped to 1-32. Nothing is dropped when they are busy; the backlog is logged instead |
 | `CERTMATE_EVENT_DRAIN_SECONDS` |    | `5`            | How long a shutdown waits for queued event dispatches to start before giving up on them. Clamped to 0-60. Whatever is left is logged with its event and domain, so a deploy hook that never ran after a renewal is named rather than lost |
+| `CERTMATE_CERTBOT_PROBE_TTL` |    | `300`          | Seconds before the certbot readiness answer is re-checked. Clamped to 30-3600. The probe used to run once per process, so a transient failure at boot made the instance permanently unready and a certbot that broke later never turned `/health/ready` red |
 | `CERTMATE_PROBE_TIMEOUT_SECONDS` | | `5`       | Deployment-probe connection timeout. Clamped to 1-30 |
 | `CERTMATE_LAST_USED_PERSIST_SECONDS` | | `60`  | How often a session's "last used" timestamp is written to disk. `0` writes on every request, which is the original behaviour and one write per request |
 | `CERTMATE_SLOW_REQUEST_LOGGING` | | `true`       | Log a warning, with the thread's stack, for requests that outlive the threshold below. The stack is what makes a hung request diagnosable after the fact |

--- a/modules/core/issuance_readiness.py
+++ b/modules/core/issuance_readiness.py
@@ -44,12 +44,31 @@ nothing. That case records `skipped`, which readiness treats as ready: a
 probe that did not run must not be reported as a probe that failed.
 """
 import logging
+import os
+import threading
+import time
 
 logger = logging.getLogger(__name__)
 
 # certbot lives in the venv in a source checkout and on PATH in the image.
 CERTBOT_CANDIDATES = ('.venv/bin/certbot', 'certbot')
 PROBE_TIMEOUT_SECONDS = 30
+
+# How long an answer about certbot stays good for. The probe used to run once
+# per process and the answer was then frozen for the life of that process,
+# which is wrong in both directions: a transient failure at boot — a filesystem
+# still settling, a fork refused under memory pressure — made the instance
+# permanently unready, and under an orchestrator that means a restart loop
+# rolling the same dice; and a certbot that broke AFTER boot (a volume
+# remounted, a dependency changed inside the container) never turned readiness
+# red, so the endpoint an orchestrator uses to decide rotation went on saying
+# yes while nothing could be issued.
+#
+# The TTL is what keeps a re-probe cheap: readiness is scraped every few
+# seconds, and running certbot that often would be its own problem. Clamped so
+# a typo cannot mean "never re-probe" or "probe on every scrape".
+DEFAULT_PROBE_TTL_SECONDS = 300
+_PROBE_TTL_MIN, _PROBE_TTL_MAX = 30, 3600
 
 # States. `ok` and `skipped` are ready; `failed` is not.
 OK = 'ok'
@@ -58,12 +77,24 @@ SKIPPED = 'skipped'
 UNKNOWN = 'unknown'
 
 _status = None
+_probed_at = 0.0
+_probe_lock = threading.Lock()
+
+
+def probe_ttl_seconds() -> float:
+    """Seconds before a recorded answer is re-checked. CERTMATE_CERTBOT_PROBE_TTL."""
+    try:
+        return max(_PROBE_TTL_MIN, min(_PROBE_TTL_MAX, float(os.environ.get(
+            'CERTMATE_CERTBOT_PROBE_TTL', DEFAULT_PROBE_TTL_SECONDS))))
+    except (TypeError, ValueError):
+        return float(DEFAULT_PROBE_TTL_SECONDS)
 
 
 def reset():
     """Forget the cached probe result. For tests, and for nothing else."""
-    global _status
+    global _status, _probed_at
     _status = None
+    _probed_at = 0.0
 
 
 def get_status():
@@ -116,18 +147,37 @@ def _run_once(shell_executor, path):
     return text, None
 
 
+def is_fresh() -> bool:
+    """Is there a recorded answer that has not aged past the TTL?"""
+    return _status is not None and (time.monotonic() - _probed_at) < probe_ttl_seconds()
+
+
 def probe(shell_executor, force=False):
-    """Run `certbot --version` once per process and record what happened.
+    """Answer whether certbot can run, re-checking when the answer has aged.
 
     Returns the status dict. Never raises: every failure mode this can hit is
     a thing to report, not a thing to crash the application over.
+
+    Called from startup and from the readiness endpoint. The TTL is what makes
+    the second one safe: an orchestrator scraping every few seconds runs certbot
+    at most once per TTL, and the rest of the time reads the recorded answer.
     """
-    global _status
-    if _status is not None and not force:
+    if is_fresh() and not force:
         return dict(_status)
 
+    with _probe_lock:
+        # Re-checked under the lock: two threads arriving together on an
+        # expired answer should run certbot once between them, not twice.
+        if is_fresh() and not force:
+            return dict(_status)
+        return _probe_locked(shell_executor)
+
+
+def _probe_locked(shell_executor):
+    global _status, _probed_at
     from .utils import utc_now_iso
     stamp = utc_now_iso()
+    _probed_at = time.monotonic()
 
     if shell_executor is None or not getattr(shell_executor,
                                              'produces_artifacts', True):

--- a/modules/core/storage_backends.py
+++ b/modules/core/storage_backends.py
@@ -2063,8 +2063,23 @@ class StorageManager:
             
             successful = sum(1 for success in migration_results.values() if success)
             logger.info(f"Migration completed: {successful}/{len(domains)} certificates migrated successfully")
-            
+
         except Exception as e:
+            # Raised, not logged and swallowed. Everything above this line that
+            # can fail is per-certificate and is already recorded as False for
+            # that certificate; what reaches here is the enumeration of the
+            # source — an expired Vault token, a role without ListBucket, an
+            # unreachable endpoint — and returning the empty dict it had
+            # accumulated made the caller compute 0 of 0 and answer HTTP 200
+            # with success: true, "Migration completed: 0/0", and an audit
+            # record stamped status='success'. An operator migrating away from
+            # a backend before decommissioning it was told it had worked.
+            #
+            # "Enumerated nothing" and "could not enumerate" are different
+            # answers and must not share a return value. The route already has
+            # an arm for this: it answers with a failure status and writes a
+            # failure audit record.
             logger.error(f"Migration failed: {e}")
-        
+            raise
+
         return migration_results

--- a/modules/web/misc_routes.py
+++ b/modules/web/misc_routes.py
@@ -234,6 +234,31 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
             logger.error(f"Metrics error: {e}")
             return jsonify({'error': 'Internal Server Error'}), 500
 
+    def _current_issuance_status(managers):
+        """Whether certbot can run, re-checked when the last answer has aged.
+
+        The probe ran once per process and its answer was then frozen for the
+        life of that process, and both routes read that frozen dict. It was
+        wrong in both directions. A transient failure at boot — a filesystem
+        still settling, a fork refused under memory pressure — made the
+        instance permanently unready, and under an orchestrator that is a
+        restart loop rolling the same dice. And a certbot that broke AFTER boot
+        never turned readiness red, so the endpoint used to decide rotation
+        went on saying yes while nothing could be issued.
+
+        `probe` is TTL-throttled, so a readiness scrape every few seconds runs
+        certbot at most once per TTL. The refreshed answer is written back to
+        `managers['issuance_status']` so anything else reading that key sees
+        the same thing these two do.
+        """
+        from modules.core import issuance_readiness
+        shell_executor = managers.get('shell_executor')
+        if shell_executor is None:
+            return managers.get('issuance_status') or {}
+        status = issuance_readiness.probe(shell_executor)
+        managers['issuance_status'] = status
+        return status
+
     @app.route('/health')
     def health_check():
         """Health check endpoint — intentionally public for load balancers"""
@@ -258,10 +283,11 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
             checks['scheduler'] = 'not_running'
             overall = 'degraded'
 
-        # certbot. The one dependency without which nothing works, probed
-        # once at startup because a broken certbot is invisible until the
-        # first renewal — hours later, on a certificate closer to expiry.
-        issuance = managers.get('issuance_status') or {}
+        # certbot. The one dependency without which nothing works, and a
+        # broken one is invisible until the first renewal — hours later, on a
+        # certificate closer to expiry. Re-checked rather than read from the
+        # startup snapshot: see _current_issuance_status.
+        issuance = _current_issuance_status(managers)
         issuance_state = issuance.get('state')
         if issuance_state:
             checks['certbot'] = issuance_state
@@ -337,7 +363,7 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
         # every probe: the instance started, said ready, and failed at the
         # first renewal. Only a probe that RAN AND FAILED withholds readiness
         # — `skipped` and `unknown` are absence of evidence, not evidence.
-        issuance = managers.get('issuance_status') or {}
+        issuance = _current_issuance_status(managers)
         issuance_ok = issuance_readiness.is_ready(issuance)
 
         ready = scheduler_ok and issuance_ok

--- a/tests/test_a_migration_that_enumerated_nothing_is_not_a_success.py
+++ b/tests/test_a_migration_that_enumerated_nothing_is_not_a_success.py
@@ -1,0 +1,158 @@
+"""A migration that could not read the source is not a migration of zero certificates.
+
+`migrate_certificates` wrapped its whole body in `except Exception: log`, and
+then returned the per-domain results it had accumulated. Everything inside that
+body which can fail per certificate already records False for that certificate,
+so the only thing that reaches the outer handler is the enumeration of the
+source — an expired Vault token, a role without ListBucket, an endpoint that is
+unreachable. It returned `{}`.
+
+The route then computed `successful = 0`, `total = 0`, and answered:
+
+    HTTP 200  {"success": true, "message": "Migration completed: 0/0 certificates migrated"}
+
+with an audit record stamped `status='success'`. An operator moving off a
+backend before decommissioning it was told the move had worked.
+
+"Enumerated nothing" and "could not enumerate" are different answers and cannot
+share a return value. The route already had the other arm — a 500, a failure
+message and a failure audit record — and now reaches it.
+
+The control matters as much as the fix: a source that genuinely holds no
+certificates must still succeed, or this trades a false success for a false
+failure.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.storage_backends import StorageManager
+
+pytestmark = [pytest.mark.unit]
+
+
+class _Source:
+    """A source backend whose enumeration behaviour the test decides."""
+
+    def __init__(self, domains=None, error=None):
+        self._domains = domains or []
+        self._error = error
+
+    def list_certificates(self):
+        if self._error:
+            raise self._error
+        return list(self._domains)
+
+    def retrieve_certificate(self, domain):
+        return ({'cert.pem': b'x'}, {'domain': domain})
+
+    def get_backend_name(self):
+        return 'source'
+
+
+class _Target:
+    def __init__(self, refuse=()):
+        self.stored = []
+        self._refuse = set(refuse)
+
+    def store_certificate(self, domain, cert_files, metadata):
+        if domain in self._refuse:
+            return False
+        self.stored.append(domain)
+        return True
+
+    def get_backend_name(self):
+        return 'target'
+
+
+@pytest.fixture
+def manager():
+    return StorageManager.__new__(StorageManager)
+
+
+# --- THE regression ------------------------------------------------------
+
+def test_an_unreadable_source_raises_rather_than_returning_nothing(manager):
+    source = _Source(error=RuntimeError('permission denied: vault token expired'))
+
+    with pytest.raises(RuntimeError, match='vault token expired'):
+        manager.migrate_certificates(source, _Target())
+
+
+# --- the controls, which are the point -----------------------------------
+
+def test_a_source_with_no_certificates_still_succeeds(manager):
+    """CONTROL. An empty source is a legitimate 0/0 and must stay one — a fix
+    that turned this into a failure would be the same defect facing the other
+    way."""
+    results = manager.migrate_certificates(_Source(domains=[]), _Target())
+
+    assert results == {}
+
+
+def test_a_certificate_that_will_not_store_is_still_per_certificate(manager):
+    """CONTROL. Per-item failure is reported per item and does not abort the
+    run: the other certificates still move."""
+    target = _Target(refuse={'b.example.com'})
+
+    results = manager.migrate_certificates(
+        _Source(domains=['a.example.com', 'b.example.com', 'c.example.com']),
+        target)
+
+    assert results == {'a.example.com': True, 'b.example.com': False,
+                       'c.example.com': True}
+    assert target.stored == ['a.example.com', 'c.example.com']
+
+
+def test_a_certificate_that_cannot_be_read_does_not_stop_the_others(manager):
+    """CONTROL. A failure retrieving ONE certificate is per-certificate too —
+    only the enumeration is fatal, because only the enumeration means the
+    result set itself is unknown."""
+    source = _Source(domains=['ok.example.com', 'broken.example.com'])
+    original = source.retrieve_certificate
+
+    def retrieve(domain):
+        if domain == 'broken.example.com':
+            raise RuntimeError('unreadable')
+        return original(domain)
+
+    source.retrieve_certificate = retrieve
+
+    results = manager.migrate_certificates(source, _Target())
+
+    assert results == {'ok.example.com': True, 'broken.example.com': False}
+
+
+# --- the connection to the route ------------------------------------------
+#
+# The route's failure arm is already exercised in tests/test_audit_hardening.py
+# (`test_storage_migrate_failure`): a manager whose migrate_certificates raises
+# produces HTTP 500, `success: false`, and an audit record stamped failure.
+# What was missing was any way for the manager to GET there on the condition
+# that matters, so the two tests below pin the type and the boundary rather
+# than rebuilding the route harness here.
+
+def test_the_exception_type_survives_for_the_operator(manager):
+    """The route reports `type(e).__name__` to the operator, so the type has to
+    mean something — a bare Exception would tell them nothing."""
+    with pytest.raises(Exception) as caught:
+        manager.migrate_certificates(
+            _Source(error=RuntimeError('boom')), _Target())
+
+    assert type(caught.value) is RuntimeError
+
+
+def test_a_partial_migration_is_still_returned_not_raised(manager):
+    """The boundary between the two behaviours, stated as a test: per-item
+    failures return, enumeration failures raise."""
+    results = manager.migrate_certificates(
+        _Source(domains=['x.example.com']), _Target(refuse={'x.example.com'}))
+
+    assert results == {'x.example.com': False}
+
+
+def test_the_manager_used_here_is_the_real_one():
+    """CONTROL for the whole file: MagicMock would let every assertion above
+    pass without the code under test existing."""
+    assert not isinstance(StorageManager.migrate_certificates, MagicMock)
+    assert StorageManager.migrate_certificates.__doc__

--- a/tests/test_the_certbot_answer_does_not_outlive_its_evidence.py
+++ b/tests/test_the_certbot_answer_does_not_outlive_its_evidence.py
@@ -1,0 +1,191 @@
+"""Readiness re-checks certbot instead of freezing the answer it got at boot.
+
+`probe` ran `certbot --version` once per process and recorded the result; every
+later caller got that recording, for the life of the process. Both directions
+of that are wrong, and both are quiet:
+
+* a transient failure at startup — a filesystem still settling, a fork refused
+  under memory pressure — records FAILED, and /health/ready then returns 503
+  "until this is fixed", which for a running container means until somebody
+  restarts it. Under an orchestrator that is a restart loop rolling the same
+  dice on every attempt;
+* a certbot that breaks AFTER startup — a volume remounted, a dependency
+  changed inside the container, a venv half-upgraded — never turns readiness
+  red. The renewal sweep will fail per domain and publish certificate_failed,
+  so it is not invisible; but the endpoint an orchestrator uses to decide
+  whether to send traffic goes on saying yes while nothing can be issued.
+
+The answer now has a TTL. That is what makes re-checking affordable: readiness
+is scraped every few seconds and running certbot that often would be its own
+problem, so at most one probe per TTL and the recorded answer in between.
+"""
+import pytest
+
+from modules.core import issuance_readiness
+
+pytestmark = [pytest.mark.unit]
+
+
+class _Certbot:
+    """A shell executor standing in for certbot, whose answer the test moves."""
+
+    produces_artifacts = True
+
+    def __init__(self, working=True):
+        self.working = working
+        self.runs = 0
+
+    def run(self, cmd, timeout=None):
+        self.runs += 1
+
+        class _Result:
+            def __init__(self, ok):
+                self.returncode = 0 if ok else 1
+                self.stdout = 'certbot 2.10.0' if ok else ''
+                self.stderr = '' if ok else 'ImportError: cannot import X509Req'
+        return _Result(self.working)
+
+
+@pytest.fixture(autouse=True)
+def clean_module_state():
+    issuance_readiness.reset()
+    yield
+    issuance_readiness.reset()
+
+
+# --- THE regression, both directions -------------------------------------
+
+def test_a_transient_failure_at_startup_does_not_last_forever(monkeypatch):
+    """The instance came up while certbot could not run, and then it could."""
+    monkeypatch.setenv('CERTMATE_CERTBOT_PROBE_TTL', '30')
+    certbot = _Certbot(working=False)
+
+    first = issuance_readiness.probe(certbot)
+    assert first['state'] == issuance_readiness.FAILED
+    assert not issuance_readiness.is_ready(first)
+
+    certbot.working = True
+    _expire(monkeypatch)
+
+    second = issuance_readiness.probe(certbot)
+    assert second['state'] == issuance_readiness.OK
+    assert issuance_readiness.is_ready(second)
+
+
+def test_a_certbot_that_breaks_after_startup_stops_being_ready(monkeypatch):
+    """The direction that matters more: readiness said yes for the life of the
+    process while nothing could be issued."""
+    monkeypatch.setenv('CERTMATE_CERTBOT_PROBE_TTL', '30')
+    certbot = _Certbot(working=True)
+
+    assert issuance_readiness.probe(certbot)['state'] == issuance_readiness.OK
+
+    certbot.working = False
+    _expire(monkeypatch)
+
+    after = issuance_readiness.probe(certbot)
+    assert after['state'] == issuance_readiness.FAILED
+    assert not issuance_readiness.is_ready(after)
+    assert 'X509Req' in after['error']
+
+
+def _expire(monkeypatch):
+    """Move the clock past the TTL rather than sleeping through it."""
+    import time as _time
+    now = _time.monotonic()
+    monkeypatch.setattr(issuance_readiness.time, 'monotonic',
+                        lambda: now + issuance_readiness.probe_ttl_seconds() + 1)
+
+
+# --- the TTL is what keeps re-checking affordable ------------------------
+
+def test_repeated_calls_inside_the_ttl_run_certbot_once():
+    """CONTROL. A readiness probe every few seconds must not mean certbot every
+    few seconds — that would be a worse problem than the one being fixed."""
+    certbot = _Certbot()
+
+    for _ in range(20):
+        issuance_readiness.probe(certbot)
+
+    assert certbot.runs == 1
+
+
+def test_force_still_bypasses_the_ttl():
+    certbot = _Certbot()
+    issuance_readiness.probe(certbot)
+
+    issuance_readiness.probe(certbot, force=True)
+
+    assert certbot.runs == 2
+
+
+@pytest.mark.parametrize('value,expected', [
+    ('600', 600.0),
+    ('1', 30.0),          # clamped up: "probe on every scrape" is not a setting
+    ('99999', 3600.0),    # clamped down: "never re-probe" is the old defect
+    ('not-a-number', 300.0),
+    ('', 300.0),
+])
+def test_the_ttl_is_clamped_not_obeyed(monkeypatch, value, expected):
+    monkeypatch.setenv('CERTMATE_CERTBOT_PROBE_TTL', value)
+
+    assert issuance_readiness.probe_ttl_seconds() == expected
+
+
+def test_two_threads_arriving_together_probe_once():
+    """CONTROL for the lock: an expired answer and a burst of scrapes should
+    run certbot once between them."""
+    import threading
+
+    certbot = _Certbot()
+    start = threading.Barrier(8)
+
+    def scrape():
+        start.wait(timeout=5)
+        issuance_readiness.probe(certbot)
+
+    threads = [threading.Thread(target=scrape) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert certbot.runs == 1
+
+
+# --- what the endpoints read ---------------------------------------------
+
+def test_a_probe_that_did_not_run_is_not_a_failure():
+    """CONTROL, unchanged behaviour: `skipped` and `unknown` are absence of
+    evidence. Reporting them as failure would flip every test app and every
+    startup window out of rotation."""
+    class _Mock:
+        produces_artifacts = False
+
+        def run(self, *args, **kwargs):  # pragma: no cover - never called
+            raise AssertionError('a mock executor must not be probed')
+
+    status = issuance_readiness.probe(_Mock())
+
+    assert status['state'] == issuance_readiness.SKIPPED
+    assert issuance_readiness.is_ready(status)
+    assert issuance_readiness.is_ready({'state': issuance_readiness.UNKNOWN})
+
+
+def test_the_routes_ask_for_a_current_answer():
+    """Both /health and /health/ready used to read managers['issuance_status'],
+    the dict written once at startup — so a TTL inside the probe would have
+    changed nothing for the endpoint an orchestrator actually calls."""
+    import inspect
+
+    from modules.web import misc_routes
+
+    source = inspect.getsource(misc_routes.register_misc_routes)
+    assert source.count('_current_issuance_status(managers)') >= 2, (
+        'the health and readiness routes are not both asking for a current '
+        'answer')
+    helper = source[source.index('def _current_issuance_status'):]
+    assert 'issuance_readiness.probe(' in helper
+    assert "managers['issuance_status'] = status" in helper, (
+        'the refreshed answer is not written back, so anything else reading '
+        'that key still sees the startup snapshot')


### PR DESCRIPTION
The last two findings from the audit of v2.30.0. Different subsystems, one shape: an answer that stayed after the evidence for it was gone.

---

## 1. A migration that could not read the source reported a migration of zero

`migrate_certificates` wrapped its whole body in `except Exception: log` and returned the per-domain results it had accumulated. Everything inside that body which can fail *per certificate* already records `False` for that certificate — so the only thing reaching the outer handler is the **enumeration of the source**: an expired Vault token, a role without `ListBucket`, an unreachable endpoint. It returned `{}`.

The route then computed `successful = 0`, `total = 0`:

```
HTTP 200  {"success": true, "message": "Migration completed: 0/0 certificates migrated"}
```

plus an audit record stamped `status='success'`. An operator moving off a backend **before decommissioning it** was told the move had worked.

"Enumerated nothing" and "could not enumerate" cannot share a return value, so the enumeration failure is raised. The route already had the other arm — 500, a failure message, a failure audit record — and now reaches it; `test_audit_hardening.py` already exercises that arm with a manager that raises.

The controls are the point: a source that genuinely holds **no** certificates still returns `{}` and still succeeds, and a per-certificate failure (a store that refuses, a retrieve that raises) is still `False` for that certificate while the rest of the run continues. Only the enumeration is fatal, because only the enumeration means the result set itself is unknown.

---

## 2. The certbot readiness answer was frozen at boot

The probe ran `certbot --version` once per process and kept that result for the life of the process. Wrong in both directions, quietly:

- a **transient** failure at startup records `FAILED`, and `/health/ready` then answers 503 *"until this is fixed"* — which for a running container means until somebody restarts it. Under an orchestrator that is a restart loop rolling the same dice each time;
- a certbot that breaks **after** startup (a volume remounted, a dependency changed inside the container) never turned readiness red, so the endpoint used to decide rotation went on saying yes while nothing could be issued.

The answer now has a TTL — `CERTMATE_CERTBOT_PROBE_TTL`, default 300, clamped 30–3600. The TTL is what makes re-checking affordable: readiness is scraped every few seconds, so at most one probe per TTL with the recorded answer in between. A lock around the refresh means a burst of scrapes on an expired answer runs certbot **once between them** rather than once each.

Half the defect was in the routes, and a TTL alone would not have touched it: `/health` and `/health/ready` both read `managers['issuance_status']`, the dict written once at startup. They now ask for a current answer, and the refreshed one is written back to that key so nothing else keeps reading the snapshot.

Unchanged: `skipped` and `unknown` are absence of evidence, not evidence, and still count as ready.

---

## Verification

- `tests/test_a_migration_that_enumerated_nothing_is_not_a_success.py` — 7 tests; 2 fail against the parent commit (the rest are the controls, which must keep passing).
- `tests/test_the_certbot_answer_does_not_outlive_its_evidence.py` — 12 tests; 9 fail against the parent commit. Includes both directions of the staleness, the TTL clamp table, a `threading.Barrier` control proving eight simultaneous scrapes run certbot once, and a test that the **routes** ask for a current answer — because fixing only the module would have left the endpoint reading the snapshot.
- Full unit suite: **4559 passed, 31 skipped**. `flake8` with the gate's own selection (including `F401,F841,E722`): clean.
- `CERTMATE_CERTBOT_PROBE_TTL` is in the README environment table; the repository's gate refuses otherwise.

Found by the 20-category audit of v2.30.0 (`CERTMA-ERR-01`, `CERTMA-REL-01`) — the last two open items from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)