### PR TITLE
fix: a credentials file that cannot be written says so

### DIFF
--- a/modules/core/utils.py
+++ b/modules/core/utils.py
@@ -806,8 +806,26 @@ def create_acme_dns_config(api_url: str, username: str, password: str, subdomain
     return _create_config_file("acme-dns", content)
 
 def create_multi_provider_config(provider: str, config_data: Dict[str, Any]) -> Optional[Path]:
-    """
-    Creates a certbot DNS plugin configuration file from a provider and data.
+    """Write the certbot plugin credentials file for a multi-provider plugin.
+
+    Returns the path, or None when this provider does not use one of these
+    files or its account is not configured. **None never means "the file could
+    not be written"**, and that distinction is the whole point of the narrow
+    catch below.
+
+    Previously the body ended with `except (KeyError, Exception): return None`
+    and no log line at all. `_create_config_file` opens the file with O_EXCL and
+    can raise OSError — a read-only config directory, a full disk — and for the
+    twelve providers that come through here that OSError was swallowed and
+    turned into the same None that means "route53 authenticates through the
+    environment". The caller then built a certbot command with
+    `--authenticator dns-hetzner` and no `--dns-hetzner-credentials`, certbot
+    failed complaining about missing plugin credentials, and the real error
+    existed nowhere. cloudflare and route53 never had the problem: their
+    builders let the OSError propagate, which is what this now does.
+
+    The `(KeyError, Exception)` tuple showed the intent — catch the template
+    lookup — so that is what is caught.
     """
     if provider not in _MULTI_PROVIDER_PLUGIN_FILES:
         return None
@@ -822,10 +840,19 @@ def create_multi_provider_config(provider: str, config_data: Dict[str, Any]) -> 
         for ini_key, source in template.items():
             value = config_data.get(*source) if isinstance(source, tuple) else config_data[source]
             config_lines.append(f"{ini_key} = {value}")
-
-        return _create_config_file(provider, "\n".join(config_lines) + "\n")
-    except (KeyError, Exception):
+    except KeyError as e:
+        # A provider in _MULTI_PROVIDER_PLUGIN_FILES with no entry in the
+        # template map, or a template naming a credential field the validator
+        # above did not require. Both are bugs in this file rather than in the
+        # operator's configuration, so they are logged as such and the caller
+        # gets the same None it always did.
+        logger.error(
+            "No credentials template entry for DNS provider %r (%s); the "
+            "issuance will fail with certbot complaining about missing plugin "
+            "credentials", provider, e)
         return None
+
+    return _create_config_file(provider, "\n".join(config_lines) + "\n")
 
 
 # =============================================

--- a/tests/test_a_credentials_file_that_cannot_be_written_says_so.py
+++ b/tests/test_a_credentials_file_that_cannot_be_written_says_so.py
@@ -1,0 +1,178 @@
+"""None means "no credentials file needed", never "I could not write one".
+
+`create_multi_provider_config` builds the certbot plugin credentials file for
+the twelve providers that use one — vultr, hetzner, hetzner-cloud, porkbun,
+godaddy, he-ddns, dynudns, desec, scaleway, rfc2136, dnsmadeeasy, nsone. It
+ended with
+
+    except (KeyError, Exception):
+        return None
+
+and no log line anywhere in that arm.
+
+`_create_config_file` opens the file with O_EXCL and can raise OSError: a
+read-only config directory, a full disk, a permission the container lost. For
+cloudflare and route53 that OSError propagates and the operator sees it,
+because their builders have no such catch. For these twelve it was swallowed
+and turned into the same `None` that legitimately means "this provider
+authenticates through the environment" — the value `_build_issuance_command`
+reads as "add no --credentials flag".
+
+So the certbot command went out with `--authenticator dns-hetzner` and no
+`--dns-hetzner-credentials`, certbot failed complaining about missing plugin
+credentials, the operator went looking at their DNS account, and the OSError
+that actually happened existed in no log, no metric and no response.
+
+The `(KeyError, Exception)` tuple is the tell: someone meant to catch the
+template lookup. That is what is caught now; everything else propagates to a
+caller that already reports issuance failures with their cause.
+"""
+import errno
+import logging
+import stat
+
+import pytest
+
+from modules.core import utils
+
+pytestmark = [pytest.mark.unit]
+
+LOGGER = 'modules.core.utils'
+
+# One provider from the twelve, with a credential set the validator accepts.
+PROVIDER = 'hetzner'
+CONFIG = {'api_token': 'a-token-that-is-long-enough'}
+
+
+@pytest.fixture
+def in_tmp_cwd(tmp_path, monkeypatch):
+    """`_create_config_file` writes to a relative `letsencrypt/config`, so the
+    working directory is what decides where these land."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+# --- the ordinary path is untouched --------------------------------------
+
+def test_a_writable_directory_produces_the_file(in_tmp_cwd):
+    path = utils.create_multi_provider_config(PROVIDER, CONFIG)
+
+    assert path is not None and path.exists()
+    assert 'dns_hetzner_api_token = a-token-that-is-long-enough' in path.read_text()
+
+
+def test_the_file_is_owner_only(in_tmp_cwd):
+    """CONTROL: it holds a DNS provider's API token."""
+    path = utils.create_multi_provider_config(PROVIDER, CONFIG)
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+@pytest.mark.parametrize('provider,config', [
+    ('cloudflare', {'api_token': 'x'}),          # not a multi-provider plugin
+    ('route53', {'access_key_id': 'a', 'secret_access_key': 'b'}),
+])
+def test_a_provider_that_does_not_use_one_still_returns_none(in_tmp_cwd, provider, config):
+    """CONTROL. This None is the legitimate one — it means the plugin needs no
+    credentials file — and it must keep meaning that."""
+    assert utils.create_multi_provider_config(provider, config) is None
+
+
+def test_an_unconfigured_account_still_returns_none(in_tmp_cwd):
+    """CONTROL. The other legitimate None: nothing to write."""
+    assert utils.create_multi_provider_config(PROVIDER, {}) is None
+
+
+# --- THE regression ------------------------------------------------------
+
+def test_a_directory_that_cannot_be_written_raises_rather_than_returning_none(in_tmp_cwd):
+    """The whole point. An OSError here is not "no credentials needed"."""
+    config_dir = in_tmp_cwd / 'letsencrypt' / 'config'
+    config_dir.mkdir(parents=True)
+    config_dir.chmod(0o500)
+    try:
+        with pytest.raises(OSError) as caught:
+            utils.create_multi_provider_config(PROVIDER, CONFIG)
+    finally:
+        config_dir.chmod(0o700)
+
+    assert caught.value.errno in (errno.EACCES, errno.EPERM)
+
+
+def test_the_same_failure_already_propagated_for_cloudflare(in_tmp_cwd):
+    """The asymmetry that made this a defect rather than a style question: the
+    single-provider builders never swallowed it, so one operator saw the error
+    and another did not, for the same broken volume."""
+    config_dir = in_tmp_cwd / 'letsencrypt' / 'config'
+    config_dir.mkdir(parents=True)
+    config_dir.chmod(0o500)
+    try:
+        with pytest.raises(OSError):
+            utils.create_cloudflare_config('a-token')
+    finally:
+        config_dir.chmod(0o700)
+
+
+def test_a_template_gap_is_reported_and_still_returns_none(in_tmp_cwd, caplog, monkeypatch):
+    """The KeyError the tuple was really about: a provider listed as using a
+    credentials file with no template to build it from. That is a bug in this
+    file, not in the operator's configuration, so it is logged as one — and the
+    caller keeps the None it always got."""
+    monkeypatch.setitem(utils._MULTI_PROVIDER_PLUGIN_FILES, 'ghost', 'ghost.ini')
+    monkeypatch.setitem(utils._DNS_PROVIDER_CREDENTIALS, 'ghost', ['api_token'])
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER):
+        result = utils.create_multi_provider_config('ghost', {'api_token': 'x'})
+
+    assert result is None
+    assert any(record.args and record.args[0] == 'ghost'
+               for record in caplog.records if record.levelno == logging.ERROR), (
+        'the template gap was not reported with the provider as an argument')
+
+
+def test_nothing_is_left_behind_when_the_write_fails(in_tmp_cwd):
+    """CONTROL. A half-written credentials file in a directory certbot reads
+    would be worse than the error: the token is in it."""
+    config_dir = in_tmp_cwd / 'letsencrypt' / 'config'
+    config_dir.mkdir(parents=True)
+    config_dir.chmod(0o500)
+    try:
+        with pytest.raises(OSError):
+            utils.create_multi_provider_config(PROVIDER, CONFIG)
+    finally:
+        config_dir.chmod(0o700)
+
+    assert list(config_dir.iterdir()) == []
+
+
+# --- the shape the caller depends on -------------------------------------
+
+def test_the_twelve_providers_all_go_through_this_builder():
+    """A control against the fix drifting: if a provider leaves this map, the
+    reasoning above stops applying to it and somebody should notice here."""
+    assert set(utils._MULTI_PROVIDER_PLUGIN_FILES) == set(utils._MULTI_PROVIDER_TEMPLATE_MAP)
+    assert len(utils._MULTI_PROVIDER_PLUGIN_FILES) == 12
+
+
+def test_the_builder_no_longer_catches_everything():
+    """The source-level pin. The behavioural tests above cover the OSError
+    case; this is what fails if a broad catch comes back for a different
+    exception nobody thought about.
+
+    The docstring is stripped first: it quotes the old line on purpose, and an
+    assertion that reads the prose as code would fail on the explanation of the
+    very thing it is checking.
+    """
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(utils.create_multi_provider_config).lstrip())
+    function = tree.body[0]
+    if (isinstance(function.body[0], ast.Expr)
+            and isinstance(function.body[0].value, ast.Constant)):
+        function.body = function.body[1:]
+    code = ast.unparse(function)
+
+    assert 'except (KeyError, Exception)' not in code
+    assert 'except Exception' not in code
+    assert 'except KeyError' in code


