### PR TITLE
fix: the shutdown handles that had no caller are called

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ from modules.core.structured_logging import (
     DEFAULT_LOG_BACKUP_COUNT,
     DEFAULT_LOG_MAX_BYTES,
 )
-from modules.core.factory import create_app
+from modules.core.factory import create_app, stop_background_work
 
 # Configure structured JSON logging.
 # CERTMATE_LOG_FILE is opt-in (#431): the container logs to stdout, which is
@@ -85,26 +85,22 @@ if __name__ == '__main__':
         )
     except KeyboardInterrupt:
         print("\n🛑 Shutting down CertMate...")
-        if container.scheduler:
-            try:
-                container.scheduler.shutdown()
-                print("📅 Background scheduler stopped")
-            except Exception as e:
-                # Ctrl-C is already on its way out; a scheduler that will not
-                # stop cleanly must not turn that into a traceback. But it is
-                # worth one line, because "stopped" printing and "stopped"
-                # happening were previously indistinguishable (#671).
-                print(f"⚠️  Background scheduler did not stop cleanly: {e}")
-        # After the scheduler, not before: stopping it first means no new
-        # renewal can queue a deploy while the bus is draining.
-        event_bus = (container.managers or {}).get('events')
-        if event_bus is not None:
-            try:
-                undelivered = event_bus.stop()
-                print("📨 Event bus drained"
-                      if not undelivered
-                      else f"⚠️  {undelivered} queued dispatch(es) never ran — "
-                           f"see the log for which certificates they were for")
-            except Exception as e:
-                print(f"⚠️  Event bus did not stop cleanly: {e}")
+        # One ordered shutdown, shared with the atexit hook that covers
+        # gunicorn: scheduler, then issuance pool, then watchdog, then the
+        # event bus. Stopping the bus first would drain a queue the scheduler
+        # is still filling. Ctrl-C is already on its way out, so a component
+        # that will not stop cleanly is a line here, never a traceback (#671).
+        summary = stop_background_work(container)
+        if summary['scheduler'] == 'stopped':
+            print("📅 Background scheduler stopped")
+        elif summary['scheduler']:
+            print(f"⚠️  Background scheduler {summary['scheduler']}")
+        if summary['issuance']:
+            print(f"⚠️  {len(summary['issuance'])} issuance job(s) unfinished: "
+                  + ', '.join(f"{job['operation']} {job['domain']}"
+                              for job in summary['issuance']))
+        print("📨 Event bus drained"
+              if not summary['undelivered']
+              else f"⚠️  {summary['undelivered']} queued dispatch(es) never ran — "
+                   f"see the log for which certificates they were for")
         sys.exit(0)

--- a/modules/core/cert_jobs.py
+++ b/modules/core/cert_jobs.py
@@ -83,7 +83,16 @@ class IssuanceExecutor:
                 'error_code': None,
             }
             self._evict_locked()
-        self._pool.submit(self._run, job_id, kind, domain, fn)
+        try:
+            self._pool.submit(self._run, job_id, kind, domain, fn)
+        except RuntimeError as e:
+            # The pool is shut down, which now actually happens: nothing will
+            # ever run this job, so it must not be left at 'queued' for a
+            # poller to wait on forever.
+            logger.warning("Issuance job %s for %s rejected: %s", job_id, domain, e)
+            self._set(job_id, status='failed', finished_at=utc_now_iso(),
+                      error='shutting down', error_code='SHUTTING_DOWN')
+            raise
         return job_id
 
     def get(self, job_id):
@@ -176,4 +185,33 @@ class IssuanceExecutor:
         return None
 
     def shutdown(self, wait=False):
-        self._pool.shutdown(wait=wait)
+        """Stop the pool and name the issuance work that never finished.
+
+        Called when the process is going away. Queued jobs that no worker has
+        picked up are cancelled; jobs already running are not — a certbot
+        subprocess cannot be taken back, and waiting for one would hold
+        shutdown open until the container runtime killed it anyway.
+
+        What it does instead is say what was lost, in the same shape as
+        `EventBus.stop`: the registry is in memory and dies with the process,
+        so a job left at 'queued' or 'running' is a certificate an operator
+        asked for and will not get, and the only place that can be recorded is
+        the log line written on the way out.
+
+        Returns the abandoned job records, newest last.
+        """
+        self._pool.shutdown(wait=wait, cancel_futures=True)
+
+        with self._lock:
+            abandoned = [dict(job) for job in self._jobs.values()
+                         if job['status'] not in _TERMINAL]
+
+        if abandoned:
+            logger.warning(
+                "Issuance executor stopped with %d job(s) unfinished: %s. "
+                "These were not completed and are not retried on startup; "
+                "re-run them if the certificate is still needed.",
+                len(abandoned),
+                ', '.join(f"{job['operation']} {job['domain']} ({job['status']})"
+                          for job in abandoned))
+        return abandoned

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -60,6 +60,9 @@ class AppContainer:
         self.backup_dir = None
         self.logs_dir = None
         self.request_watchdog = None
