### PR TITLE
feat: the renewal sweep takes on a certificate that can say how it was issued

### DIFF
--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -31,8 +31,8 @@ from cryptography import x509
 from .shell import ShellExecutor
 from .dns_strategies import DNSStrategyFactory, HTTP01Strategy, acme_webroot_dir, check_certbot_plugin_installed
 from .constants import (METADATA_SCHEMA_VERSION, CERTIFICATE_FILES,
-                        DEFAULT_RENEWAL_THRESHOLD_DAYS,
-                        iter_cert_domain_dirs)
+                        DEFAULT_RENEWAL_THRESHOLD_DAYS)
+from .inventory_sources import collect_domain_sources
 from .structured_logging import LogContext, new_correlation_id
 from .csr_issuance import (
     CSR_OUTPUT_DIRNAME, CSR_OUTPUT_FILES, CSRError, csr_domains,
@@ -3470,7 +3470,7 @@ class CertificateManager:
             # sweep "did not consider" when it considered none would be noise.
             return {'checked': 0, 'renewed': 0, 'failed': 0,
                     'skipped_disabled': 0, 'skipped_invalid': 0,
-                    'skipped_not_due': 0, 'unmanaged': 0,
+                    'skipped_not_due': 0, 'unmanaged': 0, 'reregistered': 0,
                     'auto_renew_disabled': True}
 
         # Migrate settings format if needed
@@ -3481,7 +3481,7 @@ class CertificateManager:
 
         summary = {'checked': 0, 'renewed': 0, 'failed': 0,
                    'skipped_disabled': 0, 'skipped_invalid': 0,
-                   'skipped_not_due': 0, 'unmanaged': 0}
+                   'skipped_not_due': 0, 'unmanaged': 0, 'reregistered': 0}
         # Every domain this sweep took a decision about, so the reconciliation
         # below can name the certificates it never reached. Collected rather
         # than re-derived from `domains`, because a malformed entry is skipped
@@ -3540,42 +3540,7 @@ class CertificateManager:
                     # the work it describes.
                     self._mark_sweep_progress(
                         summary['checked'], len(domains), started)
-                cert_info = self.get_certificate_info(domain, settings=settings, use_cache=False)
-
-                if cert_info and cert_info.get('needs_renewal'):
-                    logger.info(f"Renewing certificate for {domain}")
-                    renew_started = time.time()
-                    try:
-                        res = self.renew_certificate(domain)
-                        # certbot can report "not yet due" (renewed=False) when
-                        # the configured threshold is wider than certbot's own
-                        # window. That is NOT a real renewal — don't count it,
-                        # audit it, or fire deploy hooks; it retries next run.
-                        if isinstance(res, dict) and res.get('renewed') is False:
-                            summary['skipped_not_due'] += 1
-                            logger.info(f"{domain} not yet due for renewal per certbot; will retry next run")
-                        else:
-                            summary['renewed'] += 1
-                            logger.info(f"Successfully renewed certificate for {domain}")
-                            self._record_renewal_metrics(
-                                domain, cert_info, True,
-                                time.time() - renew_started)
-                            self._audit_scheduled_renew(domain, 'success')
-                            # Fire deploy hooks for background renewals too (#329):
-                            # the manual path publishes this via the executor, the
-                            # scheduler must publish it itself.
-                            self._publish_renewed_event(domain)
-                    except Exception as e:
-                        summary['failed'] += 1
-                        logger.error(f"Failed to renew certificate for {domain}: {e}")
-                        self._record_renewal_metrics(
-                            domain, cert_info, False,
-                            time.time() - renew_started, error=e)
-                        self._audit_scheduled_renew(domain, 'failure', error=e)
-                        # Notify (#417): without this the operator's configured
-                        # email/Slack channels stay silent while the cert
-                        # marches to expiry.
-                        self._publish_failed_event(domain, e)
+                self._renew_if_due(domain, settings, summary)
 
             except Exception as e:
                 summary['failed'] += 1
@@ -3593,27 +3558,27 @@ class CertificateManager:
                 summary['skipped_invalid'],
                 'y' if summary['skipped_invalid'] == 1 else 'ies',
             )
