### PR TITLE
fix: a bind mount that stats but cannot create files is named as broken

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,14 +45,18 @@ services:
     #   chgrp -R 0 ./{certificates,data,logs,backups}
     #   chmod -R g+rwX ./{certificates,data,logs,backups}
     #
+    # `:z` (shared) relabels for SELinux. Without it, Fedora/RHEL report the
+    # directories as present but creating a file inside them fails with ENOENT.
+    # nginx also mounts ./certificates, so this must be `:z` not `:Z`.
+    #
     # (Named volumes need none of this — see docs/docker.md. The app refuses to
     # start rather than half-work when a directory is not writable, and names
     # the directory and the fix in the error.)
     volumes:
-      - ./certificates:/app/certificates:rw
-      - ./logs:/app/logs:rw
-      - ./data:/app/data:rw
-      - ./backups:/app/backups:rw
+      - ./certificates:/app/certificates:rw,z
+      - ./logs:/app/logs:rw,z
+      - ./data:/app/data:rw,z
+      - ./backups:/app/backups:rw,z
     restart: unless-stopped
     cap_drop:
       - ALL
@@ -85,8 +89,8 @@ services:
     volumes:
       # Copy nginx.conf.example to nginx.conf and set your domain BEFORE `up`:
       # a missing host file makes Docker create nginx.conf as an empty DIRECTORY.
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./certificates:/etc/nginx/ssl:ro
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro,z
+      - ./certificates:/etc/nginx/ssl:ro,z
     depends_on:
       certmate:
         condition: service_healthy

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -212,23 +212,31 @@ chmod -R g+rwX ./{data,certificates,logs,backups}
 
 podman run -d --name certmate \
   -p 8000:8000 \
-  -v ./data:/app/data \
-  -v ./certificates:/app/certificates \
-  -v ./logs:/app/logs \
-  -v ./backups:/app/backups \
+  -v ./data:/app/data:z \
+  -v ./certificates:/app/certificates:z \
+  -v ./logs:/app/logs:z \
+  -v ./backups:/app/backups:z \
   docker.io/fabriziosalmi/certmate:latest
 ```
 
+On SELinux hosts (Fedora, RHEL, CentOS) the `:z` option is required: it
+relabels the bind mount so the container can create files. Without it the
+directories `stat` as present but writing a file fails with **ENOENT**, which
+looks like a missing path rather than a policy denial. Use `:z` (shared), not
+`:Z`, if another container (the nginx profile, for example) also mounts
+`./certificates`.
+
 Alternatively let podman fix the ownership for you with the `:U` mount option
-(recursively chowns the source to match the container UID/GID):
+(recursively chowns the source to match the container UID/GID); combine it
+with `:z` on SELinux hosts:
 
 ```bash
 podman run -d --name certmate \
   -p 8000:8000 \
-  -v ./data:/app/data:U \
-  -v ./certificates:/app/certificates:U \
-  -v ./logs:/app/logs:U \
-  -v ./backups:/app/backups:U \
+  -v ./data:/app/data:U,z \
+  -v ./certificates:/app/certificates:U,z \
+  -v ./logs:/app/logs:U,z \
+  -v ./backups:/app/backups:U,z \
   docker.io/fabriziosalmi/certmate:latest
 ```
 
@@ -255,8 +263,11 @@ volumes:
 ```
 
 If startup aborts with *"Required directories are not writable by the CertMate