+        # Set by stop_background_work so the atexit handler and app.py's
+        # Ctrl-C path do not both stop everything twice.
+        self.shutdown_complete = False
 
 
 def _env_float(name: str, default: float, min_value: float = 0.0) -> float:
@@ -1743,29 +1746,103 @@ def create_app(test_config=None):
     reconcile_served_copies(container)
     check_issuance_readiness(container)
     warn_if_multiple_workers()
-    _drain_event_bus_at_exit(container)
+    _stop_background_work_at_exit(container)
 
     return app, container
 
 
-def _drain_event_bus_at_exit(container: AppContainer):
-    """Give the event bus a bounded drain when the process goes away.
+def stop_background_work(container: AppContainer) -> dict:
+    """Stop everything this process started in the background, in order.
 
-    There is no shutdown hook to hang this on: the image runs gunicorn from a
-    plain command line, so there is no gunicorn config file with on_exit, and
-    app.py's KeyboardInterrupt handler only covers `python app.py`. atexit is
-    what both paths have in common — it runs when a gunicorn worker exits on
-    SIGTERM, and it does not run on SIGKILL, which is the correct behaviour for
-    a drain that must never delay a kill.
+    Four things run outside a request: the APScheduler that drives renewals,
+    the issuance thread pool behind the async API, the slow-request watchdog,
+    and the event bus that delivers deploy hooks. Three of them published a way
+    to be stopped and only one was ever called — `IssuanceExecutor.shutdown()`
+    had no caller anywhere, and the watchdog's `stop_event` was handed to the
+    container and never set. A stop handle nobody calls is not a safety net; it
+    reads like one in review, which is worse than not having it.
 
