### PR TITLE
feat: the issuance queue has a bottom, and a 429 when it is reached

### DIFF
--- a/README.md
+++ b/README.md
@@ -1584,6 +1584,7 @@ by the schema, with a message naming the accepted set — for example
 | `CERTMATE_DOMAIN_LOCK_TIMEOUT` | | `5`         | Seconds to wait for a domain's lock before answering 409 "operation in progress". Clamped to 0-60 |
 | `CERTMATE_CERT_INFO_CACHE_TTL` | | `60`        | Seconds a parsed certificate's details stay cached. `0` re-reads from disk on every request. Clamped to 0-3600 |
 | `CERTMATE_ISSUANCE_WORKERS` | | `2`            | Threads serving asynchronous issuance jobs. Clamped to 1-16; each one can be running a certbot subprocess |
+| `CERTMATE_ISSUANCE_QUEUE_LIMIT` | | `20`        | How much unfinished issuance may exist at once, counting queued and running jobs. Clamped to 1-500. Beyond it the async endpoints answer `429 ISSUANCE_QUEUE_FULL` instead of accepting work that will not be reached for hours |
 | `CERTMATE_ISSUANCE_JOB_HISTORY` | | `200`      | How many finished issuance jobs stay queryable via `/api/certificates/jobs`. Clamped to 20-2000 |
 | `CERTMATE_EVENT_WORKERS` |    | `4`            | Threads dispatching event listeners (deploy hooks, cache invalidation). Clamped to 1-32. Nothing is dropped when they are busy; the backlog is logged instead |
 | `CERTMATE_EVENT_DRAIN_SECONDS` |    | `5`            | How long a shutdown waits for queued event dispatches to start before giving up on them. Clamped to 0-60. Whatever is left is logged with its event and domain, so a deploy hook that never ran after a renewal is named rather than lost |

--- a/modules/api/resources_lifecycle.py
+++ b/modules/api/resources_lifecycle.py
@@ -11,6 +11,7 @@ from flask import current_app, request
 from flask_restx import Resource
 
 from ..core.audit_context import audit_context_from_request
+from ..core.cert_jobs import IssuanceQueueFull
 from ..core.cert_service import DomainOutOfScope
 from ..core.certificates import DomainOperationInProgress
 from ..core.utils import classify_renewal_error
@@ -22,6 +23,33 @@ from .resource_context import (
 logger = logging.getLogger(__name__)
 
 
+def _submit(ctx, operation, domain, fn):
+    """Hand the blocking half to the executor, or say no.
+
+    The queue is bounded: two workers with an unbounded queue turned a retry
+    loop into hundreds of 202s for certificates that would not be attempted
+    for hours. A 429 is the honest answer to work this process will not get to.
+
+    At module level rather than inside `create_lifecycle_resources` because
+    mccabe counts a nested function's branches against the function that
+    encloses it, and that closure is one of the thirteen already carrying a
+    complexity budget.
+    """
+    try:
+        job_id = ctx.cert_executor.submit(operation, domain, fn)
+    except IssuanceQueueFull as e:
+        return {
+            'code': 'ISSUANCE_QUEUE_FULL',
+            'error': 'Too much issuance is already in progress',
+            'hint': (f'{e.depth} job(s) queued or running against a limit of '
+                     f'{e.limit}. Retry once some finish, or raise '
+                     f'CERTMATE_ISSUANCE_QUEUE_LIMIT / '
+                     f'CERTMATE_ISSUANCE_WORKERS.'),
+        }, 429
+    return job_accepted(job_id, operation, domain,
+                        f'/api/certificates/jobs/{job_id}'), 202
+
+
 def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
     """Build the lifecycle resources against *ctx*."""
 
@@ -30,10 +58,6 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
 
     def _wants_async(payload):
         return wants_async(payload)
-
-    def _job_accepted(job_id, operation, domain):
-        return job_accepted(job_id, operation, domain,
-                            f'/api/certificates/jobs/{job_id}')
 
     class CreateCertificate(Resource):
         @api.doc(security='Bearer')
@@ -75,11 +99,8 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
                         ip_address=request.remote_addr,
                         audit_ctx=audit_ctx,
                     )
