### PR TITLE
perf: the audit tail stops at the entries it found, not at a block count

### DIFF
--- a/modules/core/audit.py
+++ b/modules/core/audit.py
@@ -16,6 +16,14 @@ from typing import Optional, Dict, Any
 
 logger = logging.getLogger(__name__)
 
+# What separates the log line's prefix from the JSON entry, in both the form
+# the tail scan counts (bytes) and the form the parse splits on (text). One
+# definition so the counting and the parsing cannot drift: a scan that counted
+# something the parse did not accept would stop the read early and silently
+# return fewer entries than were asked for.
+_ENTRY_MARKER_TEXT = ' - INFO - '
+_ENTRY_MARKER = _ENTRY_MARKER_TEXT.encode('utf-8')
+
 # Rotation defaults for the human-readable audit .log (#443). Same shape as the
 # application log's (#431), and deliberately NOT applied to the hash chain:
 # `certificate_audit.chain.jsonl` is append-only and tamper-evident, and naive
@@ -996,16 +1004,34 @@ class AuditLogger:
 
             # Read only the tail of the file so large audit logs do not block
             # the activity page or other callers that only need recent entries.
+            #
+            # The stop condition counts ENTRIES FOUND, not blocks read. It used
+            # to be `len(blocks) <= limit`, which reads one 8 KiB block per
+            # entry asked for: the activity page's default of 100 read ~827 KiB
+            # to return 100 lines of a few hundred bytes each, and the API's
+            # maximum read ~4 MiB. Two blocks is the ordinary answer now.
+            #
+            # `len(blocks) <= limit` survives as a second condition, so the
+            # worst case — a tail with no entries in it at all, which would
+            # otherwise walk the whole file — stays exactly what it was.
             block_size = 8192
             blocks = []
             remaining = file_size
+            found = 0
 
             with open(self.audit_log_file, 'rb') as f:
-                while remaining > 0 and len(blocks) <= limit:
+                while remaining > 0 and found <= limit and len(blocks) <= limit:
                     read_size = min(block_size, remaining)
                     remaining -= read_size
                     f.seek(remaining)
-                    blocks.append(f.read(read_size))
+                    block = f.read(read_size)
+                    blocks.append(block)
+                    # The same marker the parse below splits on, so this counts
+                    # candidate entries rather than newlines: a traceback or a
+                    # non-INFO line in the tail cannot make the read stop short
+                    # of `limit` entries. A marker straddling a block boundary
+                    # is missed and costs one extra block, never an entry.
+                    found += block.count(_ENTRY_MARKER)
 
             raw_lines = b''.join(reversed(blocks)).splitlines()
 
@@ -1013,18 +1039,23 @@ class AuditLogger:
             if remaining > 0 and raw_lines:
                 raw_lines = raw_lines[1:]
 
+            # Parse first, then take the last `limit` ENTRIES. Slicing the
+            # raw lines instead meant `limit` LINES, so anything in the tail
+            # that is not an entry — a traceback, a non-INFO line — came out
+            # of the caller's allowance: a tail with two noise lines per entry
+            # returned 33 rows for a request of 100, with nothing to say why.
             entries = []
-            for line in raw_lines[-limit:]:
+            for line in raw_lines:
                 try:
                     raw = line.decode('utf-8', errors='replace')
-                    if ' - INFO - ' not in raw:
+                    if _ENTRY_MARKER_TEXT not in raw:
                         continue
-                    json_str = raw.split(' - INFO - ', 1)[1].strip()
+                    json_str = raw.split(_ENTRY_MARKER_TEXT, 1)[1].strip()
                     entries.append(json.loads(json_str))
                 except (UnicodeDecodeError, json.JSONDecodeError, IndexError):
                     continue
 
-            return entries
+            return entries[-limit:]
 
         except Exception as e:
             logger.error(f"Error reading audit logs: {e}")