-        # A certificate in CertMate's own store that no settings entry names is
-        # invisible to this loop, which iterates settings and nothing else. It
-        # is NOT invisible to the rest of the application: `digest.py` takes
-        # the union of settings and the certificate directories, and
-        # `get_certificate_info` reads the disk — so the dashboard shows it,
-        # the digest reports it expiring, and the sweep that is supposed to
-        # renew it never mentions it. That disagreement is what made #759 look
-        # like a threshold bug: the log had no line for the domain at all,
-        # because the sweep never reached it.
+        # A certificate in CertMate's own store that no settings entry names
+        # was invisible to the loop above, which iterates settings and nothing
+        # else. It was never invisible to the rest of the application: the
+        # listing, discovery and the digest all take the union of settings and
+        # the certificate directories, so the dashboard showed it, the digest
+        # reported it expiring, and the sweep that is supposed to renew it
+        # never mentioned it. That disagreement is what made #759 read as a
+        # threshold bug — the log had no line for the domain at all.
         #
-        # It is reported, not adopted. Renewing a certificate the operator
-        # never registered would issue against a CA for a domain CertMate was
-        # not asked to manage, and the sweep is not the place to make that
-        # decision. Saying so out loud is.
-        for orphan in self._certificates_absent_from_settings(considered):
-            summary['unmanaged'] += 1
-            logger.warning(
-                "Certificate %r exists on disk but no settings entry names it, "
-                "so this renewal sweep did not consider it and it will not "
-                "renew. Re-register it with the 'Add Domain' flow or "
-                "POST /api/settings.", orphan)
+        # #789 made the sweep report them. #792 decided what to do with them,
+        # and the answer is here: renew the ones that can say how they were
+        # issued, report the rest.
+        #
+        # The union comes from collect_domain_sources, the one implementation
+        # of "which certificates exist" (#670), so the sweep now answers that
+        # question the same way the other three components do. The loop above
+        # still walks settings directly, deliberately: it is what counts a
+        # malformed entry as skipped_invalid, and the union silently drops
+        # those — a typo must not become an absence.
+        for domain in self._unregistered_on_disk(settings, considered):
+            self._sweep_unregistered(domain, settings, summary)
 
         duration = time.time() - started
         summary['duration_seconds'] = round(duration, 2)
@@ -3623,29 +3588,190 @@ class CertificateManager:
         self._mark_sweep_finished(summary, duration)
         logger.info(
             "Renewal check complete in %.1fs: %d checked, %d renewed, "
-            "%d failed, %d disabled, %d invalid, %d not-due, %d unmanaged",
+            "%d failed, %d disabled, %d invalid, %d not-due, %d unmanaged, "
+            "%d re-registered",
             duration,
             summary['checked'], summary['renewed'], summary['failed'],
             summary['skipped_disabled'], summary['skipped_invalid'],
             summary['skipped_not_due'], summary['unmanaged'],
+            summary['reregistered'],
         )
         return summary
 
