### PR TITLE
fix: a domain entry has one shape, and normalising it invents nothing

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -216,7 +216,10 @@ def create_api_models(api):
 
     settings_model = api.model('Settings', {
         'cloudflare_token': MaskedString(description='Cloudflare API token (deprecated, use dns_providers)'),
-        'domains': fields.List(fields.Raw, description='List of domains (can be strings or objects)'),
+        'domains': fields.List(fields.Raw, description=(
+            'Managed domains. A request may send either a bare domain string or an '
+            'object carrying the domain plus per-domain overrides; both are accepted '
+            'and stored as objects, so a response always returns the object form.')),
         'email': fields.String(description='Email for Let\'s Encrypt'),
         'auto_renew': fields.Boolean(description='Enable auto-renewal'),
         'api_bearer_token': MaskedString(description='API bearer token for authentication'),

--- a/modules/api/resources_settings.py
+++ b/modules/api/resources_settings.py
@@ -17,6 +17,7 @@ from flask_restx import Resource
 import logging
 
 from .resource_context import ApiContext
+from ..core.domain_entries import entry_domain
 
 logger = logging.getLogger(__name__)
 
@@ -56,10 +57,7 @@ def create_settings_resources(api, models, ctx: ApiContext) -> dict:
                     raw_domains = settings.get('domains') or []
                     filtered = []
                     for entry in raw_domains:
-                        domain_name = (
-                            entry if isinstance(entry, str)
-                            else (entry.get('domain') if isinstance(entry, dict) else None)
-                        )
+                        domain_name = entry_domain(entry)
                         if domain_name and ctx.auth.domain_matches_scope(domain_name, scope):
                             filtered.append(entry)
                     settings['domains'] = filtered

--- a/modules/core/cert_discovery.py
+++ b/modules/core/cert_discovery.py
@@ -17,6 +17,7 @@ certificate operation. Every endpoint yields a per-endpoint status record.
 """
 
 import logging
+from .domain_entries import entry_domain
 
 from .cert_probe import probe_certificate, STATUS_OK
 
@@ -181,10 +182,9 @@ def _managed_domain_map(settings):
     """
     mapping = {}
     for entry in settings.get('domains', []) or []:
-        name = entry.get('domain') if isinstance(entry, dict) else entry
+        name = entry_domain(entry)
         if not name:
             continue
-        name = str(name)
         if name.startswith('*.'):
             continue
         mapping[name] = name

--- a/modules/core/certificates.py
+++ b/modules/core/certificates.py
@@ -33,6 +33,7 @@ from .dns_strategies import DNSStrategyFactory, HTTP01Strategy, acme_webroot_dir
 from .constants import (METADATA_SCHEMA_VERSION, CERTIFICATE_FILES,
                         DEFAULT_RENEWAL_THRESHOLD_DAYS)
 from .inventory_sources import collect_domain_sources
+from .domain_entries import entry_auto_renew, entry_domain
 from .structured_logging import LogContext, new_correlation_id
 from .csr_issuance import (
     CSR_OUTPUT_DIRNAME, CSR_OUTPUT_FILES, CSRError, csr_domains,
@@ -3497,22 +3498,12 @@ class CertificateManager:
             # would attribute the failure to the wrong certificate.
             domain = None
             try:
-                # Handle both old and new domain formats
-                if isinstance(domain_entry, str):
-                    domain = domain_entry
-                    per_cert_auto_renew = True
-                elif isinstance(domain_entry, dict):
-                    domain = domain_entry.get('domain')
-                    per_cert_auto_renew = domain_entry.get('auto_renew', True)
-                else:
-                    logger.warning(f"Skipping malformed domain entry (not str/dict): {domain_entry!r}")
-                    summary['skipped_invalid'] += 1
-                    continue
-
+                domain = entry_domain(domain_entry)
                 if not domain:
-                    logger.warning(f"Skipping domain entry with no domain name: {domain_entry!r}")
+                    logger.warning(f"Skipping domain entry that names no domain: {domain_entry!r}")
                     summary['skipped_invalid'] += 1
                     continue
+                per_cert_auto_renew = entry_auto_renew(domain_entry)
 
                 considered.add(domain)
 

--- a/modules/core/ct_monitor.py
+++ b/modules/core/ct_monitor.py
@@ -28,6 +28,7 @@ Two practical constraints shape the design:
 
 import json
 import logging
+from .domain_entries import entry_domain
 import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
@@ -145,9 +146,9 @@ def _managed_domains(settings):
     """Non-wildcard managed domain names from settings['domains']."""
     out = []
     for entry in settings.get('domains', []) or []:
-        name = entry.get('domain') if isinstance(entry, dict) else entry
-        if name and not str(name).startswith('*.'):
-            out.append(str(name))
+        name = entry_domain(entry)
+        if name and not name.startswith('*.'):
+            out.append(name)
     return out
 
 

--- a/modules/core/digest.py
+++ b/modules/core/digest.py
@@ -5,6 +5,7 @@ email via the existing Notifier SMTP channel.
 """
 
 import logging
+from .domain_entries import entry_domain
 import smtplib
 from datetime import timedelta
 from .utils import utc_now
@@ -38,12 +39,9 @@ class WeeklyDigest:
         all_domains = set()
 
         for entry in domains_from_settings:
-            if isinstance(entry, str):
-                all_domains.add(entry)
-            elif isinstance(entry, dict):
-                d = entry.get('domain')
-                if d:
-                    all_domains.add(d)
+            name = entry_domain(entry)
+            if name:
+                all_domains.add(name)
 
         for p in iter_cert_domain_dirs(cert_dir):
             all_domains.add(p.name)

--- a/modules/core/domain_entries.py
+++ b/modules/core/domain_entries.py
@@ -1,0 +1,116 @@
+"""What an entry in ``settings['domains']`` is, in one place.
+
+An entry is a bare domain string or an object carrying that domain plus
+per-domain overrides. Both spellings are in the wild: the string form is what
+early versions wrote, the object form is what everything since writes, and no
+migration ever converted a list that held both. Seven modules decoded that
+union independently, each with its own idea of what a third shape means.
+
+Two rules, and the second is the one that had been broken.
+
+**One decoder.** ``entry_domain`` and ``entry_auto_renew`` are the only places
+that know an entry can be a string. Everything else asks them.
+
+**Normalisation is lossless.** ``normalize_entry`` turns a string into
+``{'domain': ...}`` and nothing else. It does not fill in ``dns_provider`` or
+``account_id``, and that restraint is the point rather than an omission:
+
+    the string 'a.example.com' means "this domain follows the global
+    dns_provider setting", and {'domain': 'a.example.com'} means exactly the
+    same thing, because get_domain_dns_provider falls back to the global when
+    the entry names no provider.
+
+    {'domain': 'a.example.com', 'dns_provider': 'cloudflare'} means something
+    DIFFERENT: this domain is pinned to cloudflare whatever the global says.
+
+The previous normaliser wrote the third form when it was given the first. It
+ran inside settings mutators, so an unrelated operation -- flipping auto_renew
+on one domain, or the renewal sweep re-registering a certificate -- rewrote
+every string entry with the global provider of that moment baked into it. From
+then on, changing the global DNS provider had no effect on any existing domain:
+they all kept resolving to the value that had been frozen in. Nothing read
+those injected fields (the provider is resolved by
+``SettingsManager.get_domain_dns_provider``, the account by the certificate's
+own metadata), so the injection bought nothing and cost that.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def entry_domain(raw: Any) -> Optional[str]:
+    """The domain name an entry names, or None when it names none.
+
+    None means "this is not a usable entry" for every caller: a malformed
+    element must be skipped rather than making the whole certificate list
+    unreachable.
+    """
+    if isinstance(raw, str):
+        return raw or None
+    if isinstance(raw, dict):
+        domain = raw.get('domain')
+        return domain if isinstance(domain, str) and domain else None
+    return None
+
+
+def entry_auto_renew(raw: Any) -> bool:
+    """Whether unattended renewal is enabled for this entry.
+
+    Absent means enabled, in both spellings — the string form cannot carry the
+    flag at all, and a dict without it has always been read as True. This is
+    the PER-DOMAIN switch; the global ``auto_renew`` setting is a separate gate
+    checked before the sweep iterates.
+    """
+    if isinstance(raw, dict):
+        return bool(raw.get('auto_renew', True))
+    return True
+
+
+def normalize_entry(raw: Any) -> Optional[dict]:
+    """One entry in the object form, or None if it is not an entry at all.
+
+    Lossless by construction: a string becomes ``{'domain': ...}`` and a dict
+    is copied unchanged. No field is invented. See this module's docstring for
+    why inventing ``dns_provider`` here is a semantic change rather than a
+    tidy-up.
+    """
+    domain = entry_domain(raw)
+    if domain is None:
+        return None
+    if isinstance(raw, dict):
+        entry = dict(raw)
+        entry['domain'] = domain
+        return entry
+    return {'domain': domain}
+
+
+def normalize_domains(domains: Any) -> tuple[list, int]:
+    """Normalise a whole list. Returns ``(entries, dropped)``.
+
+    ``dropped`` counts elements that name no domain — a number rather than an
+    exception, because one malformed entry must not make every other
+    certificate unreachable, and a number is what the caller can report.
+    """
+    if not isinstance(domains, list):
+        return [], 0
+    entries = []
+    dropped = 0
+    for raw in domains:
+        entry = normalize_entry(raw)
+        if entry is None:
+            dropped += 1
+            continue
+        entries.append(entry)
+    return entries, dropped
+
+
+def iter_domains(settings: Any):
+    """``(domain, auto_renew)`` for every usable entry in *settings*."""
+    domains = (settings or {}).get('domains') if isinstance(settings, dict) else None
+    for raw in domains or []:
+        domain = entry_domain(raw)
+        if domain:
+            yield domain, entry_auto_renew(raw)

--- a/modules/core/file_operations.py
+++ b/modules/core/file_operations.py
@@ -13,6 +13,7 @@ import zipfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import logging
+from .domain_entries import iter_domains
 
 from .utils import utc_now, utc_now_iso, repair_certbot_lineage_symlinks
 
@@ -501,7 +502,7 @@ class FileOperations:
                 "version": "2.2.0",  # New unified format
                 "type": "unified",
                 "domains": domains,
-                "settings_domains": [d.get('domain') if isinstance(d, dict) else d for d in settings_data.get('domains', [])],
+                "settings_domains": [name for name, _ in iter_domains(settings_data)],
                 "total_domains": len(domains),
                 # Count of PKI/audit files carried under the "data/" prefix
                 # (private CA, client certs, CRL, audit chain) — #409.

--- a/modules/core/inventory_sources.py
+++ b/modules/core/inventory_sources.py
@@ -23,6 +23,7 @@ the reconciliation this issue asks for has something to reconcile.
 from dataclasses import dataclass
 
 from .constants import iter_cert_domain_dirs
+from .domain_entries import iter_domains
 
 
 @dataclass(frozen=True)
@@ -51,18 +52,13 @@ class DomainSources:
 def _settings_domains(settings):
     """Yield ``(domain, auto_renew)`` from the settings list.
 
-    Entries are strings or dicts — both spellings are in the wild and neither
-    is being migrated here — and anything else is skipped rather than raising:
-    one malformed entry must not make the certificate list unreachable.
+    Both spellings of an entry are still readable — load_settings normalises
+    them to the object form, but this reads whatever it is given, including a
+    settings dict assembled in a test or handed over by a restore that has not
+    been through the boundary yet. The decoding itself lives in
+    :mod:`modules.core.domain_entries`.
     """
-    for entry in (settings or {}).get('domains', []) or []:
-        if isinstance(entry, str):
-            if entry:
-                yield entry, True
-        elif isinstance(entry, dict):
-            domain = entry.get('domain')
-            if domain:
-                yield domain, bool(entry.get('auto_renew', True))
+    yield from iter_domains(settings)
 
 
 def collect_domain_sources(settings, cert_dir):

--- a/modules/core/metrics.py
+++ b/modules/core/metrics.py
@@ -8,6 +8,7 @@ SSL certificate infrastructure health and status.
 import time
 from datetime import datetime, timezone
 import logging
+from .domain_entries import entry_domain
 
 from .constants import DEFAULT_RENEWAL_THRESHOLD_DAYS, iter_cert_domain_dirs
 
@@ -407,7 +408,7 @@ class CertMateMetricsCollector:
             
             # Add domains from settings
             for domain_config in domains:
-                domain_name = domain_config.get('domain') if isinstance(domain_config, dict) else domain_config
+                domain_name = entry_domain(domain_config)
                 if domain_name:
                     all_domains.add(domain_name)
             

--- a/modules/core/settings.py
+++ b/modules/core/settings.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from modules import __version__ as _CERTMATE_VERSION
 from .constants import SETTINGS_SCHEMA_VERSION, iter_cert_domain_dirs
+from .domain_entries import normalize_domains, normalize_entry
 from .file_operations import FileOperations, _backup_passphrase
 from .utils import (
     generate_secure_token, validate_email, validate_api_token, validate_domain,
@@ -1491,22 +1492,25 @@ class SettingsManager:
                         return False
 
                 # Validate domains
+                # Emit the same shape load_settings returns, so normalising
+                # is a fixed point. This used to write a validated string
+                # entry straight back as a string, which meant the migration
+                # above could be undone by the very next save and the mixed
+                # list could never be retired.
                 if 'domains' in settings:
                     validated_domains = []
                     for domain_entry in settings['domains']:
-                        if isinstance(domain_entry, str):
-                            is_valid, domain_or_error = validate_domain(domain_entry)
-                            if is_valid:
-                                validated_domains.append(domain_or_error)
-                            else:
-                                logger.warning(f"Invalid domain skipped: {domain_or_error}")
-                        elif isinstance(domain_entry, dict) and 'domain' in domain_entry:
-                            is_valid, domain_or_error = validate_domain(domain_entry['domain'])
-                            if is_valid:
-                                domain_entry['domain'] = domain_or_error
-                                validated_domains.append(domain_entry)
-                            else:
-                                logger.warning(f"Invalid domain in object skipped: {domain_or_error}")
+                        entry = normalize_entry(domain_entry)
+                        if entry is None:
+                            logger.warning(
+                                "Skipped a domain entry that named no domain")
+                            continue
+                        is_valid, domain_or_error = validate_domain(entry['domain'])
+                        if not is_valid:
+                            logger.warning(f"Invalid domain skipped: {domain_or_error}")
+                            continue
+                        entry['domain'] = domain_or_error
+                        validated_domains.append(entry)
                     settings['domains'] = validated_domains
 
                 # Ensure required fields exist (but don't fail on missing fields, just warn).
@@ -1564,44 +1568,30 @@ class SettingsManager:
                 return False
 
     def migrate_domains_format(self, settings):
-        """Migrate old domain format (string) to new format (object with dns_provider)"""
-        try:
-            if 'domains' not in settings:
-                return settings
+        """Normalise ``settings['domains']`` in place and return *settings*.
 
-            domains = settings['domains']
-            default_provider = settings.get('dns_provider', 'cloudflare')
-            migrated_domains = []
+        Kept as a method because four call sites and a good deal of the test
+        suite reach for it by name, but it is now exactly the boundary
+        normalisation: string entries become objects and nothing else changes.
 
-            for domain_entry in domains:
-                if isinstance(domain_entry, str):
-                    # Old format: just domain string
-                    migrated_domains.append({
-                        'domain': domain_entry,
-                        'dns_provider': default_provider,
-                        'account_id': 'default'
-                    })
-                elif isinstance(domain_entry, dict):
-                    # New format: already has structure
-                    if 'domain' in domain_entry:
-                        # Ensure required fields exist
-                        if 'dns_provider' not in domain_entry:
-                            domain_entry['dns_provider'] = default_provider
-                        if 'account_id' not in domain_entry:
-                            domain_entry['account_id'] = 'default'
-                        migrated_domains.append(domain_entry)
-                    else:
-                        logger.warning(f"Invalid domain entry format: {domain_entry}")
-                else:
-                    logger.warning(f"Unexpected domain entry type: {type(domain_entry)}")
-
-            settings['domains'] = migrated_domains
+        It used to fill in ``dns_provider`` and ``account_id`` from the global
+        defaults. Two of its callers invoke it INSIDE a settings mutator, so
+        those injected values were persisted — and an entry that named no
+        provider had meant "follow the global setting", while one that names a
+        provider is pinned to it. The observable consequence was that after any
+        such operation, changing the global DNS provider stopped taking effect
+        for every existing domain: they all went on resolving to whatever had
+        been frozen in. Nothing ever read the injected fields.
+        """
+        if not isinstance(settings, dict) or 'domains' not in settings:
             return settings
-
-        except Exception as e:
-            logger.error(f"Error during domain format migration: {e}")
-            return settings
-
+        entries, dropped = normalize_domains(settings['domains'])
+        if dropped:
+            logger.warning(
+                "Ignored %d domain entr%s that named no domain",
+                dropped, 'y' if dropped == 1 else 'ies')
+        settings['domains'] = entries
+        return settings
     def migrate_dns_providers_to_multi_account(self, settings):
         """Migrate old single-account DNS provider configurations to multi-account format"""
         try:
@@ -1758,24 +1748,33 @@ class SettingsManager:
             settings = settings['settings']
             migrated = True
 
-        # Migration 2: Handle domains format transition (string array <-> object array)
+        # Migration 2: every domain entry is an object.
+        #
+        # This used to convert only when EVERY entry was a string, so a list
+        # that held both spellings — which is what any instance that added a
+        # domain after the object format arrived actually has — was left mixed
+        # forever, and seven modules were each written to cope with that.
+        # It now normalises per entry, so the union ends at this boundary.
+        #
+        # It also used to fill in dns_provider and account_id from the global
+        # defaults, which is not a shape change but a MEANING change: a string
+        # entry follows the global provider, and an entry naming a provider is
+        # pinned to it. See modules/core/domain_entries.py. Nothing reads
+        # either field off the entry — the provider is resolved by
+        # get_domain_dns_provider and the account comes from the certificate's
+        # metadata — so the injection is dropped rather than preserved.
         if 'domains' in settings:
-            domains = settings['domains']
-            if domains and all(isinstance(d, str) for d in domains):
-                # Convert simple string array to object array for new multi-account support
-                logger.info("Migrating domains from string array to object array format")
-                default_provider = settings.get('dns_provider', 'cloudflare')
-                default_accounts = settings.get('default_accounts', {})
-                default_account = default_accounts.get(default_provider, 'default')
-
-                new_domains = []
-                for domain in domains:
-                    new_domains.append({
-                        'domain': domain,
-                        'dns_provider': default_provider,
-                        'account_id': default_account
-                    })
-                settings['domains'] = new_domains
+            entries, dropped = normalize_domains(settings['domains'])
+            if entries != settings['domains']:
+                logger.info(
+                    "Normalising %d domain entr%s to the object format",
+                    len(entries), 'y' if len(entries) == 1 else 'ies')
+                settings['domains'] = entries
+                migrated = True
+            if dropped:
+                logger.warning(
+                    "Dropped %d settings domain entr%s that named no domain",
+                    dropped, 'y' if dropped == 1 else 'ies')
                 migrated = True
 
         # Migration 4 (#279): the letsencrypt 'environment' field is retired —

--- a/modules/web/settings_routes.py
+++ b/modules/web/settings_routes.py
@@ -4,6 +4,7 @@ import re
 from flask import request, jsonify
 
 from modules.core.constants import iter_cert_domain_dirs
+from modules.core.domain_entries import entry_domain
 
 logger = logging.getLogger(__name__)
 
@@ -57,10 +58,7 @@ def register_settings_routes(app, managers, require_web_auth, auth_manager,
                 raw_domains = masked.get('domains') or []
                 filtered = []
                 for entry in raw_domains:
-                    domain_name = (
-                        entry if isinstance(entry, str)
-                        else (entry.get('domain') if isinstance(entry, dict) else None)
-                    )
+                    domain_name = entry_domain(entry)
                     if domain_name and auth_manager.domain_matches_scope(domain_name, scope):
                         filtered.append(entry)
                 masked['domains'] = filtered

--- a/scripts/check_coverage_floors.py
+++ b/scripts/check_coverage_floors.py
@@ -129,6 +129,10 @@ FLOORS = {
     'modules/core/deployer.py': 85,
     'modules/core/digest.py': 85,
     'modules/core/dns_alias_hook.py': 65,
+    # The one home for what a settings['domains'] entry is. High on
+    # purpose: it is four small pure functions with no I/O, and every
+    # other module now trusts them to decide what a domain entry means.
+    'modules/core/domain_entries.py': 95,
     'modules/core/dns_providers.py': 85,
     'modules/core/dns_strategies.py': 80,
     'modules/core/dns_zone_discovery.py': 95,

--- a/tests/test_a_domain_entry_has_one_shape.py
+++ b/tests/test_a_domain_entry_has_one_shape.py
@@ -1,0 +1,295 @@
+"""A domain entry has one shape, and normalising it changes nothing else.
+
+`settings['domains']` accepted a bare string or an object, both spellings were
+live, and nine modules decoded that union independently. Three separate
+defects came out of it, and only the first is a tidiness problem.
+
+**The union never ended.** The load-time migration converted only when EVERY
+entry was a string, so the moment one object entry existed the list was frozen
+mixed — which is the state of any instance that added a domain after the object
+format arrived. And `save_settings` wrote a validated string entry straight
+back as a string, so even a fully converted list could be un-converted by the
+next save. Normalisation was not a fixed point.
+
+**The normaliser that did run was not lossless.** `migrate_domains_format`
+filled in `dns_provider` and `account_id` from the global defaults. Two of its
+callers invoke it inside a settings mutator — `set_auto_renew` and the sweep's
+re-registration — so those invented values were PERSISTED. An entry naming no
+provider means "follow the global setting"; an entry naming one is pinned to
+it. So an unrelated operation silently converted the first into the second, and
+from then on changing the global DNS provider had no effect on any existing
+domain. Measured before the fix, on a mixed list, after one unrelated write:
+
+    global dns_provider set to route53
+      a.example.com resolves to cloudflare
+      b.example.com resolves to cloudflare
+
+Nothing ever read the injected fields: the provider comes from
+`get_domain_dns_provider`, the account from the certificate's own metadata.
+
+**The flag one spelling cannot carry.** A string entry has nowhere to put
+`auto_renew`, so it reads as True. That stays true after normalisation only
+because `{'domain': x}` is read as True as well — which is the property the
+losslessness tests below pin.
+"""
+import json
+
+import pytest
+
+from modules.core.domain_entries import (
+    entry_auto_renew, entry_domain, iter_domains, normalize_domains,
+    normalize_entry,
+)
+from modules.core.file_operations import FileOperations
+from modules.core.settings import SettingsManager
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def manager(tmp_path):
+    """A real SettingsManager over a real file — the boundary under test."""
+    for name in ('certificates', 'data', 'backups', 'logs'):
+        (tmp_path / name).mkdir()
+    file_ops = FileOperations(cert_dir=tmp_path / 'certificates',
+                              data_dir=tmp_path / 'data',
+                              backup_dir=tmp_path / 'backups',
+                              logs_dir=tmp_path / 'logs')
+    settings_file = tmp_path / 'data' / 'settings.json'
+    return SettingsManager(file_ops, settings_file), settings_file
+
+
+def _write(settings_file, domains, provider='cloudflare'):
+    settings_file.write_text(json.dumps({
+        'domains': domains, 'dns_provider': provider, 'auto_renew': True,
+    }), encoding='utf-8')
+
+
+# --- THE regression: normalising must not pin a provider -----------------
+
+def test_an_unrelated_write_does_not_pin_the_global_provider(manager):
+    """The defect, end to end. Before the fix both domains resolved to
+    cloudflare after this sequence, because the normaliser had written the
+    global provider of that moment into every entry."""
+    sm, settings_file = manager
+    _write(settings_file, ['a.example.com', {'domain': 'b.example.com'}])
+
+    # Any operation that normalises inside a settings mutator.
+    sm.update(lambda s: sm.migrate_domains_format(s), reason='unrelated')
+    # The operator then changes the global provider, as the settings UI does.
+    sm.update(lambda s: s.__setitem__('dns_provider', 'route53'),
+              reason='global change')
+
+    settings = sm.load_settings()
+    assert sm.get_domain_dns_provider('a.example.com', settings) == 'route53'
+    assert sm.get_domain_dns_provider('b.example.com', settings) == 'route53'
+
+
+def test_normalising_does_not_invent_fields(manager):
+    """The same property at the unit level: what is written back is the entry,
+    not the entry plus the defaults of the moment."""
+    sm, settings_file = manager
+    _write(settings_file, ['a.example.com'])
+
+    sm.update(lambda s: sm.migrate_domains_format(s), reason='unrelated')
+
+    stored = json.loads(settings_file.read_text(encoding='utf-8'))['domains']
+    assert stored == [{'domain': 'a.example.com'}]
+
+
+def test_a_pinned_provider_survives_normalising(manager):
+    """CONTROL for the finding above: an entry that DOES name a provider is
+    stating a per-domain override, and normalising must not drop it."""
+    sm, settings_file = manager
+    _write(settings_file, [{'domain': 'pinned.example.com',
+                            'dns_provider': 'route53'}])
+
+    sm.update(lambda s: s.__setitem__('dns_provider', 'digitalocean'),
+              reason='global change')
+
+    settings = sm.load_settings()
+    assert sm.get_domain_dns_provider('pinned.example.com', settings) == 'route53'
+
+
+# --- normalisation is a fixed point --------------------------------------
+
+def test_a_mixed_list_is_normalised(manager):
+    """The old migration converted only when every entry was a string, so a
+    mixed list -- which is what any instance that added a domain after the
+    object format has -- stayed mixed forever."""
+    sm, settings_file = manager
+    _write(settings_file, ['a.example.com', {'domain': 'b.example.com'},
+                           'c.example.com'])
+
+    settings = sm.load_settings()
+
+    assert settings['domains'] == [{'domain': 'a.example.com'},
+                                   {'domain': 'b.example.com'},
+                                   {'domain': 'c.example.com'}]
+
+
+def test_saving_does_not_undo_the_normalisation(manager):
+    """The other half of the fixed point. save_settings used to write a
+    validated string entry back as a string, so the union could reappear on
+    any save after a clean load."""
+    sm, settings_file = manager
+    _write(settings_file, ['a.example.com'])
+
+    sm.save_settings({'domains': ['a.example.com'], 'dns_provider': 'cloudflare'})
+
+    stored = json.loads(settings_file.read_text(encoding='utf-8'))['domains']
+    assert stored == [{'domain': 'a.example.com'}]
+
+
+def test_load_save_load_is_stable(manager):
+    """A round trip through the boundary must reach a fixed point, not
+    oscillate: this is what makes the object form retirable."""
+    sm, settings_file = manager
+    _write(settings_file, ['a.example.com', {'domain': 'b.example.com',
+                                             'auto_renew': False}])
+
+    first = sm.load_settings()
+    sm.save_settings(first)
+    second = sm.load_settings()
+    sm.save_settings(second)
+    third = sm.load_settings()
+
+    assert first['domains'] == second['domains'] == third['domains']
+    # And the fixed point is the OBJECT form. Without this the assertion above
+    # is satisfied by the old behaviour too, which was stable at the mixed
+    # shape: stability alone was never the problem.
+    assert third['domains'] == [{'domain': 'a.example.com'},
+                                {'domain': 'b.example.com', 'auto_renew': False}]
+
+
+@pytest.mark.parametrize('raw', [
+    'a.example.com',
+    {'domain': 'a.example.com'},
+    {'domain': 'a.example.com', 'auto_renew': False},
+    {'domain': 'a.example.com', 'dns_provider': 'route53', 'account_id': 'x'},
+])
+def test_normalising_is_idempotent(raw):
+    once = normalize_entry(raw)
+    assert normalize_entry(once) == once
+
+
+# --- what the two spellings mean, before and after -----------------------
+
+@pytest.mark.parametrize('raw,expected', [
+    ('a.example.com', True),
+    ({'domain': 'a.example.com'}, True),
+    ({'domain': 'a.example.com', 'auto_renew': True}, True),
+    ({'domain': 'a.example.com', 'auto_renew': False}, False),
+])
+def test_auto_renew_survives_normalisation(raw, expected):
+    """The property that makes the conversion safe: a string and
+    {'domain': x} are read identically, so turning one into the other cannot
+    change whether a certificate renews."""
+    assert entry_auto_renew(raw) is expected
+    assert entry_auto_renew(normalize_entry(raw)) is expected
+
+
+@pytest.mark.parametrize('raw,expected', [
+    ('a.example.com', 'a.example.com'),
+    ({'domain': 'a.example.com'}, 'a.example.com'),
+    ('', None),
+    ({}, None),
+    ({'domain': ''}, None),
+    ({'domain': None}, None),
+    ({'nope': 'a.example.com'}, None),
+    (42, None),
+    (None, None),
+    ([], None),
+])
+def test_what_counts_as_naming_a_domain(raw, expected):
+    assert entry_domain(raw) == expected
+
+
+def test_a_malformed_entry_is_dropped_and_counted_and_the_rest_survive():
+    """One bad element must not make the certificate list unreachable, and the
+    caller needs a number it can report rather than an exception."""
+    entries, dropped = normalize_domains(
+        ['a.example.com', 42, {'domain': 'b.example.com'}, {'nope': 1}, None])
+
+    assert entries == [{'domain': 'a.example.com'}, {'domain': 'b.example.com'}]
+    assert dropped == 3
+
+
+def test_a_malformed_entry_does_not_hide_the_others_at_the_boundary(manager):
+    """The same property through the real load path."""
+    sm, settings_file = manager
+    _write(settings_file, ['a.example.com', 42, {'domain': 'b.example.com'}])
+
+    settings = sm.load_settings()
+
+    assert [e['domain'] for e in settings['domains']] == ['a.example.com',
+                                                          'b.example.com']
+
+
+# --- one decoder ---------------------------------------------------------
+
+def test_nothing_else_decodes_the_union():
+    """The guard that keeps this fixed. Nine modules each had their own
+    version of 'a string or an object', with three different answers for a
+    third shape; the value of consolidating is lost the moment a tenth is
+    written."""
+    import pathlib
+    import re
+
+    root = pathlib.Path(__file__).resolve().parent.parent / 'modules'
+    pattern = re.compile(
+        r"get\('domain'\)\s+if\s+isinstance|isinstance\(entry,\s*str\)"
+        r"|isinstance\(domain_entry,\s*(?:str|dict)\)")
+
+    offenders = []
+    for path in sorted(root.rglob('*.py')):
+        if path.name == 'domain_entries.py':
+            continue
+        for number, line in enumerate(path.read_text(encoding='utf-8').splitlines(), 1):
+            if pattern.search(line):
+                offenders.append(f'{path.relative_to(root.parent)}:{number}: {line.strip()}')
+
+    # auth.py validates API-key allowed_domains, which is a list of patterns
+    # rather than domain entries -- a different structure with a different rule.
+    offenders = [o for o in offenders if 'core/auth.py' not in o]
+
+    assert not offenders, (
+        'these decode the domain-entry union outside modules/core/'
+        'domain_entries.py:\n  ' + '\n  '.join(offenders))
+
+
+def test_the_canonical_reader_is_what_inventory_uses():
+    """collect_domain_sources is the one answer to 'which certificates exist',
+    so it must read entries the same way everything else does."""
+    import inspect
+
+    from modules.core import inventory_sources
+
+    assert 'iter_domains' in inspect.getsource(inventory_sources._settings_domains)
+
+
+# --- the shape older builds already read ---------------------------------
+
+def test_the_normalised_shape_is_the_one_older_builds_expect(manager):
+    """Downgrade safety. The object form is not new -- it is the format every
+    build since the multi-account change has written -- so normalising cannot
+    strand a rollback. What would have been unsafe is inventing a field, which
+    is exactly what the previous normaliser did."""
+    sm, settings_file = manager
+    _write(settings_file, ['a.example.com'])
+
+    settings = sm.load_settings()
+
+    assert all(isinstance(entry, dict) and 'domain' in entry
+               for entry in settings['domains'])
+    assert all(set(entry) <= {'domain'} for entry in settings['domains']), (
+        'normalisation added a field an older build would have to understand')
+
+
+def test_iter_domains_reads_an_un_normalised_dict_too():
+    """Settings assembled in a test, or handed over by a restore, have not
+    been through the boundary. The readers must still cope."""
+    assert list(iter_domains({'domains': ['a.example.com',
+                                          {'domain': 'b.example.com',
+                                           'auto_renew': False}]})) == [
+        ('a.example.com', True), ('b.example.com', False)]


### PR DESCRIPTION
The audit scored Domain Model 50.3, the lowest of the twenty categories. Working the finding turned up something worse than the shape problem it started from.

## The defect that matters

`migrate_domains_format` filled in `dns_provider` and `account_id` from the global defaults. Two of its four callers invoke it **inside a settings mutator** — `set_auto_renew` and the renewal sweep's re-registration — so those invented values were **persisted**.

That is not a shape change, it is a meaning change:

- `'a.example.com'` means *this domain follows the global `dns_provider`*
- `{'domain': 'a.example.com', 'dns_provider': 'cloudflare'}` means *this domain is pinned to cloudflare whatever the global says*

Measured against `main` before the fix — a mixed list, one unrelated write, then the operator changes the global provider as the settings UI does:

```
su disco dopo l'operazione non correlata:
    {'domain': 'a.example.com', 'dns_provider': 'cloudflare', 'account_id': 'default'}
    {'domain': 'b.example.com', 'dns_provider': 'cloudflare', 'account_id': 'default'}
provider globale ora: route53
  a.example.com: risolve a cloudflare
  b.example.com: risolve a cloudflare
```

**Changing the global DNS provider stops taking effect for every existing domain**, including `b.example.com`, which was an object entry that named no provider and should have followed it. An operator who changes the global provider because they moved DNS hosting keeps renewing against the old provider's credentials.

Nothing ever read the injected fields: the provider is resolved by `get_domain_dns_provider` (which already falls back to the global), and the account comes from the certificate's own `metadata.json`. The injection bought nothing and cost that.

After the fix, the same sequence:

```
su disco: {'domain': 'a.example.com'} / {'domain': 'b.example.com'}
provider globale ora: route53
  a.example.com: risolve a route53
  b.example.com: risolve a route53
```

## The two structural problems underneath

**The union never ended.** The load-time migration converted only when *every* entry was a string (`all(isinstance(d, str) for d in domains)`), so a mixed list — what any instance that added a domain after the object format has — stayed mixed forever. And `save_settings` wrote a validated string entry back **as a string**, so a converted list could be un-converted by the next save. Normalisation was not a fixed point, which is why nine modules each had to cope with both spellings.

**One spelling cannot carry `auto_renew`.** A string entry has nowhere to put it. That is safe only because `{'domain': x}` is read as `True` too — the equivalence that makes the conversion lossless, now pinned by test rather than assumed.

## The fix

`modules/core/domain_entries.py`: one decoder (`entry_domain`, `entry_auto_renew`, `iter_domains`) and one **lossless** normaliser. A string becomes `{'domain': ...}` and nothing else is invented — the module's docstring states why inventing a provider here is a semantic change rather than a tidy-up.

Applied at **both** boundaries so it is a fixed point:

| | before | after |
|---|---|---|
| `load_settings` | converts only all-string lists | normalises per entry |
| `save_settings` | writes strings back as strings | emits the shape load returns |
| `migrate_domains_format` | injects provider + account | lossless, same as the boundary |

The nine decode sites now ask the decoder, and a test fails if a tenth is written. `auth.py`'s `allowed_domains` validation is excluded by name in that test: it is a list of API-key scope patterns, a different structure with a different rule.

## Verified by reverting

With the tests in place and only the production change reverted, **9 of the 30 fail**, including the provider-pinning regression. `test_load_save_load_is_stable` was strengthened after it passed both ways — the old behaviour was stable too, just stable at the mixed shape, so stability alone was never the property worth asserting.

A realistic round trip (mixed list, a pinned entry, an `auto_renew: False` entry, credentials alongside) normalises the two string entries, preserves the pin, preserves the flag, and changes no other key in `settings.json`.

## Compatibility

Input is unchanged: a request may still send either spelling. Responses now always return the object form, which the Swagger model already described as possible (`'can be strings or objects'`) — its description is updated to say which is stored and which is returned. No contract-version bump: nothing removed, nothing retyped, no status changed for an existing condition.

Downgrade-safe: the object form is what every build since the multi-account change has written. A test asserts the normalised entry carries no field an older build would have to understand — which is precisely what the previous normaliser got wrong.

## Test plan

`tests/test_a_domain_entry_has_one_shape.py`, 30 tests. Full gated suite: **4750 passed, 46 skipped**. Coverage 82.02%, floors met for 82 modules (`domain_entries.py` added at 95). `flake8` CI selection → 0, `bandit` medium → clean, complexity budget → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)