--- a/tests/test_the_audit_tail_counts_entries_not_blocks.py
+++ b/tests/test_the_audit_tail_counts_entries_not_blocks.py
@@ -1,0 +1,228 @@
+"""The activity page read 827 KiB to show 100 lines.
+
+`get_recent_entries` walks the audit log backwards in 8 KiB blocks, which is
+the right shape — the file rotates at megabytes and the caller wants the end of
+it. The stop condition was the wrong quantity:
+
+    while remaining > 0 and len(blocks) <= limit:
+
+One block per entry *asked for*, not per entry *found*. An audit line is a
+timestamp, a level and a JSON object: around 170 bytes. So 100 entries live in
+two blocks and the loop read a hundred and one.
+
+Measured on a 3.2 MiB log of 20,000 entries:
+
+    limit=10    90,112 bytes ->    8,192
+    limit=100  827,392 bytes ->   24,576
+    limit=500  3,377,780 bytes (the whole file) -> 90,112
+
+The counter is now the entry marker itself — the same string the parse splits
+on — rather than newlines, so a traceback or a non-INFO line in the tail cannot
+make the read stop short of the entries it was asked for. And `len(blocks) <=
+limit` stays as a second condition, so the pathological case of a tail
+containing no entries at all reads exactly what it read before rather than
+walking to the start of the file.
+"""
+import json
+
+import pytest
+
+from modules.core.audit import AuditLogger
+
+pytestmark = [pytest.mark.unit]
+
+PREFIX = '2026-09-09 10:00:00 - audit - INFO - '
+
+
+class _CountingPath:
+    """A path whose opened file reports how many bytes were actually read."""
+
+    def __init__(self, path):
+        self._path = path
+        self.bytes_read = 0
+
+    def __getattr__(self, name):
+        return getattr(self._path, name)
+
+    def open(self, *args, **kwargs):
+        return self._wrap(self._path.open(*args, **kwargs))
+
+    def _wrap(self, handle):
+        counter = self
+
+        class _Handle:
+            def __enter__(self_inner):
+                handle.__enter__()
+                return self_inner
+
+            def __exit__(self_inner, *exc):
+                return handle.__exit__(*exc)
+
+            def seek(self_inner, *args):
+                return handle.seek(*args)
+
+            def read(self_inner, size=-1):
+                data = handle.read(size)
+                counter.bytes_read += len(data)
+                return data
+
+        return _Handle()
+
+
+@pytest.fixture
+def log(tmp_path, monkeypatch):
+    """An audit log of 20,000 entries, and a byte counter over it."""
+    path = tmp_path / 'audit.log'
+    with path.open('w', encoding='utf-8') as handle:
+        for n in range(20000):
+            handle.write(PREFIX + json.dumps({
+                'action': 'certificate_created',
+                'n': n,
+                'user': 'admin',
+                'resource': f'{n}.example.com',
+            }) + '\n')
+
+    counting = _CountingPath(path)
+    reader = AuditLogger.__new__(AuditLogger)
+    reader.audit_log_file = counting
+
+    import builtins
+    real_open = builtins.open
+
+    def _open(target, mode='r', *args, **kwargs):
+        if target is counting:
+            return counting.open(mode, *args, **kwargs)
+        return real_open(target, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, 'open', _open)
+    return reader, counting
+
+
+# --- THE regression -------------------------------------------------------
+
+@pytest.mark.parametrize('limit,ceiling', [
+    (10, 16 * 1024),
+    (100, 48 * 1024),
+    (500, 128 * 1024),
+])
+def test_the_read_is_sized_by_what_it_finds(log, limit, ceiling):
+    """Before: 90 KiB, 827 KiB and the entire 3.2 MiB file respectively."""
+    reader, counting = log
+
+    entries = reader.get_recent_entries(limit=limit)
+
+    assert len(entries) == limit
+    assert counting.bytes_read <= ceiling, (
+        f'{counting.bytes_read} bytes read to return {limit} entries')
+
+
+def test_the_newest_entries_are_the_ones_returned(log):
+    """CONTROL. A read that stops early must stop at the RIGHT end: this walks
+    backwards from EOF, and an off-by-one in the new stop condition would show
+    up as the wrong entries rather than as an error."""
+    reader, _ = log
+
+    entries = reader.get_recent_entries(limit=5)
+
+    assert [entry['n'] for entry in entries] == [19995, 19996, 19997, 19998, 19999]
+
+
+def test_a_partial_first_line_is_still_dropped(log):
+    """The block boundary lands mid-line almost always. That half line is not
+    parseable JSON and must not be counted or returned."""
+    reader, _ = log
+
+    entries = reader.get_recent_entries(limit=100)
+
+    assert len(entries) == 100
+    assert all('n' in entry for entry in entries)
+
+
+# --- what the marker-counting buys ---------------------------------------
+
+def test_noise_in_the_tail_does_not_shorten_the_answer(tmp_path):
+    """Counting newlines would stop at `limit` LINES. A traceback, a WARNING,
+    a rotated-file header — anything the parse skips — would then come out of
+    the caller's allowance and the page would show fewer rows than it asked
+    for, with nothing to say why."""
+    path = tmp_path / 'audit.log'
+    with path.open('w', encoding='utf-8') as handle:
+        for n in range(500):
+            handle.write(PREFIX + json.dumps({'action': 'x', 'n': n}) + '\n')
+            handle.write('2026-09-09 10:00:00 - audit - WARNING - not an entry\n')
+            handle.write('  File "somewhere.py", line 1, in <module>\n')
+
+    reader = AuditLogger.__new__(AuditLogger)
+    reader.audit_log_file = path
+
+    assert len(reader.get_recent_entries(limit=100)) == 100
+
+
+def test_a_tail_with_no_entries_reads_no_more_than_before(tmp_path):
+    """CONTROL on the worst case. Counting entries alone would walk to the
+    start of a file that has none; `len(blocks) <= limit` is still there, so
+    the ceiling is exactly the old behaviour."""
+    path = tmp_path / 'audit.log'
+    path.write_text('x' * (8192 * 40), encoding='utf-8')
+
+    counting = _CountingPath(path)
+    reader = AuditLogger.__new__(AuditLogger)
+    reader.audit_log_file = counting
+
+    import builtins
+    real_open = builtins.open
+
+    def _open(target, mode='r', *args, **kwargs):
+        if target is counting:
+            return counting.open(mode, *args, **kwargs)
+        return real_open(target, mode, *args, **kwargs)
+
+    original = builtins.open
+    builtins.open = _open
+    try:
+        assert reader.get_recent_entries(limit=5) == []
+    finally:
+        builtins.open = original
+
+    assert counting.bytes_read <= 6 * 8192
+
+
+# --- unchanged behaviour --------------------------------------------------
+
+def test_a_short_log_returns_everything_it_has(tmp_path):
+    path = tmp_path / 'audit.log'
+    with path.open('w', encoding='utf-8') as handle:
+        for n in range(3):
+            handle.write(PREFIX + json.dumps({'action': 'x', 'n': n}) + '\n')
+
+    reader = AuditLogger.__new__(AuditLogger)
+    reader.audit_log_file = path
+
+    assert [e['n'] for e in reader.get_recent_entries(limit=100)] == [0, 1, 2]
+
+
+@pytest.mark.parametrize('limit', [0, -1])
+def test_a_useless_limit_reads_nothing(tmp_path, limit):
+    path = tmp_path / 'audit.log'
+    path.write_text(PREFIX + '{"action": "x"}\n', encoding='utf-8')
+
+    reader = AuditLogger.__new__(AuditLogger)
+    reader.audit_log_file = path
+
+    assert reader.get_recent_entries(limit=limit) == []
+
+
+def test_the_counter_and_the_parser_use_one_marker():
+    """They must not drift: a scan counting something the parse rejects stops
+    the read early and returns fewer entries than were asked for, silently."""
+    import inspect
+
+    from modules.core import audit
+
+    source = inspect.getsource(audit.AuditLogger.get_recent_entries)
+
+    assert source.count('_ENTRY_MARKER') >= 2
+    assert " - INFO - " not in source, (
+        'the marker is spelled out again inside the function, so the byte '
+        'scan and the text parse can drift apart')
+    assert audit._ENTRY_MARKER == audit._ENTRY_MARKER_TEXT.encode('utf-8')