-    def _certificates_absent_from_settings(self, considered):
-        """Certificate directories no settings entry named, sorted.
+    def _renew_if_due(self, domain, settings, summary):
+        """Renew one certificate if it is due, and account for the outcome.
+
+        Extracted so the registered path and the disk-only path cannot drift:
+        they are the same work, and this codebase's own history is a list of
+        two copies of one operation growing apart (create/renew, #423, #666).
+        Everything a renewal owes the operator happens here — the counters, the
+        duration metric, the attributed audit record, and the events that reach
+        their notification channels — so a caller cannot get half of it.
+
+        Returns True when a certificate was actually renewed, which is the
+        signal the disk-only path needs before it writes anything back to
+        settings. `skipped_not_due` is not that: certbot said no.
+        """
+        cert_info = self.get_certificate_info(domain, settings=settings, use_cache=False)
+        if not (cert_info and cert_info.get('needs_renewal')):
+            return False
+
+        logger.info(f"Renewing certificate for {domain}")
+        renew_started = time.time()
+        try:
+            res = self.renew_certificate(domain)
+            # certbot can report "not yet due" (renewed=False) when the
+            # configured threshold is wider than certbot's own window. That is
+            # NOT a real renewal — don't count it, audit it, or fire deploy
+            # hooks; it retries next run.
+            if isinstance(res, dict) and res.get('renewed') is False:
+                summary['skipped_not_due'] += 1
+                logger.info(f"{domain} not yet due for renewal per certbot; will retry next run")
+                return False
+            summary['renewed'] += 1
+            logger.info(f"Successfully renewed certificate for {domain}")
+            self._record_renewal_metrics(
+                domain, cert_info, True, time.time() - renew_started)
+            self._audit_scheduled_renew(domain, 'success')
+            # Fire deploy hooks for background renewals too (#329): the manual
+            # path publishes this via the executor, the scheduler must publish
+            # it itself.
+            self._publish_renewed_event(domain)
+            return True
+        except Exception as e:
+            summary['failed'] += 1
+            logger.error(f"Failed to renew certificate for {domain}: {e}")
+            self._record_renewal_metrics(
+                domain, cert_info, False, time.time() - renew_started, error=e)
+            self._audit_scheduled_renew(domain, 'failure', error=e)
+            # Notify (#417): without this the operator's configured email/Slack
+            # channels stay silent while the cert marches to expiry.
+            self._publish_failed_event(domain, e)
+            return False
+
+    def _sweep_unregistered(self, domain, settings, summary):
+        """A certificate on disk that no settings entry names (#792).
+
+        Renewed when it can say how it was issued and that answer still holds;
+        reported otherwise. The guard is not a second copy of the renewal
+        path's requirements — it asks the same resolver the renewal will ask,
+        so the two cannot disagree about what "renewable" means.
+
+        On success the domain is written back to settings. Without that the
+        warning below returns every night for the life of the certificate, and
+        a warning that repeats forever is one an operator learns to scroll
+        past — which is how #759 stayed invisible long enough to be reported
+        as something else. After this, the warning only ever names
+        certificates the sweep genuinely could not take on.
+        """
+        renewable, reason = self._unregistered_is_renewable(domain, settings)
+        if not renewable:
+            summary['unmanaged'] += 1
+            logger.warning(
+                "Certificate %r exists on disk but no settings entry names it, "
+                "and it cannot be renewed on its own: %s. Re-register it with "
+                "the 'Add Domain' flow or POST /api/settings.", domain, reason)
+            return
+
+        logger.info(
+            "Certificate %r exists on disk with no settings entry; its "
+            "metadata names how it was issued, so this sweep takes it on.",
+            domain)
+        summary['checked'] += 1
+        if self._renew_if_due(domain, settings, summary):
+            self._reregister_domain(domain, summary)
+
+    def _unregistered_is_renewable(self, domain, settings):
+        """Can a disk-only certificate be renewed from what it carries?
+
+        Returns ``(True, None)`` or ``(False, reason)`` — the reason goes in
+        front of an operator, so it names the missing thing rather than saying
+        no.
+        """
+        metadata = self._load_metadata(domain)
+        if not metadata:
+            return False, 'it has no readable metadata.json'
+
+        challenge_type = metadata.get('challenge_type', 'dns-01')
+        if challenge_type == 'http-01':
+            # No per-domain credential to check: the webroot is instance-level
+            # and the renewal needs nothing this instance does not already have.
+            return True, None
+
+        dns_provider = metadata.get('dns_provider')
+        if not dns_provider:
+            return False, 'its metadata.json does not name a DNS provider'
+
+        # The same call renew_certificate makes. Asking it here means the
+        # guard cannot drift from the requirement it is guarding.
+        try:
+            dns_config, _ = self.dns_manager.get_dns_provider_account_config(
+                dns_provider, metadata.get('account_id'), settings)
+        except Exception as e:                       # pragma: no cover - defensive
+            return False, f'its DNS provider {dns_provider!r} could not be resolved ({e})'
+        if not dns_config:
+            account = metadata.get('account_id') or 'default'
+            return False, (f'its DNS provider {dns_provider!r} (account '
+                           f'{account!r}) is not configured on this instance')
+        return True, None
+
+    def _reregister_domain(self, domain, summary):
+        """Put a renewed disk-only certificate back in settings.
+
+        Through the mutator form, on the fresh on-disk list, so a registration
+        or deletion that landed while the sweep was running is not lost — the
+        lesson `set_auto_renew` records. Never raises: the certificate has
+        already been renewed, and losing the bookkeeping again is a smaller
+        failure than reporting a successful renewal as a failed one.
+        """
+        def _add(stored):
+            self.settings_manager.migrate_domains_format(stored)
+            entries = stored.get('domains', [])
+            for entry in entries:
+                if isinstance(entry, dict) and entry.get('domain') == domain:
+                    return
+            metadata = self._load_metadata(domain) or {}
+            entry = {'domain': domain, 'auto_renew': True}
+            for key in ('dns_provider', 'account_id', 'ca_provider'):
+                if metadata.get(key):
+                    entry[key] = metadata[key]
+            stored['domains'] = entries + [entry]
+
+        try:
+            self.settings_manager.update(_add, reason='sweep_reregistered')
+        except Exception as e:
+            logger.error(
+                "Renewed %r but could not re-register it in settings (%s); it "
+                "will be taken on again next sweep", domain, e)
+            return
+        summary['reregistered'] = summary.get('reregistered', 0) + 1
+        self._audit_scheduled_renew(domain, 'success')
+        logger.warning(
+            "Certificate %r was renewed and re-registered in settings: it was "
+            "on disk with no entry naming it, and its metadata said how it had "
+            "been issued.", domain)
+
+    def _unregistered_on_disk(self, settings, considered):
+        """Certificates on disk that no settings entry names, sorted.
+
+        The union comes from `collect_domain_sources`, the one implementation
+        of "which certificates exist" (#670) — the same answer the listing, the
+        digest and discovery use, which is the point of #792.
 
         Read-only and failure-tolerant: an unreadable certificate directory
-        must not turn a completed renewal sweep into a failed one. Losing the
-        warning is bad; losing the sweep that renews everything else is worse.
+        must not turn a completed renewal sweep into a failed one. Losing this
+        reconciliation is bad; losing the sweep that renewed everything else,
+        after it has already done the work, is worse.
         """
         try:
-            on_disk = {path.name for path in iter_cert_domain_dirs(self.cert_dir)}
+            sources = collect_domain_sources(settings, self.cert_dir)
         except OSError as e:
             logger.warning(
                 "Could not enumerate certificate directories to check for "
                 "unmanaged certificates: %s", e)
             return []
-        return sorted(on_disk - set(considered))
+        return [source.domain for source in sources.values()
+                if source.only_on_disk and source.domain not in considered]
 
     # ------------------------------------------------------------------
     # Renewal sweep progress

--- a/tests/test_check_renewals_summary.py
+++ b/tests/test_check_renewals_summary.py
@@ -62,6 +62,10 @@ def test_summary_counts_every_kind_of_entry(tmp_path):
         # A certificate present on disk that no entry names is counted here and
         # named in the log (#759); it used to be skipped in silence.
         'unmanaged': 0,
+        # Same reason: since #792 the sweep renews a disk-only certificate
+        # whose metadata says how it was issued, and writes it back into
+        # settings. Nothing on disk here, so nothing to take on.
+        'reregistered': 0,
     }
     # The sweep also reports its own shape now — how long it took and how many
     # entries it looked at — so an instance that is slowly outgrowing its

--- a/tests/test_the_sweep_names_what_it_cannot_renew.py
+++ b/tests/test_the_sweep_names_what_it_cannot_renew.py
@@ -21,10 +21,26 @@ A certificate present on disk and absent from settings is therefore visible
 everywhere except in the one component whose job is to renew it — and that
 component said nothing, which is why the report reads as a threshold bug.
 
-The sweep now names every such certificate and counts it in `unmanaged`. It
-does **not** adopt it: renewing a certificate the operator never registered
-would issue against a CA for a domain CertMate was not asked to manage, and a
-background sweep is not where that decision belongs.
+#789 made the sweep name every such certificate and count it in `unmanaged`,
+and stopped there: whether to renew them was a product decision about issuing
+certificates, recorded as #792 rather than taken in a bug fix.
+
+#792 took it. The sweep now asks `collect_domain_sources` — the one
+implementation of "which certificates exist" — and for a certificate on disk
+that no settings entry names it **renews the ones that can say how they were
+issued**, then writes them back into settings. "Can say how" is not a second
+copy of the renewal path's requirements: the guard calls the same resolver the
+renewal will call, so the two cannot disagree.
+
+Everything else is still reported and not renewed — no metadata, no DNS
+provider named in it, or a provider that is no longer configured on this
+instance. That is the previous behaviour, kept as the fallback rather than
+replaced.
+
+The re-registration is not tidiness. Without it the warning returns every night
+for the life of the certificate, and a warning that repeats forever is one an
+operator learns to scroll past — which is how #759 stayed invisible long enough
+to be reported as a threshold bug.
 """
 import json
 import logging
@@ -269,7 +285,10 @@ def test_an_unreadable_certificate_directory_does_not_fail_the_sweep(
     def _explode(_):
         raise OSError('permission denied')
 
-    monkeypatch.setattr('modules.core.certificates.iter_cert_domain_dirs',
+    # Patched where the read now happens: the sweep asks
+    # collect_domain_sources (#792), which owns the directory walk. Patching
+    # the old symbol would leave this test green while injecting nothing.
+    monkeypatch.setattr('modules.core.inventory_sources.iter_cert_domain_dirs',
                         _explode)
 
     with caplog.at_level(logging.WARNING, logger=LOGGER):
@@ -305,3 +324,181 @@ def test_the_completion_line_reports_the_count(instance, caplog):
                   if 'Renewal check complete' in record.getMessage()]
     assert completion, 'the sweep no longer logs a completion line'
     assert '1 unmanaged' in completion[0]
+
+
+# --- #792: the ones that can say how they were issued --------------------
+
+def _renewable(instance, config=None):
+    """Make the instance's DNS resolver answer the way a configured provider
+    does — a (config, account_id) pair rather than a MagicMock, which is what
+    the guard and the renewal both unpack."""
+    instance.dns_manager.get_dns_provider_account_config.return_value = (
+        config if config is not None else {'api_token': 'x'}, 'default')
+
+
+def _renewal_returns(instance, result):
+    calls = []
+
+    def _renew(domain):
+        calls.append(domain)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    instance.renew_certificate = _renew
+    return calls
+
+
+def test_a_disk_only_certificate_that_knows_its_provider_is_renewed(instance):
+    """THE change. On disk, absent from settings, metadata names a provider
+    that is configured: the sweep takes it on instead of only naming it."""
+    instance.put_on_disk('orphan.example.com')
+    instance.register()
+    _renewable(instance)
+    renewed = _renewal_returns(instance, {'success': True})
+
+    summary = instance.check_renewals()
+
+    assert renewed == ['orphan.example.com']
+    assert summary['renewed'] == 1
+    assert summary['unmanaged'] == 0
+    assert summary['checked'] == 1
+
+
+def test_a_renewed_disk_only_certificate_is_written_back_to_settings(instance):
+    """The convergence. Next sweep it is an ordinary registered certificate,
+    and the warning stops."""
+    instance.put_on_disk('orphan.example.com')
+    instance.register()
+    _renewable(instance)
+    _renewal_returns(instance, {'success': True})
+
+    summary = instance.check_renewals()
+
+    assert summary['reregistered'] == 1
+    entries = instance.settings_manager.load_settings()['domains']
+    entry = next(e for e in entries if e.get('domain') == 'orphan.example.com')
+    assert entry['auto_renew'] is True
+    assert entry['dns_provider'] == 'cloudflare'
+    assert entry['ca_provider'] == 'private_ca'
+
+
+def test_the_second_sweep_treats_it_as_an_ordinary_certificate(instance, caplog):
+    """The point of writing it back, as behaviour rather than as a field."""
+    instance.put_on_disk('orphan.example.com')
+    instance.register()
+    _renewable(instance)
+    _renewal_returns(instance, {'success': True})
+    instance.check_renewals()
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        second = instance.check_renewals()
+
+    assert second['unmanaged'] == 0
+    assert second['reregistered'] == 0
+    assert _reported(caplog) == set(), 'the warning came back for a certificate it took on'
+
+
+# --- the fallbacks, which are the old behaviour kept ---------------------
+
+def test_a_certificate_with_no_metadata_is_reported_not_renewed(instance, caplog):
+    """CONTROL. Nothing to go on: this is the case the decision deliberately
+    refuses, and it must stay refused."""
+    instance.put_on_disk('orphan.example.com')
+    (instance.cert_dir / 'orphan.example.com' / 'metadata.json').unlink()
+    instance.register()
+    _renewable(instance)
+    renewed = _renewal_returns(instance, {'success': True})
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        summary = instance.check_renewals()
+
+    assert renewed == []
+    assert summary['unmanaged'] == 1
+    assert summary['renewed'] == 0
+    assert _reported(caplog) == {'orphan.example.com'}
+
+
+def test_a_certificate_whose_provider_is_gone_is_reported_not_renewed(instance, caplog):
+    """CONTROL. The metadata names a provider this instance no longer has
+    credentials for — the renewal would fail, so the sweep does not start it,
+    and the message names the provider rather than saying no."""
+    instance.put_on_disk('orphan.example.com')
+    instance.register()
+    _renewable(instance, config={})          # resolver answers "not configured"
+    renewed = _renewal_returns(instance, {'success': True})
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        summary = instance.check_renewals()
+
+    assert renewed == []
+    assert summary['unmanaged'] == 1
+    message = '\n'.join(r.getMessage() for r in caplog.records)
+    assert 'cloudflare' in message
+
+
+def test_an_http01_certificate_needs_no_dns_credentials(instance):
+    """http-01 renews from the instance's own webroot, so a missing DNS
+    provider is not a reason to refuse it."""
+    instance.put_on_disk('orphan.example.com')
+    path = instance.cert_dir / 'orphan.example.com' / 'metadata.json'
+    path.write_text(json.dumps({'domain': 'orphan.example.com',
+                                'challenge_type': 'http-01'}))
+    instance.register()
+    instance.dns_manager.get_dns_provider_account_config.side_effect = AssertionError(
+        'http-01 must not need a DNS account')
+    renewed = _renewal_returns(instance, {'success': True})
+
+    summary = instance.check_renewals()
+
+    assert renewed == ['orphan.example.com']
+    assert summary['renewed'] == 1
+
+
+# --- the boundary: renewed is not the same as attempted ------------------
+
+def test_a_certbot_not_due_answer_does_not_re_register(instance):
+    """CONTROL. certbot said no, so nothing was renewed and nothing is written
+    back — the settings entry would claim a certificate this sweep manages
+    while the sweep has not managed anything yet."""
+    instance.put_on_disk('orphan.example.com')
+    instance.register()
+    _renewable(instance)
+    _renewal_returns(instance, {'renewed': False})
+
+    summary = instance.check_renewals()
+
+    assert summary['skipped_not_due'] == 1
+    assert summary['reregistered'] == 0
+    assert instance.settings_manager.load_settings()['domains'] == []
+
+
+def test_a_failed_renewal_does_not_re_register(instance):
+    """CONTROL, the other half: a renewal that raised leaves the bookkeeping
+    exactly as it was."""
+    instance.put_on_disk('orphan.example.com')
+    instance.register()
+    _renewable(instance)
+    _renewal_returns(instance, RuntimeError('certbot said no'))
+
+    summary = instance.check_renewals()
+
+    assert summary['failed'] == 1
+    assert summary['reregistered'] == 0
+    assert instance.settings_manager.load_settings()['domains'] == []
+
+
+def test_a_registered_certificate_still_goes_through_the_same_path(instance):
+    """CONTROL for the extraction: the registered path was refactored into the
+    shared unit, and it has to behave exactly as it did."""
+    instance.put_on_disk('registered.example.com')
+    instance.register({'domain': 'registered.example.com',
+                       'dns_provider': 'cloudflare'})
+    _renewable(instance)
+    renewed = _renewal_returns(instance, {'success': True})
+
+    summary = instance.check_renewals()
+
+    assert renewed == ['registered.example.com']
+    assert summary['checked'] == 1 and summary['renewed'] == 1
+    assert summary['unmanaged'] == 0 and summary['reregistered'] == 0


### PR DESCRIPTION
Implements the decision recorded in #792, which closes the second half of #759.

## The state before

`#789` made the sweep **report** a certificate that is on disk with no settings entry naming it — until then the log carried nothing at all for that domain, which is why #759 read as a threshold bug. It deliberately stopped there: whether to renew them is a decision about issuing certificates, not a bug fix.

Meanwhile three of the four components that answer *"which certificates exist"* used `collect_domain_sources`; the sweep was the outlier, walking `settings['domains']` alone.

## The decision, and why

Full reasoning in [#792](https://github.com/fabriziosalmi/certmate/issues/792#issuecomment-5598265725). The short form:

- The objection that carried the most weight — *a half-restored backup or an old volume snapshot would start requesting certificates on its own* — **does not distinguish the options**. `settings.json` lives on the same volume as the certificates and is in the same backup, so an instance brought up on an old snapshot already renews everything that snapshot registers. That scenario is two writers against one store, which the product addresses elsewhere (one replica enforced by the chart, one worker, a flock per job).
- *"A domain CertMate was not asked to manage"* describes a different situation than this one. A certificate under CertMate's own certificate directory, beside a `metadata.json` **CertMate wrote**, was issued by this instance. This is a lost bookkeeping entry, not a foreign domain.

## What it does

The sweep asks `collect_domain_sources`, so all four components now answer the question the same way. The loop over registered domains still walks settings directly, deliberately — it is what counts a malformed entry as `skipped_invalid`, and the union silently drops those. A typo must not become an absence.

A disk-only certificate is **renewed** when:

- its `metadata.json` names the DNS provider and account **and** that provider is configured on this instance now, or
- it is http-01, which needs no per-domain credential.

The guard is not a second copy of the renewal path's requirements: it calls **the same resolver the renewal calls**, so the two cannot disagree about what "renewable" means. Everything else is **reported exactly as before**: no metadata, no provider named in it, or a provider this instance no longer has. The old behaviour is the fallback, not the thing replaced.

On success the domain is written back to settings through the mutator form, on the fresh on-disk list, so a registration that landed mid-sweep is not lost. Without that the warning returns every night for the life of the certificate — and a warning that repeats forever is one an operator learns to scroll past, which is how #759 stayed invisible long enough to be reported as something else.

`summary['reregistered']` joins the sweep's counters and its completion log line.

## The extraction

The per-domain body is now `_renew_if_due`, and both paths go through it. Two copies of one operation growing apart is this codebase's own recurring defect — create/renew, #423 — and adding a second renewal site without a shared unit would have been the next instalment.

## Verification

- `tests/test_the_sweep_names_what_it_cannot_renew.py` grows to 19 tests. **9 fail against the parent commit**; the 10 that pass on both are the preserved behaviour, which is the point.
- The controls are half the file: certbot answering *not due* does not re-register (nothing was renewed), a failed renewal does not re-register, a certificate with no metadata is still only reported, a provider that is gone is reported **with the provider named**, and a registered certificate goes through the shared unit unchanged.
- A control caught a regression I introduced on the way: the reconciliation reads the certificate directories **after** the sweep has done its work, and reading them unguarded would have discarded a completed sweep on an unreadable directory. The guard moved with the read, and the test now injects the failure where the read actually happens.
- Full unit suite: **4574 passed, 31 skipped**. `flake8` gated selection clean; `--max-complexity=40` clean on the file.

Closes #792. #759 is already closed; this is its remaining half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)