### PR TITLE
chore: the API contract records the new issuance-queue refusal (2.0 → 2.1)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -650,10 +650,12 @@ the application — an unmatched path, a wrong method, a body over the size limi
 }
 ```
 
-Until the contract version below moved to 1.1, `code` on that second shape was
+Until the contract version moved to **2.0**, `code` on that second shape was
 the status *integer* while every application error used a string, so a client
 could not branch on the field without checking its type first. It is one type
-now. The version is on every response as `X-CertMate-API-Version`.
+now, and the number a caller may have been reading is in `status` on those same
+responses. The version is on every response as `X-CertMate-API-Version`; it is
+**2.1** since the async issuance endpoints gained `ISSUANCE_QUEUE_FULL`.
 
 ### Codes
 
@@ -684,6 +686,7 @@ and may be reworded.
 | `CERTIFICATE_CREATION_FAILED` / `CERTIFICATE_REISSUE_FAILED` / `CERTIFICATE_REISSUE_REJECTED` | 422 | Issuance was attempted and refused |
 | `RENEWAL_CONFIG_BROKEN` | 422 | certbot's renewal config for this lineage no longer resolves; reissue |
 | `DNS_ACCOUNT_NOT_CONFIGURED` | 422 | The DNS account this certificate uses is gone from settings |
+| `ISSUANCE_QUEUE_FULL` | 429 | Too much async issuance is already queued or running; the body carries the depth and the limit |
 | `ADOPTION_UNAVAILABLE` | 503 | Discovery/adoption is not available on this build |
 | `ASYNC_ISSUANCE_DISABLED` | 503 | Async issuance is switched off |
 | `CERTIFICATE_CREATION_ERROR` / `CERTIFICATE_RENEWAL_ERROR` / `CERTIFICATE_REISSUE_ERROR` / `CERTIFICATE_DOWNLOAD_ERROR` / `AUTO_RENEW_UPDATE_FAILED` | 500 | The operation failed unexpectedly; the server log has the cause |

--- a/modules/core/constants.py
+++ b/modules/core/constants.py
@@ -113,7 +113,15 @@ METADATA_SCHEMA_VERSION = 1
 # one-line migration, and the version is how they learn to make it. By the rule
 # above this is a retype, and a retype is a MAJOR; picking the comfortable
 # number instead would make the rule decorative.
-API_CONTRACT_VERSION = '2.0'
+#
+# 2.1 for the bounded issuance queue: the async create/renew/reissue endpoints
+# can now answer 429 with code ISSUANCE_QUEUE_FULL when too much issuance is
+# already outstanding, where they used to accept it. MINOR rather than MAJOR
+# because it is a new code on a status those endpoints could already return —
+# every /api/ path goes through the rate limiter, which answers 429 — so a
+# client that handles 429 at all needs no change, and one that does not was
+# already exposed. What is new is a condition, not a type or a shape.
+API_CONTRACT_VERSION = '2.1'
 
 # Protocols the deployment probe can speak. A domain fact, not an API one: the
 # service validates against it and modules/api/tls_probe drives it (#672 — it


### PR DESCRIPTION
Prepares the v2.32.0 release.

## Why it moves

The async create/renew/reissue endpoints can now answer `429 ISSUANCE_QUEUE_FULL` when too much issuance is already outstanding (#815), where they used to accept it. That is a surface change, and `API_CONTRACT_VERSION` is how a client finds out.

## Why MINOR and not MAJOR

The rule beside the constant makes "a status code that changes for an existing condition" a MAJOR. This is not that:

- **429 was already reachable on those endpoints.** Every `/api/` path goes through the rate limiter, which answers 429. A client that handles 429 at all needs no change; one that does not was already exposed.
- **What is new is a condition, not a type or a shape.** The queue-full case did not exist before — the queue was unbounded — so nothing that used to return one status returns another. No field was removed, retyped, or made required.

Additive and ignorable: **2.0 → 2.1**.

## Also in here

`docs/api.md` said *"Until the contract version below moved to 1.1, `code` on that second shape was the status integer"*. It moved to **2.0** — that is what the note beside the constant has always said, and the two disagreeing is exactly the drift this version exists to prevent. Corrected, and the sentence now also names the current value.

`ISSUANCE_QUEUE_FULL` joins the error-code table.

## Test plan

- full gated suite: **4720 passed, 46 skipped**
- `flake8` CI selection → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)