### PR DESCRIPTION
Second row, item 8 of the audit follow-through.

## What was wrong

`modules/core/audit.py` walks the audit log backwards in 8 KiB blocks — the right shape, since the file rotates at megabytes and the caller wants the end of it. The stop condition counted the wrong quantity:

```python
while remaining > 0 and len(blocks) <= limit:
```

**One block per entry asked for, not per entry found.** An audit line is a timestamp, a level and a JSON object — around 170 bytes — so a hundred entries live in two blocks and the loop read a hundred and one.

Measured on a 3.2 MiB log of 20,000 entries, counting bytes actually read:

| `limit` | before | after |
|---:|---:|---:|
| 10 | 90,112 | **8,192** |
| 100 (the activity page) | 827,392 | **24,576** |
| 500 (the API maximum) | 3,377,780 — *the entire file* | **90,112** |

## What this does

The counter is the **entry marker** — the same string the parse splits on, defined once at module level so the byte scan and the text parse cannot drift. Counting newlines instead would have stopped at `limit` *lines*, so a traceback or a non-INFO line in the tail would come out of the caller's allowance.

`len(blocks) <= limit` stays as a second condition, so the pathological case — a tail with no entries in it at all — reads exactly what it read before rather than walking to the start of the file. There is a control test for that ceiling.

## A second defect, found by writing the test for the first

The result was sliced as `raw_lines[-limit:]` — `limit` **lines**, not entries. So anything in the tail that is not an entry came straight out of the caller's allowance:

```
a log with two noise lines per entry:  get_recent_entries(limit=100) -> 33 rows
```

with nothing anywhere to say why. It now parses first and takes the last `limit` entries. That test (`test_noise_in_the_tail_does_not_shorten_the_answer`) failed against my own first version of this change, which is how the defect surfaced.

## Test plan

`tests/test_the_audit_tail_counts_entries_not_blocks.py`, 11 tests, using a file handle that reports the bytes actually read: three parametrised size ceilings; the newest entries are the ones returned (a stop condition off by one would show up as the wrong entries, not an error); the partial first line still dropped; noise in the tail; the worst-case ceiling unchanged; a short log; useless limits; and a guard that the counter and the parser share one marker.

- full gated suite: **4627 passed, 46 skipped**
- `flake8` CI selection → 0; complexity budget → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)