### PR TITLE
fix: the certificate status nothing ever assigns is no longer exported

### DIFF
--- a/modules/core/metrics.py
+++ b/modules/core/metrics.py
@@ -377,12 +377,25 @@ class CertMateMetricsCollector:
             # Collect certificate metrics
             cert_count = 0
             provider_counts = {}
+            # The four states a certificate on disk can be in, and they
+            # partition it: the branch below picks exactly one per domain.
+            #
+            # A fifth, 'renewal_failed', used to be here. Nothing ever assigned
+            # it — every scrape exported
+            # certmate_certificates_by_status{status="renewal_failed"} 0 — and
+            # it could not be assigned, because it is not a state a certificate
+            # is IN. A certificate whose renewal failed is still valid,
+            # expiring_soon or expired; the failure is an event, and it is
+            # already counted as one by
+            # certmate_certificate_renewals_total{status="failure"}, which the
+            # renewal sweep increments and which CertMateRenewalsFailing alerts
+            # on. A constant zero is worse than an absent series: an alert
+            # written against it can never fire, and reads as "no failures".
             status_counts = {
                 'valid': 0,
                 'expiring_soon': 0,
                 'expired': 0,
                 'missing': 0,
-                'renewal_failed': 0
             }
             
             # Check existing certificate directories (filters out FS artifacts

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -75,11 +75,15 @@ Recorded on the operations side:
   from the real event in the certificate's metadata, not derived from the
   expiry date.
 
-Still not populated, and left out of the dashboard for that reason:
-
-- `certmate_certificates_by_status{status="renewal_failed"}`: the collector
-  assigns `valid`, `expiring_soon`, `expired` and `missing`, and nothing
-  assigns this one, so it is constant 0.
+`certmate_certificates_by_status` had a fifth label, `renewal_failed`, which
+nothing ever assigned: every scrape exported it as 0. It has been removed
+rather than populated, because it is not a state a certificate is *in* — one
+whose renewal failed is still `valid`, `expiring_soon` or `expired`. The
+failure is an event, and it is counted as one by
+`certmate_certificate_renewals_total{status="failure"}`, which the renewal
+sweep increments and which the `CertMateRenewalsFailing` rule alerts on. A
+constant zero is worse than an absent series: an alert written against it can
+never fire, and reads as "no failures ever".
 
 There is no `certmate_dns_provider_api_calls_total`. It was defined and never
 recorded, and it cannot be recorded from where those calls happen: certbot

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -530,21 +530,6 @@
                 }
               }
             ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "renewal_failed"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "dark-red"
-                }
-              }
-            ]
           }
         ]
       },

--- a/tests/test_no_status_is_exported_that_nothing_assigns.py
+++ b/tests/test_no_status_is_exported_that_nothing_assigns.py
@@ -35,6 +35,19 @@ pytestmark = [pytest.mark.unit]
 EXPECTED = {'valid', 'expiring_soon', 'expired', 'missing'}
 
 
+def _labelled_samples(body, metric):
+    """The label sets present for one metric name, parsed rather than matched."""
+    import re
+
+    samples = []
+    for line in body.splitlines():
+        if not line.startswith(metric + '{'):
+            continue
+        blob = line[len(metric) + 1:line.rindex('}')]
+        samples.append(dict(re.findall(r'(\w+)="([^"]*)"', blob)))
+    return samples
+
+
 def _exported_statuses():
     """The label values actually present in the registry's output."""
     from prometheus_client import generate_latest
@@ -133,11 +146,15 @@ def test_renewal_failures_are_counted_somewhere_real():
     metrics.metrics_collector.record_certificate_renewal(
         'fails.example.com', 'cloudflare', success=False)
 