-    Registered here rather than in EventBus.__init__ so that constructing a bus
-    — which most of the test suite does — does not leave a handler behind
-    holding a reference to it.
+    Order is the point, not the calls. Producers first, consumers last: the
+    scheduler can queue a renewal, a renewal publishes an event, and an event
+    dispatches a deploy hook — so stopping the bus first would drain a queue
+    that is still being filled. The watchdog goes with them because it only
+    reports on requests, and by here there are none.
+
+    Bounded throughout. Nothing here waits for a certbot subprocess or a deploy
+    hook: the scheduler is asked not to wait, the pool cancels what no worker
+    has started, and the bus drains against a deadline. What could not be
+    finished is named in the log rather than waited for.
+
+    Idempotent: `python app.py` calls this on Ctrl-C and atexit calls it again
+    on the way out, and under gunicorn only atexit does.
     """
-    bus = container.managers.get('events') if container.managers else None
-    if bus is None:
-        return
-    atexit.register(bus.stop)
+    summary = {'scheduler': None, 'issuance': [], 'undelivered': 0}
+    if container.shutdown_complete:
+        return summary
+    container.shutdown_complete = True
+
+    if container.scheduler is not None:
+        if not getattr(container.scheduler, 'running', True):
+            # Never started, or already stopped. Not a fault, and saying so at
+            # WARNING on every clean exit is how a real warning gets ignored.
+            summary['scheduler'] = 'not running'
+        else:
+            try:
+                # wait=False: a renewal sweep runs for minutes, and holding
+                # exit open for it only means the container runtime kills us
+                # instead.
+                container.scheduler.shutdown(wait=False)
+                summary['scheduler'] = 'stopped'
+            except Exception as e:
+                # Refusing to stop. The process is going away and this must
+                # not become a traceback — but it is worth a line, because
+                # "stopped" happening and "stopped" being reported were
+                # previously indistinguishable.
+                summary['scheduler'] = f'not stopped cleanly: {e}'
+                logger.warning(f"Scheduler did not stop cleanly: {e}")
+
+    managers = container.managers or {}
+
+    executor = managers.get('cert_executor')
+    if executor is not None:
+        try:
+            summary['issuance'] = executor.shutdown() or []
+        except Exception as e:
+            logger.warning(f"Issuance executor did not stop cleanly: {e}")
+
+    watchdog = container.request_watchdog or {}
+    stop_event = watchdog.get('stop_event')
+    if stop_event is not None:
+        # It is a daemon thread, so this changes nothing about whether the
+        # process exits. It changes whether the thread is torn down in the
+        # middle of formatting another thread's stack.
+        stop_event.set()
+
+    bus = managers.get('events')
+    if bus is not None:
+        try:
+            summary['undelivered'] = bus.stop() or 0
+        except Exception as e:
+            logger.warning(f"Event bus did not stop cleanly: {e}")
+
+    return summary
+
+
+def _stop_background_work_at_exit(container: AppContainer):
+    """Register the shutdown above on the one hook both entry points have.
+
+    There is no shutdown hook to hang this on otherwise: the image runs
+    gunicorn from a plain command line, so there is no gunicorn config file
+    with on_exit, and app.py's KeyboardInterrupt handler only covers
+    `python app.py`. atexit runs when a gunicorn worker exits on SIGTERM, and
+    does not run on SIGKILL — which is the correct behaviour for work that
+    must never delay a kill.
+
+    Registered here rather than in each component's constructor so that
+    building one in a test does not leave a handler behind holding a reference
+    to it.
+    """
+    atexit.register(stop_background_work, container)
 
 
 def check_issuance_readiness(container: AppContainer):

--- a/tests/test_the_bus_says_what_it_could_not_deliver.py
+++ b/tests/test_the_bus_says_what_it_could_not_deliver.py
@@ -214,10 +214,13 @@ def test_the_application_registers_the_drain_at_exit():
 
     from modules.core import factory
 
-    source = inspect.getsource(factory._drain_event_bus_at_exit)
+    source = inspect.getsource(factory._stop_background_work_at_exit)
     assert 'atexit.register' in source
-    assert '.stop' in source
+
+    stopper = inspect.getsource(factory.stop_background_work)
+    assert 'bus.stop()' in stopper, (
+        'the shutdown path no longer drains the event bus')
 
     entrypoint = inspect.getsource(factory.create_app)
-    assert '_drain_event_bus_at_exit(container)' in entrypoint, (
+    assert '_stop_background_work_at_exit(container)' in entrypoint, (
         'the drain is defined but nothing calls it during app creation')

--- a/tests/test_the_shutdown_handles_are_called.py
+++ b/tests/test_the_shutdown_handles_are_called.py
@@ -71,7 +71,11 @@ def test_a_job_still_running_is_named_on_the_way_out(caplog):
 
     assert [job['domain'] for job in abandoned] == ['slow.example.com']
     assert abandoned[0]['status'] == 'running'
-    assert any('slow.example.com' in record.getMessage()
+    # Exact equality on the formatting argument rather than a substring search
+    # over the rendered message: this repository's CodeQL configuration reads
+    # `'a.example.com' in text` as an incomplete URL check, and it is right to
+    # in general.
+    assert any(record.args and record.args[1] == 'create slow.example.com (running)'
                for record in caplog.records), (
         'the abandoned job was returned but never logged, so nothing survives '
         'the process that says which certificate was not issued')

--- a/tests/test_the_shutdown_handles_are_called.py
+++ b/tests/test_the_shutdown_handles_are_called.py
@@ -1,0 +1,308 @@
+"""Two stop handles were published and never called.
+
+`IssuanceExecutor.shutdown()` had no caller anywhere in the tree, and the
+slow-request watchdog's `stop_event` was handed to the container and never set.
+Both read in review like a safety net — a reader finds a shutdown method and
+stops asking what happens on SIGTERM — and neither ran.
+
+What was actually wired was half of it: app.py's KeyboardInterrupt path stopped
+the scheduler and drained the event bus, and only for `python app.py`. Under
+gunicorn, which is how the image runs, an atexit hook drained the bus and
+nothing else. So a container stopped during an async issuance left the pool's
+queued jobs unrecorded anywhere: the registry is in memory, it dies with the
+process, and the certificate the operator asked for simply never appeared.
+
+`stop_background_work(container)` is now the single ordered shutdown, called
+from atexit (both deployment shapes) and from app.py's Ctrl-C path.
+
+Order is the substance of it. Producers stop before consumers — the scheduler
+queues renewals, a renewal publishes an event, an event dispatches a deploy
+hook — so draining the bus first would drain a queue still being filled. And
+nothing waits: certbot subprocesses and deploy hooks are bounded or abandoned,
+never joined, because a shutdown that outlives the container runtime's patience
+is a SIGKILL with extra steps.
+"""
+import logging
+import threading
+import time
+
+import pytest
+
+from modules.core import factory
+from modules.core.cert_jobs import IssuanceExecutor
+
+pytestmark = [pytest.mark.unit]
+
+LOGGER = 'modules.core.cert_jobs'
+
+
+def _executor(**kw):
+    return IssuanceExecutor(app=None, event_bus=None, **kw)
+
+
+def _wait_for(predicate, timeout=5):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+# --- the issuance pool says what it abandoned -----------------------------
+
+def test_a_job_still_running_is_named_on_the_way_out(caplog):
+    """THE regression. The registry dies with the process, so the log line is
+    the only place a half-done issuance can be recorded."""
+    executor = _executor(max_workers=1)
+    release = threading.Event()
+    started = threading.Event()
+
+    def blocking():
+        started.set()
+        release.wait(timeout=5)
+
+    executor.submit('create', 'slow.example.com', blocking)
+    assert started.wait(timeout=5)
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        abandoned = executor.shutdown()
+    release.set()
+
+    assert [job['domain'] for job in abandoned] == ['slow.example.com']
+    assert abandoned[0]['status'] == 'running'
+    assert any('slow.example.com' in record.getMessage()
+               for record in caplog.records), (
+        'the abandoned job was returned but never logged, so nothing survives '
+        'the process that says which certificate was not issued')
+
+
+def test_a_queued_job_no_worker_reached_is_cancelled_and_named():
+    """One worker, two jobs: the second never starts. Before, it sat at
+    'queued' in a registry nobody would ever read again."""
+    executor = _executor(max_workers=1)
+    release = threading.Event()
+    started = threading.Event()
+    second_ran = threading.Event()
+
+    executor.submit('create', 'first.example.com',
+                    lambda: (started.set(), release.wait(timeout=5)))
+    assert started.wait(timeout=5)
+    executor.submit('create', 'second.example.com', second_ran.set)
+
+    abandoned = executor.shutdown()
+    release.set()
+
+    assert {job['domain'] for job in abandoned} == {
+        'first.example.com', 'second.example.com'}
+    assert not second_ran.wait(timeout=0.5), (
+        'the queued job ran after shutdown; cancel_futures is not in effect')
+
+
+def test_a_finished_job_is_not_reported_as_abandoned():
+    """CONTROL. A shutdown that named every job ever submitted would be noise,
+    and an operator would learn to ignore the line."""
+    executor = _executor(max_workers=1)
+    executor.submit('create', 'done.example.com', lambda: None)
+    assert _wait_for(lambda: not executor.list_active())
+
+    assert executor.shutdown() == []
+
+
+def test_a_submission_after_shutdown_does_not_sit_at_queued(caplog):
+    """The consequence of calling shutdown for the first time: the pool starts
+    refusing work. The job record must not be left at 'queued', because
+    /certificates/jobs/<id> would then report work that will never happen."""
+    executor = _executor(max_workers=1)
+    executor.shutdown()
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        with pytest.raises(RuntimeError):
+            executor.submit('create', 'late.example.com', lambda: None)
+
+    late = [job for job in executor._jobs.values()
+            if job['domain'] == 'late.example.com']
+    assert late and late[0]['status'] == 'failed'
+    assert late[0]['error_code'] == 'SHUTTING_DOWN'
+
+
+# --- the ordered shutdown -------------------------------------------------
+
+class _Recorder:
+    """A container shaped like the real one, whose parts record being stopped."""
+
+    def __init__(self, scheduler_raises=False):
+        self.calls = []
+        self.shutdown_complete = False
+        self.scheduler = self._Scheduler(self.calls, scheduler_raises)
+        self.stop_event = threading.Event()
+        self.request_watchdog = {'thread': None, 'stop_event': self.stop_event}
+        self.managers = {
+            'cert_executor': self._Executor(self.calls),
+            'events': self._Bus(self.calls),
+        }
+
+    class _Scheduler:
+        def __init__(self, calls, raises):
+            self.calls, self.raises = calls, raises
+            self.wait = None
+
+        def shutdown(self, wait=True):
+            self.calls.append('scheduler')
+            self.wait = wait
+            if self.raises:
+                raise RuntimeError('scheduler is not running')
+
+    class _Executor:
+        def __init__(self, calls):
+            self.calls = calls
+
+        def shutdown(self):
+            self.calls.append('executor')
+            return [{'operation': 'create', 'domain': 'x.example.com',
+                     'status': 'queued'}]
+
+    class _Bus:
+        def __init__(self, calls):
+            self.calls = calls
+
+        def stop(self):
+            self.calls.append('bus')
+            return 3
+
+
+def test_producers_stop_before_consumers():
+    """The scheduler queues renewals, a renewal publishes, a publish dispatches
+    a deploy hook. Draining the bus first drains a queue still being filled."""
+    container = _Recorder()
+
+    factory.stop_background_work(container)
+
+    assert container.calls == ['scheduler', 'executor', 'bus']
+
+
+def test_the_scheduler_is_not_waited_for():
+    """A renewal sweep runs for minutes. Holding exit open for it only means
+    the container runtime kills the process instead."""
+    container = _Recorder()
+
+    factory.stop_background_work(container)
+
+    assert container.scheduler.wait is False
+
+
+def test_the_watchdog_is_told_to_stop():
+    """The other handle that had no caller. It is a daemon thread, so this does
+    not decide whether the process exits — it decides whether the thread is
+    torn down halfway through formatting another thread's stack."""
+    container = _Recorder()
+
+    factory.stop_background_work(container)
+
+    assert container.stop_event.is_set()
+
+
+def test_what_was_lost_is_reported_to_the_caller():
+    """app.py prints from this, so it has to carry both losses, not just the
+    bus's."""
+    container = _Recorder()
+
+    summary = factory.stop_background_work(container)
+
+    assert summary['scheduler'] == 'stopped'
+    assert summary['undelivered'] == 3
+    assert [job['domain'] for job in summary['issuance']] == ['x.example.com']
+
+
+def test_a_scheduler_that_never_started_is_not_a_warning():
+    """The atexit handler runs for every process that built an app, including
+    the many in this suite that never start a scheduler. A WARNING on every
+    clean exit is how the real one stops being read."""
+    class _NeverStarted(_Recorder):
+        def __init__(self):
+            super().__init__()
+            self.scheduler.running = False
+
+    container = _NeverStarted()
+
+    summary = factory.stop_background_work(container)
+
+    assert summary['scheduler'] == 'not running'
+    assert container.calls == ['executor', 'bus'], (
+        'a scheduler that is not running was asked to stop anyway')
+
+
+def test_one_component_refusing_does_not_strand_the_others():
+    """Ctrl-C is already on its way out. A scheduler that will not stop must
+    not turn into a traceback that skips the bus drain."""
+    container = _Recorder(scheduler_raises=True)
+
+    summary = factory.stop_background_work(container)
+
+    assert container.calls == ['scheduler', 'executor', 'bus']
+    assert 'not stopped cleanly' in summary['scheduler']
+
+
+def test_it_runs_once():
+    """app.py calls it on Ctrl-C and atexit calls it again on the way out.
+    Stopping an already-stopped scheduler logs a warning that reads like a
+    fault, and draining an empty bus twice reports nothing twice."""
+    container = _Recorder()
+
+    factory.stop_background_work(container)
+    factory.stop_background_work(container)
+
+    assert container.calls == ['scheduler', 'executor', 'bus']
+
+
+def test_a_container_with_nothing_running_is_not_an_error():
+    """CONTROL: most of the test suite builds partial containers, and the
+    atexit handler runs for them too."""
+    class _Bare:
+        shutdown_complete = False
+        scheduler = None
+        managers = None
+        request_watchdog = None
+
+    assert factory.stop_background_work(_Bare()) == {
+        'scheduler': None, 'issuance': [], 'undelivered': 0}
+
+
+# --- it is actually wired -------------------------------------------------
+
+def test_atexit_registers_the_whole_shutdown_not_just_the_bus():
+    """The property this file exists for: under gunicorn there is no other
+    hook, and what was registered there stopped only the event bus."""
+    import inspect
+
+    source = inspect.getsource(factory._stop_background_work_at_exit)
+
+    assert 'atexit.register(stop_background_work, container)' in source
+    assert '_stop_background_work_at_exit(container)' in inspect.getsource(
+        factory.create_app)
+
+
+def test_the_interactive_entrypoint_uses_the_same_path():
+    """Two shutdown sequences that must stay in the same order is how one of
+    them drifts. app.py had its own, and it stopped two of the four things."""
+    import pathlib
+
+    # From this file, not from factory.__file__: the suite redirects the
+    # application's state directories by monkeypatching that attribute.
+    repo = pathlib.Path(__file__).resolve().parent.parent
+    source = (repo / 'app.py').read_text(encoding='utf-8')
+
+    assert 'stop_background_work(container)' in source
+    assert 'container.scheduler.shutdown()' not in source, (
+        'app.py still stops the scheduler on its own, so the order lives in '
+        'two places')
+
+
+def test_no_other_caller_reaches_past_it():
+    """CONTROL against the handles going unused again: the pool is shut down
+    through the executor's own method, and nothing else touches the pool."""
+    import inspect
+
+    source = inspect.getsource(IssuanceExecutor)
+
+    assert source.count('self._pool.shutdown') == 1