### PR DESCRIPTION
The live instance named in #671, and the reason that issue is about a defect rather than a count.

## What it was

```python
    except (KeyError, Exception):
        return None
```

No log line in that arm. The tuple is the tell: someone meant to catch the template lookup.

`_create_config_file` opens the credentials file with `O_EXCL` and can raise `OSError` — a read-only config directory, a full disk, a permission the container lost. For **cloudflare and route53** that propagates and the operator sees it, because their builders have no such catch. For the **twelve** providers that come through this one (vultr, hetzner, hetzner-cloud, porkbun, godaddy, he-ddns, dynudns, desec, scaleway, rfc2136, dnsmadeeasy, nsone) it was swallowed and turned into the same `None` that legitimately means *"this plugin authenticates through the environment"* — which is exactly what `_build_issuance_command` reads as "add no `--credentials` flag".

So certbot ran with `--authenticator dns-hetzner` and **no** `--dns-hetzner-credentials`, failed complaining about missing plugin credentials, the operator went looking at their DNS account, and the `OSError` that actually happened existed in no log, no metric and no response. One broken volume, two different experiences depending on which provider you happen to use.

## What it is

`KeyError` alone is caught, logged with the provider as a log **argument**, and still returns `None` — a provider listed as using a credentials file with no template to build it from is a bug in this file, not in anyone's configuration. Everything else propagates to a caller that already reports issuance failures with their cause.

## Verification

`tests/test_a_credentials_file_that_cannot_be_written_says_so.py` — 11 tests, 4 fail against the parent commit.

- The failure is exercised with a **real unwritable directory**, not a patched `open`.
- Both legitimate `None`s are pinned so they keep meaning what they mean: a provider that uses no credentials file, and an account that is not configured.
- One test pins **cloudflare's** behaviour too, because the asymmetry is what made this a defect rather than a style question.
- A control asserts nothing half-written is left behind — the file holds a DNS provider's API token.
- The source-level pin parses the function and **strips its docstring** before looking for a broad catch: the docstring quotes the old line on purpose, and my first version of that test failed on its own explanation.

Full unit suite: **4576 passed, 31 skipped**. `flake8` gated selection clean.

Related to #671, which I have re-scoped to this instance — the counts in its title are stale (bare `except:` is 0 and gated, broad-with-`pass` is 0 and gated) and a named defect is worth more than a number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)