-    body = generate_latest().decode('utf-8')
-    assert any('certmate_certificate_renewals_total{' in line
-               and 'status="failure"' in line
-               and 'fails.example.com' in line
-               for line in body.splitlines()), (
+    # The labels are compared as a parsed set rather than searched for in the
+    # line: a substring test against a hostname is what this repository's
+    # CodeQL configuration flags as an incomplete URL check, and it is right
+    # to in general.
+    samples = _labelled_samples(generate_latest().decode('utf-8'),
+                                'certmate_certificate_renewals_total')
+
+    assert {'domain': 'fails.example.com', 'dns_provider': 'cloudflare',
+            'status': 'failure'} in samples, (
         'nothing records a failed renewal, so removing the status label would '
         'lose the information rather than move it')
 

--- a/tests/test_no_status_is_exported_that_nothing_assigns.py
+++ b/tests/test_no_status_is_exported_that_nothing_assigns.py
@@ -1,0 +1,177 @@
+"""A gauge that is always zero is not a metric, it is a promise nobody keeps.
+
+`certmate_certificates_by_status` was exported with five labels and the
+collector assigned four. Every scrape, for every deployment, carried
+
+    certmate_certificates_by_status{status="renewal_failed"} 0
+
+An operator building a dashboard finds that series, writes
+`certmate_certificates_by_status{status="renewal_failed"} > 0`, and has an
+alert that can never fire — which reads, for as long as nobody checks, as "no
+renewal has ever failed here". That is worse than the series not existing: an
+absent series makes the rule visibly broken, or is caught by `absent()`.
+
+It could not be assigned either, and that is the substance rather than an
+oversight: it is not a state a certificate is IN. A certificate whose renewal
+failed is still valid, or expiring soon, or expired — the other four partition
+the set, and this one overlaps all of them. The failure is an EVENT, and it is
+already counted as one:
+
+    certmate_certificate_renewals_total{status="failure"}
+
+which `_record_renewal_metrics` increments from the renewal sweep and which the
+shipped `CertMateRenewalsFailing` rule alerts on with `increase(...)` over 6h —
+what matters being that renewals are failing now, not that one ever did.
+
+So the label is removed. This file pins both halves: it is gone, and what it
+was meant to tell you is somewhere real.
+"""
+import pytest
+
+from modules.core import metrics
+
+pytestmark = [pytest.mark.unit]
+
+EXPECTED = {'valid', 'expiring_soon', 'expired', 'missing'}
+
+
+def _exported_statuses():
+    """The label values actually present in the registry's output."""
+    from prometheus_client import generate_latest
+
+    body = generate_latest(metrics.REGISTRY).decode('utf-8') if hasattr(
+        metrics, 'REGISTRY') else generate_latest().decode('utf-8')
+    found = set()
+    for line in body.splitlines():
+        if line.startswith('certmate_certificates_by_status{'):
+            found.add(line.split('status="', 1)[1].split('"', 1)[0])
+    return found
+
+
+@pytest.fixture
+def collected(tmp_path):
+    """One collection over a single valid certificate."""
+    metrics.metrics_collector.last_collection = 0
+    metrics.metrics_collector.collect_all_metrics({
+        'settings': {'domains': [{'domain': 'a.example.com'}],
+                     'renewal_threshold_days': 30},
+        'cert_dir': tmp_path,
+        'get_certificate_info': lambda domain: {
+            'exists': True, 'days_left': 60, 'dns_provider': 'cloudflare'},
+    })
+    return _exported_statuses()
+
+
+# --- THE regression -------------------------------------------------------
+
+def test_no_status_is_exported_that_the_collector_cannot_assign(collected):
+    assert 'renewal_failed' not in collected, (
+        'certmate_certificates_by_status still exports a label the collector '
+        'never assigns, so an alert written on it can never fire')
+
+
+def test_the_four_real_statuses_are_still_exported(collected):
+    """CONTROL. Removing the fifth must not have removed the metric: the
+    shipped dashboard and the CertMateCertificatesExpired rule read three of
+    these."""
+    assert EXPECTED <= collected, f'missing: {sorted(EXPECTED - collected)}'
+
+
+def test_the_source_does_not_carry_the_dead_label():
+    """The collector builds its counts from a literal dict, and a key put back
+    there is exported whether or not any branch can produce it."""
+    import inspect
+
+    source = inspect.getsource(
+        metrics.CertMateMetricsCollector._collect_certificate_metrics)
+    counts = source[source.index('status_counts = {'):]
+    counts = counts[:counts.index('}')]
+
+    assert 'renewal_failed' not in counts
+
+
+# --- the four assignable statuses partition the certificates -------------
+
+@pytest.mark.parametrize('days_left,expected', [
+    (60, 'valid'),
+    (10, 'expiring_soon'),
+    (-1, 'expired'),
+    (None, 'missing'),
+])
+def test_each_certificate_lands_in_exactly_one(tmp_path, days_left, expected):
+    """Why a fifth could not be assigned: the branch picks one per domain, and
+    'renewal_failed' is not an alternative to any of these — a certificate
+    whose renewal failed is still in one of the four."""
+    from prometheus_client import generate_latest
+
+    metrics.metrics_collector.last_collection = 0
+    metrics.metrics_collector.collect_all_metrics({
+        'settings': {'domains': [{'domain': 'only.example.com'}],
+                     'renewal_threshold_days': 30},
+        'cert_dir': tmp_path,
+        'get_certificate_info': lambda domain: {
+            'exists': True, 'days_left': days_left, 'dns_provider': 'cf'},
+    })
+
+    body = generate_latest().decode('utf-8')
+    counts = {}
+    for line in body.splitlines():
+        if line.startswith('certmate_certificates_by_status{'):
+            status = line.split('status="', 1)[1].split('"', 1)[0]
+            counts[status] = float(line.rsplit(' ', 1)[1])
+
+    assert counts[expected] == 1.0
+    assert sum(counts.values()) == 1.0
+
+
+# --- what it was meant to tell you, where it really is -------------------
+
+def test_renewal_failures_are_counted_somewhere_real():
+    """The replacement has to exist, or this change loses information."""
+    from prometheus_client import generate_latest
+
+    metrics.metrics_collector.record_certificate_renewal(
+        'fails.example.com', 'cloudflare', success=False)
+
+    body = generate_latest().decode('utf-8')
+    assert any('certmate_certificate_renewals_total{' in line
+               and 'status="failure"' in line
+               and 'fails.example.com' in line
+               for line in body.splitlines()), (
+        'nothing records a failed renewal, so removing the status label would '
+        'lose the information rather than move it')
+
+
+def test_the_renewal_sweep_is_what_records_it():
+    """CONTROL against the counter going the way of the label: it is recorded
+    from one place, and if that call goes the metric is silently empty again."""
+    import inspect
+
+    from modules.core.certificates import CertificateManager
+
+    source = inspect.getsource(CertificateManager._record_renewal_metrics)
+
+    assert 'record_certificate_renewal(' in source
+
+
+def test_the_shipped_alert_uses_the_counter():
+    """The rule an operator would otherwise have written against the constant
+    zero. It ships, and it reads the metric that moves."""
+    import pathlib
+
+    rules = (pathlib.Path(__file__).resolve().parent.parent
+             / 'monitoring' / 'prometheus-alerts.yml').read_text(encoding='utf-8')
+
+    assert 'certmate_certificate_renewals_total{status="failure"}' in rules
+    assert 'renewal_failed' not in rules
+
+
+def test_the_dashboard_no_longer_styles_a_series_that_cannot_exist():
+    """A field override for a series nothing emits is a reader's evidence that
+    the series should be there."""
+    import pathlib
+
+    dashboard = (pathlib.Path(__file__).resolve().parent.parent
+                 / 'monitoring' / 'grafana-dashboard.json').read_text(encoding='utf-8')
+
+    assert 'renewal_failed' not in dashboard


### PR DESCRIPTION
Second row, item 11 of the audit follow-through — the last of that row.

## What was wrong

`certmate_certificates_by_status` was exported with five labels. The collector assigns four:

```python
status_counts = {'valid': 0, 'expiring_soon': 0, 'expired': 0,
                 'missing': 0, 'renewal_failed': 0}
...
if days_left is None:      status = 'missing'
elif days_left < 0:        status = 'expired'
elif days_left <= threshold: status = 'expiring_soon'
else:                      status = 'valid'
```

So every scrape, for every deployment, carried:

```
certmate_certificates_by_status{status="renewal_failed"} 0
```

An operator who finds that series writes `... {status="renewal_failed"} > 0` and has an alert that **can never fire** — which reads, for as long as nobody checks it, as "no renewal has ever failed here". A constant zero is worse than an absent series: an absent one makes the rule visibly broken, or is caught by `absent()`.

## Why it is removed rather than populated

It is not a state a certificate is **in**. A certificate whose renewal failed is still `valid`, or `expiring_soon`, or `expired` — the other four partition the set and this one overlaps all of them. There is a parametrised test for that partition, because it is the reason a fifth could not simply be assigned.

The failure is an **event**, and it is already counted as one:

```
certmate_certificate_renewals_total{status="failure"}
```

incremented by `_record_renewal_metrics` from the renewal sweep, and alerted on by the shipped `CertMateRenewalsFailing` rule with `increase(...)` over 6h — what matters being that renewals are failing *now*, not that one ever did since process start.

## Also removed

- the Grafana field override that styled `renewal_failed` dark red — a style rule for a series nothing can emit is a reader's evidence that the series should be there;
- `monitoring/README.md`'s entry listing it under "still not populated", replaced with why it is not going to be, and where to look instead.

## Verified by putting it back

With the key restored in the dict, 2 of the 11 new tests fail. Removed again, all 11 pass.

## Test plan

`tests/test_no_status_is_exported_that_nothing_assigns.py`, 11 tests, reading the actual registry output rather than the source: the dead label is not exported; the four real ones still are (control — the shipped dashboard and `CertMateCertificatesExpired` read three of them); each certificate lands in exactly one status; failed renewals are counted somewhere real; the sweep is what records them (control against the counter going the same way); and the alert and dashboard no longer mention the label.

- full gated suite: **4679 passed, 46 skipped**
- `flake8` CI selection → 0; complexity budget → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)