### PR DESCRIPTION
Second row, item 4 of the audit follow-through.

## What was wrong

Two stop handles were published and never used:

- `IssuanceExecutor.shutdown()` — **no caller anywhere in the tree**;
- the slow-request watchdog's `stop_event` — handed to the container in `setup_slow_request_logging` and never set.

Both read in review like a safety net. A reader finds a `shutdown()` method and stops asking what happens on SIGTERM.

What *was* wired covered half the components and one of the two deployment shapes:

| | `python app.py` (Ctrl-C) | gunicorn (SIGTERM, the image) |
|---|---|---|
| scheduler | stopped | — |
| issuance pool | — | — |
| request watchdog | — | — |
| event bus | drained | drained (atexit) |

So a container stopped during an async issuance left the pool's queued jobs recorded nowhere. The job registry is in memory and dies with the process: the certificate an operator asked for simply never appeared, and no line anywhere said so.

## What this does

`stop_background_work(container)` is one ordered shutdown, registered on atexit (which covers both shapes) and called from app.py's Ctrl-C path so the order lives in one place.

**Order is the substance.** Producers before consumers: the scheduler queues renewals, a renewal publishes an event, an event dispatches a deploy hook — draining the bus first drains a queue still being filled.

```
scheduler → issuance pool → request watchdog → event bus
```