-                    job_id = ctx.cert_executor.submit(
-                        'create', domain,
-                        lambda: ctx.cert_service.issue_create(prepared),
-                    )
-                    return _job_accepted(job_id, 'create', domain), 202
+                    return _submit(ctx, 'create', domain,
+                                   lambda: ctx.cert_service.issue_create(prepared))
 
                 result = ctx.cert_service.create(
                     domain=domain,
@@ -187,11 +208,8 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
                         domain=domain, user=user, ip_address=request.remote_addr,
                         audit_ctx=audit_ctx,
                     )
-                    job_id = ctx.cert_executor.submit(
-                        'renew', domain,
-                        lambda: ctx.cert_service.issue_renew(prepared, force=force),
-                    )
-                    return _job_accepted(job_id, 'renew', domain), 202
+                    return _submit(ctx, 'renew', domain,
+                                   lambda: ctx.cert_service.issue_renew(prepared, force=force))
 
                 result = ctx.cert_service.renew(
                     domain=domain, force=force,
@@ -287,11 +305,8 @@ def create_lifecycle_resources(api, models, ctx: ApiContext) -> dict:
 
                 if _wants_async(data) and ctx.cert_executor is not None:
                     prepared = ctx.cert_service.prepare_reissue(**kwargs)
-                    job_id = ctx.cert_executor.submit(
-                        'reissue', domain,
-                        lambda: ctx.cert_service.issue_reissue(prepared),
-                    )
-                    return _job_accepted(job_id, 'reissue', domain), 202
+                    return _submit(ctx, 'reissue', domain,
+                                   lambda: ctx.cert_service.issue_reissue(prepared))
 
                 result = ctx.cert_service.issue_reissue(
                     ctx.cert_service.prepare_reissue(**kwargs)

--- a/modules/core/cert_jobs.py
+++ b/modules/core/cert_jobs.py
@@ -25,6 +25,28 @@ logger = logging.getLogger(__name__)
 
 _TERMINAL = ('succeeded', 'failed')
 
+
+class IssuanceQueueFull(Exception):
+    """Raised by `submit` when too much issuance is already outstanding.
+
+    The pool has two workers and had an unbounded queue, so a client in a
+    retry loop — or a script iterating a domain list — could park hundreds of
+    certbot runs behind them. Nothing rejected the work, so every one of those
+    callers got a 202 and a job id promising a certificate that would not be
+    attempted for hours, and the pending ones were invisible: the eviction that
+    bounds the registry never touches a job that has not finished, so the
+    memory they hold is not bounded by the history cap either.
+
+    Refusing is the honest answer. A 429 tells the caller to come back; a 202
+    for work nobody will reach for an hour does not.
+    """
+
+    def __init__(self, depth, limit):
+        super().__init__(
+            f'{depth} issuance job(s) already queued or running (limit {limit})')
+        self.depth = depth
+        self.limit = limit
+
 # Success event per issuance kind, mirroring the synchronous routes. Renewal
 # failures (other than "busy") emit certificate_failed like the sync API renew
 # route; create failures emit nothing, also matching the sync create route.
@@ -54,7 +76,8 @@ class IssuanceExecutor:
     ``CERTMATE_ISSUANCE_JOB_HISTORY`` (default 200, clamped 20-2000).
     """
 
-    def __init__(self, app, event_bus=None, max_workers=None, capacity=None):
+    def __init__(self, app, event_bus=None, max_workers=None, capacity=None,
+                 queue_limit=None):
         self._app = app
         self._event_bus = event_bus
         self._pool = ThreadPoolExecutor(
@@ -62,14 +85,35 @@ class IssuanceExecutor:
             thread_name_prefix='cert-issue',
         )
         self._capacity = capacity or _clamp_env_int('CERTMATE_ISSUANCE_JOB_HISTORY', 200, 20, 2000)
+        # How much unfinished work is allowed to exist at once, counting both
+        # the running jobs and the ones waiting for a worker. Separate from the
+        # history cap above, which bounds how many FINISHED jobs are remembered
+        # and deliberately never evicts an unfinished one.
+        self._queue_limit = queue_limit or _clamp_env_int(
+            'CERTMATE_ISSUANCE_QUEUE_LIMIT', 20, 1, 500)
         self._jobs = OrderedDict()  # job_id -> record (insertion-ordered for eviction)
         self._lock = threading.Lock()
 
     def submit(self, kind, domain, fn):
         """Register a job and run *fn* (a zero-arg callable performing the
-        blocking issuance) on the pool. Returns the job_id immediately."""
+        blocking issuance) on the pool. Returns the job_id immediately.
+
+        Raises `IssuanceQueueFull` when the backlog is already at the limit,
+        which the API turns into a 429. The check and the registration happen
+        under one lock: two requests arriving together must not both read a
+        depth one below the limit and both be admitted.
+        """
         job_id = uuid.uuid4().hex
         with self._lock:
+            depth = self._pending_locked()
+            if depth >= self._queue_limit:
+                logger.warning(
+                    "Issuance refused for %s: %d job(s) already queued or "
+                    "running against a limit of %d. Raise "
+                    "CERTMATE_ISSUANCE_QUEUE_LIMIT or CERTMATE_ISSUANCE_WORKERS "
+                    "if this is steady-state load rather than a retry storm.",
+                    domain, depth, self._queue_limit)
+                raise IssuanceQueueFull(depth, self._queue_limit)
             self._jobs[job_id] = {
                 'job_id': job_id,
                 'operation': kind,
@@ -100,6 +144,26 @@ class IssuanceExecutor:
         with self._lock:
             job = self._jobs.get(job_id)
             return dict(job) if job else None
+
+    def pending(self):
+        """How much issuance is outstanding: queued plus running.
+
+        The number an operator needs before raising the worker count, and the
+        one a 429 is explained by. `EventBus.pending_dispatches` is the same
+        idea for the other queue in this process.
+        """
+        with self._lock:
+            return self._pending_locked()
+
+    def _pending_locked(self):
+        """Caller holds the lock."""
+        return sum(1 for job in self._jobs.values()
+                   if job['status'] not in _TERMINAL)
+
+    def queue_limit(self):
+        """The configured ceiling, so the metric and the depth can be read
+        against each other rather than against a number in a docstring."""
+        return self._queue_limit
 
     def list_active(self):
         """Every job still queued or running, oldest first.

--- a/modules/core/metrics.py
+++ b/modules/core/metrics.py
@@ -271,6 +271,25 @@ cache_entries = Gauge(
     'Number of entries in cache'
 )
 
+# Work waiting for a worker. Both queues live in this process and neither was
+# visible from outside it: an operator raising CERTMATE_ISSUANCE_WORKERS or
+# CERTMATE_EVENT_WORKERS was guessing, and a 429 from a full issuance queue
+# had no number behind it that anyone could graph.
+issuance_queue_depth = Gauge(
+    'certmate_issuance_queue_depth',
+    'Async issuance jobs queued or running'
+)
+
+issuance_queue_limit = Gauge(
+    'certmate_issuance_queue_limit',
+    'Configured ceiling on queued or running issuance jobs'
+)
+
+event_dispatch_backlog = Gauge(
+    'certmate_event_dispatch_backlog',
+    'Listener invocations waiting for an event-bus worker'
+)
+
 # =============================================
 # METRICS COLLECTION FUNCTIONS
 # =============================================
@@ -330,6 +349,7 @@ class CertMateMetricsCollector:
                 self._collect_certificate_metrics(app_context)
                 self._collect_dns_provider_metrics(app_context)
                 self._collect_cache_metrics(app_context)
+                self._collect_queue_metrics(app_context)
             
             self.last_collection = time.time()
             logger.debug("Metrics collection completed")
@@ -484,6 +504,25 @@ class CertMateMetricsCollector:
         except Exception as e:
             logger.error(f"Error collecting DNS provider metrics: {e}")
     
+    def _collect_queue_metrics(self, app_context):
+        """Depth of the two in-process work queues.
+
+        Read through the accessors rather than the internals: both objects
+        already published one, and `EventBus.pending_dispatches` had no caller
+        at all — a number computed for nobody.
+        """
+        try:
+            executor = app_context.get('cert_executor')
+            if executor is not None:
+                issuance_queue_depth.set(executor.pending())
+                issuance_queue_limit.set(executor.queue_limit())
+
+            events = app_context.get('events')
+            if events is not None:
+                event_dispatch_backlog.set(events.pending_dispatches())
+        except Exception as e:
+            logger.error(f"Error collecting queue metrics: {e}")
+
     def _collect_cache_metrics(self, app_context):
         """Collect cache-related metrics."""
         try:

--- a/modules/web/misc_routes.py
+++ b/modules/web/misc_routes.py
@@ -224,6 +224,11 @@ def register_misc_routes(app, managers, require_web_auth, auth_manager):
                         'cert_dir': file_ops.cert_dir,
                         'get_certificate_info': cert_manager.get_certificate_info,
                         'cache': managers.get('cache'),
+                        # The two in-process queues. Without these the gauges
+                        # exist and read zero forever, which is worse than not
+                        # having them.
+                        'cert_executor': managers.get('cert_executor'),
+                        'events': managers.get('events'),
                     }
                 except Exception as ctx_err:
                     logger.warning(

--- a/scripts/check_complexity_budget.py
+++ b/scripts/check_complexity_budget.py
@@ -56,7 +56,7 @@ BUDGET = {
     'modules/web/misc_routes.py::register_misc_routes': 104,
     'modules/api/client_certificates.py::create_client_certificate_resources': 89,
     'modules/api/resources_storage.py::create_storage_resources': 68,
-    'modules/api/resources_lifecycle.py::create_lifecycle_resources': 61,
+    'modules/api/resources_lifecycle.py::create_lifecycle_resources': 60,
     'modules/web/cert_routes.py::register_cert_routes': 60,
     'modules/api/resources_downloads.py::create_download_resources': 55,
     'modules/api/resources_settings.py::create_settings_resources': 54,

--- a/tests/test_the_issuance_queue_has_a_bottom.py
+++ b/tests/test_the_issuance_queue_has_a_bottom.py
@@ -1,0 +1,253 @@
+"""Two workers and an unbounded queue is a promise the process cannot keep.
+
+`IssuanceExecutor.submit` accepted everything. The pool has two workers by
+default, each one running a certbot subprocess that takes tens of seconds to
+minutes, and the queue behind them had no limit — so a client in a retry loop,
+or a script walking a domain list, could park hundreds of jobs there. Every one
+of those callers got `202 Accepted` and a job id for a certificate that would
+not be attempted for hours.
+
+The registry's own bound did not help. `_evict_locked` drops the oldest
+*terminal* jobs once over the history cap and deliberately never evicts a job
+that has not finished, so a backlog of queued work is not bounded by that cap
+either — it is exactly the case the cap declines to touch.
+
+A 429 is the honest answer: the caller learns now, and can come back, instead
+of holding a job id that means nothing. The depth behind the refusal is a
+gauge, along with the event bus's backlog — whose `pending_dispatches()` had no
+caller at all, a number computed for nobody.
+"""
+import threading
+
+import pytest
+
+from modules.core.cert_jobs import IssuanceExecutor, IssuanceQueueFull
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def blocked():
+    """An executor whose single worker is stuck, so everything else queues."""
+    executor = IssuanceExecutor(app=None, event_bus=None, max_workers=1,
+                                queue_limit=3)
+    release = threading.Event()
+    running = threading.Event()
+    executor.submit('create', 'busy.example.com',
+                    lambda: (running.set(), release.wait(timeout=5)))
+    assert running.wait(timeout=5)
+    try:
+        yield executor, release
+    finally:
+        release.set()
+        executor.shutdown()
+
+
+# --- THE regression -------------------------------------------------------
+
+def test_the_queue_refuses_past_its_limit(blocked):
+    executor, _ = blocked
+    executor.submit('create', 'a.example.com', lambda: None)
+    executor.submit('create', 'b.example.com', lambda: None)
+
+    with pytest.raises(IssuanceQueueFull) as caught:
+        executor.submit('create', 'c.example.com', lambda: None)
+
+    assert caught.value.depth == 3
+    assert caught.value.limit == 3
+
+
+def test_a_refused_job_leaves_no_record(blocked):
+    """A rejected submission must not appear as work in flight: the caller has
+    no job id for it, so a record would be a job nobody can ever ask about."""
+    executor, _ = blocked
+    executor.submit('create', 'a.example.com', lambda: None)
+    executor.submit('create', 'b.example.com', lambda: None)
+
+    with pytest.raises(IssuanceQueueFull):
+        executor.submit('create', 'refused.example.com', lambda: None)
+
+    assert 'refused.example.com' not in {job['domain']
+                                         for job in executor.list_active()}
+
+
+def test_room_reappears_as_jobs_finish(blocked):
+    """CONTROL, and the reason this is a queue limit and not a rate limit: it
+    is about how much is outstanding, not how fast requests arrive."""
+    executor, release = blocked
+    executor.submit('create', 'a.example.com', lambda: None)
+    executor.submit('create', 'b.example.com', lambda: None)
+    with pytest.raises(IssuanceQueueFull):
+        executor.submit('create', 'c.example.com', lambda: None)
+
+    release.set()
+
+    assert _eventually(lambda: executor.pending() == 0)
+    assert executor.submit('create', 'later.example.com', lambda: None)
+
+
+def test_finished_jobs_do_not_count_against_the_limit(blocked):
+    """The history cap keeps 200 finished jobs around by default. If those
+    counted, an instance would refuse issuance after 200 successful ones."""
+    executor, release = blocked
+    release.set()
+    assert _eventually(lambda: executor.pending() == 0)
+
+    for n in range(10):
+        executor.submit('create', f'{n}.example.com', lambda: None)
+        assert _eventually(lambda: executor.pending() == 0)
+
+    assert len(executor._jobs) == 11
+    assert executor.pending() == 0
+
+
+def test_two_callers_arriving_together_cannot_both_take_the_last_slot():
+    """The check and the registration are under one lock. Read the depth,
+    then register, and both threads see one below the limit."""
+    executor = IssuanceExecutor(app=None, event_bus=None, max_workers=1,
+                                queue_limit=4)
+    release = threading.Event()
+    running = threading.Event()
+    executor.submit('create', 'busy.example.com',
+                    lambda: (running.set(), release.wait(timeout=5)))
+    assert running.wait(timeout=5)
+    executor.submit('create', 'a.example.com', lambda: None)
+    executor.submit('create', 'b.example.com', lambda: None)
+
+    start = threading.Barrier(8)
+    accepted = []
+    refused = []
+
+    def racer(n):
+        start.wait(timeout=5)
+        try:
+            executor.submit('create', f'race{n}.example.com', lambda: None)
+            accepted.append(n)
+        except IssuanceQueueFull:
+            refused.append(n)
+
+    threads = [threading.Thread(target=racer, args=(n,)) for n in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+    release.set()
+    executor.shutdown()
+
+    assert len(accepted) == 1, (
+        f'{len(accepted)} submissions took the last slot; the depth check and '
+        f'the registration are not atomic')
+    assert len(refused) == 7
+
+
+# --- what an operator can see --------------------------------------------
+
+def test_the_depth_and_the_limit_are_readable(blocked):
+    """A 429 with no number behind it leaves an operator guessing whether to
+    raise the limit or find what is stuck."""
+    executor, _ = blocked
+
+    assert executor.pending() == 1
+    assert executor.queue_limit() == 3
+
+
+def test_the_gauges_are_fed_from_the_accessors():
+    """`EventBus.pending_dispatches` had no caller in the tree. The collector
+    is now it, for both queues."""
+    from modules.core import metrics
+
+    class _Executor:
+        def pending(self):
+            return 7
+
+        def queue_limit(self):
+            return 20
+
+    class _Bus:
+        def pending_dispatches(self):
+            return 3
+
+    metrics.metrics_collector._collect_queue_metrics(
+        {'cert_executor': _Executor(), 'events': _Bus()})
+
+    assert metrics.issuance_queue_depth._value.get() == 7
+    assert metrics.issuance_queue_limit._value.get() == 20
+    assert metrics.event_dispatch_backlog._value.get() == 3
+
+
+def test_the_metrics_endpoint_passes_both_queues():
+    """CONTROL. The gauges exist and read zero forever if the context the
+    collector receives does not carry the objects."""
+    import inspect
+
+    from modules.web import misc_routes
+
+    source = inspect.getsource(misc_routes.register_misc_routes)
+    context = source[source.index("app_context = {"):]
+
+    assert "'cert_executor': managers.get('cert_executor')" in context
+    assert "'events': managers.get('events')" in context
+
+
+# --- the API says 429, not 202 -------------------------------------------
+
+def test_the_api_turns_a_full_queue_into_429():
+    from modules.api import resources_lifecycle
+
+    class _Executor:
+        def submit(self, *args, **kwargs):
+            raise IssuanceQueueFull(20, 20)
+
+    class _Ctx:
+        cert_executor = _Executor()
+
+    body, status = resources_lifecycle._submit(
+        _Ctx(), 'create', 'x.example.com', lambda: None)
+
+    assert status == 429
+    assert body['code'] == 'ISSUANCE_QUEUE_FULL'
+    assert '20' in body['hint']
+
+
+def test_an_accepted_submission_still_answers_202():
+    """CONTROL: the ordinary path is unchanged, and the job id still points at
+    the endpoint that reports on it."""
+    from modules.api import resources_lifecycle
+
+    class _Executor:
+        def submit(self, kind, domain, fn):
+            return 'abc123'
+
+    class _Ctx:
+        cert_executor = _Executor()
+
+    body, status = resources_lifecycle._submit(
+        _Ctx(), 'create', 'x.example.com', lambda: None)
+
+    assert status == 202
+    assert body['job_id'] == 'abc123'
+    assert body['status_url'] == '/api/certificates/jobs/abc123'
+
+
+def test_every_async_path_goes_through_the_helper():
+    """Create, renew and reissue. A path submitting directly would keep the
+    unbounded behaviour and nobody would notice until the queue was deep."""
+    import inspect
+
+    from modules.api import resources_lifecycle
+
+    source = inspect.getsource(
+        resources_lifecycle.create_lifecycle_resources)
+
+    assert source.count('_submit(ctx,') == 3
+    assert 'cert_executor.submit(' not in source
+
+
+def _eventually(predicate, timeout=5):
+    import time
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False


### PR DESCRIPTION
Second row, item 6 of the audit follow-through.

## What was wrong

`IssuanceExecutor.submit` accepted everything:

- **two workers** by default, each running a certbot subprocess that takes tens of seconds to minutes;
- **no limit** on the queue behind them.

So a client in a retry loop — or a script walking a domain list — could park hundreds of jobs there, and every one of those callers got `202 Accepted` and a job id for a certificate that would not be attempted for hours.

The registry's own bound does not cover this, and cannot: `_evict_locked` drops the oldest **terminal** jobs past the history cap and deliberately never evicts an unfinished one. A backlog of queued work is exactly the case that cap declines to touch.

## What this does

`CERTMATE_ISSUANCE_QUEUE_LIMIT` (default **20**, clamped 1–500) bounds how much unfinished issuance may exist at once — queued *and* running. Past it:

```json
HTTP 429
{
  "code": "ISSUANCE_QUEUE_FULL",
  "error": "Too much issuance is already in progress",
  "hint": "20 job(s) queued or running against a limit of 20. Retry once some
           finish, or raise CERTMATE_ISSUANCE_QUEUE_LIMIT / CERTMATE_ISSUANCE_WORKERS."
}
```

The depth check and the registration happen **under one lock**, so two requests arriving together cannot both read a depth one below the limit and both be admitted — there is a test with eight threads on a barrier for exactly that.

Finished jobs do not count, or an instance would refuse issuance after 200 successful ones.

## The numbers behind the refusal

A 429 with nothing to graph leaves an operator guessing whether to raise the limit or find what is stuck. Three gauges:

```
certmate_issuance_queue_depth      jobs queued or running
certmate_issuance_queue_limit      the ceiling, so the two read against each other
certmate_event_dispatch_backlog    listener invocations waiting for a bus worker
```

The third is here because `EventBus.pending_dispatches()` **had no caller anywhere in the tree** — a number computed for nobody, the same defect class as #813's unused shutdown handles. `/metrics` now passes both queue objects into the collection context; without that the gauges would exist and read zero forever, which is worse than not having them.

## The complexity budget from #812 shaped this diff

Worth recording, since it is the gate's first real use:

1. Adding `_submit` **inside** the resource closure took `create_lifecycle_resources` from 61 to 64 and the gate refused it — mccabe counts a nested function's branches against its enclosing one. Moving `_submit` to module level (it only needed `ctx`, now a parameter) brought it back to 61.
2. Removing the then-dead `_job_accepted` closure helper took it to **60**, and the gate asked for the entry to be lowered. Done.

## Verified by breaking it

With the limit check disabled, 4 of the 11 new tests fail: the refusal, the no-record-for-a-refusal, the room-reappears case and the eight-thread race. Restored, all 11 pass.

## Test plan

`tests/test_the_issuance_queue_has_a_bottom.py`, 11 tests. Plus:

- full gated suite: **4627 passed, 46 skipped**
- `flake8` CI selection → 0; `bandit --severity-level medium` → clean; complexity budget → clean
- `CERTMATE_ISSUANCE_QUEUE_LIMIT` documented in the README env table (the gate that checks that is green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)