### PR TITLE
feat: the four state directories are configurable, and test_config is read

### DIFF
--- a/README.md
+++ b/README.md
@@ -1584,6 +1584,10 @@ by the schema, with a message naming the accepted set — for example
 | `CERTMATE_DOMAIN_LOCK_TIMEOUT` | | `5`         | Seconds to wait for a domain's lock before answering 409 "operation in progress". Clamped to 0-60 |
 | `CERTMATE_CERT_INFO_CACHE_TTL` | | `60`        | Seconds a parsed certificate's details stay cached. `0` re-reads from disk on every request. Clamped to 0-3600 |
 | `CERTMATE_ISSUANCE_WORKERS` | | `2`            | Threads serving asynchronous issuance jobs. Clamped to 1-16; each one can be running a certbot subprocess |
+| `CERTMATE_CERT_DIR` |    | `<install>/certificates` | Where issued certificates live. Absolute, or relative to the working directory |
+| `CERTMATE_DATA_DIR` |    | `<install>/data`         | Settings, the certificate inventory and the audit chain |
+| `CERTMATE_BACKUP_DIR` |  | `<install>/backups`      | Where backups are written and restored from |
+| `CERTMATE_LOGS_DIR` |    | `<install>/logs`         | Application and audit logs |
 | `CERTMATE_ISSUANCE_QUEUE_LIMIT` | | `20`        | How much unfinished issuance may exist at once, counting queued and running jobs. Clamped to 1-500. Beyond it the async endpoints answer `429 ISSUANCE_QUEUE_FULL` instead of accepting work that will not be reached for hours |
 | `CERTMATE_ISSUANCE_JOB_HISTORY` | | `200`      | How many finished issuance jobs stay queryable via `/api/certificates/jobs`. Clamped to 20-2000 |
 | `CERTMATE_EVENT_WORKERS` |    | `4`            | Threads dispatching event listeners (deploy hooks, cache invalidation). Clamped to 1-32. Nothing is dropped when they are busy; the backlog is logged instead |

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -279,12 +279,48 @@ def _data_dir_is_on_its_own_mount(data_dir: Path) -> bool:
         current = current.parent
 
 
+# The four directories CertMate keeps its state in, with the environment
+# variable that relocates each and the name it has under the install root.
+STATE_DIRECTORIES = (
+    ('cert_dir', 'CERTMATE_CERT_DIR', 'certificates'),
+    ('data_dir', 'CERTMATE_DATA_DIR', 'data'),
+    ('backup_dir', 'CERTMATE_BACKUP_DIR', 'backups'),
+    ('logs_dir', 'CERTMATE_LOGS_DIR', 'logs'),
+)
+
+
+def resolve_state_directories(test_config=None) -> dict:
+    """Where the four state directories are, in order of who decides.
+
+    They were derived from `Path(__file__).parent.parent.parent` and nothing
+    could move them. That is a sound default — it is what makes the image and
+    the systemd unit work with no configuration — but it was also the only
+    answer available, so a deployment that wanted certificates on one volume
+    and backups on another had to bind-mount over the install tree, and this
+    repository's own test suite redirects state by monkeypatching
+    `modules.core.factory.__file__`, which is not a thing an application
+    should require of anyone.
+
+    `test_config` is honoured first because it was already in the signature
+    and read nowhere: `create_app(test_config={...})` accepted a config that
+    could not affect anything, which is worse than not accepting one.
+
+    Relative values resolve against the current working directory, and every
+    result is resolved, so what the container reports is always absolute.
+    """
+    base = Path(__file__).resolve().parent.parent.parent
+    config = test_config or {}
+    resolved = {}
+    for attribute, env_name, default_name in STATE_DIRECTORIES:
+        override = config.get(env_name) or os.getenv(env_name, '').strip()
+        resolved[attribute] = (Path(override) if override
+                               else base / default_name).resolve()
+    return resolved
+
+
 def setup_directories(container: AppContainer, test_config=None):