**Nothing is joined.** The scheduler is asked not to wait (a renewal sweep runs for minutes, and holding exit open for it only means the runtime kills the process instead); the pool cancels what no worker has started and abandons what is running (a certbot subprocess cannot be taken back); the bus drains against its existing deadline. What could not be finished is *named*, in the same shape `EventBus.stop` already uses:

```
Issuance executor stopped with 2 job(s) unfinished: create a.example.com (running),
create b.example.com (queued). These were not completed and are not retried on
startup; re-run them if the certificate is still needed.
```

## Two consequences of calling shutdown for the first time

Both are in this PR because both only exist once the handle is actually used:

1. **`submit()` after shutdown left a job at `queued` forever.** The pool raises `RuntimeError`, but the registry entry was already written, so `GET /certificates/jobs/<id>` reported work that would never happen. It is now marked failed with `SHUTTING_DOWN` before the error propagates.
2. **A scheduler that was never started must not warn.** atexit runs for every process that built an app — including most of this suite — and `SchedulerNotRunningError` on every clean exit is how a real warning stops being read. It now reports `not running` and says nothing.

## Test plan

`tests/test_the_shutdown_handles_are_called.py`, 15 tests: the running job is named, the queued job is cancelled *and* named, a finished job is not reported (control), a late submission does not sit at `queued`, producers stop before consumers, the scheduler is not waited for, the watchdog is told to stop, one component refusing does not strand the others, it runs once, a bare container is not an error (control), and both entry points reach the same function.

- full gated suite: **4608 passed, 46 skipped** (local `e2e` errors are Docker not on PATH on this machine, not the change)
- coverage floors: met for 81 modules
- `flake8` CI selection → 0; `bandit --severity-level medium` → clean; complexity budget → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)