-process"*, the mount is not group-0 writable — apply the `chgrp 0 … && chmod
-g+rwX …` above, switch to a named volume, or add `:U` to the bind mounts.
+process"*, read the per-directory reason: a permission error means the mount is
+not group-0 writable — apply the `chgrp 0 … && chmod g+rwX …` above, switch to
+a named volume, or add `:U` to the bind mounts. **ENOENT** on a directory that
+exists is a broken or SELinux-blocked mount — add `:z` (the shipped
+`docker-compose.yml` already does), or recreate the host directory.
 
 > **Kubernetes / OpenShift:** no changes needed. Set
 > `spec.securityContext.fsGroup: 0` (or rely on the default restricted SCC,

--- a/modules/core/factory.py
+++ b/modules/core/factory.py
@@ -1,4 +1,5 @@
 import atexit
+import errno
 import os
 import re
 import secrets
@@ -209,6 +210,20 @@ def _verify_dir_writable(directory: Path) -> Optional[str]:
     except PermissionError:
         return "not writable by the container user (check host mount permissions)"
     except OSError as e:
+        # ENOENT after exists()+is_dir() succeeded is not a mode bit problem.
+        # Typical causes: SELinux blocking create and reporting it as ENOENT
+        # (Fedora/RHEL bind mounts without ':z'), a bind mount whose host
+        # path was deleted, or a Kubernetes subPath that did not materialise.
+        # ESTALE is the NFS equivalent of a vanished mount.
+        if e.errno in (errno.ENOENT, errno.ESTALE):
+            return (
+                f"visible as a directory but creating a file failed ({e}). "
+                "This is a broken or blocked mount, not a chmod problem. On "
+                "SELinux hosts (Fedora/RHEL) add ':z' to the bind mount; "
+                "otherwise recreate the host directory or volume"
+            )
+        if e.errno == errno.EROFS:
+            return "read-only filesystem (mount the volume read-write)"
         return f"OS error during write probe: {e}"
     return None
 
@@ -228,15 +243,21 @@ def _make_dir_arbitrary_uid_ready(directory: Path):
     """
     import stat as _stat
     try:
-        directory.mkdir()
-        _created = True
-    except FileExistsError:
-        _created = False
+        already_present = directory.exists() and directory.is_dir()
+    except OSError:
+        already_present = False
+
+    try:
+        # parents=True: CERTMATE_*_DIR can point at a nested path on a fresh
+        # volume, and backups/unified is one level below backups/. Without
+        # parents, a missing ancestor becomes ENOENT on the leaf and the
+        # write probe then misreports every directory as a permission error.
+        directory.mkdir(parents=True, exist_ok=True)
     except OSError as e:
         logger.error(f"Failed to create {directory}: {e}")
         return
 
-    if not _created:
+    if already_present:
         return
     # Only relax group perms inside a container (the rootless-podman / OpenShift
     # arbitrary-UID case). On a bare-metal install we keep the umask default so a
@@ -348,11 +369,13 @@ def setup_directories(container: AppContainer, test_config=None):
     if failures:
         msg = (
             "Required directories are not writable by the CertMate process. "
-            "Fix host-mount permissions and restart. The default image runs as "
-            "UID/GID 1000:1000; under rootless podman / OpenShift it runs as an "
-            "arbitrary UID in group 0, so the mounts must be group-0 writable "
-            "(chown :0 and chmod g+rwX, or use a named volume / the ':U' mount "
-            "option). See issue #380:\n" + "\n".join(failures)
+            "Fix the mounts and restart. Permission errors: the default image "
+            "runs as UID/GID 1000:1000; under rootless podman / OpenShift it "
+            "runs as an arbitrary UID in group 0, so the mounts must be "
+            "group-0 writable (chown :0 and chmod g+rwX, a named volume, or "
+            "podman's ':U' mount option). ENOENT on a directory that exists "
+            "is a broken bind mount — on SELinux (Fedora/RHEL) add ':z', or "
+            "recreate the host directory. See issue #380:\n" + "\n".join(failures)
         )
         logger.error(msg)
         raise RuntimeError(msg)

--- a/tests/test_compose_bind_mounts_relabel_for_selinux.py
+++ b/tests/test_compose_bind_mounts_relabel_for_selinux.py
@@ -1,0 +1,45 @@
+"""Bind mounts of the gitignored state dirs need SELinux relabeling.
+
+On Fedora/RHEL the four compose bind mounts `stat` as directories inside the
+container but creating a file in them fails with ENOENT unless the mount is
+relabeled. `:z` (shared) is the option that does that; `:Z` would lock
+./certificates to one container and break the nginx profile, which mounts the
+same host directory.
+"""
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+COMPOSE = Path(__file__).resolve().parent.parent / 'docker-compose.yml'
+
+
+def _volume_lines():
+    return [
+        line.strip().lstrip('- ').strip()
+        for line in COMPOSE.read_text(encoding='utf-8').splitlines()
+        if ':/app/' in line or ':/etc/nginx/' in line
+    ]
+
+
+def test_the_four_state_bind_mounts_are_selinux_shared():
+    mounts = {
+        'certificates': './certificates:/app/certificates:rw,z',
+        'logs': './logs:/app/logs:rw,z',
+        'data': './data:/app/data:rw,z',
+        'backups': './backups:/app/backups:rw,z',
+    }
+    volume_lines = _volume_lines()
+    missing = [spec for spec in mounts.values() if spec not in volume_lines]
+    assert not missing, (
+        f"compose bind mounts must carry ':z' (shared SELinux relabel); "
+        f"missing or private ':Z' would reproduce ENOENT on Fedora: {missing}"
+    )
+
+
+def test_nginx_shares_certificates_with_z_not_Z():
+    """`:Z` (private) on either side would deny the other container."""
+    volume_lines = _volume_lines()
+    assert './certificates:/etc/nginx/ssl:ro,z' in volume_lines
+    assert not any(':Z' in line for line in volume_lines)

--- a/tests/test_factory_directories.py
+++ b/tests/test_factory_directories.py
@@ -26,3 +26,49 @@ def test_setup_directories_keeps_project_data_dir(tmp_path, monkeypatch):
     assert container.logs_dir == (project_root / "logs").resolve()
     assert container.data_dir.exists()
     assert not Path(str(container.data_dir)).name.startswith("certmate_data_")
+
+
+def test_a_nested_directory_that_does_not_exist_yet_is_created(tmp_path):
+    """CERTMATE_*_DIR exists so a volume can hold certificates in one tree
+    and backups in another. The nested path is the ordinary first-boot case
+    for a fresh volume, and mkdir() without parents turned it into ENOENT
+    on the leaf — the same errno the write probe then reported as a host-mount
+    permission error."""
+    from modules.core import factory
+
+    nested = tmp_path / 'state' / 'data'
+    container = factory.AppContainer()
+    factory.setup_directories(container, {
+        'CERTMATE_DATA_DIR': str(nested),
+        'CERTMATE_CERT_DIR': str(tmp_path / 'certs'),
+        'CERTMATE_BACKUP_DIR': str(tmp_path / 'backups'),
+        'CERTMATE_LOGS_DIR': str(tmp_path / 'logs'),
+    })
+
+    assert nested.is_dir()
+    assert (tmp_path / 'backups' / 'unified').is_dir()
+
+
+def test_enoent_during_the_write_probe_is_not_a_chmod_problem(tmp_path, monkeypatch):
+    """exists() and is_dir() succeeding, then create failing with ENOENT, is
+    a broken or SELinux-blocked mount. The old probe stringed the raw OSError
+    and the boot error told the operator to chmod g+rwX, which cannot help."""
+    import errno
+
+    from modules.core import factory
+
+    target = tmp_path / 'certs'
+    target.mkdir()
+
+    def boom(self, *args, **kwargs):
+        raise FileNotFoundError(
+            errno.ENOENT, 'No such file or directory', str(self))
+
+    monkeypatch.setattr(Path, 'write_text', boom)
+
+    reason = factory._verify_dir_writable(target)
+
+    assert reason is not None
+    assert 'chmod problem' in reason
+    assert ':z' in reason
+    assert 'not writable by the container user' not in reason


### PR DESCRIPTION
SELinux on Fedora/RHEL reports ENOENT instead of EACCES when the volume is not relabeled. The boot probe called that a chmod problem. Compose now uses :z, mkdir creates parents, and the error tells the operator to relabel.

<!--
Thanks for contributing. The checklist below is the same set of gates CI runs;
ticking it locally is faster than a round trip. Delete anything that does not
apply — an honest "not run, here is why" is more useful than a tick you are not
sure about.
-->

## What this changes

<!-- What behaviour is different after this merges, and why. If it fixes a bug,
     say what the bug did — not just which line was wrong. -->

Fixes #

## How it was verified

<!-- Not "tests pass" — what did you actually run or observe? For a bug fix,
     the useful sentence is: this test fails against the old code and passes
     against the new one. -->

## Checklist

- [ ] `pytest -v --tb=short -m "not ui and not e2e"` is green
      *(the marker expression is not optional — a bare `pytest` fails on the UI suite)*
- [ ] `flake8 . --count --select=E9,F63,F7,F82,F811,F632,E711,E712,E713,E714` reports 0
- [ ] `bandit -r modules/ app.py --severity-level medium` reports 0
- [ ] New behaviour has a test, and I checked that it **fails without the fix**

If you touched templates or CSS:

- [ ] `npm ci && npm run css:build`, and `static/css/tailwind.min.css` is committed
- [ ] `python3 scripts/theme_codemod.py --check` is clean

If you touched docs:

- [ ] `pytest tests/test_docs_navigation.py` is green
      *(links out of `docs/<lang>/` need `../../`, not `../`)*

## Issuance pipeline

- [ ] This change touches certificate issuance, a DNS provider, or the ACME path

If ticked, `scripts/release.sh` will require a real certificate against Let's
Encrypt **staging** before a release carrying this can be cut. Say here which
provider and path you exercised, if you did.

---

<!--
Before merge: every review conversation has to be resolved, bots included.
Copilot and CodeQL comment on most PRs and branch protection will block the
merge until each thread is closed. Please read them rather than resolving on
sight — they are more often right than not.
-->