-    _base = Path(__file__).resolve().parent.parent.parent
-    container.cert_dir = (_base / "certificates").resolve()
-    container.data_dir = (_base / "data").resolve()
-    container.backup_dir = (_base / "backups").resolve()
-    container.logs_dir = (_base / "logs").resolve()
+    for attribute, value in resolve_state_directories(test_config).items():
+        setattr(container, attribute, value)
 
     required = [
         ('certificates', container.cert_dir),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,15 @@ def _isolate_runtime_dirs(tmp_path_factory):
     with pytest.MonkeyPatch.context() as patch:
         patch.setattr("modules.core.factory.__file__", str(anchor),
                       raising=False)
+        # The four directories are now relocatable with CERTMATE_*_DIR, which
+        # takes precedence over the anchor above. Unset them for the whole
+        # session so a developer who has them exported — pointing at their own
+        # running instance — cannot have the suite write there, and so the
+        # per-test anchors in the twenty-odd files that set their own keep
+        # deciding.
+        for _var in ('CERTMATE_CERT_DIR', 'CERTMATE_DATA_DIR',
+                     'CERTMATE_BACKUP_DIR', 'CERTMATE_LOGS_DIR'):
+            patch.delenv(_var, raising=False)
         yield
 
 

--- a/tests/test_the_state_directories_are_configurable.py
+++ b/tests/test_the_state_directories_are_configurable.py
@@ -1,0 +1,192 @@
+"""Four directories that nothing could move, and a config parameter read nowhere.
+
+    def setup_directories(container: AppContainer, test_config=None):
+        _base = Path(__file__).resolve().parent.parent.parent
+        container.cert_dir = (_base / "certificates").resolve()
+        ...
+
+Deriving them from the module's own location is a good default — it is what
+makes the image and the systemd unit work with no configuration at all — but it
+was the only answer available. A deployment wanting certificates on one volume
+and backups on another had to bind-mount over the install tree, and this
+repository's own suite redirects state by monkeypatching
+`modules.core.factory.__file__`, which is not something an application should
+require of anyone.
+
+`test_config` made it worse rather than better: `create_app(test_config={...})`
+accepted a configuration that could not affect any of this, so a caller passing
+paths in it got the install tree and no error.
+
+The defaults are unchanged. What is new is that CERTMATE_CERT_DIR,
+CERTMATE_DATA_DIR, CERTMATE_BACKUP_DIR and CERTMATE_LOGS_DIR are read, and that
+`test_config` wins over them — a test that passes paths gets those paths rather
+than whatever the developer has exported.
+"""
+import os
+
+import pytest
+
+from modules.core import factory
+
+pytestmark = [pytest.mark.unit]
+
+VARIABLES = ('CERTMATE_CERT_DIR', 'CERTMATE_DATA_DIR',
+             'CERTMATE_BACKUP_DIR', 'CERTMATE_LOGS_DIR')
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for name in VARIABLES:
+        monkeypatch.delenv(name, raising=False)
+
+
+# --- the default is what it always was -----------------------------------
+
+def test_with_nothing_set_the_directories_are_where_they_were():
+    """CONTROL, and the one that matters most: the image, the compose file and
+    the systemd unit all rely on this derivation and none of them was changed."""
+    from pathlib import Path
+
+    base = Path(factory.__file__).resolve().parent.parent.parent
+    resolved = factory.resolve_state_directories()
+
+    assert resolved == {
+        'cert_dir': (base / 'certificates').resolve(),
+        'data_dir': (base / 'data').resolve(),
+        'backup_dir': (base / 'backups').resolve(),
+        'logs_dir': (base / 'logs').resolve(),
+    }
+
+
+# --- THE change -----------------------------------------------------------
+
+@pytest.mark.parametrize('name,attribute', [
+    ('CERTMATE_CERT_DIR', 'cert_dir'),
+    ('CERTMATE_DATA_DIR', 'data_dir'),
+    ('CERTMATE_BACKUP_DIR', 'backup_dir'),
+    ('CERTMATE_LOGS_DIR', 'logs_dir'),
+])
+def test_each_directory_moves_on_its_own(tmp_path, monkeypatch, name, attribute):
+    """Separately, not as a set: the deployment this exists for puts
+    certificates on one volume and backups on another."""
+    target = tmp_path / attribute
+    monkeypatch.setenv(name, str(target))
+
+    resolved = factory.resolve_state_directories()
+
+    assert resolved[attribute] == target.resolve()
+    for other, value in resolved.items():
+        if other != attribute:
+            assert value != target.resolve()
+
+
+def test_a_relative_value_resolves_and_is_absolute(tmp_path, monkeypatch):
+    """What the container reports must be absolute wherever it came from: a
+    relative path recorded as relative would mean something different to the
+    scheduler thread than to the request that set it."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv('CERTMATE_DATA_DIR', 'state/data')
+
+    resolved = factory.resolve_state_directories()
+
+    assert resolved['data_dir'].is_absolute()
+    assert resolved['data_dir'] == (tmp_path / 'state' / 'data').resolve()
+
+
+def test_an_empty_value_is_not_a_path(monkeypatch):
+    """`CERTMATE_DATA_DIR=` in a compose file is an unset variable, not a
+    request to put the data directory at the filesystem root."""
+    from pathlib import Path
+
+    monkeypatch.setenv('CERTMATE_DATA_DIR', '   ')
+
+    base = Path(factory.__file__).resolve().parent.parent.parent
+    assert factory.resolve_state_directories()['data_dir'] == (base / 'data').resolve()
+
+
+# --- the parameter that was accepted and ignored -------------------------
+
+def test_test_config_is_read_at_last(tmp_path, monkeypatch):
+    """It was in the signature and consulted nowhere, so a caller passing
+    paths got the install tree and no error."""
+    from_env = tmp_path / 'from-env'
+    from_config = tmp_path / 'from-config'
+    monkeypatch.setenv('CERTMATE_DATA_DIR', str(from_env))
+
+    resolved = factory.resolve_state_directories(
+        {'CERTMATE_DATA_DIR': str(from_config)})
+
+    assert resolved['data_dir'] == from_config.resolve()
+
+
+def test_a_config_without_paths_leaves_the_environment_alone(tmp_path, monkeypatch):
+    """CONTROL: `create_app(test_config={'TESTING': True})` is what most of
+    this suite passes, and it must not mean 'put everything in the CWD'."""
+    monkeypatch.setenv('CERTMATE_CERT_DIR', str(tmp_path / 'certs'))
+
+    resolved = factory.resolve_state_directories({'TESTING': True})
+
+    assert resolved['cert_dir'] == (tmp_path / 'certs').resolve()
+
+
+# --- what the container ends up holding ----------------------------------
+
+def test_the_container_gets_what_was_resolved(tmp_path, monkeypatch):
+    monkeypatch.setenv('CERTMATE_BACKUP_DIR', str(tmp_path / 'b'))
+    monkeypatch.setenv('CERTMATE_CERT_DIR', str(tmp_path / 'c'))
+    monkeypatch.setenv('CERTMATE_DATA_DIR', str(tmp_path / 'd'))
+    monkeypatch.setenv('CERTMATE_LOGS_DIR', str(tmp_path / 'l'))
+
+    container = factory.AppContainer()
+    factory.setup_directories(container)
+
+    assert container.backup_dir == (tmp_path / 'b').resolve()
+    assert container.cert_dir == (tmp_path / 'c').resolve()
+    assert container.data_dir == (tmp_path / 'd').resolve()
+    assert container.logs_dir == (tmp_path / 'l').resolve()
+    # setup_directories also creates them; a configured directory that does
+    # not exist yet is the ordinary first-boot case for a fresh volume.
+    assert container.backup_dir.is_dir() and (container.backup_dir / 'unified').is_dir()
+
+
+def test_a_directory_that_cannot_be_written_still_fails_at_boot(tmp_path):
+    """CONTROL for #121, which is the reason this function does more than
+    assign four attributes: a misconfigured mount must be a clean error at
+    startup, not a half-succeeding setup wizard. Relocating them must not have
+    routed around the probe."""
+    unwritable = tmp_path / 'ro'
+    unwritable.mkdir()
+    unwritable.chmod(0o500)   # so the data directory cannot be created in it
+    container = factory.AppContainer()
+    try:
+        with pytest.raises(RuntimeError) as caught:
+            factory.setup_directories(
+                container, {'CERTMATE_DATA_DIR': str(unwritable / 'data')})
+    finally:
+        unwritable.chmod(0o700)
+
+    assert 'not writable' in str(caught.value)
+
+
+# --- the suite cannot be steered by the developer's environment ----------
+
+def test_the_suite_unsets_them():
+    """The anchor in conftest redirects state by monkeypatching
+    `factory.__file__`, and these variables now take precedence over it. A
+    developer with CERTMATE_DATA_DIR exported at their own instance would
+    otherwise have the suite write into it."""
+    import pathlib
+
+    source = (pathlib.Path(__file__).resolve().parent
+              / 'conftest.py').read_text(encoding='utf-8')
+
+    assert 'delenv' in source
+    for name in VARIABLES:
+        assert name in source, (
+            f'{name} is not unset by the session fixture, so an exported '
+            f'value would redirect the suite')
+
+
+def test_they_are_unset_right_now():
+    """The behavioural half of the check above."""
+    assert not any(os.getenv(name) for name in VARIABLES)


### PR DESCRIPTION
Second row, item 9 of the audit follow-through.

## What was wrong

```python
def setup_directories(container: AppContainer, test_config=None):
    _base = Path(__file__).resolve().parent.parent.parent
    container.cert_dir = (_base / "certificates").resolve()
    container.data_dir = (_base / "data").resolve()
    container.backup_dir = (_base / "backups").resolve()
    container.logs_dir = (_base / "logs").resolve()
```

Deriving them from the module's own location is a **good default** — it is what makes the image and the systemd unit work with no configuration at all. It was also the only answer available:

- a deployment wanting certificates on one volume and backups on another had to bind-mount over the install tree;
- this repository's own suite redirects state by monkeypatching `modules.core.factory.__file__` — 22 test files do it — which is not something an application should require of anyone;
- `test_config` was in the signature and **read nowhere**. `create_app(test_config={...})` accepted a configuration that could not affect any of this and reported no error, which is worse than not accepting one.

## What this does

Four variables, each moving one directory:

| variable | default |
|---|---|
| `CERTMATE_CERT_DIR` | `<install>/certificates` |
| `CERTMATE_DATA_DIR` | `<install>/data` |
| `CERTMATE_BACKUP_DIR` | `<install>/backups` |
| `CERTMATE_LOGS_DIR` | `<install>/logs` |

Precedence is `test_config` → environment → the derivation, so a test that passes paths gets those paths rather than whatever the developer has exported. Values are resolved, so what the container holds is absolute wherever it came from; an empty or whitespace value is an unset variable, not a request to put the data directory at `/`.

**The defaults are unchanged**, and there is a control test asserting exactly that — the image, the compose file and the systemd unit all rely on the derivation and none of them was touched.

**The boot-time writability probe (#121) still runs on whatever was resolved.** That check is the reason this function does more than assign four attributes, and relocating the directories must not route around it; the test points `CERTMATE_DATA_DIR` at a path inside an unwritable parent and asserts the same clean `RuntimeError`.

## The suite unsets them

The new variables take precedence over conftest's `__file__` anchor. A developer with `CERTMATE_DATA_DIR` exported at their own running instance would otherwise have the test run write into it — which is the defect #702 fixed, arriving through a new door. The session fixture now `delenv`s all four, and two tests check that (one on the source, one on the actual environment).

## Test plan

`tests/test_the_state_directories_are_configurable.py`, 13 tests: defaults unchanged (control); each directory moving on its own and not dragging the others; a relative value resolved to absolute; an empty value ignored; `test_config` beating the environment; `{'TESTING': True}` not meaning "use the CWD" (control — it is what most of this suite passes); the container holding what was resolved and the directories created; the #121 probe still failing on a configured path; and the suite's own environment.

- full gated suite: **4640 passed, 46 skipped**
- `flake8` CI selection → 0; `bandit --severity-level medium` → clean; complexity budget → clean
- all four documented in the README env table (that gate is green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)